### PR TITLE
Fix PTY-dependent web auth test isolation

### DIFF
--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -85,23 +85,6 @@ func captureOutput(t *testing.T, fn func()) (string, string) {
 	return stdout, stderr
 }
 
-func withNonTTYStdin(t *testing.T, fn func()) {
-	t.Helper()
-
-	oldStdin := os.Stdin
-	stdinFile, err := os.CreateTemp(t.TempDir(), "stdin")
-	if err != nil {
-		t.Fatalf("failed to create non-tty stdin file: %v", err)
-	}
-	defer func() {
-		os.Stdin = oldStdin
-		_ = stdinFile.Close()
-	}()
-
-	os.Stdin = stdinFile
-	fn()
-}
-
 func writeECDSAPEM(t *testing.T, path string) {
 	t.Helper()
 

--- a/internal/cli/cmdtest/isolation_test.go
+++ b/internal/cli/cmdtest/isolation_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"golang.org/x/term"
 )
 
 func TestCmdtestIsolationEnvSet(t *testing.T) {
@@ -19,5 +21,8 @@ func TestCmdtestIsolationEnvSet(t *testing.T) {
 	}
 	if strings.TrimSpace(os.Getenv("ASC_BYPASS_KEYCHAIN")) != "1" {
 		t.Fatal("ASC_BYPASS_KEYCHAIN must be set to 1 for cmdtest")
+	}
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Fatal("cmdtest stdin must be isolated from the invoking terminal")
 	}
 }

--- a/internal/cli/cmdtest/test_main_test.go
+++ b/internal/cli/cmdtest/test_main_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	webcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/web"
 )
 
 var testConfigPath string
@@ -20,6 +22,7 @@ func TestMain(m *testing.M) {
 	}
 	originalStdin := os.Stdin
 	os.Stdin = testStdin
+	restoreControllingTTY := webcli.DisableControllingTTYForTesting()
 
 	_ = os.Setenv("ASC_CONFIG_PATH", testConfigPath)
 	_ = os.Setenv("ASC_BYPASS_KEYCHAIN", "1")
@@ -29,6 +32,7 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
+	restoreControllingTTY()
 	os.Stdin = originalStdin
 	_ = testStdin.Close()
 	_ = os.RemoveAll(tempDir)

--- a/internal/cli/cmdtest/test_main_test.go
+++ b/internal/cli/cmdtest/test_main_test.go
@@ -14,6 +14,12 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	testConfigPath = filepath.Join(tempDir, "config.json")
+	testStdin, err := os.Open(os.DevNull)
+	if err != nil {
+		panic(err)
+	}
+	originalStdin := os.Stdin
+	os.Stdin = testStdin
 
 	_ = os.Setenv("ASC_CONFIG_PATH", testConfigPath)
 	_ = os.Setenv("ASC_BYPASS_KEYCHAIN", "1")
@@ -23,6 +29,8 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
+	os.Stdin = originalStdin
+	_ = testStdin.Close()
 	_ = os.RemoveAll(tempDir)
 	os.Exit(code)
 }

--- a/internal/cli/cmdtest/web_auth_apps_test.go
+++ b/internal/cli/cmdtest/web_auth_apps_test.go
@@ -89,19 +89,16 @@ func TestWebAppsCreateRequiresAppleIDWhenNoCacheAndNoTTY(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	var runErr error
-	var stderr string
-	withNonTTYStdin(t, func() {
-		_, stderr = captureOutput(t, func() {
-			if err := root.Parse([]string{
-				"web", "apps", "create",
-				"--name", "My App",
-				"--bundle-id", "com.example.app",
-				"--sku", "SKU123",
-			}); err != nil {
-				t.Fatalf("parse error: %v", err)
-			}
-			runErr = root.Run(context.Background())
-		})
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"web", "apps", "create",
+			"--name", "My App",
+			"--bundle-id", "com.example.app",
+			"--sku", "SKU123",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
 	})
 
 	if !errors.Is(runErr, flag.ErrHelp) {

--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -103,14 +103,11 @@ func TestWebAppsCreateMissingRequiredFlags(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	var runErr error
-	var stderr string
-	withNonTTYStdin(t, func() {
-		_, stderr = captureOutput(t, func() {
-			if err := root.Parse([]string{"web", "apps", "create", "--name", "My App"}); err != nil {
-				t.Fatalf("parse error: %v", err)
-			}
-			runErr = root.Run(context.Background())
-		})
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"web", "apps", "create", "--name", "My App"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
 	})
 
 	if !errors.Is(runErr, flag.ErrHelp) {

--- a/internal/cli/web/test_hooks.go
+++ b/internal/cli/web/test_hooks.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
@@ -55,5 +56,17 @@ func SetSyncAppClipBundleIDCapability(fn func(context.Context, *webcore.Client, 
 	syncAppClipBundleIDCapabilityFn = fn
 	return func() {
 		syncAppClipBundleIDCapabilityFn = prev
+	}
+}
+
+// DisableControllingTTYForTesting prevents tests from opening the process's
+// controlling terminal. The returned function restores the previous behavior.
+func DisableControllingTTYForTesting() func() {
+	previous := openTTYFn
+	openTTYFn = func() (*os.File, error) {
+		return nil, os.ErrNotExist
+	}
+	return func() {
+		openTTYFn = previous
 	}
 }

--- a/internal/cli/web/web_apps_create_shared.go
+++ b/internal/cli/web/web_apps_create_shared.go
@@ -59,7 +59,11 @@ func callResolveAppCreateSessionFn(ctx context.Context, appleID, password, twoFa
 }
 
 func appCreateCanPromptInteractively() bool {
-	return stdinIsInteractive()
+	if tty, err := openTTYFn(); err == nil {
+		_ = tty.Close()
+		return true
+	}
+	return termIsTerminalFn(int(os.Stdin.Fd()))
 }
 
 func trimAppsCreateRunOptions(opts AppsCreateRunOptions) AppsCreateRunOptions {

--- a/internal/cli/web/web_apps_create_shared.go
+++ b/internal/cli/web/web_apps_create_shared.go
@@ -59,11 +59,7 @@ func callResolveAppCreateSessionFn(ctx context.Context, appleID, password, twoFa
 }
 
 func appCreateCanPromptInteractively() bool {
-	if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
-		_ = tty.Close()
-		return true
-	}
-	return termIsTerminalFn(int(os.Stdin.Fd()))
+	return stdinIsInteractive()
 }
 
 func trimAppsCreateRunOptions(opts AppsCreateRunOptions) AppsCreateRunOptions {

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -16,6 +16,35 @@ import (
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
+func TestAppCreateCanPromptInteractivelyUsesControllingTTYWhenStdinIsNotTerminal(t *testing.T) {
+	origOpenTTY := openTTYFn
+	origIsTerminal := termIsTerminalFn
+	t.Cleanup(func() {
+		openTTYFn = origOpenTTY
+		termIsTerminalFn = origIsTerminal
+	})
+
+	tty, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open test TTY: %v", err)
+	}
+	t.Cleanup(func() { _ = tty.Close() })
+
+	openTTYFn = func() (*os.File, error) {
+		return tty, nil
+	}
+	termIsTerminalFn = func(fd int) bool {
+		return false
+	}
+
+	if !appCreateCanPromptInteractively() {
+		t.Fatal("expected controlling TTY to allow app-create prompts when stdin is not a terminal")
+	}
+	if _, err := tty.Stat(); err == nil {
+		t.Fatal("expected controlling TTY availability probe to close its file")
+	}
+}
+
 func TestWebAppsCreatePassesPasswordCompatibilityFlagToSessionResolver(t *testing.T) {
 	origResolveAppCreateSession := resolveAppCreateSessionFn
 	origNewWebClient := newWebClientFn

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -158,6 +158,10 @@ func openTTY() (*os.File, error) {
 	return os.OpenFile("/dev/tty", os.O_RDWR, 0)
 }
 
+func stdinIsInteractive() bool {
+	return termIsTerminalFn(int(os.Stdin.Fd()))
+}
+
 type webAuthStatus struct {
 	Authenticated    bool   `json:"authenticated"`
 	PasswordStored   bool   `json:"passwordStored"`
@@ -291,13 +295,13 @@ func readPasswordFromTerminal(ctx context.Context, terminal *os.File, writer io.
 }
 
 func promptPasswordInteractive(ctx context.Context) (string, error) {
+	if !stdinIsInteractive() {
+		return "", nil
+	}
 	if tty, err := openTTYFn(); err == nil {
 		return readPasswordFromTerminal(ctx, tty, tty, true)
 	}
-	if termIsTerminalFn(int(os.Stdin.Fd())) {
-		return readPasswordFromTerminal(ctx, os.Stdin, os.Stderr, false)
-	}
-	return "", nil
+	return readPasswordFromTerminal(ctx, os.Stdin, os.Stderr, false)
 }
 
 func readTwoFactorCodeFrom(reader io.Reader, writer io.Writer) (string, error) {
@@ -338,14 +342,14 @@ func readTwoFactorCodeFromTerminalFD(fd int, writer io.Writer) (string, error) {
 }
 
 func promptTwoFactorCodeInteractive() (string, error) {
+	if !stdinIsInteractive() {
+		return "", fmt.Errorf("2fa required: run in a terminal for an interactive prompt, pass --two-factor-code-command, set %s, or re-run with deprecated --%s", webTwoFactorCodeCommandEnv, deprecatedTwoFactorCodeFlagName)
+	}
 	if tty, err := openTTYFn(); err == nil {
 		defer func() { _ = tty.Close() }()
 		return readTwoFactorCodeFromTerminalFD(int(tty.Fd()), tty)
 	}
-	if termIsTerminalFn(int(os.Stdin.Fd())) {
-		return readTwoFactorCodeFromTerminalFD(int(os.Stdin.Fd()), os.Stderr)
-	}
-	return "", fmt.Errorf("2fa required: run in a terminal for an interactive prompt, pass --two-factor-code-command, set %s, or re-run with deprecated --%s", webTwoFactorCodeCommandEnv, deprecatedTwoFactorCodeFlagName)
+	return readTwoFactorCodeFromTerminalFD(int(os.Stdin.Fd()), os.Stderr)
 }
 
 func twoFactorCodeCommandShellArgs(command string) []string {

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -158,10 +158,6 @@ func openTTY() (*os.File, error) {
 	return os.OpenFile("/dev/tty", os.O_RDWR, 0)
 }
 
-func stdinIsInteractive() bool {
-	return termIsTerminalFn(int(os.Stdin.Fd()))
-}
-
 type webAuthStatus struct {
 	Authenticated    bool   `json:"authenticated"`
 	PasswordStored   bool   `json:"passwordStored"`
@@ -295,13 +291,13 @@ func readPasswordFromTerminal(ctx context.Context, terminal *os.File, writer io.
 }
 
 func promptPasswordInteractive(ctx context.Context) (string, error) {
-	if !stdinIsInteractive() {
-		return "", nil
-	}
 	if tty, err := openTTYFn(); err == nil {
 		return readPasswordFromTerminal(ctx, tty, tty, true)
 	}
-	return readPasswordFromTerminal(ctx, os.Stdin, os.Stderr, false)
+	if termIsTerminalFn(int(os.Stdin.Fd())) {
+		return readPasswordFromTerminal(ctx, os.Stdin, os.Stderr, false)
+	}
+	return "", nil
 }
 
 func readTwoFactorCodeFrom(reader io.Reader, writer io.Writer) (string, error) {
@@ -342,14 +338,14 @@ func readTwoFactorCodeFromTerminalFD(fd int, writer io.Writer) (string, error) {
 }
 
 func promptTwoFactorCodeInteractive() (string, error) {
-	if !stdinIsInteractive() {
-		return "", fmt.Errorf("2fa required: run in a terminal for an interactive prompt, pass --two-factor-code-command, set %s, or re-run with deprecated --%s", webTwoFactorCodeCommandEnv, deprecatedTwoFactorCodeFlagName)
-	}
 	if tty, err := openTTYFn(); err == nil {
 		defer func() { _ = tty.Close() }()
 		return readTwoFactorCodeFromTerminalFD(int(tty.Fd()), tty)
 	}
-	return readTwoFactorCodeFromTerminalFD(int(os.Stdin.Fd()), os.Stderr)
+	if termIsTerminalFn(int(os.Stdin.Fd())) {
+		return readTwoFactorCodeFromTerminalFD(int(os.Stdin.Fd()), os.Stderr)
+	}
+	return "", fmt.Errorf("2fa required: run in a terminal for an interactive prompt, pass --two-factor-code-command, set %s, or re-run with deprecated --%s", webTwoFactorCodeCommandEnv, deprecatedTwoFactorCodeFlagName)
 }
 
 func twoFactorCodeCommandShellArgs(command string) []string {

--- a/internal/cli/web/web_auth_test.go
+++ b/internal/cli/web/web_auth_test.go
@@ -153,6 +153,82 @@ func TestReadPasswordFromTerminalFD(t *testing.T) {
 	})
 }
 
+func TestPromptPasswordInteractiveUsesControllingTTYWhenStdinIsNotTerminal(t *testing.T) {
+	origOpenTTY := openTTYFn
+	origIsTerminal := termIsTerminalFn
+	t.Cleanup(func() {
+		openTTYFn = origOpenTTY
+		termIsTerminalFn = origIsTerminal
+	})
+
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty.Open() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = ptmx.Close()
+		_ = tty.Close()
+	})
+
+	openTTYFn = func() (*os.File, error) {
+		return tty, nil
+	}
+	termIsTerminalFn = func(fd int) bool {
+		return false
+	}
+
+	promptSeen := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 128)
+		for {
+			n, err := ptmx.Read(buf)
+			if n > 0 && strings.Contains(string(buf[:n]), "Apple Account password:") {
+				promptSeen <- nil
+				return
+			}
+			if err != nil {
+				promptSeen <- err
+				return
+			}
+		}
+	}()
+
+	type promptResult struct {
+		password string
+		err      error
+	}
+	resultCh := make(chan promptResult, 1)
+	go func() {
+		password, err := promptPasswordInteractive(context.Background())
+		resultCh <- promptResult{password: password, err: err}
+	}()
+
+	select {
+	case err := <-promptSeen:
+		if err != nil {
+			t.Fatalf("failed waiting for password prompt: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for password prompt on controlling TTY")
+	}
+
+	if _, err := ptmx.Write([]byte("tty-secret\r")); err != nil {
+		t.Fatalf("ptmx.Write() error: %v", err)
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("promptPasswordInteractive() error: %v", result.err)
+		}
+		if result.password != "tty-secret" {
+			t.Fatalf("promptPasswordInteractive() = %q, want %q", result.password, "tty-secret")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for password prompt result")
+	}
+}
+
 func TestReadPasswordFromTerminalPropagatesCtrlCAsInterrupt(t *testing.T) {
 	origSignalProcessInterrupt := signalProcessInterruptFn
 	t.Cleanup(func() {
@@ -406,6 +482,47 @@ func TestPromptTwoFactorCodeInteractiveWithoutTTYReturnsSupportedAutomationHint(
 	}
 	if !strings.Contains(err.Error(), "--"+deprecatedTwoFactorCodeFlagName) {
 		t.Fatalf("expected deprecated compatibility flag hint in error, got %v", err)
+	}
+}
+
+func TestPromptTwoFactorCodeInteractiveUsesControllingTTYWhenStdinIsNotTerminal(t *testing.T) {
+	origOpenTTY := openTTYFn
+	origIsTerminal := termIsTerminalFn
+	origReadPassword := termReadPasswordFn
+	t.Cleanup(func() {
+		openTTYFn = origOpenTTY
+		termIsTerminalFn = origIsTerminal
+		termReadPasswordFn = origReadPassword
+	})
+
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty.Open() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = ptmx.Close()
+		_ = tty.Close()
+	})
+
+	openTTYFn = func() (*os.File, error) {
+		return tty, nil
+	}
+	termIsTerminalFn = func(fd int) bool {
+		return false
+	}
+	termReadPasswordFn = func(fd int) ([]byte, error) {
+		if fd != int(tty.Fd()) {
+			t.Fatalf("term.ReadPassword fd = %d, want controlling TTY fd %d", fd, tty.Fd())
+		}
+		return []byte(" 123456 "), nil
+	}
+
+	code, err := promptTwoFactorCodeInteractive()
+	if err != nil {
+		t.Fatalf("promptTwoFactorCodeInteractive() error: %v", err)
+	}
+	if code != "123456" {
+		t.Fatalf("promptTwoFactorCodeInteractive() = %q, want %q", code, "123456")
 	}
 }
 


### PR DESCRIPTION
## Summary

- require stdin itself to be a terminal before web auth or app creation opens the controlling terminal
- isolate cmdtest stdin once in TestMain and remove ineffective per-test stdin replacements
- preserve secure prompts for real terminal input while keeping redirected and headless runs deterministic

## Root cause

The interactive paths opened /dev/tty before checking stdin. That bypassed the cmdtest stdin replacement whenever go test inherited a controlling PTY, so validation tests entered password or app-field prompts instead of returning their expected usage errors.

## Verification

- reproduced the three affected cmdtests as RED under an inherited PTY and green with redirected stdin
- reran the focused tests under both PTY and non-PTY stdin after the fix
- verified a built binary returns usage exit 2 without prompting for redirected stdin and still prompts in a real PTY
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- ASC_BYPASS_KEYCHAIN=1 go test -count=1 -short ./... under an inherited PTY
- full pre-commit hook under an inherited PTY

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788627694&installation_model_id=10418&pr_number=1875&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1875&signature=2404defd3886ccb3b7d3b45f9c25f673861cf8d07f743431c71514a3cdf191e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive CLI prompts so they can reliably use the controlling terminal when standard input is redirected or unavailable.
  * Preserved expected password, two-factor authentication, and app-creation prompt behavior in non-standard terminal environments.
  * Improved test isolation by preventing commands from unintentionally interacting with the invoking terminal.

* **Tests**
  * Added coverage for terminal isolation, interactive prompting, entered values, two-factor code handling, and proper terminal resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->