### PR TITLE
Fix app event and nomination validation contracts

### DIFF
--- a/commands/app-events.mdx
+++ b/commands/app-events.mdx
@@ -63,20 +63,17 @@ Create a new in-app event.
 ```bash  theme={null}
 asc app-events create \
   --app "APP_ID" \
-  --name "Summer Challenge" \
-  --event-type CHALLENGE \
-  --start "2026-06-01T00:00:00Z" \
-  --end "2026-06-30T23:59:59Z"
+  --name "Summer Challenge"
 ```
 
 **Required Flags:**
 
 * `--app` - App ID (or `ASC_APP_ID` env)
 * `--name` - Reference name (internal identifier)
-* `--event-type` - Event badge type (see [Event Types](#event-types))
 
 **Optional Flags:**
 
+* `--event-type` - Event badge type (see [Event Types](#event-types))
 * `--start` - Event start time (RFC3339 format)
 * `--end` - Event end time (RFC3339 format)
 * `--publish-start` - Publish start time (when event appears on App Store)

--- a/internal/asc/client_app_events_test.go
+++ b/internal/asc/client_app_events_test.go
@@ -113,7 +113,7 @@ func TestGetAppEvent(t *testing.T) {
 }
 
 func TestCreateAppEvent(t *testing.T) {
-	response := jsonResponse(http.StatusCreated, `{"data":{"type":"appEvents","id":"event-1","attributes":{"referenceName":"Launch","badge":"PREMIERE"}}}`)
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"appEvents","id":"event-1","attributes":{"referenceName":"Launch"}}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
@@ -130,6 +130,9 @@ func TestCreateAppEvent(t *testing.T) {
 		if requireString(t, attrs["referenceName"], "referenceName") != "Launch" {
 			t.Fatalf("unexpected referenceName %v", attrs["referenceName"])
 		}
+		if _, ok := attrs["badge"]; ok {
+			t.Fatalf("expected optional badge to be omitted, got %v", attrs["badge"])
+		}
 		rels := requireMap(t, data["relationships"], "data.relationships")
 		app := requireMap(t, rels["app"], "relationships.app")
 		appData := requireMap(t, app["data"], "app.data")
@@ -139,10 +142,7 @@ func TestCreateAppEvent(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	attrs := AppEventCreateAttributes{
-		ReferenceName: "Launch",
-		Badge:         "PREMIERE",
-	}
+	attrs := AppEventCreateAttributes{ReferenceName: "Launch"}
 	if _, err := client.CreateAppEvent(context.Background(), "app-123", attrs); err != nil {
 		t.Fatalf("CreateAppEvent() error: %v", err)
 	}

--- a/internal/cli/app_events/app_events.go
+++ b/internal/cli/app_events/app_events.go
@@ -193,6 +193,7 @@ func AppEventsCreateCommand() *ffcli.Command {
 		LongHelp: `Create a new in-app event.
 
 Examples:
+  asc app-events create --app "APP_ID" --name "Summer Challenge"
   asc app-events create --app "APP_ID" --name "Summer Challenge" --event-type CHALLENGE --start "2026-06-01T00:00:00Z" --end "2026-06-30T23:59:59Z"
   asc app-events create --app "APP_ID" --name "Launch Party" --event-type PREMIERE --priority HIGH --purpose ATTRACT_NEW_USERS
   asc app-events create --app "APP_ID" --name "Retro Challenge" --event-type LIVE_EVENT --priority HIGH --purpose APPROPRIATE_FOR_ALL_USERS`,
@@ -211,7 +212,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			normalizedBadge, err := normalizeAppEventBadge(*eventType, true)
+			normalizedBadge, err := normalizeAppEventBadge(*eventType)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp
@@ -358,7 +359,7 @@ Examples:
 			}
 
 			if strings.TrimSpace(*eventType) != "" {
-				normalized, err := normalizeAppEventBadge(*eventType, false)
+				normalized, err := normalizeAppEventBadge(*eventType)
 				if err != nil {
 					fmt.Fprintln(os.Stderr, "Error:", err.Error())
 					return flag.ErrHelp

--- a/internal/cli/app_events/helpers.go
+++ b/internal/cli/app_events/helpers.go
@@ -20,12 +20,9 @@ func supportedAppEventPurchaseRequirementValues() string {
 	return string(asc.AppEventPurchaseRequirementNoCostAssociated)
 }
 
-func normalizeAppEventBadge(value string, required bool) (string, error) {
+func normalizeAppEventBadge(value string) (string, error) {
 	normalized := strings.ToUpper(strings.TrimSpace(value))
 	if normalized == "" {
-		if required {
-			return "", fmt.Errorf("--event-type is required")
-		}
 		return "", nil
 	}
 	if slices.Contains(asc.ValidAppEventBadges, normalized) {

--- a/internal/cli/cmdtest/app_events_purchase_requirement_test.go
+++ b/internal/cli/cmdtest/app_events_purchase_requirement_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
-func TestAppEventsCreateNormalizesPurchaseRequirement(t *testing.T) {
+func TestAppEventsCreateAllowsOptionalEventTypeAndNormalizesPurchaseRequirement(t *testing.T) {
 	setupAuth(t)
 
 	originalTransport := http.DefaultTransport
@@ -36,6 +38,9 @@ func TestAppEventsCreateNormalizesPurchaseRequirement(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected data object, got %T", payload["data"])
 		}
+		if data["type"] != "appEvents" {
+			t.Fatalf("expected data type appEvents, got %v", data["type"])
+		}
 		attrs, ok := data["attributes"].(map[string]any)
 		if !ok {
 			t.Fatalf("expected attributes object, got %T", data["attributes"])
@@ -44,8 +49,11 @@ func TestAppEventsCreateNormalizesPurchaseRequirement(t *testing.T) {
 		if attrs["purchaseRequirement"] != "NO_COST_ASSOCIATED" {
 			t.Fatalf("expected purchaseRequirement NO_COST_ASSOCIATED, got %v", attrs["purchaseRequirement"])
 		}
+		if _, ok := attrs["badge"]; ok {
+			t.Fatalf("expected optional badge to be omitted, got %v", attrs["badge"])
+		}
 
-		body := `{"data":{"type":"appEvents","id":"event-1","attributes":{"referenceName":"Launch","badge":"CHALLENGE"}}}`
+		body := `{"data":{"type":"appEvents","id":"event-1","attributes":{"referenceName":"Launch"}}}`
 		return &http.Response{
 			StatusCode: http.StatusCreated,
 			Body:       io.NopCloser(strings.NewReader(body)),
@@ -61,7 +69,6 @@ func TestAppEventsCreateNormalizesPurchaseRequirement(t *testing.T) {
 			"app-events", "create",
 			"--app", "APP_ID",
 			"--name", "Launch",
-			"--event-type", "CHALLENGE",
 			"--purchase-requirement", "noCostAssociated",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -74,8 +81,12 @@ func TestAppEventsCreateNormalizesPurchaseRequirement(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, `"id":"event-1"`) {
-		t.Fatalf("expected created event output, got %q", stdout)
+	var response asc.AppEventResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if response.Data.ID != "event-1" {
+		t.Fatalf("expected created event id event-1, got %q", response.Data.ID)
 	}
 }
 

--- a/internal/cli/cmdtest/app_events_purchase_requirement_test.go
+++ b/internal/cli/cmdtest/app_events_purchase_requirement_test.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -16,12 +18,7 @@ import (
 func TestAppEventsCreateAllowsOptionalEventTypeAndNormalizesPurchaseRequirement(t *testing.T) {
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
 		}
@@ -53,13 +50,22 @@ func TestAppEventsCreateAllowsOptionalEventTypeAndNormalizesPurchaseRequirement(
 			t.Fatalf("expected optional badge to be omitted, got %v", attrs["badge"])
 		}
 
-		body := `{"data":{"type":"appEvents","id":"event-1","attributes":{"referenceName":"Launch"}}}`
-		return &http.Response{
-			StatusCode: http.StatusCreated,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
-	})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"data":{"type":"appEvents","id":"event-1","attributes":{"referenceName":"Launch"}}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -5874,11 +5874,6 @@ func TestAppEventsCreateValidationErrors(t *testing.T) {
 			wantErr: "Error: --name is required",
 		},
 		{
-			name:    "missing event type",
-			args:    []string{"app-events", "create", "--app", "APP_ID", "--name", "Launch", "--start", "2026-01-01T00:00:00Z", "--end", "2026-01-02T00:00:00Z"},
-			wantErr: "Error: --event-type is required",
-		},
-		{
 			name:    "missing end time",
 			args:    []string{"app-events", "create", "--app", "APP_ID", "--name", "Launch", "--event-type", "CHALLENGE", "--start", "2026-01-01T00:00:00Z"},
 			wantErr: "Error: --end is required",

--- a/internal/cli/cmdtest/nominations_test.go
+++ b/internal/cli/cmdtest/nominations_test.go
@@ -77,7 +77,7 @@ func TestNominationsValidationErrors(t *testing.T) {
 		{
 			name:    "nominations update missing submitted or archived",
 			args:    []string{"nominations", "update", "--id", "NOM_ID", "--notes", "Updated"},
-			wantErr: "--submitted or --archived is required",
+			wantErr: "--submitted or --archived is required by Apple's live API",
 		},
 		{
 			name:    "nominations delete missing id",

--- a/internal/cli/nominations/nominations.go
+++ b/internal/cli/nominations/nominations.go
@@ -28,7 +28,7 @@ Examples:
   asc nominations list --status DRAFT
   asc nominations view --id "NOMINATION_ID"
   asc nominations create --app "APP_ID" --name "Launch" --type APP_LAUNCH --description "New launch" --submitted=false --publish-start-date "2026-02-01T08:00:00Z"
-  asc nominations update --id "NOMINATION_ID" --notes "Updated notes"
+  asc nominations update --id "NOMINATION_ID" --submitted=false --notes "Updated notes"
   asc nominations delete --id "NOMINATION_ID" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -476,11 +476,11 @@ func NominationsUpdateCommand() *ffcli.Command {
 		ShortHelp:  "Update a featuring nomination.",
 		LongHelp: `Update a featuring nomination.
 
-Note: --submitted or --archived is required by the API.
+Apple's live API requires --submitted or --archived even though its OpenAPI schema does not.
 
 Examples:
-  asc nominations update --id "NOMINATION_ID" --notes "Updated notes"
-  asc nominations update --id "NOMINATION_ID" --type NEW_CONTENT --publish-start-date "2026-03-01T08:00:00Z"
+  asc nominations update --id "NOMINATION_ID" --submitted=false --notes "Updated notes"
+  asc nominations update --id "NOMINATION_ID" --submitted=false --type NEW_CONTENT --publish-start-date "2026-03-01T08:00:00Z"
   asc nominations update --id "NOMINATION_ID" --archived=true`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -517,7 +517,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 			if !visited["submitted"] && !visited["archived"] {
-				fmt.Fprintln(os.Stderr, "Error: --submitted or --archived is required")
+				fmt.Fprintln(os.Stderr, "Error: --submitted or --archived is required by Apple's live API")
 				return shared.MissingRequiredUsageError()
 			}
 


### PR DESCRIPTION
## Summary

- make `app-events create --event-type` optional, matching Apple's `AppEventCreateRequest` where only `referenceName` is required
- keep validating `--event-type` when supplied and omit `badge` when it is absent
- preserve the live-required nominations `--submitted`/`--archived` guard, but fix every contradictory notes-only/type-only help example and explain the OpenAPI discrepancy

## Contract and history

Apple's current OpenAPI 4.4.1 download is byte-identical to `docs/openapi/latest.json` (SHA-256 `ed0202ef37155b9334772482d2ea0be688c3046b284c895bcbea5455fbe54fd8`). `POST /v1/appEvents` requires the app relationship plus `attributes.referenceName`; `badge` is optional. Maintained generated ASC SDKs model it the same way.

The event-type requirement came from #314 without live verification; the original model already used `badge,omitempty`. The nominations guard came from #226 as an undocumented live-API constraint, but its help simultaneously advertised invocations that the guard rejected.

A current safe comparison against the same deliberately nonexistent nomination ID confirmed the undocumented constraint:

- notes-only `PATCH /v1/nominations/{id}` -> HTTP 400: at least one of `submitted` or `archived` is required
- identical PATCH with `submitted=false` -> HTTP 404 during resource lookup

Validation therefore occurs before lookup, so the guard remains necessary despite the permissive OpenAPI schema. The nonexistent target and non-2xx responses guarantee that no nomination changed.

For app events, name-only and name-plus-badge POST probes both reached Apple and returned the same HTTP 403 permission error. No event was created. That live result is inconclusive about payload validation, so this change relies on Apple's exact current schema and independent generated SDK shape rather than overstating the probe.

## Verification

- focused ASC client and CLI request tests
- built binary help and mutation-shaped probes using deliberately nonexistent IDs
- `make format`
- `make check-docs`
- `GOLANGCI_LINT_CACHE=/tmp/asc-lint-nominations make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- mandatory commit hook: command docs, format, plain `make lint` (`0 issues`), and full short test suite

## Compatibility

Existing app-event invocations with `--event-type` are unchanged. Omitting it now sends Apple's supported reference-name-only create payload. Nominations update behavior is unchanged; only its diagnostics and examples now tell the truth about Apple's live requirement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788626849&installation_model_id=10418&pr_number=1872&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1872&signature=cf95fef6008701b055eb60ecaa54c3b41c83fc4415ac4f1526f144bea47a32c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App event creation now allows omitting the event type and badge.
  * Added a basic app event creation usage example.

* **Bug Fixes**
  * Empty badge values no longer trigger unnecessary validation errors.

* **Documentation**
  * Updated nomination command examples to show explicit boolean values.
  * Clarified that Apple’s live API requires either `--submitted` or `--archived` when updating nominations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

