### PR TITLE
fix(video-previews): accept iPhone 6.9 device alias

### DIFF
--- a/internal/cli/assets/assets_previews.go
+++ b/internal/cli/assets/assets_previews.go
@@ -612,6 +612,9 @@ func normalizePreviewType(input string) (string, error) {
 		return "", fmt.Errorf("device type is required")
 	}
 	value = strings.TrimPrefix(value, "APP_")
+	if value == "IPHONE_69" {
+		value = "IPHONE_67"
+	}
 	if !asc.IsValidPreviewType(value) {
 		return "", fmt.Errorf("unsupported preview type %q", value)
 	}

--- a/internal/cli/assets/assets_previews_test.go
+++ b/internal/cli/assets/assets_previews_test.go
@@ -38,6 +38,36 @@ func TestAssetsPreviewsUploadCommandRejectsSkipExistingWithReplace(t *testing.T)
 	}
 }
 
+func TestNormalizePreviewTypeCanonicalizesIPhone69Alias(t *testing.T) {
+	testCases := []string{
+		"IPHONE_69",
+		"APP_IPHONE_69",
+		" app_iphone_69 ",
+	}
+
+	for _, input := range testCases {
+		t.Run(input, func(t *testing.T) {
+			got, err := normalizePreviewType(input)
+			if err != nil {
+				t.Fatalf("normalizePreviewType(%q) error: %v", input, err)
+			}
+			if got != "IPHONE_67" {
+				t.Fatalf("normalizePreviewType(%q) = %q, want %q", input, got, "IPHONE_67")
+			}
+		})
+	}
+}
+
+func TestNormalizePreviewTypeRejectsUnknownType(t *testing.T) {
+	_, err := normalizePreviewType("IPHONE_70")
+	if err == nil {
+		t.Fatal("normalizePreviewType() expected an error")
+	}
+	if !strings.Contains(err.Error(), `unsupported preview type "IPHONE_70"`) {
+		t.Fatalf("normalizePreviewType() error = %q", err)
+	}
+}
+
 func TestIsValidPreviewFrameTimeCode(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

- accept `IPHONE_69` and `APP_IPHONE_69` for video-preview uploads
- send the current App Store Connect API value, `IPHONE_67`
- retain the existing error for unknown preview types

## Test plan

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assets -count=1`
- built-binary check with `video-previews upload --device-type IPHONE_69 --dry-run`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788612984&installation_model_id=10418&pr_number=1870&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1870&signature=dff2ded6689bb1dd219fbad23c53759112c2bc15c2fa79e3c33f632a95ced039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing `IPHONE_69` and `APP_IPHONE_69` preview type aliases as `IPHONE_67`, including varied capitalization and spacing.

* **Bug Fixes**
  * Improved handling of unsupported preview types with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->