### PR TITLE
Add web API key creation command

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -11,6 +11,9 @@ The `asc web` command family automates App Store Connect workflows through Apple
 asc web auth login --apple-id "user@example.com"
 asc web auth status
 
+# Create a team API key and save its one-time P8
+asc web api-keys create --name "Release automation" --output-dir ~/.asc/keys
+
 # Create an app through the web flow
 asc web apps create --name "My App" --bundle-id "com.example.app" --sku "MYAPP123"
 
@@ -42,7 +45,7 @@ Use `asc web` when one of these is true:
 
 ## Session model
 
-`asc web` does not use App Store Connect API keys. It uses a cached Apple Account web session created with `asc web auth login`.
+`asc web` authenticates with a cached Apple Account web session created with `asc web auth login`. The `api-keys create` command uses that session to create an App Store Connect API key; it does not require an existing API key.
 
 Common session commands:
 
@@ -63,6 +66,26 @@ Available commands:
 * `asc web auth status` - inspect the current session state
 * `asc web auth capabilities` - inspect web-visible capability metadata
 * `asc web auth logout` - clear the cached web session
+
+### `asc web api-keys`
+
+Team API key creation through an Apple Account web session.
+
+Available commands:
+
+* `asc web api-keys create` - create an all-apps team key and save its one-time P8 as `AuthKey_<KEY_ID>.p8`
+
+Example:
+
+```bash  theme={null}
+asc web api-keys create \
+  --name "Release automation" \
+  --role APP_MANAGER \
+  --output-dir ~/.asc/keys \
+  --output json
+```
+
+The role defaults to `ADMIN`. The output file is created with mode `0600`, existing files are not replaced, and key contents are not printed to command output.
 
 ### `asc web apps`
 
@@ -227,6 +250,7 @@ Use the CLI help directly to explore the current surface:
 ```bash  theme={null}
 asc web --help
 asc web auth --help
+asc web api-keys --help
 asc web apps --help
 asc web privacy --help
 asc web review --help

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -87,6 +87,8 @@ asc web api-keys create \
 
 The role defaults to `ADMIN`. The output file is created with mode `0600`, existing files are not replaced, and key contents are not printed to command output.
 
+Role requirement: creating a team API key requires an Account Holder or Admin web session. The `--role` value must be one of Apple's selectable team-key roles.
+
 ### `asc web apps`
 
 App management workflows over Apple web-session endpoints.

--- a/internal/cli/cmdtest/web_api_keys_commands_test.go
+++ b/internal/cli/cmdtest/web_api_keys_commands_test.go
@@ -23,4 +23,7 @@ func TestWebAPIKeysCreateCommandRegistration(t *testing.T) {
 			t.Fatalf("expected --%s flag", flagName)
 		}
 	}
+	if got := cmd.FlagSet.Lookup("role").DefValue; got != "ADMIN" {
+		t.Fatalf("expected --role default ADMIN, got %q", got)
+	}
 }

--- a/internal/cli/cmdtest/web_api_keys_commands_test.go
+++ b/internal/cli/cmdtest/web_api_keys_commands_test.go
@@ -1,0 +1,26 @@
+package cmdtest
+
+import "testing"
+
+func TestWebAPIKeysCreateCommandRegistration(t *testing.T) {
+	root := RootCommand("1.2.3")
+	cmd := findSubcommand(root, "web", "api-keys", "create")
+	if cmd == nil {
+		t.Fatal("expected web api-keys create command")
+	}
+	for _, flagName := range []string{
+		"name",
+		"role",
+		"output-dir",
+		"apple-id",
+		"two-factor-code-command",
+		"provider-id",
+		"public-provider-id",
+		"output",
+		"pretty",
+	} {
+		if cmd.FlagSet.Lookup(flagName) == nil {
+			t.Fatalf("expected --%s flag", flagName)
+		}
+	}
+}

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -27,6 +27,7 @@ Use ` + "`asc web apps create`" + ` as the canonical app-creation command in thi
 
 Examples:
   asc web auth status
+  asc web api-keys create --name "Release automation"
   asc web sandbox create --first-name "Jane" --last-name "Tester" --email "jane+sandbox@example.com" --password "Passwordtest1" --territory "USA"
   asc web auth login --apple-id "user@example.com"
   asc web apps create --name "My App" --bundle-id "com.example.app" --sku "MYAPP123"
@@ -41,6 +42,7 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			WebAuthCommand(),
+			WebAPIKeysCommand(),
 			WebSandboxCommand(),
 			WebAppsCommand(),
 			WebRemovedAppsCommand(),

--- a/internal/cli/web/web_api_keys.go
+++ b/internal/cli/web/web_api_keys.go
@@ -307,7 +307,7 @@ func firstNonEmptyRoles(values ...[]string) []string {
 	return nil
 }
 
-func renderWebAPIKeyCreateTable(result *webAPIKeyCreateResult) error {
+func webAPIKeyCreateRows(result *webAPIKeyCreateResult) ([]string, [][]string) {
 	headers := []string{"Key ID", "Name", "Issuer ID", "Team ID", "Roles", "P8 Path"}
 	rows := [][]string{{
 		result.KeyID,
@@ -317,20 +317,17 @@ func renderWebAPIKeyCreateTable(result *webAPIKeyCreateResult) error {
 		strings.Join(result.Roles, ", "),
 		result.P8Path,
 	}}
+	return headers, rows
+}
+
+func renderWebAPIKeyCreateTable(result *webAPIKeyCreateResult) error {
+	headers, rows := webAPIKeyCreateRows(result)
 	asc.RenderTable(headers, rows)
 	return nil
 }
 
 func renderWebAPIKeyCreateMarkdown(result *webAPIKeyCreateResult) error {
-	headers := []string{"Key ID", "Name", "Issuer ID", "Team ID", "Roles", "P8 Path"}
-	rows := [][]string{{
-		result.KeyID,
-		result.Name,
-		result.IssuerID,
-		result.TeamID,
-		strings.Join(result.Roles, ", "),
-		result.P8Path,
-	}}
+	headers, rows := webAPIKeyCreateRows(result)
 	asc.RenderMarkdown(headers, rows)
 	return nil
 }

--- a/internal/cli/web/web_api_keys.go
+++ b/internal/cli/web/web_api_keys.go
@@ -1,0 +1,317 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+	webref "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web/reference"
+)
+
+const webAPIKeyDownloadAttempts = 3
+
+var (
+	newWebAPIKeyClientFn = webcore.NewClient
+	createWebAPIKeyFn    = func(ctx context.Context, client *webcore.Client, attrs webcore.APIKeyCreateAttributes) (*webcore.APIKey, error) {
+		return client.CreateAPIKey(ctx, attrs)
+	}
+	downloadWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) ([]byte, error) {
+		return client.DownloadAPIKey(ctx, keyID)
+	}
+	getWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) (*webcore.APIKey, error) {
+		return client.GetAPIKey(ctx, keyID)
+	}
+	waitWebAPIKeyRetryFn = waitForWebAPIKeyRetry
+)
+
+type webAPIKeyCreateResult struct {
+	KeyID          string   `json:"keyId"`
+	Name           string   `json:"name"`
+	IssuerID       string   `json:"issuerId"`
+	TeamID         string   `json:"teamId,omitempty"`
+	Roles          []string `json:"roles"`
+	Active         bool     `json:"active"`
+	AllAppsVisible bool     `json:"allAppsVisible"`
+	KeyType        string   `json:"keyType"`
+	P8Path         string   `json:"p8Path"`
+}
+
+// WebAPIKeysCommand returns the web-session API keys command group.
+func WebAPIKeysCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web api-keys", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "api-keys",
+		ShortUsage: "asc web api-keys <subcommand> [flags]",
+		ShortHelp:  "Manage App Store Connect API keys via web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+Manage App Store Connect API keys using a cached Apple Account web session.
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebAPIKeysCreateCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebAPIKeysCreateCommand creates a team API key and saves its one-time P8.
+func WebAPIKeysCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web api-keys create", flag.ExitOnError)
+
+	name := fs.String("name", "", "API key name")
+	role := fs.String("role", "ADMIN", "API key role")
+	outputDir := fs.String("output-dir", ".", "Directory for AuthKey_<KEY_ID>.p8")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "asc web api-keys create --name NAME [--role ROLE] [--output-dir DIR] [flags]",
+		ShortHelp:  "Create a team API key and save its one-time P8.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+Create an all-apps App Store Connect team API key using a cached Apple Account
+web session. The one-time P8 is saved as AuthKey_<KEY_ID>.p8 with mode 0600.
+The P8 contents are never written to command output.
+
+Account Holder or Admin access is required. The role defaults to ADMIN and must
+be one of Apple's selectable team-key roles.
+
+Examples:
+  asc web api-keys create --name "Release automation"
+  asc web api-keys create --name "CI uploads" --role APP_MANAGER --output-dir ~/.asc/keys --output json
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web api-keys create does not accept positional arguments")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			nameValue := strings.TrimSpace(*name)
+			if nameValue == "" {
+				return shared.UsageError("--name is required")
+			}
+			roleValue, err := normalizeWebAPIKeyRole(*role)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			outputDirValue := strings.TrimSpace(*outputDir)
+			if outputDirValue == "" {
+				return shared.UsageError("--output-dir is required")
+			}
+			outputRoot, err := rootfs.New(outputDirValue)
+			if err != nil {
+				return shared.UsageErrorf("invalid --output-dir: %v", err)
+			}
+			if err := outputRoot.MkdirAll(".", 0o700); err != nil {
+				return fmt.Errorf("prepare API key output directory: %w", err)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebAPIKeyClientFn(session)
+
+			var created *webcore.APIKey
+			err = withWebSpinner("Creating App Store Connect API key", func() error {
+				var createErr error
+				created, createErr = createWebAPIKeyFn(requestCtx, client, webcore.APIKeyCreateAttributes{
+					Nickname: nameValue,
+					Role:     roleValue,
+				})
+				return createErr
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web api-keys create")
+			}
+			if created == nil || strings.TrimSpace(created.KeyID) == "" {
+				return fmt.Errorf("web api-keys create failed: create response did not include a key id")
+			}
+
+			var p8 []byte
+			err = withWebSpinner("Downloading one-time API key P8", func() error {
+				var downloadErr error
+				p8, downloadErr = downloadWebAPIKeyWithRetry(requestCtx, client, created.KeyID)
+				return downloadErr
+			})
+			if err != nil {
+				return fmt.Errorf(
+					"API key %q (%s) was created, but its one-time P8 could not be downloaded: %w",
+					nameValue,
+					created.KeyID,
+					withWebAuthHint(err, "web api-keys create"),
+				)
+			}
+
+			fileName := fmt.Sprintf("AuthKey_%s.p8", strings.TrimSpace(created.KeyID))
+			p8Path := filepath.Join(outputRoot.Path(), fileName)
+			if err := outputRoot.CreateNewFile(fileName, p8, 0o600); err != nil {
+				return fmt.Errorf(
+					"API key %q (%s) was created and its one-time P8 was downloaded, but saving %q failed; the P8 cannot be downloaded again: %w",
+					nameValue,
+					created.KeyID,
+					p8Path,
+					err,
+				)
+			}
+
+			var details *webcore.APIKey
+			err = withWebSpinner("Loading API key issuer ID", func() error {
+				var getErr error
+				details, getErr = getWebAPIKeyFn(requestCtx, client, created.KeyID)
+				return getErr
+			})
+			if err != nil {
+				return fmt.Errorf(
+					"API key %q (%s) was created and its P8 was saved to %q, but the issuer ID could not be loaded: %w",
+					nameValue,
+					created.KeyID,
+					p8Path,
+					err,
+				)
+			}
+			if details == nil || strings.TrimSpace(details.IssuerID) == "" {
+				return fmt.Errorf(
+					"API key %q (%s) was created and its P8 was saved to %q, but the response did not include an issuer ID",
+					nameValue,
+					created.KeyID,
+					p8Path,
+				)
+			}
+
+			result := &webAPIKeyCreateResult{
+				KeyID:          created.KeyID,
+				Name:           firstNonEmpty(details.Name, created.Name, nameValue),
+				IssuerID:       details.IssuerID,
+				TeamID:         strings.TrimSpace(session.TeamID),
+				Roles:          firstNonEmptyRoles(details.Roles, created.Roles, []string{roleValue}),
+				Active:         details.Active,
+				AllAppsVisible: details.AllAppsVisible,
+				KeyType:        firstNonEmpty(details.KeyType, created.KeyType, "PUBLIC_API"),
+				P8Path:         p8Path,
+			}
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderWebAPIKeyCreateTable(result) },
+				func() error { return renderWebAPIKeyCreateMarkdown(result) },
+			)
+		},
+	}
+}
+
+func normalizeWebAPIKeyRole(value string) (string, error) {
+	role := strings.ToUpper(strings.TrimSpace(value))
+	if role == "" {
+		return "", fmt.Errorf("--role is required")
+	}
+	reference, err := webref.Load()
+	if err != nil {
+		return "", fmt.Errorf("load API key role reference: %w", err)
+	}
+	for _, selectable := range reference.APIKeyNotes.Team.SelectableRoles {
+		if role == selectable {
+			return role, nil
+		}
+	}
+	return "", fmt.Errorf("--role must be one of %s", strings.Join(reference.APIKeyNotes.Team.SelectableRoles, ", "))
+}
+
+func downloadWebAPIKeyWithRetry(ctx context.Context, client *webcore.Client, keyID string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < webAPIKeyDownloadAttempts; attempt++ {
+		p8, err := downloadWebAPIKeyFn(ctx, client, keyID)
+		if err == nil {
+			return p8, nil
+		}
+		lastErr = err
+		if attempt == webAPIKeyDownloadAttempts-1 || !webcore.IsAPIKeyDownloadRetryable(err) {
+			break
+		}
+		if err := waitWebAPIKeyRetryFn(ctx, time.Duration(attempt+1)*time.Second); err != nil {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func waitForWebAPIKeyRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func firstNonEmptyRoles(values ...[]string) []string {
+	for _, roles := range values {
+		if len(roles) > 0 {
+			return append([]string(nil), roles...)
+		}
+	}
+	return nil
+}
+
+func renderWebAPIKeyCreateTable(result *webAPIKeyCreateResult) error {
+	headers := []string{"Key ID", "Name", "Issuer ID", "Team ID", "Roles", "P8 Path"}
+	rows := [][]string{{
+		result.KeyID,
+		result.Name,
+		result.IssuerID,
+		result.TeamID,
+		strings.Join(result.Roles, ", "),
+		result.P8Path,
+	}}
+	asc.RenderTable(headers, rows)
+	return nil
+}
+
+func renderWebAPIKeyCreateMarkdown(result *webAPIKeyCreateResult) error {
+	headers := []string{"Key ID", "Name", "Issuer ID", "Team ID", "Roles", "P8 Path"}
+	rows := [][]string{{
+		result.KeyID,
+		result.Name,
+		result.IssuerID,
+		result.TeamID,
+		strings.Join(result.Roles, ", "),
+		result.P8Path,
+	}}
+	asc.RenderMarkdown(headers, rows)
+	return nil
+}

--- a/internal/cli/web/web_api_keys.go
+++ b/internal/cli/web/web_api_keys.go
@@ -2,8 +2,10 @@ package web
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -151,6 +153,18 @@ Examples:
 				return fmt.Errorf("web api-keys create failed: create response did not include a key id")
 			}
 
+			fileName := fmt.Sprintf("AuthKey_%s.p8", strings.TrimSpace(created.KeyID))
+			p8Path := filepath.Join(outputRoot.Path(), fileName)
+			if err := outputRoot.CreateNewFile(fileName, nil, 0o600); err != nil {
+				return fmt.Errorf(
+					"API key %q (%s) was created, but destination %q could not be reserved before its one-time P8 download; the P8 was not downloaded: %w",
+					nameValue,
+					created.KeyID,
+					p8Path,
+					err,
+				)
+			}
+
 			var p8 []byte
 			err = withWebSpinner("Downloading one-time API key P8", func() error {
 				var downloadErr error
@@ -158,17 +172,22 @@ Examples:
 				return downloadErr
 			})
 			if err != nil {
-				return fmt.Errorf(
+				downloadFailure := fmt.Errorf(
 					"API key %q (%s) was created, but its one-time P8 could not be downloaded: %w",
 					nameValue,
 					created.KeyID,
 					withWebAuthHint(err, "web api-keys create"),
 				)
+				if removeErr := os.Remove(p8Path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+					return errors.Join(
+						downloadFailure,
+						fmt.Errorf("remove empty reserved P8 file %q: %w", p8Path, removeErr),
+					)
+				}
+				return downloadFailure
 			}
 
-			fileName := fmt.Sprintf("AuthKey_%s.p8", strings.TrimSpace(created.KeyID))
-			p8Path := filepath.Join(outputRoot.Path(), fileName)
-			if err := outputRoot.CreateNewFile(fileName, p8, 0o600); err != nil {
+			if err := outputRoot.WriteFile(fileName, p8, 0o600); err != nil {
 				return fmt.Errorf(
 					"API key %q (%s) was created and its one-time P8 was downloaded, but saving %q failed; the P8 cannot be downloaded again: %w",
 					nameValue,

--- a/internal/cli/web/web_api_keys_test.go
+++ b/internal/cli/web/web_api_keys_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -125,6 +126,34 @@ func TestDownloadWebAPIKeyWithRetryRetriesPropagationErrors(t *testing.T) {
 	}
 	if len(waits) != 2 || waits[0] != time.Second || waits[1] != 2*time.Second {
 		t.Fatalf("unexpected waits: %#v", waits)
+	}
+}
+
+func TestDownloadWebAPIKeyWithRetryDoesNotRetryInvalidResponse(t *testing.T) {
+	originalDownload := downloadWebAPIKeyFn
+	originalWait := waitWebAPIKeyRetryFn
+	t.Cleanup(func() {
+		downloadWebAPIKeyFn = originalDownload
+		waitWebAPIKeyRetryFn = originalWait
+	})
+
+	attempts := 0
+	downloadWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) ([]byte, error) {
+		attempts++
+		return nil, fmt.Errorf("decode failed: %w", webcore.ErrAPIKeyResponseInvalid)
+	}
+	waits := 0
+	waitWebAPIKeyRetryFn = func(ctx context.Context, delay time.Duration) error {
+		waits++
+		return nil
+	}
+
+	_, err := downloadWebAPIKeyWithRetry(context.Background(), &webcore.Client{}, "ABC123XYZ")
+	if !errors.Is(err, webcore.ErrAPIKeyResponseInvalid) {
+		t.Fatalf("expected invalid response error, got %v", err)
+	}
+	if attempts != 1 || waits != 0 {
+		t.Fatalf("expected one attempt and no waits, got %d attempts and %d waits", attempts, waits)
 	}
 }
 

--- a/internal/cli/web/web_api_keys_test.go
+++ b/internal/cli/web/web_api_keys_test.go
@@ -131,6 +131,11 @@ func TestDownloadWebAPIKeyWithRetryRetriesPropagationErrors(t *testing.T) {
 func TestWebAPIKeysCreateDoesNotReplaceExistingP8(t *testing.T) {
 	restore := installWebAPIKeyCreateFakes(t)
 	t.Cleanup(restore)
+	downloadCalls := 0
+	downloadWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) ([]byte, error) {
+		downloadCalls++
+		return []byte(apiKeyFixtureP8), nil
+	}
 
 	outputDir := t.TempDir()
 	path := filepath.Join(outputDir, "AuthKey_ABC123XYZ.p8")
@@ -159,6 +164,34 @@ func TestWebAPIKeysCreateDoesNotReplaceExistingP8(t *testing.T) {
 	}
 	if string(contents) != "existing" {
 		t.Fatalf("existing file was replaced: %q", string(contents))
+	}
+	if downloadCalls != 0 {
+		t.Fatalf("expected destination collision before one-time download, got %d download calls", downloadCalls)
+	}
+}
+
+func TestWebAPIKeysCreateRemovesReservationWhenDownloadFails(t *testing.T) {
+	restore := installWebAPIKeyCreateFakes(t)
+	t.Cleanup(restore)
+
+	downloadErr := &webcore.APIError{Status: 403}
+	downloadWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) ([]byte, error) {
+		return nil, downloadErr
+	}
+
+	outputDir := t.TempDir()
+	cmd := WebAPIKeysCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{"--name", "Release automation", "--output-dir", outputDir}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if !errors.Is(err, downloadErr) {
+		t.Fatalf("expected download error, got %v", err)
+	}
+	path := filepath.Join(outputDir, "AuthKey_ABC123XYZ.p8")
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected failed-download reservation to be removed, stat error = %v", statErr)
 	}
 }
 

--- a/internal/cli/web/web_api_keys_test.go
+++ b/internal/cli/web/web_api_keys_test.go
@@ -1,0 +1,248 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+const apiKeyFixtureP8 = "-----BEGIN PRIVATE KEY-----\nfixture-secret\n-----END PRIVATE KEY-----\n"
+
+func TestWebAPIKeysCreateSavesP8AndPrintsMetadata(t *testing.T) {
+	restore := installWebAPIKeyCreateFakes(t)
+	t.Cleanup(restore)
+
+	outputDir := t.TempDir()
+	cmd := WebAPIKeysCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--name", "Release automation",
+		"--role", "APP_MANAGER",
+		"--output-dir", outputDir,
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{
+		`"keyId":"ABC123XYZ"`,
+		`"issuerId":"69a6de00-aaaa-bbbb-cccc-123456789abc"`,
+		`"roles":["APP_MANAGER"]`,
+		`"p8Path":`,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected stdout to contain %s, got %q", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "fixture-secret") || strings.Contains(stderr, "fixture-secret") {
+		t.Fatal("expected P8 contents to stay out of command output")
+	}
+
+	path := filepath.Join(outputDir, "AuthKey_ABC123XYZ.p8")
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved P8: %v", err)
+	}
+	if string(contents) != apiKeyFixtureP8 {
+		t.Fatalf("unexpected P8 contents: %q", string(contents))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat saved P8: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected mode 0600, got %04o", info.Mode().Perm())
+	}
+}
+
+func TestWebAPIKeysCreateValidatesBeforeResolvingSession(t *testing.T) {
+	resolveCalled := false
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		resolveCalled = true
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	cmd := WebAPIKeysCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{"--name", "Release automation", "--role", "NOT_A_ROLE"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if resolveCalled {
+		t.Fatal("did not expect session resolution before role validation")
+	}
+}
+
+func TestDownloadWebAPIKeyWithRetryRetriesPropagationErrors(t *testing.T) {
+	originalDownload := downloadWebAPIKeyFn
+	originalWait := waitWebAPIKeyRetryFn
+	t.Cleanup(func() {
+		downloadWebAPIKeyFn = originalDownload
+		waitWebAPIKeyRetryFn = originalWait
+	})
+
+	attempts := 0
+	downloadWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) ([]byte, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, &webcore.APIError{Status: 404}
+		}
+		return []byte(apiKeyFixtureP8), nil
+	}
+	var waits []time.Duration
+	waitWebAPIKeyRetryFn = func(ctx context.Context, delay time.Duration) error {
+		waits = append(waits, delay)
+		return nil
+	}
+
+	got, err := downloadWebAPIKeyWithRetry(context.Background(), &webcore.Client{}, "ABC123XYZ")
+	if err != nil {
+		t.Fatalf("downloadWebAPIKeyWithRetry() error: %v", err)
+	}
+	if string(got) != apiKeyFixtureP8 {
+		t.Fatalf("unexpected P8 contents: %q", string(got))
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+	if len(waits) != 2 || waits[0] != time.Second || waits[1] != 2*time.Second {
+		t.Fatalf("unexpected waits: %#v", waits)
+	}
+}
+
+func TestWebAPIKeysCreateDoesNotReplaceExistingP8(t *testing.T) {
+	restore := installWebAPIKeyCreateFakes(t)
+	t.Cleanup(restore)
+
+	outputDir := t.TempDir()
+	path := filepath.Join(outputDir, "AuthKey_ABC123XYZ.p8")
+	if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	cmd := WebAPIKeysCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{"--name", "Release automation", "--output-dir", outputDir, "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	stdout, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if execErr == nil {
+		t.Fatal("expected existing destination error")
+	}
+	if stdout != "" || strings.Contains(stderr, "fixture-secret") || strings.Contains(execErr.Error(), "fixture-secret") {
+		t.Fatalf("expected no key material in output; stdout=%q stderr=%q err=%v", stdout, stderr, execErr)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read existing file: %v", err)
+	}
+	if string(contents) != "existing" {
+		t.Fatalf("existing file was replaced: %q", string(contents))
+	}
+}
+
+func TestWebAPIKeysCreatePreservesP8WhenIssuerLookupFails(t *testing.T) {
+	restore := installWebAPIKeyCreateFakes(t)
+	t.Cleanup(restore)
+
+	lookupErr := errors.New("lookup failed")
+	getWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) (*webcore.APIKey, error) {
+		return nil, lookupErr
+	}
+	outputDir := t.TempDir()
+	cmd := WebAPIKeysCreateCommand()
+	if err := cmd.FlagSet.Parse([]string{"--name", "Release automation", "--output-dir", outputDir}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("expected issuer lookup error, got %v", err)
+	}
+	path := filepath.Join(outputDir, "AuthKey_ABC123XYZ.p8")
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected recovery path in error, got %v", err)
+	}
+	contents, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("expected saved P8 after lookup failure: %v", readErr)
+	}
+	if string(contents) != apiKeyFixtureP8 {
+		t.Fatalf("unexpected saved P8: %q", string(contents))
+	}
+}
+
+func installWebAPIKeyCreateFakes(t *testing.T) func() {
+	t.Helper()
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{TeamID: "TEAM123"}, "cache", nil
+	})
+	originalNewClient := newWebAPIKeyClientFn
+	originalCreate := createWebAPIKeyFn
+	originalDownload := downloadWebAPIKeyFn
+	originalGet := getWebAPIKeyFn
+	originalWait := waitWebAPIKeyRetryFn
+
+	newWebAPIKeyClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+	createWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, attrs webcore.APIKeyCreateAttributes) (*webcore.APIKey, error) {
+		if attrs.Nickname != "Release automation" {
+			t.Fatalf("unexpected nickname %q", attrs.Nickname)
+		}
+		return &webcore.APIKey{
+			KeyID:          "ABC123XYZ",
+			Name:           attrs.Nickname,
+			Roles:          []string{attrs.Role},
+			Active:         true,
+			AllAppsVisible: true,
+			CanDownload:    true,
+			KeyType:        "PUBLIC_API",
+		}, nil
+	}
+	downloadWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) ([]byte, error) {
+		return []byte(apiKeyFixtureP8), nil
+	}
+	getWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) (*webcore.APIKey, error) {
+		return &webcore.APIKey{
+			KeyID:          keyID,
+			Name:           "Release automation",
+			IssuerID:       "69a6de00-aaaa-bbbb-cccc-123456789abc",
+			Roles:          []string{"APP_MANAGER"},
+			Active:         true,
+			AllAppsVisible: true,
+			KeyType:        "PUBLIC_API",
+		}, nil
+	}
+	waitWebAPIKeyRetryFn = func(ctx context.Context, delay time.Duration) error { return nil }
+
+	return func() {
+		restoreSession()
+		newWebAPIKeyClientFn = originalNewClient
+		createWebAPIKeyFn = originalCreate
+		downloadWebAPIKeyFn = originalDownload
+		getWebAPIKeyFn = originalGet
+		waitWebAPIKeyRetryFn = originalWait
+	}
+}

--- a/internal/web/api_keys.go
+++ b/internal/web/api_keys.go
@@ -14,6 +14,9 @@ import (
 
 const apiKeyTypePublic = "PUBLIC_API"
 
+// ErrAPIKeyResponseInvalid reports a malformed or incomplete one-time P8 response.
+var ErrAPIKeyResponseInvalid = errors.New("invalid api key download response")
+
 // APIKeyCreateAttributes describes a team API key created through a web session.
 type APIKeyCreateAttributes struct {
 	Nickname string
@@ -124,21 +127,21 @@ func (c *Client) DownloadAPIKey(ctx context.Context, keyID string) ([]byte, erro
 
 	var payload apiKeyPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
-		return nil, fmt.Errorf("failed to parse api key download response: %w", err)
+		return nil, fmt.Errorf("%w: failed to parse JSON: %w", ErrAPIKeyResponseInvalid, err)
 	}
 	encoded := strings.TrimSpace(payload.Data.Attributes.PrivateKey)
 	if encoded == "" {
-		return nil, fmt.Errorf("api key download response did not include a P8")
+		return nil, fmt.Errorf("%w: response did not include a P8", ErrAPIKeyResponseInvalid)
 	}
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		decoded, err = base64.RawStdEncoding.DecodeString(encoded)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode api key P8: %w", err)
+		return nil, fmt.Errorf("%w: failed to decode P8: %w", ErrAPIKeyResponseInvalid, err)
 	}
 	if !bytes.Contains(decoded, []byte("-----BEGIN PRIVATE KEY-----")) || !bytes.Contains(decoded, []byte("-----END PRIVATE KEY-----")) {
-		return nil, fmt.Errorf("api key download response contained an invalid P8")
+		return nil, fmt.Errorf("%w: response contained an invalid P8", ErrAPIKeyResponseInvalid)
 	}
 	return decoded, nil
 }
@@ -147,6 +150,9 @@ func (c *Client) DownloadAPIKey(ctx context.Context, keyID string) ([]byte, erro
 // succeed after Apple's API-key resource finishes propagating.
 func IsAPIKeyDownloadRetryable(err error) bool {
 	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrAPIKeyResponseInvalid) {
 		return false
 	}
 	var apiErr *APIError

--- a/internal/web/api_keys.go
+++ b/internal/web/api_keys.go
@@ -1,0 +1,195 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const apiKeyTypePublic = "PUBLIC_API"
+
+// APIKeyCreateAttributes describes a team API key created through a web session.
+type APIKeyCreateAttributes struct {
+	Nickname string
+	Role     string
+}
+
+// APIKey contains non-secret metadata for an App Store Connect API key.
+type APIKey struct {
+	KeyID          string   `json:"keyId"`
+	Name           string   `json:"name,omitempty"`
+	IssuerID       string   `json:"issuerId,omitempty"`
+	Roles          []string `json:"roles,omitempty"`
+	Active         bool     `json:"active"`
+	AllAppsVisible bool     `json:"allAppsVisible"`
+	CanDownload    bool     `json:"canDownload"`
+	KeyType        string   `json:"keyType,omitempty"`
+	LastUsed       string   `json:"lastUsed,omitempty"`
+	RevokingDate   string   `json:"revokingDate,omitempty"`
+}
+
+type apiKeyResource struct {
+	Type       string `json:"type"`
+	ID         string `json:"id"`
+	Attributes struct {
+		Nickname       string   `json:"nickname"`
+		Roles          []string `json:"roles"`
+		AllAppsVisible bool     `json:"allAppsVisible"`
+		CanDownload    bool     `json:"canDownload"`
+		IsActive       bool     `json:"isActive"`
+		KeyType        string   `json:"keyType"`
+		LastUsed       string   `json:"lastUsed"`
+		RevokingDate   string   `json:"revokingDate"`
+		PrivateKey     string   `json:"privateKey"`
+		Provider       *struct {
+			ID string `json:"id"`
+		} `json:"provider"`
+	} `json:"attributes"`
+	Relationships struct {
+		Provider struct {
+			Data *struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		} `json:"provider"`
+	} `json:"relationships"`
+}
+
+type apiKeyPayload struct {
+	Data     apiKeyResource   `json:"data"`
+	Included []apiKeyResource `json:"included"`
+}
+
+// CreateAPIKey creates an all-apps team API key using the selected web session.
+func (c *Client) CreateAPIKey(ctx context.Context, attrs APIKeyCreateAttributes) (*APIKey, error) {
+	nickname := strings.TrimSpace(attrs.Nickname)
+	if nickname == "" {
+		return nil, fmt.Errorf("api key nickname is required")
+	}
+	role := strings.ToUpper(strings.TrimSpace(attrs.Role))
+	if role == "" {
+		return nil, fmt.Errorf("api key role is required")
+	}
+
+	request := map[string]any{
+		"data": map[string]any{
+			"type": "apiKeys",
+			"attributes": map[string]any{
+				"nickname":       nickname,
+				"roles":          []string{role},
+				"allAppsVisible": true,
+				"keyType":        apiKeyTypePublic,
+			},
+		},
+	}
+	body, err := c.doIrisV1Request(ctx, http.MethodPost, "/apiKeys", request)
+	if err != nil {
+		return nil, err
+	}
+	return parseAPIKeyResponse(body, "create api key")
+}
+
+// GetAPIKey returns API key metadata, including its issuer/provider ID.
+func (c *Client) GetAPIKey(ctx context.Context, keyID string) (*APIKey, error) {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		return nil, fmt.Errorf("api key id is required")
+	}
+	path := "/apiKeys/" + url.PathEscape(keyID) + "?include=provider"
+	body, err := c.doIrisV1Request(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseAPIKeyResponse(body, "get api key")
+}
+
+// DownloadAPIKey downloads and decodes the one-time P8 for an API key.
+func (c *Client) DownloadAPIKey(ctx context.Context, keyID string) ([]byte, error) {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		return nil, fmt.Errorf("api key id is required")
+	}
+	query := url.Values{}
+	query.Set("fields[apiKeys]", "privateKey")
+	path := "/apiKeys/" + url.PathEscape(keyID) + "?" + query.Encode()
+	body, err := c.doIrisV1Request(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload apiKeyPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse api key download response: %w", err)
+	}
+	encoded := strings.TrimSpace(payload.Data.Attributes.PrivateKey)
+	if encoded == "" {
+		return nil, fmt.Errorf("api key download response did not include a P8")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		decoded, err = base64.RawStdEncoding.DecodeString(encoded)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode api key P8: %w", err)
+	}
+	if !bytes.Contains(decoded, []byte("-----BEGIN PRIVATE KEY-----")) || !bytes.Contains(decoded, []byte("-----END PRIVATE KEY-----")) {
+		return nil, fmt.Errorf("api key download response contained an invalid P8")
+	}
+	return decoded, nil
+}
+
+// IsAPIKeyDownloadRetryable reports whether a newly created key download may
+// succeed after Apple's API-key resource finishes propagating.
+func IsAPIKeyDownloadRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return true
+	}
+	switch apiErr.Status {
+	case http.StatusNotFound, http.StatusConflict, http.StatusTooManyRequests:
+		return true
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusBadRequest:
+		return false
+	default:
+		return apiErr.Status >= http.StatusInternalServerError
+	}
+}
+
+func parseAPIKeyResponse(body []byte, operation string) (*APIKey, error) {
+	var payload apiKeyPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse %s response: %w", operation, err)
+	}
+	if strings.TrimSpace(payload.Data.ID) == "" {
+		return nil, fmt.Errorf("%s response did not include a key id", operation)
+	}
+
+	issuerID := ""
+	if payload.Data.Attributes.Provider != nil {
+		issuerID = strings.TrimSpace(payload.Data.Attributes.Provider.ID)
+	}
+	if issuerID == "" && payload.Data.Relationships.Provider.Data != nil {
+		issuerID = strings.TrimSpace(payload.Data.Relationships.Provider.Data.ID)
+	}
+
+	return &APIKey{
+		KeyID:          strings.TrimSpace(payload.Data.ID),
+		Name:           strings.TrimSpace(payload.Data.Attributes.Nickname),
+		IssuerID:       issuerID,
+		Roles:          append([]string(nil), payload.Data.Attributes.Roles...),
+		Active:         payload.Data.Attributes.IsActive,
+		AllAppsVisible: payload.Data.Attributes.AllAppsVisible,
+		CanDownload:    payload.Data.Attributes.CanDownload,
+		KeyType:        strings.TrimSpace(payload.Data.Attributes.KeyType),
+		LastUsed:       strings.TrimSpace(payload.Data.Attributes.LastUsed),
+		RevokingDate:   strings.TrimSpace(payload.Data.Attributes.RevokingDate),
+	}, nil
+}

--- a/internal/web/api_keys_test.go
+++ b/internal/web/api_keys_test.go
@@ -1,0 +1,181 @@
+package web
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestClientCreateAPIKeySendsTeamKeyPayload(t *testing.T) {
+	var requestBody map[string]any
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/iris/v1/apiKeys" {
+			t.Fatalf("expected /iris/v1/apiKeys, got %s", r.URL.Path)
+		}
+		if r.Header.Get("X-CSRF-ITC") != "[asc-ui]" {
+			t.Fatalf("expected integrations CSRF header, got %q", r.Header.Get("X-CSRF-ITC"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+					"data": {
+						"type": "apiKeys",
+						"id": "ABC123XYZ",
+						"attributes": {
+							"nickname": "Release automation",
+							"roles": ["APP_MANAGER"],
+							"allAppsVisible": true,
+							"canDownload": true,
+							"isActive": true,
+							"keyType": "PUBLIC_API"
+						}
+					}
+				}`))
+	}))
+
+	key, err := client.CreateAPIKey(context.Background(), APIKeyCreateAttributes{
+		Nickname: "Release automation",
+		Role:     "APP_MANAGER",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey() error: %v", err)
+	}
+	if key.KeyID != "ABC123XYZ" || key.Name != "Release automation" {
+		t.Fatalf("unexpected key: %#v", key)
+	}
+
+	data, ok := requestBody["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected JSON:API data object, got %#v", requestBody)
+	}
+	if data["type"] != "apiKeys" {
+		t.Fatalf("expected apiKeys type, got %#v", data["type"])
+	}
+	attrs, ok := data["attributes"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected attributes object, got %#v", data)
+	}
+	if attrs["nickname"] != "Release automation" || attrs["keyType"] != "PUBLIC_API" || attrs["allAppsVisible"] != true {
+		t.Fatalf("unexpected attributes: %#v", attrs)
+	}
+	roles, ok := attrs["roles"].([]any)
+	if !ok || len(roles) != 1 || roles[0] != "APP_MANAGER" {
+		t.Fatalf("unexpected roles: %#v", attrs["roles"])
+	}
+}
+
+func TestClientDownloadAPIKeyDecodesP8(t *testing.T) {
+	p8 := "-----BEGIN PRIVATE KEY-----\nfixture\n-----END PRIVATE KEY-----\n"
+	encoded := base64.StdEncoding.EncodeToString([]byte(p8))
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/iris/v1/apiKeys/ABC123XYZ" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("fields[apiKeys]") != "privateKey" {
+			t.Fatalf("unexpected query %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"type":"apiKeys","id":"ABC123XYZ","attributes":{"privateKey":"` + encoded + `"}}}`))
+	}))
+
+	got, err := client.DownloadAPIKey(context.Background(), "ABC123XYZ")
+	if err != nil {
+		t.Fatalf("DownloadAPIKey() error: %v", err)
+	}
+	if string(got) != p8 {
+		t.Fatalf("unexpected decoded P8: %q", string(got))
+	}
+}
+
+func TestClientDownloadAPIKeyRejectsNonPEMPayload(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("not a key"))
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"attributes":{"privateKey":"` + encoded + `"}}}`))
+	}))
+
+	if _, err := client.DownloadAPIKey(context.Background(), "ABC123XYZ"); err == nil {
+		t.Fatal("expected invalid P8 error")
+	}
+}
+
+func TestClientGetAPIKeyParsesIssuerID(t *testing.T) {
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("include") != "provider" {
+			t.Fatalf("expected provider include, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+					"data": {
+						"type": "apiKeys",
+						"id": "ABC123XYZ",
+						"attributes": {"nickname":"Release automation","roles":["ADMIN"],"allAppsVisible":true,"isActive":true,"keyType":"PUBLIC_API"},
+						"relationships": {"provider":{"data":{"type":"contentProviders","id":"69a6de00-aaaa-bbbb-cccc-123456789abc"}}}
+					}
+				}`))
+	}))
+
+	key, err := client.GetAPIKey(context.Background(), "ABC123XYZ")
+	if err != nil {
+		t.Fatalf("GetAPIKey() error: %v", err)
+	}
+	if key.IssuerID != "69a6de00-aaaa-bbbb-cccc-123456789abc" {
+		t.Fatalf("unexpected issuer ID %q", key.IssuerID)
+	}
+}
+
+func TestIsAPIKeyDownloadRetryable(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusConflict, http.StatusTooManyRequests, http.StatusBadGateway} {
+		if !IsAPIKeyDownloadRetryable(&APIError{Status: status}) {
+			t.Fatalf("expected status %d to be retryable", status)
+		}
+	}
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden} {
+		if IsAPIKeyDownloadRetryable(&APIError{Status: status}) {
+			t.Fatalf("expected status %d not to be retryable", status)
+		}
+	}
+}
+
+type apiKeyRewriteTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (t apiKeyRewriteTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	clone := request.Clone(request.Context())
+	requestURL := *request.URL
+	requestURL.Scheme = t.target.Scheme
+	requestURL.Host = t.target.Host
+	clone.URL = &requestURL
+	return t.base.RoundTrip(clone)
+}
+
+func newAPIKeyHTTPTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	return &Client{
+		httpClient: &http.Client{Transport: apiKeyRewriteTransport{
+			target: target,
+			base:   server.Client().Transport,
+		}},
+	}
+}

--- a/internal/web/api_keys_test.go
+++ b/internal/web/api_keys_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,19 +14,13 @@ import (
 
 func TestClientCreateAPIKeySendsTeamKeyPayload(t *testing.T) {
 	var requestBody map[string]any
+	var requestMethod, requestPath, requestCSRF string
+	var requestDecodeErr error
 	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Fatalf("expected POST, got %s", r.Method)
-		}
-		if r.URL.Path != "/iris/v1/apiKeys" {
-			t.Fatalf("expected /iris/v1/apiKeys, got %s", r.URL.Path)
-		}
-		if r.Header.Get("X-CSRF-ITC") != "[asc-ui]" {
-			t.Fatalf("expected integrations CSRF header, got %q", r.Header.Get("X-CSRF-ITC"))
-		}
-		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
+		requestMethod = r.Method
+		requestPath = r.URL.Path
+		requestCSRF = r.Header.Get("X-CSRF-ITC")
+		requestDecodeErr = json.NewDecoder(r.Body).Decode(&requestBody)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{
@@ -49,6 +45,18 @@ func TestClientCreateAPIKeySendsTeamKeyPayload(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateAPIKey() error: %v", err)
+	}
+	if requestMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %s", requestMethod)
+	}
+	if requestPath != "/iris/v1/apiKeys" {
+		t.Fatalf("expected /iris/v1/apiKeys, got %s", requestPath)
+	}
+	if requestCSRF != "[asc-ui]" {
+		t.Fatalf("expected integrations CSRF header, got %q", requestCSRF)
+	}
+	if requestDecodeErr != nil {
+		t.Fatalf("decode request: %v", requestDecodeErr)
 	}
 	if key.KeyID != "ABC123XYZ" || key.Name != "Release automation" {
 		t.Fatalf("unexpected key: %#v", key)
@@ -77,16 +85,11 @@ func TestClientCreateAPIKeySendsTeamKeyPayload(t *testing.T) {
 func TestClientDownloadAPIKeyDecodesP8(t *testing.T) {
 	p8 := "-----BEGIN PRIVATE KEY-----\nfixture\n-----END PRIVATE KEY-----\n"
 	encoded := base64.StdEncoding.EncodeToString([]byte(p8))
+	var requestMethod, requestPath, requestedField string
 	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Fatalf("expected GET, got %s", r.Method)
-		}
-		if r.URL.Path != "/iris/v1/apiKeys/ABC123XYZ" {
-			t.Fatalf("unexpected path %q", r.URL.Path)
-		}
-		if r.URL.Query().Get("fields[apiKeys]") != "privateKey" {
-			t.Fatalf("unexpected query %q", r.URL.RawQuery)
-		}
+		requestMethod = r.Method
+		requestPath = r.URL.Path
+		requestedField = r.URL.Query().Get("fields[apiKeys]")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"type":"apiKeys","id":"ABC123XYZ","attributes":{"privateKey":"` + encoded + `"}}}`))
 	}))
@@ -94,6 +97,15 @@ func TestClientDownloadAPIKeyDecodesP8(t *testing.T) {
 	got, err := client.DownloadAPIKey(context.Background(), "ABC123XYZ")
 	if err != nil {
 		t.Fatalf("DownloadAPIKey() error: %v", err)
+	}
+	if requestMethod != http.MethodGet {
+		t.Fatalf("expected GET, got %s", requestMethod)
+	}
+	if requestPath != "/iris/v1/apiKeys/ABC123XYZ" {
+		t.Fatalf("unexpected path %q", requestPath)
+	}
+	if requestedField != "privateKey" {
+		t.Fatalf("unexpected private-key field %q", requestedField)
 	}
 	if string(got) != p8 {
 		t.Fatalf("unexpected decoded P8: %q", string(got))
@@ -107,16 +119,15 @@ func TestClientDownloadAPIKeyRejectsNonPEMPayload(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"attributes":{"privateKey":"` + encoded + `"}}}`))
 	}))
 
-	if _, err := client.DownloadAPIKey(context.Background(), "ABC123XYZ"); err == nil {
-		t.Fatal("expected invalid P8 error")
+	if _, err := client.DownloadAPIKey(context.Background(), "ABC123XYZ"); !errors.Is(err, ErrAPIKeyResponseInvalid) {
+		t.Fatalf("expected invalid P8 response error, got %v", err)
 	}
 }
 
 func TestClientGetAPIKeyParsesIssuerID(t *testing.T) {
+	var includedResource string
 	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("include") != "provider" {
-			t.Fatalf("expected provider include, got %q", r.URL.RawQuery)
-		}
+		includedResource = r.URL.Query().Get("include")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 					"data": {
@@ -132,12 +143,24 @@ func TestClientGetAPIKeyParsesIssuerID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAPIKey() error: %v", err)
 	}
+	if includedResource != "provider" {
+		t.Fatalf("expected provider include, got %q", includedResource)
+	}
 	if key.IssuerID != "69a6de00-aaaa-bbbb-cccc-123456789abc" {
 		t.Fatalf("unexpected issuer ID %q", key.IssuerID)
 	}
 }
 
 func TestIsAPIKeyDownloadRetryable(t *testing.T) {
+	if IsAPIKeyDownloadRetryable(nil) {
+		t.Fatal("expected nil error not to be retryable")
+	}
+	if !IsAPIKeyDownloadRetryable(fmt.Errorf("temporary transport failure")) {
+		t.Fatal("expected generic transport error to be retryable")
+	}
+	if IsAPIKeyDownloadRetryable(fmt.Errorf("download failed: %w", ErrAPIKeyResponseInvalid)) {
+		t.Fatal("expected invalid download response not to be retryable")
+	}
 	for _, status := range []int{http.StatusNotFound, http.StatusConflict, http.StatusTooManyRequests, http.StatusBadGateway} {
 		if !IsAPIKeyDownloadRetryable(&APIError{Status: status}) {
 			t.Fatalf("expected status %d to be retryable", status)


### PR DESCRIPTION
## Summary

- add a web-session API key client for team-key creation, one-time P8 download, and issuer lookup
- add `asc web api-keys create` with selectable-role validation, propagation retries, and secure `0600` file output
- keep P8 contents out of stdout, stderr, and errors; preserve the saved file if the follow-up issuer lookup fails
- document the command and cover its HTTP contract, CLI registration, validation order, retry behavior, and file safety

## Testing

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Live account verification

Not run. Creating a key consumes an account key slot and the P8 is downloadable only once; the command is ready for an account-level smoke test before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788548503&installation_model_id=10418&pr_number=1868&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1868&signature=325af2783cedfb820c75920eca13ad0eda5f6bc18fe1bf053fd175f811a7ddbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `asc web api-keys create` for creating API keys through a cached web session, without requiring an existing API key.
  * Supports role selection, provider and output options, and table, Markdown, or JSON results.
  * Securely saves one-time P8 private-key files with restricted permissions.
  * Automatically retries temporary download failures and prevents overwriting existing key files.

* **Documentation**
  * Added workflow examples, security details, session requirements, and command discoverability guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->