### PR TITLE
chore(asset-library): add unexposed command skeleton

### DIFF
--- a/internal/cli/assetlibrary/command.go
+++ b/internal/cli/assetlibrary/command.go
@@ -1,0 +1,27 @@
+package assetlibrary
+
+import (
+	"context"
+	"flag"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// Command returns the internal Asset Library command group.
+//
+// The group intentionally remains unregistered until Apple publishes the
+// corresponding App Store Connect API contract.
+func Command() *ffcli.Command {
+	fs := flag.NewFlagSet("asset-library", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:      "asset-library",
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(context.Context, []string) error {
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/cli/assetlibrary/command_test.go
+++ b/internal/cli/assetlibrary/command_test.go
@@ -1,0 +1,40 @@
+package assetlibrary
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"testing"
+)
+
+func TestCommandIsBehaviorlessInternalSkeleton(t *testing.T) {
+	cmd := Command()
+	if cmd == nil {
+		t.Fatal("expected command constructor to return a command")
+	}
+	if cmd.Name != "asset-library" {
+		t.Fatalf("expected asset-library command name, got %q", cmd.Name)
+	}
+	if cmd.FlagSet == nil {
+		t.Fatal("expected a flag set")
+	}
+	registeredFlags := 0
+	cmd.FlagSet.VisitAll(func(*flag.Flag) {
+		registeredFlags++
+	})
+	if registeredFlags != 0 {
+		t.Fatalf("expected no speculative flags, got %d", registeredFlags)
+	}
+	if len(cmd.Subcommands) != 0 {
+		t.Fatalf("expected no speculative subcommands, got %d", len(cmd.Subcommands))
+	}
+	if cmd.ShortUsage != "" || cmd.ShortHelp != "" || cmd.LongHelp != "" {
+		t.Fatalf("expected no public help copy, got usage=%q short=%q long=%q", cmd.ShortUsage, cmd.ShortHelp, cmd.LongHelp)
+	}
+	if cmd.UsageFunc == nil {
+		t.Fatal("expected repository-standard usage function")
+	}
+	if !errors.Is(cmd.Exec(context.Background(), nil), flag.ErrHelp) {
+		t.Fatal("expected behaviorless command group to return flag.ErrHelp")
+	}
+}

--- a/internal/cli/capabilities/asset_library_unexposed_test.go
+++ b/internal/cli/capabilities/asset_library_unexposed_test.go
@@ -1,0 +1,23 @@
+package capabilities
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAssetLibraryIsNotInPublicCapabilities(t *testing.T) {
+	for _, capability := range capabilityRows() {
+		fields := []string{
+			capability.Area,
+			capability.Capability,
+			strings.Join(capability.Commands, " "),
+			strings.Join(capability.APIResources, " "),
+			strings.Join(capability.Notes, " "),
+			capability.NextAction,
+		}
+		row := strings.ToLower(strings.Join(fields, " "))
+		if strings.Contains(row, "asset library") || strings.Contains(row, "creative asset") {
+			t.Fatalf("Asset Library must remain absent from public capabilities, got %+v", capability)
+		}
+	}
+}

--- a/internal/cli/registry/asset_library_unexposed_test.go
+++ b/internal/cli/registry/asset_library_unexposed_test.go
@@ -1,0 +1,11 @@
+package registry
+
+import "testing"
+
+func TestAssetLibraryIsNotRegistered(t *testing.T) {
+	for _, cmd := range NewCatalog("dev").MetadataCommands() {
+		if cmd.Name == "asset-library" {
+			t.Fatal("asset-library must remain absent from the public root registry")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add an internal, behaviorless `asset-library` ffcli command-group constructor
- keep it out of the root registry, generated help/docs, search/completion surfaces, and the production dependency graph
- add fail-closed tests preventing accidental root-command or `asc capabilities` exposure

## OpenAPI verification

On 2026-08-06 I downloaded Apple's official App Store Connect OpenAPI zip from:

https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip

The current artifact is App Store Connect API 4.4.1 with 966 paths and 1,393 schemas. Its SHA-256 is `ed0202ef37155b9334772482d2ea0be688c3046b284c895bcbea5455fbe54fd8`, byte-for-byte identical to `docs/openapi/latest.json`. Neither artifact contains Asset Library or creative-assets paths or schemas.

Apple has announced future API automation for Asset Library, but has not published endpoints, methods, request/response schemas, query parameters, resource types, or enums. This PR therefore adds no HTTP client, domain schema, flags, subcommands, or behavioral claims.

## Public-surface checks

- `asc --help` remains byte-for-byte unchanged
- `asc asset-library --help` remains an unknown command with exit code 2
- `asc capabilities --output json` contains no Asset Library or creative-assets row
- the production dependency graph and built binary contain no `asset-library`, Asset Library, or creative-assets strings
- `docs/COMMANDS.md` remains unchanged and in sync

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/assetlibrary ./internal/cli/registry ./internal/cli/capabilities`
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- repository pre-commit hook, including its short suite

## Judgment calls

- Used Apple's exact product term for the internal package/constructor, while leaving the eventual public command shape uncommitted because the constructor is not linked into `asc`.
- Kept the new package separate from `internal/cli/assets`, which already contains shared screenshot and app-preview implementation code.
- Rejected placeholder client types, media enums, upload inputs, API routes, capability rows, and hidden/experimental registration because each would speculate beyond Apple's published contract.
- Skipped live verification because no public Asset Library API operation exists to call.

This branch starts directly from current `origin/main` (`a87a1b61`) and does not include or depend on the separate `IPHONE_69` preview-alias worktree/branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788613277&installation_model_id=10418&pr_number=1871&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1871&signature=be72fe2d5cf0c045f6161bfa9fb4463dcc79c173d1b057dbf9bbecf589650c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the foundation for an Asset Library command in the CLI, including standard usage and help handling.

* **Tests**
  * Added coverage for command initialization and help behavior.
  * Added safeguards confirming Asset Library details remain absent from public capabilities and command metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->