### PR TITLE
fix(xcode-cloud): preserve typed response fields

### DIFF
--- a/internal/asc/build_bundles_test.go
+++ b/internal/asc/build_bundles_test.go
@@ -55,7 +55,8 @@ func TestExtractBuildBundles(t *testing.T) {
 			"id": "bundle-1",
 			"attributes": {
 				"bundleId": "com.example.app",
-				"bundleType": "APP"
+				"bundleType": "APP",
+				"minimumOsVersion": "18.0"
 			}
 		},
 		{
@@ -79,5 +80,8 @@ func TestExtractBuildBundles(t *testing.T) {
 	}
 	if bundles[0].Attributes.BundleType == nil || *bundles[0].Attributes.BundleType != BuildBundleTypeApp {
 		t.Fatalf("expected bundleType APP, got %v", bundles[0].Attributes.BundleType)
+	}
+	if bundles[0].Attributes.MinimumOSVersion == nil || *bundles[0].Attributes.MinimumOSVersion != "18.0" {
+		t.Fatalf("expected minimumOsVersion 18.0, got %v", bundles[0].Attributes.MinimumOSVersion)
 	}
 }

--- a/internal/asc/client_build_bundles.go
+++ b/internal/asc/client_build_bundles.go
@@ -36,6 +36,7 @@ type BuildBundleAttributes struct {
 	Entitlements                    map[string]map[string]string `json:"entitlements,omitempty"`
 	BADownloadAllowance             *int64                       `json:"baDownloadAllowance,omitempty"`
 	BAMaxInstallSize                *int64                       `json:"baMaxInstallSize,omitempty"`
+	MinimumOSVersion                *string                      `json:"minimumOsVersion,omitempty"`
 }
 
 // BuildBundleFileSizeAttributes describes a build bundle file size resource.

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -5392,7 +5392,20 @@ func TestGetCiProducts_WithAppFilterAndLimit(t *testing.T) {
 }
 
 func TestGetCiProduct(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciProducts","id":"prod-1"}}`)
+	response := jsonResponse(http.StatusOK, `{
+		"data": {
+			"type": "ciProducts",
+			"id": "prod-1",
+			"relationships": {
+				"app": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciProducts/prod-1/app"}, "data": {"type": "apps", "id": "app-1"}},
+				"bundleId": {"data": {"type": "bundleIds", "id": "bundle-id-1"}},
+				"workflows": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciProducts/prod-1/workflows"}},
+				"primaryRepositories": {"data": [{"type": "scmRepositories", "id": "repo-1"}]},
+				"additionalRepositories": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciProducts/prod-1/additionalRepositories"}},
+				"buildRuns": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciProducts/prod-1/buildRuns"}}
+			}
+		}
+	}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -5403,8 +5416,28 @@ func TestGetCiProduct(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetCiProduct(context.Background(), "prod-1"); err != nil {
+	got, err := client.GetCiProduct(context.Background(), "prod-1")
+	if err != nil {
 		t.Fatalf("GetCiProduct() error: %v", err)
+	}
+	relationships := got.Data.Relationships
+	if relationships == nil || relationships.App == nil || relationships.App.Data == nil || relationships.App.Data.ID != "app-1" || relationships.App.Links == nil || relationships.App.Links.Related == "" {
+		t.Fatalf("unexpected app relationship: %#v", relationships)
+	}
+	if relationships.BundleID == nil || relationships.BundleID.Data.ID != "bundle-id-1" {
+		t.Fatalf("unexpected bundle ID relationship: %#v", relationships)
+	}
+	if relationships.Workflows == nil || relationships.Workflows.Links == nil || relationships.Workflows.Links.Related == "" {
+		t.Fatalf("unexpected workflows relationship: %#v", relationships)
+	}
+	if relationships.PrimaryRepositories == nil || len(relationships.PrimaryRepositories.Data) != 1 {
+		t.Fatalf("unexpected primary repositories relationship: %#v", relationships)
+	}
+	if relationships.AdditionalRepositories == nil || relationships.AdditionalRepositories.Links == nil || relationships.AdditionalRepositories.Links.Related == "" {
+		t.Fatalf("unexpected additional repositories relationship: %#v", relationships)
+	}
+	if relationships.BuildRuns == nil || relationships.BuildRuns.Links == nil || relationships.BuildRuns.Links.Related == "" {
+		t.Fatalf("unexpected build runs relationship: %#v", relationships)
 	}
 }
 
@@ -5511,6 +5544,16 @@ func TestGetCiWorkflow(t *testing.T) {
 			"type": "ciWorkflows",
 			"id": "wf-1",
 			"attributes": {
+				"branchStartCondition": {
+					"filesAndFoldersRule": {
+						"mode": "START_IF_ANY_FILE_MATCHES",
+						"matchers": [{"directory": "Sources", "fileExtension": "swift", "fileName": "App.swift"}]
+					}
+				},
+				"manualPullRequestStartCondition": {
+					"source": {"patterns": [{"pattern": "feature/", "isPrefix": true}]},
+					"destination": {"patterns": [{"pattern": "main", "isPrefix": false}]}
+				},
 				"actions": [{
 					"name": "Archive - iOS",
 					"actionType": "ARCHIVE",
@@ -5554,6 +5597,14 @@ func TestGetCiWorkflow(t *testing.T) {
 	if len(got.Data.Attributes.Actions) != 1 || got.Data.Attributes.Actions[0].Scheme != "Example" {
 		t.Fatalf("unexpected actions: %#v", got.Data.Attributes.Actions)
 	}
+	matchers := got.Data.Attributes.BranchStartCondition.FilesAndFoldersRule.Matchers
+	if len(matchers) != 1 || matchers[0].Directory != "Sources" || matchers[0].FileExtension != "swift" || matchers[0].FileName != "App.swift" {
+		t.Fatalf("unexpected file matchers: %#v", matchers)
+	}
+	manualPullRequest := got.Data.Attributes.ManualPullRequestStartCondition
+	if manualPullRequest == nil || manualPullRequest.Destination == nil || len(manualPullRequest.Destination.Patterns) != 1 || manualPullRequest.Destination.Patterns[0].Pattern != "main" {
+		t.Fatalf("unexpected manual pull request condition: %#v", manualPullRequest)
+	}
 	if got.Data.Relationships == nil || got.Data.Relationships.Repository == nil {
 		t.Fatal("expected repository relationship")
 	}
@@ -5590,10 +5641,39 @@ func TestCreateCiWorkflow(t *testing.T) {
 		if !ok || data["type"] != "ciWorkflows" {
 			t.Fatalf("expected data.type=ciWorkflows")
 		}
+		attributes, ok := data["attributes"].(map[string]any)
+		if !ok || attributes["name"] != "CI" || attributes["description"] != "Build and test" || attributes["containerFilePath"] != "App.xcodeproj" || attributes["isEnabled"] != true || attributes["clean"] != true {
+			t.Fatalf("unexpected workflow attributes: %#v", data["attributes"])
+		}
+		if actions, ok := attributes["actions"].([]any); !ok || len(actions) != 0 {
+			t.Fatalf("unexpected workflow actions: %#v", attributes["actions"])
+		}
+		relationships, ok := data["relationships"].(map[string]any)
+		if !ok || len(relationships) != 4 {
+			t.Fatalf("unexpected workflow relationships: %#v", data["relationships"])
+		}
 		assertAuthorized(t, req)
 	}, response)
 
-	body := json.RawMessage(`{"data":{"type":"ciWorkflows"}}`)
+	body := json.RawMessage(`{
+		"data": {
+			"type": "ciWorkflows",
+			"attributes": {
+				"name": "CI",
+				"description": "Build and test",
+				"containerFilePath": "App.xcodeproj",
+				"isEnabled": true,
+				"clean": true,
+				"actions": []
+			},
+			"relationships": {
+				"product": {"data": {"type": "ciProducts", "id": "prod-1"}},
+				"repository": {"data": {"type": "scmRepositories", "id": "repo-1"}},
+				"xcodeVersion": {"data": {"type": "ciXcodeVersions", "id": "xcode-1"}},
+				"macOsVersion": {"data": {"type": "ciMacOsVersions", "id": "macos-1"}}
+			}
+		}
+	}`)
 	if _, err := client.CreateCiWorkflow(context.Background(), body); err != nil {
 		t.Fatalf("CreateCiWorkflow() error: %v", err)
 	}
@@ -5894,7 +5974,22 @@ func TestGetCiBuildRuns_WithSort(t *testing.T) {
 }
 
 func TestGetCiBuildRun(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"number":1}}}`)
+	response := jsonResponse(http.StatusOK, `{
+		"data": {
+			"type": "ciBuildRuns",
+			"id": "run-1",
+			"attributes": {"number": 1},
+			"relationships": {
+				"builds": {"data": [{"type": "builds", "id": "build-1"}]},
+				"workflow": {"data": {"type": "ciWorkflows", "id": "wf-1"}},
+				"product": {"data": {"type": "ciProducts", "id": "prod-1"}},
+				"sourceBranchOrTag": {"data": {"type": "scmGitReferences", "id": "source-ref-1"}},
+				"destinationBranch": {"data": {"type": "scmGitReferences", "id": "destination-ref-1"}},
+				"actions": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciBuildRuns/run-1/actions"}},
+				"pullRequest": {"data": {"type": "scmPullRequests", "id": "pr-1"}}
+			}
+		}
+	}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -5905,8 +6000,22 @@ func TestGetCiBuildRun(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetCiBuildRun(context.Background(), "run-1"); err != nil {
+	got, err := client.GetCiBuildRun(context.Background(), "run-1")
+	if err != nil {
 		t.Fatalf("GetCiBuildRun() error: %v", err)
+	}
+	relationships := got.Data.Relationships
+	if relationships == nil || relationships.Builds == nil || len(relationships.Builds.Data) != 1 {
+		t.Fatalf("unexpected builds relationship: %#v", relationships)
+	}
+	if relationships.Workflow == nil || relationships.Workflow.Data.ID != "wf-1" || relationships.Product == nil || relationships.Product.Data.ID != "prod-1" {
+		t.Fatalf("unexpected workflow/product relationships: %#v", relationships)
+	}
+	if relationships.SourceBranchOrTag == nil || relationships.SourceBranchOrTag.Data.ID != "source-ref-1" || relationships.DestinationBranch == nil || relationships.DestinationBranch.Data.ID != "destination-ref-1" {
+		t.Fatalf("unexpected source/destination relationships: %#v", relationships)
+	}
+	if relationships.Actions == nil || relationships.Actions.Links == nil || relationships.Actions.Links.Related == "" || relationships.PullRequest == nil || relationships.PullRequest.Data.ID != "pr-1" {
+		t.Fatalf("unexpected actions/pull request relationships: %#v", relationships)
 	}
 }
 
@@ -6128,7 +6237,19 @@ func TestCreateCiBuildRun_WithSourceBuildRunOnly(t *testing.T) {
 }
 
 func TestGetCiBuildAction(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"ciBuildActions","id":"action-1"}}`)
+	response := jsonResponse(http.StatusOK, `{
+		"data": {
+			"type": "ciBuildActions",
+			"id": "action-1",
+			"attributes": {"name": "Archive", "isRequiredToPass": false},
+			"relationships": {
+				"buildRun": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-1/buildRun"}, "data": {"type": "ciBuildRuns", "id": "run-1"}},
+				"artifacts": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-1/artifacts"}},
+				"issues": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-1/issues"}},
+				"testResults": {"links": {"related": "https://api.appstoreconnect.apple.com/v1/ciBuildActions/action-1/testResults"}}
+			}
+		}
+	}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -6139,8 +6260,26 @@ func TestGetCiBuildAction(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetCiBuildAction(context.Background(), "action-1"); err != nil {
+	got, err := client.GetCiBuildAction(context.Background(), "action-1")
+	if err != nil {
 		t.Fatalf("GetCiBuildAction() error: %v", err)
+	}
+	if got.Data.Attributes.IsRequiredToPass == nil || *got.Data.Attributes.IsRequiredToPass {
+		t.Fatalf("expected explicit false isRequiredToPass, got %#v", got.Data.Attributes.IsRequiredToPass)
+	}
+	relationships := got.Data.Relationships
+	if relationships == nil || relationships.BuildRun == nil || relationships.BuildRun.Data == nil || relationships.BuildRun.Data.ID != "run-1" || relationships.BuildRun.Links == nil || relationships.BuildRun.Links.Related == "" {
+		t.Fatalf("unexpected build run relationship: %#v", relationships)
+	}
+	if relationships.Artifacts == nil || relationships.Artifacts.Links == nil || relationships.Artifacts.Links.Related == "" || relationships.Issues == nil || relationships.Issues.Links == nil || relationships.Issues.Links.Related == "" || relationships.TestResults == nil || relationships.TestResults.Links == nil || relationships.TestResults.Links.Related == "" {
+		t.Fatalf("unexpected action resource relationships: %#v", relationships)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"isRequiredToPass":false`) {
+		t.Fatalf("action response lost explicit false isRequiredToPass: %s", encoded)
 	}
 }
 

--- a/internal/asc/xcode_cloud_build_runs.go
+++ b/internal/asc/xcode_cloud_build_runs.go
@@ -69,12 +69,13 @@ type CiIssueCounts struct {
 
 // CiBuildRunRelationships describes relationships for a CI build run.
 type CiBuildRunRelationships struct {
-	Builds            *RelationshipList `json:"builds,omitempty"`
-	Workflow          *Relationship     `json:"workflow,omitempty"`
-	Product           *Relationship     `json:"product,omitempty"`
-	SourceBranchOrTag *Relationship     `json:"sourceBranchOrTag,omitempty"`
-	DestinationBranch *Relationship     `json:"destinationBranch,omitempty"`
-	PullRequest       *Relationship     `json:"pullRequest,omitempty"`
+	Builds            *RelationshipList        `json:"builds,omitempty"`
+	Workflow          *Relationship            `json:"workflow,omitempty"`
+	Product           *Relationship            `json:"product,omitempty"`
+	SourceBranchOrTag *Relationship            `json:"sourceBranchOrTag,omitempty"`
+	DestinationBranch *Relationship            `json:"destinationBranch,omitempty"`
+	Actions           *CiRelationshipLinksOnly `json:"actions,omitempty"`
+	PullRequest       *Relationship            `json:"pullRequest,omitempty"`
 }
 
 // CiBuildRunResource represents a CI build run resource.

--- a/internal/asc/xcode_cloud_output.go
+++ b/internal/asc/xcode_cloud_output.go
@@ -232,7 +232,7 @@ func ciBuildRunsRows(resp *CiBuildRunsResponse) ([]string, [][]string) {
 }
 
 func ciBuildActionsRows(resp *CiBuildActionsResponse) ([]string, [][]string) {
-	headers := []string{"Name", "Type", "Progress", "Status", "Errors", "Warnings", "Started", "Finished"}
+	headers := []string{"ID", "Name", "Type", "Progress", "Status", "Errors", "Warnings", "Started", "Finished"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		errors := 0
@@ -242,6 +242,7 @@ func ciBuildActionsRows(resp *CiBuildActionsResponse) ([]string, [][]string) {
 			warnings = item.Attributes.IssueCounts.Warnings
 		}
 		rows = append(rows, []string{
+			item.ID,
 			item.Attributes.Name,
 			item.Attributes.ActionType,
 			string(item.Attributes.ExecutionProgress),

--- a/internal/asc/xcode_cloud_products.go
+++ b/internal/asc/xcode_cloud_products.go
@@ -36,8 +36,12 @@ type CiProductAttributes struct {
 
 // CiProductRelationships describes relationships for a CI product.
 type CiProductRelationships struct {
-	App                 *Relationship     `json:"app,omitempty"`
-	PrimaryRepositories *RelationshipList `json:"primaryRepositories,omitempty"`
+	App                    *CiResourceRelationship  `json:"app,omitempty"`
+	BundleID               *Relationship            `json:"bundleId,omitempty"`
+	Workflows              *CiRelationshipLinksOnly `json:"workflows,omitempty"`
+	PrimaryRepositories    *RelationshipList        `json:"primaryRepositories,omitempty"`
+	AdditionalRepositories *CiRelationshipLinksOnly `json:"additionalRepositories,omitempty"`
+	BuildRuns              *CiRelationshipLinksOnly `json:"buildRuns,omitempty"`
 }
 
 // CiProductResource represents a CI product resource.
@@ -72,21 +76,21 @@ type CiProductResponse struct {
 
 // CiWorkflowAttributes describes a CI workflow resource.
 type CiWorkflowAttributes struct {
-	Name                            string                       `json:"name,omitempty"`
-	Description                     string                       `json:"description,omitempty"`
-	BranchStartCondition            *CiBranchStartCondition      `json:"branchStartCondition,omitempty"`
-	TagStartCondition               *CiTagStartCondition         `json:"tagStartCondition,omitempty"`
-	PullRequestStartCondition       *CiPullRequestStartCondition `json:"pullRequestStartCondition,omitempty"`
-	ScheduledStartCondition         *CiScheduledStartCondition   `json:"scheduledStartCondition,omitempty"`
-	ManualBranchStartCondition      *CiManualStartCondition      `json:"manualBranchStartCondition,omitempty"`
-	ManualTagStartCondition         *CiManualStartCondition      `json:"manualTagStartCondition,omitempty"`
-	ManualPullRequestStartCondition *CiManualStartCondition      `json:"manualPullRequestStartCondition,omitempty"`
-	Actions                         []CiAction                   `json:"actions,omitempty"`
-	IsEnabled                       bool                         `json:"isEnabled,omitempty"`
-	IsLockedForEditing              bool                         `json:"isLockedForEditing,omitempty"`
-	Clean                           bool                         `json:"clean,omitempty"`
-	ContainerFilePath               string                       `json:"containerFilePath,omitempty"`
-	LastModifiedDate                string                       `json:"lastModifiedDate,omitempty"`
+	Name                            string                             `json:"name,omitempty"`
+	Description                     string                             `json:"description,omitempty"`
+	BranchStartCondition            *CiBranchStartCondition            `json:"branchStartCondition,omitempty"`
+	TagStartCondition               *CiTagStartCondition               `json:"tagStartCondition,omitempty"`
+	PullRequestStartCondition       *CiPullRequestStartCondition       `json:"pullRequestStartCondition,omitempty"`
+	ScheduledStartCondition         *CiScheduledStartCondition         `json:"scheduledStartCondition,omitempty"`
+	ManualBranchStartCondition      *CiManualStartCondition            `json:"manualBranchStartCondition,omitempty"`
+	ManualTagStartCondition         *CiManualStartCondition            `json:"manualTagStartCondition,omitempty"`
+	ManualPullRequestStartCondition *CiManualPullRequestStartCondition `json:"manualPullRequestStartCondition,omitempty"`
+	Actions                         []CiAction                         `json:"actions,omitempty"`
+	IsEnabled                       bool                               `json:"isEnabled,omitempty"`
+	IsLockedForEditing              bool                               `json:"isLockedForEditing,omitempty"`
+	Clean                           bool                               `json:"clean,omitempty"`
+	ContainerFilePath               string                             `json:"containerFilePath,omitempty"`
+	LastModifiedDate                string                             `json:"lastModifiedDate,omitempty"`
 }
 
 // CiAction describes a build, analyze, test, or archive action in a CI workflow.
@@ -134,6 +138,12 @@ type CiManualStartCondition struct {
 	Source *CiBranchPatterns `json:"source,omitempty"`
 }
 
+// CiManualPullRequestStartCondition describes manual pull request start conditions.
+type CiManualPullRequestStartCondition struct {
+	Source      *CiBranchPatterns `json:"source,omitempty"`
+	Destination *CiBranchPatterns `json:"destination,omitempty"`
+}
+
 // CiBranchPatterns describes branch patterns.
 type CiBranchPatterns struct {
 	Patterns   []CiStartConditionPattern `json:"patterns,omitempty"`
@@ -154,8 +164,15 @@ type CiStartConditionPattern struct {
 
 // CiFilesAndFoldersRule describes files and folders rules.
 type CiFilesAndFoldersRule struct {
-	Mode  string   `json:"mode,omitempty"`
-	Paths []string `json:"paths,omitempty"`
+	Mode     string                        `json:"mode,omitempty"`
+	Matchers []CiStartConditionFileMatcher `json:"matchers,omitempty"`
+}
+
+// CiStartConditionFileMatcher describes a file or directory matcher in a start condition.
+type CiStartConditionFileMatcher struct {
+	Directory     string `json:"directory,omitempty"`
+	FileExtension string `json:"fileExtension,omitempty"`
+	FileName      string `json:"fileName,omitempty"`
 }
 
 // CiSchedule describes a CI schedule.
@@ -180,6 +197,17 @@ type CiWorkflowRelationships struct {
 type CiRelationshipLinks struct {
 	Self    string `json:"self,omitempty"`
 	Related string `json:"related,omitempty"`
+}
+
+// CiRelationshipLinksOnly describes a relationship represented only by links.
+type CiRelationshipLinksOnly struct {
+	Links *CiRelationshipLinks `json:"links,omitempty"`
+}
+
+// CiResourceRelationship describes a to-one response relationship with links and data.
+type CiResourceRelationship struct {
+	Links *CiRelationshipLinks `json:"links,omitempty"`
+	Data  *ResourceData        `json:"data,omitempty"`
 }
 
 // CiWorkflowRepositoryRelationship describes a workflow's repository relationship.

--- a/internal/asc/xcode_cloud_results.go
+++ b/internal/asc/xcode_cloud_results.go
@@ -34,13 +34,23 @@ type CiBuildActionAttributes struct {
 	StartedDate       string                      `json:"startedDate,omitempty"`
 	FinishedDate      string                      `json:"finishedDate,omitempty"`
 	IssueCounts       *CiIssueCounts              `json:"issueCounts,omitempty"`
+	IsRequiredToPass  *bool                       `json:"isRequiredToPass,omitempty"`
+}
+
+// CiBuildActionRelationships describes relationships for a CI build action.
+type CiBuildActionRelationships struct {
+	BuildRun    *CiResourceRelationship  `json:"buildRun,omitempty"`
+	Artifacts   *CiRelationshipLinksOnly `json:"artifacts,omitempty"`
+	Issues      *CiRelationshipLinksOnly `json:"issues,omitempty"`
+	TestResults *CiRelationshipLinksOnly `json:"testResults,omitempty"`
 }
 
 // CiBuildActionResource represents a CI build action resource.
 type CiBuildActionResource struct {
-	Type       ResourceType            `json:"type"`
-	ID         string                  `json:"id"`
-	Attributes CiBuildActionAttributes `json:"attributes"`
+	Type          ResourceType                `json:"type"`
+	ID            string                      `json:"id"`
+	Attributes    CiBuildActionAttributes     `json:"attributes"`
+	Relationships *CiBuildActionRelationships `json:"relationships,omitempty"`
 }
 
 // CiBuildActionsResponse is the response from CI build actions endpoints.

--- a/internal/asc/xcode_cloud_test.go
+++ b/internal/asc/xcode_cloud_test.go
@@ -339,6 +339,27 @@ func TestPrintMarkdown_CiBuildRuns(t *testing.T) {
 	}
 }
 
+func TestPrintTable_CiBuildActionsIncludesID(t *testing.T) {
+	resp := &CiBuildActionsResponse{
+		Data: []CiBuildActionResource{{
+			ID: "action-1",
+			Attributes: CiBuildActionAttributes{
+				Name:              "Archive",
+				ActionType:        "ARCHIVE",
+				ExecutionProgress: CiBuildRunExecutionProgressComplete,
+			},
+		}},
+	}
+
+	headers, rows := ciBuildActionsRows(resp)
+	if len(headers) == 0 || headers[0] != "ID" {
+		t.Fatalf("expected first action header ID, got %#v", headers)
+	}
+	if len(rows) != 1 || len(rows[0]) == 0 || rows[0][0] != "action-1" {
+		t.Fatalf("expected first action value action-1, got %#v", rows)
+	}
+}
+
 func TestPrintTable_CiArtifacts(t *testing.T) {
 	resp := &CiArtifactsResponse{
 		Data: []CiArtifactResource{


### PR DESCRIPTION
## Summary

- Replace the nonexistent `filesAndFoldersRule.paths` response field with Apple's typed `matchers` objects, and give manual pull-request conditions their missing destination patterns.
- Preserve the documented product, build-run, and build-action relationships. `CiBuildAction.isRequiredToPass` now retains an explicit `false`, and build bundles retain `minimumOsVersion`.
- Put the action resource ID first in table and Markdown output so the listed value can be passed to action detail, artifact, issue, and test-result commands.
- Replace the workflow-create test payload that mocked a successful Apple response for a schema-invalid body.

## Why these fields were missing

The gaps came from several rounds of hand-written coverage, not undocumented Apple behavior:

- PR #43 added the first Xcode Cloud models before this repository carried an offline OpenAPI snapshot. Its live checks covered run triggering and status, but not workflow start-condition decoding. `CiFilesAndFoldersRule.Paths` has no caller. The first snapshot in PR #214 already described `matchers` and the manual pull-request destination.
- PR #140 introduced the action table without IDs. PR #231 then added follow-up commands that require an action ID and told operators to get it from the action list, but the table never changed.
- PR #227 added build-bundle decoding before Apple added `minimumOsVersion` to the 4.3 schema imported by PR #951.
- PR #237 covered the documented read endpoints, though its detail fixtures contained little more than resource type and ID. PR #1720 later established the response rule used here: links-only and links-plus-data relationships need their exact wire shapes.

Apple's current 4.4.1 OpenAPI still supports the existing product, workflow, build-run, and build-action reads, along with workflow create and update. Maintained generated clients such as Bagbutik and appstoreconnect-swift-sdk expose the same workflow mutation contract. This patch therefore removes only the dead `paths` representation and keeps the supported command/client surface.

`CiProductAttributes.BundleID` stays in place. It isn't an Apple response attribute, but the CLI deliberately hydrates it from the related app for table output, so it is functional compatibility code rather than a dead wire field.

## Verification

RED was established first: the focused suite failed to compile because the requested response fields and relationships didn't exist. The corrected fixtures then passed with the smallest model/output change.

Passed on commit `7acc3a7a00b317c05af70531514a7b0cd8b69efd`:

```text
make format
make check-docs
GOLANGCI_LINT_CACHE=/tmp/asc-lint-xcode-cloud make lint
ASC_BYPASS_KEYCHAIN=1 make test
ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run 'Test(GetCiProduct$|GetCiWorkflow$|CreateCiWorkflow$|GetCiBuildRun$|GetCiBuildAction$|ExtractBuildBundles|PrintTable_CiBuildActionsIncludesID)' -count=1
ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -count=1
ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'Test.*XcodeCloud|Test.*BuildBundles' -count=1
```

The commit hook also passed command-doc checks, format, lint with zero findings, and `ASC_BYPASS_KEYCHAIN=1 go test -short ./...` with stdin redirected from `/dev/null`.

## Live Apple checks

All calls used the built binary, file-backed API credential authentication, `ASC_BYPASS_KEYCHAIN=1`, and explicit resource IDs. No configured app ID was used.

- Real product, workflow, build-run, and action GETs returned HTTP 200. The action collection included `isRequiredToPass` plus `buildRun`, `artifacts`, `issues`, and `testResults` relationships; table output included the action ID.
- `GET /v1/builds/{id}?include=buildBundles&limit[buildBundles]=50` returned HTTP 200 and a build bundle with `minimumOsVersion`.
- The sampled live workflow had no file matcher or manual pull-request destination configured, so those optional shapes remain fixture-proven against the exact OpenAPI schema rather than claimed as live-observed.
- A mutation-shaped `POST /v1/ciWorkflows` used the complete required request shape and deliberately nonexistent relationship IDs. Apple returned HTTP 409 for the nonexistent product, the CLI exited 5, no resource ID was returned, and no real resource was targeted or changed.

No command flags or help changed, so `docs/COMMANDS.md` remains current. JSON response fidelity is additive; human-readable action output gains a leading ID column.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788627075&installation_model_id=10418&pr_number=1873&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1873&signature=2bc089ea178afcfadae07212b526dffdf5b23f2653153c4d78e3bf2084b63ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying Xcode Cloud build action IDs in results.
  * Improved Xcode Cloud data handling for products, workflows, repositories, build runs, artifacts, issues, and test results.
  * Added support for manual pull-request start conditions with branch and file matching rules.
  * Exposed minimum OS version and required-to-pass status for relevant build data.
* **Bug Fixes**
  * Improved preservation of relationship links, related data, and explicit false values when processing API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

