### PR TITLE
Fix App Store version contract validation

### DIFF
--- a/commands/versions.mdx
+++ b/commands/versions.mdx
@@ -90,7 +90,7 @@ In 1.0, the deprecated `asc versions get` alias was removed. Use
 </ParamField>
 
 <ParamField path="--include" type="string">
-  Include related resources (comma-separated): `ageRatingDeclaration`, `appStoreReviewDetail`, `appClipDefaultExperience`, `appStoreVersionExperiments`, `appStoreVersionExperimentsV2`, `appStoreVersionSubmission`, `customerReviews`, `routingAppCoverage`, `alternativeDistributionPackage`, `gameCenterAppVersion`
+  Include related resources (comma-separated): `ageRatingDeclaration`, `app`, `appStoreVersionLocalizations`, `build`, `appStoreVersionPhasedRelease`, `gameCenterAppVersion`, `routingAppCoverage`, `appStoreReviewDetail`, `appStoreVersionSubmission`, `appClipDefaultExperience`, `appStoreVersionExperiments`, `appStoreVersionExperimentsV2`, `alternativeDistributionPackage`
 </ParamField>
 
 **Examples:**

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -1015,15 +1015,15 @@ func TestAppStoreVersionStateOptionsPreserveExistingComposition(t *testing.T) {
 
 func TestBuildAppStoreVersionQuery(t *testing.T) {
 	query := &appStoreVersionQuery{}
-	WithAppStoreVersionInclude([]string{"appStoreReviewDetail", "ageRatingDeclaration"})(query)
+	WithAppStoreVersionInclude([]string{"app", "appStoreReviewDetail"})(query)
 	WithAppStoreVersionLocalizationsIncludeLimit(50)(query)
 
 	values, err := url.ParseQuery(buildAppStoreVersionQuery(query))
 	if err != nil {
 		t.Fatalf("failed to parse query: %v", err)
 	}
-	if got := values.Get("include"); got != "appStoreReviewDetail,ageRatingDeclaration" {
-		t.Fatalf("expected include=appStoreReviewDetail,ageRatingDeclaration, got %q", got)
+	if got := values.Get("include"); got != "app,appStoreReviewDetail" {
+		t.Fatalf("expected include=app,appStoreReviewDetail, got %q", got)
 	}
 	if got := values.Get("limit[appStoreVersionLocalizations]"); got != "50" {
 		t.Fatalf("expected localization include limit 50, got %q", got)

--- a/internal/cli/cmdtest/versions_contract_test.go
+++ b/internal/cli/cmdtest/versions_contract_test.go
@@ -1,0 +1,205 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+const releaseTypeValues = "MANUAL, AFTER_APPROVAL, SCHEDULED"
+
+func clearASCAuth(t *testing.T) {
+	t.Helper()
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_STRICT_AUTH", "")
+}
+
+func TestVersionsViewSendsExactSupportedIncludeQuery(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const include = "app,appStoreVersionLocalizations,build,appStoreVersionPhasedRelease"
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1" {
+			t.Fatalf("request = %s %s, want GET /v1/appStoreVersions/version-1", req.Method, req.URL.Path)
+		}
+		if got := req.URL.Query().Get("include"); got != include {
+			t.Fatalf("include query = %q, want %q", got, include)
+		}
+		return jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.0","platform":"IOS"}},"included":[]}`)
+	})
+
+	root := RootCommand("test")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"versions", "view",
+			"--version-id", "version-1",
+			"--include", include,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var payload struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v; stdout=%q", err, stdout)
+	}
+	if payload.Data.ID != "version-1" {
+		t.Fatalf("version id = %q, want version-1", payload.Data.ID)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestVersionsReleaseTypeValidationBeforeAuth(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		prefix string
+	}{
+		{
+			name:   "create",
+			args:   []string{"versions", "create", "--app", "app-1", "--version", "1.0", "--release-type", "INVALID"},
+			prefix: "versions create",
+		},
+		{
+			name:   "update",
+			args:   []string{"versions", "update", "--version-id", "version-1", "--release-type", "INVALID"},
+			prefix: "versions update",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearASCAuth(t)
+			stdout, stderr := captureOutput(t, func() {
+				code := rootcmd.Run(test.args, "test")
+				if code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			want := "Error: " + test.prefix + ": --release-type must be one of: " + releaseTypeValues
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
+			}
+			if strings.Contains(stderr, "missing authentication") {
+				t.Fatalf("stderr = %q, validation must run before auth", stderr)
+			}
+		})
+	}
+}
+
+func TestVersionsReleaseTypePayloads(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		method     string
+		path       string
+		responseID string
+	}{
+		{
+			name:       "create",
+			args:       []string{"versions", "create", "--app", "app-1", "--version", "2.0", "--release-type", "scheduled", "--output", "json"},
+			method:     http.MethodPost,
+			path:       "/v1/appStoreVersions",
+			responseID: "version-new",
+		},
+		{
+			name:       "update",
+			args:       []string{"versions", "update", "--version-id", "version-1", "--release-type", "scheduled", "--output", "json"},
+			method:     http.MethodPatch,
+			path:       "/v1/appStoreVersions/version-1",
+			responseID: "version-1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != test.method || req.URL.Path != test.path {
+					t.Fatalf("request = %s %s, want %s %s", req.Method, req.URL.Path, test.method, test.path)
+				}
+				var request struct {
+					Data struct {
+						Attributes map[string]any `json:"attributes"`
+					} `json:"data"`
+				}
+				if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				if got := request.Data.Attributes["releaseType"]; got != "SCHEDULED" {
+					t.Fatalf("releaseType = %#v, want SCHEDULED", got)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"data":{"type":"appStoreVersions","id":"`+test.responseID+`","attributes":{"versionString":"2.0","platform":"IOS"}}}`)
+			}))
+			t.Cleanup(server.Close)
+
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("parse server URL: %v", err)
+			}
+			installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				cloned := req.Clone(req.Context())
+				cloned.URL.Scheme = serverURL.Scheme
+				cloned.URL.Host = serverURL.Host
+				return server.Client().Transport.RoundTrip(cloned)
+			}))
+
+			root := RootCommand("test")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			var result struct {
+				ID string `json:"id"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("unmarshal stdout: %v; stdout=%q", err, stdout)
+			}
+			if result.ID != test.responseID {
+				t.Fatalf("response id = %q, want %q", result.ID, test.responseID)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/versions_contract_test.go
+++ b/internal/cli/cmdtest/versions_contract_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -146,9 +147,12 @@ func TestVersionsReleaseTypePayloads(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			setupAuth(t)
 			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			requestErr := make(chan error, 1)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if req.Method != test.method || req.URL.Path != test.path {
-					t.Fatalf("request = %s %s, want %s %s", req.Method, req.URL.Path, test.method, test.path)
+					requestErr <- fmt.Errorf("request = %s %s, want %s %s", req.Method, req.URL.Path, test.method, test.path)
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+					return
 				}
 				var request struct {
 					Data struct {
@@ -156,11 +160,16 @@ func TestVersionsReleaseTypePayloads(t *testing.T) {
 					} `json:"data"`
 				}
 				if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
-					t.Fatalf("decode request: %v", err)
+					requestErr <- fmt.Errorf("decode request: %w", err)
+					http.Error(w, "invalid request", http.StatusBadRequest)
+					return
 				}
 				if got := request.Data.Attributes["releaseType"]; got != "SCHEDULED" {
-					t.Fatalf("releaseType = %#v, want SCHEDULED", got)
+					requestErr <- fmt.Errorf("releaseType = %#v, want SCHEDULED", got)
+					http.Error(w, "invalid release type", http.StatusBadRequest)
+					return
 				}
+				requestErr <- nil
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = io.WriteString(w, `{"data":{"type":"appStoreVersions","id":"`+test.responseID+`","attributes":{"versionString":"2.0","platform":"IOS"}}}`)
 			}))
@@ -199,6 +208,9 @@ func TestVersionsReleaseTypePayloads(t *testing.T) {
 			}
 			if stderr != "" {
 				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+			if err := <-requestErr; err != nil {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/internal/cli/versions/include_helpers.go
+++ b/internal/cli/versions/include_helpers.go
@@ -9,14 +9,17 @@ func normalizeAppStoreVersionInclude(value string) ([]string, error) {
 func appStoreVersionIncludeList() []string {
 	return []string{
 		"ageRatingDeclaration",
+		"app",
+		"appStoreVersionLocalizations",
+		"build",
+		"appStoreVersionPhasedRelease",
+		"gameCenterAppVersion",
+		"routingAppCoverage",
 		"appStoreReviewDetail",
+		"appStoreVersionSubmission",
 		"appClipDefaultExperience",
 		"appStoreVersionExperiments",
 		"appStoreVersionExperimentsV2",
-		"appStoreVersionSubmission",
-		"customerReviews",
-		"routingAppCoverage",
 		"alternativeDistributionPackage",
-		"gameCenterAppVersion",
 	}
 }

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -589,7 +589,12 @@ func fetchOptionalBuild(ctx context.Context, versionID string, fetch func(contex
 }
 
 func normalizeAppStoreVersionReleaseType(value string) (string, error) {
-	normalized := strings.ToUpper(strings.TrimSpace(value))
+	trimmed := strings.TrimSpace(value)
+	if value != "" && trimmed == "" {
+		return "", fmt.Errorf("--release-type must be one of: MANUAL, AFTER_APPROVAL, SCHEDULED")
+	}
+
+	normalized := strings.ToUpper(trimmed)
 	switch normalized {
 	case "", "MANUAL", "AFTER_APPROVAL", "SCHEDULED":
 		return normalized, nil

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -330,6 +330,11 @@ Examples:
 				}
 			}
 
+			normalizedReleaseType, err := normalizeAppStoreVersionReleaseType(*releaseType)
+			if err != nil {
+				return shared.UsageErrorf("versions create: %v", err)
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("versions create: %w", err)
@@ -345,8 +350,8 @@ Examples:
 			if *copyright != "" {
 				attrs.Copyright = *copyright
 			}
-			if *releaseType != "" {
-				attrs.ReleaseType = strings.ToUpper(*releaseType)
+			if normalizedReleaseType != "" {
+				attrs.ReleaseType = normalizedReleaseType
 			}
 
 			resp, err := client.CreateAppStoreVersion(requestCtx, resolvedAppID, attrs)
@@ -417,8 +422,13 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
+			normalizedReleaseType, err := normalizeAppStoreVersionReleaseType(*releaseType)
+			if err != nil {
+				return shared.UsageErrorf("versions update: %v", err)
+			}
+
 			// Check that at least one update field is provided
-			if *copyright == "" && *releaseType == "" && *earliestReleaseDate == "" && *versionString == "" {
+			if *copyright == "" && normalizedReleaseType == "" && *earliestReleaseDate == "" && *versionString == "" {
 				fmt.Fprintln(os.Stderr, "Error: at least one of --copyright, --release-type, --earliest-release-date, or --version is required")
 				return shared.MissingRequiredUsageError()
 			}
@@ -435,9 +445,8 @@ Examples:
 			if *copyright != "" {
 				attrs.Copyright = copyright
 			}
-			if *releaseType != "" {
-				rt := strings.ToUpper(*releaseType)
-				attrs.ReleaseType = &rt
+			if normalizedReleaseType != "" {
+				attrs.ReleaseType = &normalizedReleaseType
 			}
 			if *earliestReleaseDate != "" {
 				attrs.EarliestReleaseDate = earliestReleaseDate
@@ -577,6 +586,16 @@ func fetchOptionalBuild(ctx context.Context, versionID string, fetch func(contex
 		return nil, err
 	}
 	return resp, nil
+}
+
+func normalizeAppStoreVersionReleaseType(value string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	switch normalized {
+	case "", "MANUAL", "AFTER_APPROVAL", "SCHEDULED":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("--release-type must be one of: MANUAL, AFTER_APPROVAL, SCHEDULED")
+	}
 }
 
 func fetchOptionalSubmission(ctx context.Context, versionID string, fetch func(context.Context, string) (*asc.AppStoreVersionSubmissionResourceResponse, error)) (*asc.AppStoreVersionSubmissionResourceResponse, error) {

--- a/internal/cli/versions/versions_test.go
+++ b/internal/cli/versions/versions_test.go
@@ -158,9 +158,13 @@ func TestNormalizeAppStoreVersionReleaseType(t *testing.T) {
 }
 
 func TestNormalizeAppStoreVersionReleaseTypeRejectsUnknown(t *testing.T) {
-	_, err := normalizeAppStoreVersionReleaseType("IMMEDIATE")
-	if err == nil || !strings.Contains(err.Error(), "--release-type must be one of: MANUAL, AFTER_APPROVAL, SCHEDULED") {
-		t.Fatalf("expected release type error, got %v", err)
+	for _, input := range []string{"IMMEDIATE", "   "} {
+		t.Run(input, func(t *testing.T) {
+			_, err := normalizeAppStoreVersionReleaseType(input)
+			if err == nil || !strings.Contains(err.Error(), "--release-type must be one of: MANUAL, AFTER_APPROVAL, SCHEDULED") {
+				t.Fatalf("expected release type error, got %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/versions/versions_test.go
+++ b/internal/cli/versions/versions_test.go
@@ -133,6 +133,37 @@ func TestSplitCompatAppStoreVersionIncludes(t *testing.T) {
 	}
 }
 
+func TestNormalizeAppStoreVersionReleaseType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: ""},
+		{input: "manual", want: "MANUAL"},
+		{input: "AFTER_APPROVAL", want: "AFTER_APPROVAL"},
+		{input: " scheduled ", want: "SCHEDULED"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			got, err := normalizeAppStoreVersionReleaseType(test.input)
+			if err != nil {
+				t.Fatalf("normalizeAppStoreVersionReleaseType() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("normalizeAppStoreVersionReleaseType() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeAppStoreVersionReleaseTypeRejectsUnknown(t *testing.T) {
+	_, err := normalizeAppStoreVersionReleaseType("IMMEDIATE")
+	if err == nil || !strings.Contains(err.Error(), "--release-type must be one of: MANUAL, AFTER_APPROVAL, SCHEDULED") {
+		t.Fatalf("expected release type error, got %v", err)
+	}
+}
+
 func TestAppendAgeRatingDeclarationInclude(t *testing.T) {
 	versionResp := &asc.AppStoreVersionResponse{
 		Data: asc.Resource[asc.AppStoreVersionAttributes]{


### PR DESCRIPTION
## Summary

- Match `versions view --include` to Apple's current `GET /v1/appStoreVersions/{id}` include enum.
- Remove the broken `customerReviews` compound include; version reviews remain available through `versions customer-reviews`, which calls the supported related-resource endpoint.
- Keep the `ageRatingDeclaration` compatibility flow that resolves through app info instead of sending an unsupported include.
- Validate `versions create/update --release-type` before auth and accept only `MANUAL`, `AFTER_APPROVAL`, or `SCHEDULED` (case-insensitive input).

## Why

PR #346 added `customerReviews` to the view allowlist while adding the separate customer-review relationship commands. Apple's OpenAPI did not list it as a compound include then, the current 4.4.1 schema still excludes it, and a live request returns HTTP 400: `The relationship 'customerReviews' cannot be included`. The same request succeeds through `GET /v1/appStoreVersions/{id}/customerReviews`.

The current Apple-generated Swift client reaches the same split: its [version-view include enum](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/651b56950c917d30d7aaa863baadd290f2e28cb7/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionsWithID.swift#L233-L246) excludes reviews, while its [version customer-reviews API](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/651b56950c917d30d7aaa863baadd290f2e28cb7/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionsWithIDCustomerReviews.swift#L7-L18) uses the dedicated endpoint.

PR #951 deliberately preserved `ageRatingDeclaration` after Apple removed the version-scoped age-rating paths. That compatibility branch stays intact and continues to use supported app-info endpoints.

Both App Store version create and update schemas define the same three release-type values. The CLI advertised them but previously uppercased and sent any string after resolving auth.

## Verification

- Added HTTP contract tests for the four previously omitted includes and exact POST/PATCH `releaseType` payloads.
- Added pre-auth usage-exit coverage for invalid create/update release types.
- Replaced the mock that sent `ageRatingDeclaration` as a direct version include.
- Ran `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`.
- Built the CLI and confirmed invalid release types exit 2 before auth.
- Live read-only checks returned HTTP 200 for `GET /v1/appStoreVersions/{id}?include=app,appStoreVersionLocalizations,build,appStoreVersionPhasedRelease` and for every GET in the age-rating compatibility chain. Every live request used GET; no resource changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788627291&installation_model_id=10418&pr_number=1874&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1874&signature=b06c041ad67d77416c0f8de5d55b6785a28fb8fc76f39294a43f10a480885482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App Store version details now support related app, localization, build, phased release, and submission information.
  * Version commands accept supported release types regardless of capitalization or surrounding whitespace.

* **Bug Fixes**
  * Invalid release types are rejected with clear usage errors before requests are submitted.
  * Scheduled release types are handled consistently when creating or updating versions.

* **Documentation**
  * Updated `versions view --include` documentation to reflect the available related resources.

* **Tests**
  * Expanded coverage for version requests, responses, output, and release-type validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
