### PR TITLE
fix(testflight): preserve feedback fields with screenshots

### DIFF
--- a/docs/design/testflight-feedback-screenshot-fieldset.md
+++ b/docs/design/testflight-feedback-screenshot-fieldset.md
@@ -48,15 +48,9 @@ notes](https://developer.apple.com/documentation/appstoreconnectapi/app-store-co
 The current official OpenAPI download is byte-for-byte identical to the
 repository snapshot.
 
-Actively maintained tooling corroborates the workflow. Expo's current
-[`eas-cli` TestFlight
-implementation](https://github.com/expo/eas-cli/blob/42cf2cb997f2ba0d754044ebd0ea2a916a3688b6/packages/eas-cli/src/testflight/fetch.ts)
-fetches beta feedback screenshot submissions and maps each screenshot's URL,
-dimensions, and expiration date. The maintained [AppStoreConnect Swift
+The maintained [AppStoreConnect Swift
 SDK](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/651b56950c917d30d7aaa863baadd290f2e28cb7/Sources/OpenAPI/Generated/Paths/PathsV1AppsWithIDBetaFeedbackScreenshotSubmissions.swift)
-exposes this exact GET operation and the complete documented field enum.
-Fastlane's current source does not implement this resource, but it provides no
-contrary contract evidence.
+defines this exact GET operation and the complete documented field enum.
 
 The flag originated in PR #20, which used all seven feedback attributes modeled
 at that time plus `screenshots`. A later model expansion added 13 documented

--- a/docs/design/testflight-feedback-screenshot-fieldset.md
+++ b/docs/design/testflight-feedback-screenshot-fieldset.md
@@ -63,13 +63,15 @@ command regression tests.
 
 ## Behavior and compatibility
 
-JSON remains the default output; table and Markdown keep their existing
-conditional Screenshots column. Data stays on stdout, diagnostics stay on
-stderr, and existing success and usage exit codes are unchanged. The fix is
-backward-compatible and additive: it restores the 13 feedback attributes that
-the current eight-name sparse fieldset suppresses while preserving screenshots
-and requested relationships. No lifecycle, migration, or deprecation change is
-required.
+Output selection remains TTY-aware: explicit `--output` wins,
+`ASC_DEFAULT_OUTPUT` otherwise pins the default, and without either setting
+interactive terminals use table while pipes and CI use minified JSON. Table and
+Markdown keep their existing conditional Screenshots column. Data stays on
+stdout, diagnostics stay on stderr, and existing success and usage exit codes
+are unchanged. The fix is backward-compatible and additive: it restores the 13
+feedback attributes that the current eight-name sparse fieldset suppresses
+while preserving screenshots and requested relationships. No lifecycle,
+migration, or deprecation change is required.
 
 ## Verification
 

--- a/docs/design/testflight-feedback-screenshot-fieldset.md
+++ b/docs/design/testflight-feedback-screenshot-fieldset.md
@@ -1,0 +1,100 @@
+# TestFlight feedback screenshot fieldset
+
+## Placement and command shape
+
+The change stays in the existing `asc testflight feedback list` command and its
+shared `internal/cli/feedback` implementation. The public invocation remains:
+
+```sh
+asc testflight feedback list --app "APP_ID" --include-screenshots
+```
+
+Current help describes `--include-screenshots` as including screenshot URLs in
+feedback output. No command, flag, registry, help, or generated-command-doc
+change is needed.
+
+## API contract
+
+The command performs `GET /v1/apps/{id}/betaFeedbackScreenshotSubmissions`.
+The App Store Connect 4.4.1
+OpenAPI operation accepts filters for device, platform, build, pre-release
+version, and tester; `sort`; sparse fields; `limit`; and `include=build,tester`.
+Its `200` response is `BetaFeedbackScreenshotSubmissionsResponse`, containing
+`BetaFeedbackScreenshotSubmission` resources and optional included builds or
+beta testers.
+
+`screenshots` is an attribute selectable through
+`fields[betaFeedbackScreenshotSubmissions]`, not an included relationship. When
+the flag is enabled, the fieldset must contain all 20 regular feedback
+attributes plus `screenshots` and both relationship fields:
+
+```text
+createdDate,comment,email,deviceModel,osVersion,locale,timeZone,architecture,connectionType,pairedAppleWatch,appUptimeInMilliseconds,diskBytesAvailable,diskBytesTotal,batteryPercentage,screenWidthInPoints,screenHeightInPoints,appPlatform,devicePlatform,deviceFamily,buildBundleId,screenshots,build,tester
+```
+
+The `build` and `tester` field names preserve relationship linkages on the
+primary feedback resources. If `--include build`, `--include tester`, or both
+are also present, the separate `include` query asks Apple to return those
+related resources as compound `included` data.
+
+## Support and history evidence
+
+Apple's current [endpoint
+documentation](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-apps-_id_-betafeedbackscreenshotsubmissions)
+describes this GET workflow and lists `screenshots` among the supported sparse
+fields. Apple introduced TestFlight feedback screenshot retrieval in the
+[App Store Connect API 4.0 release
+notes](https://developer.apple.com/documentation/appstoreconnectapi/app-store-connect-api-4-0-release-notes).
+The current official OpenAPI download is byte-for-byte identical to the
+repository snapshot.
+
+Actively maintained tooling corroborates the workflow. Expo's current
+[`eas-cli` TestFlight
+implementation](https://github.com/expo/eas-cli/blob/42cf2cb997f2ba0d754044ebd0ea2a916a3688b6/packages/eas-cli/src/testflight/fetch.ts)
+fetches beta feedback screenshot submissions and maps each screenshot's URL,
+dimensions, and expiration date. The maintained [AppStoreConnect Swift
+SDK](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/651b56950c917d30d7aaa863baadd290f2e28cb7/Sources/OpenAPI/Generated/Paths/PathsV1AppsWithIDBetaFeedbackScreenshotSubmissions.swift)
+exposes this exact GET operation and the complete documented field enum.
+Fastlane's current source does not implement this resource, but it provides no
+contrary contract evidence.
+
+The flag originated in PR #20, which used all seven feedback attributes modeled
+at that time plus `screenshots`. A later model expansion added 13 documented
+attributes without updating the sparse fieldset or its mock. Neither PR history
+nor review discussion indicates that discarding those attributes was intended.
+Live read-only GETs against an explicit disposable app ID returned HTTP 200 with
+and without the current screenshot fieldset; the app had no feedback rows, so
+response-field preservation remains covered deterministically by HTTP and
+command regression tests.
+
+## Behavior and compatibility
+
+JSON remains the default output; table and Markdown keep their existing
+conditional Screenshots column. Data stays on stdout, diagnostics stay on
+stderr, and existing success and usage exit codes are unchanged. The fix is
+backward-compatible and additive: it restores the 13 feedback attributes that
+the current eight-name sparse fieldset suppresses while preserving screenshots
+and requested relationships. No lifecycle, migration, or deprecation change is
+required.
+
+## Verification
+
+RED coverage will assert the exact method, path, and complete query fieldset at
+the query-builder, HTTP-client, and canonical command levels. The mocked
+response will contain every feedback attribute plus a screenshot, and the
+command test will prove JSON retains representative restored fields and the
+screenshot. Focused tests will be followed by a built-binary check, read-only
+live requests with explicit app ID and file-backed authentication, and the full
+format, docs, lint, and test gates.
+
+Edge cases include combining screenshots with build/tester includes, empty
+feedback collections, and pagination through Apple's `links.next` URL. API
+errors continue through the existing client error path.
+
+## Alternatives
+
+Omitting the sparse fieldset would avoid suppressing normal attributes, but it
+does not explicitly request the opt-in screenshot data and would undo the
+flag's purpose. Requesting only `screenshots` is even more destructive. Sending
+the complete documented attribute fieldset is explicit, additive, and keeps
+the existing public contract intact.

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -3939,18 +3939,58 @@ func TestGetFeedback_BuildsQuery(t *testing.T) {
 }
 
 func TestGetFeedback_IncludesScreenshots(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"1","attributes":{"createdDate":"2026-01-20T00:00:00Z","comment":"Nice","email":"tester@example.com","screenshots":[{"url":"https://example.com/shot.png","width":320,"height":640,"expirationDate":"2026-01-21T00:00:00Z"}]}}]}`)
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"1","attributes":{"createdDate":"2026-01-20T00:00:00Z","comment":"Nice","email":"tester@example.com","deviceModel":"iPhone17,1","osVersion":"18.0","locale":"en-US","timeZone":"America/Los_Angeles","architecture":"arm64","connectionType":"WIFI","pairedAppleWatch":"Watch7,1","appUptimeInMilliseconds":1234,"diskBytesAvailable":2000,"diskBytesTotal":4000,"batteryPercentage":85,"screenWidthInPoints":430,"screenHeightInPoints":932,"appPlatform":"IOS","devicePlatform":"IOS","deviceFamily":"IPHONE","buildBundleId":"com.example.app","screenshots":[{"url":"https://example.com/shot.png","width":320,"height":640,"expirationDate":"2026-01-21T00:00:00Z"}]},"relationships":{"build":{"data":{"type":"builds","id":"build-1"}},"tester":{"data":{"type":"betaTesters","id":"tester-1"}}}}]}`)
 	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaFeedbackScreenshotSubmissions" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
 		values := req.URL.Query()
-		expected := "createdDate,comment,email,deviceModel,osVersion,appPlatform,devicePlatform,screenshots"
+		if len(values) != 1 {
+			t.Fatalf("expected only the feedback sparse fieldset, got %q", values.Encode())
+		}
+		expected := "createdDate,comment,email,deviceModel,osVersion,locale,timeZone,architecture,connectionType,pairedAppleWatch,appUptimeInMilliseconds,diskBytesAvailable,diskBytesTotal,batteryPercentage,screenWidthInPoints,screenHeightInPoints,appPlatform,devicePlatform,deviceFamily,buildBundleId,screenshots,build,tester"
 		if values.Get("fields[betaFeedbackScreenshotSubmissions]") != expected {
 			t.Fatalf("expected screenshot fields, got %q", values.Get("fields[betaFeedbackScreenshotSubmissions]"))
 		}
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetFeedback(context.Background(), "123", WithFeedbackIncludeScreenshots()); err != nil {
+	feedback, err := client.GetFeedback(context.Background(), "123", WithFeedbackIncludeScreenshots())
+	if err != nil {
 		t.Fatalf("GetFeedback() error: %v", err)
+	}
+	if len(feedback.Data) != 1 {
+		t.Fatalf("feedback count = %d, want 1", len(feedback.Data))
+	}
+	attributes := feedback.Data[0].Attributes
+	if attributes.Locale != "en-US" || attributes.TimeZone != "America/Los_Angeles" || attributes.Architecture != "arm64" {
+		t.Fatalf("environment attributes were not decoded: %+v", attributes)
+	}
+	if attributes.ConnectionType != DeviceConnectionType("WIFI") || attributes.PairedAppleWatch != "Watch7,1" {
+		t.Fatalf("device attributes were not decoded: %+v", attributes)
+	}
+	if attributes.AppUptimeInMilliseconds != 1234 || attributes.DiskBytesAvailable != 2000 || attributes.DiskBytesTotal != 4000 {
+		t.Fatalf("runtime attributes were not decoded: %+v", attributes)
+	}
+	if attributes.BatteryPercentage != 85 || attributes.ScreenWidthInPoints != 430 || attributes.ScreenHeightInPoints != 932 {
+		t.Fatalf("screen and battery attributes were not decoded: %+v", attributes)
+	}
+	if attributes.DeviceFamily != DeviceFamily("IPHONE") || attributes.BuildBundleID != "com.example.app" {
+		t.Fatalf("family and bundle attributes were not decoded: %+v", attributes)
+	}
+	if len(attributes.Screenshots) != 1 || attributes.Screenshots[0].URL != "https://example.com/shot.png" {
+		t.Fatalf("screenshots were not decoded: %+v", attributes.Screenshots)
+	}
+	var relationships map[string]struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(feedback.Data[0].Relationships, &relationships); err != nil {
+		t.Fatalf("failed to decode relationships: %v", err)
+	}
+	if relationships["build"].Data.ID != "build-1" || relationships["tester"].Data.ID != "tester-1" {
+		t.Fatalf("relationships were not preserved: %+v", relationships)
 	}
 }
 

--- a/internal/asc/client_query_testflight.go
+++ b/internal/asc/client_query_testflight.go
@@ -107,15 +107,30 @@ func buildFeedbackQuery(query *feedbackQuery) string {
 			"email",
 			"deviceModel",
 			"osVersion",
+			"locale",
+			"timeZone",
+			"architecture",
+			"connectionType",
+			"pairedAppleWatch",
+			"appUptimeInMilliseconds",
+			"diskBytesAvailable",
+			"diskBytesTotal",
+			"batteryPercentage",
+			"screenWidthInPoints",
+			"screenHeightInPoints",
 			"appPlatform",
 			"devicePlatform",
+			"deviceFamily",
+			"buildBundleId",
 			"screenshots",
+			"build",
+			"tester",
 		}
 		// A sparse fieldset omits any field not listed, including relationship
-		// fields. If the caller also requested relationships via include, those
-		// relationship names must be present here or ASC will not return the
-		// linked resources. `build`/`tester` are valid screenshot submission
-		// fields, so append whatever was included.
+		// fields. Keep build and tester above even when the caller did not ask
+		// for compound resources via include, so enabling screenshots does not
+		// suppress the primary resources' relationship linkages. Also append any
+		// included relationship defensively if this endpoint gains another one.
 		for _, rel := range normalizeList(query.include) {
 			if !slices.Contains(fields, rel) {
 				fields = append(fields, rel)

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -133,7 +133,7 @@ func TestBuildFeedbackQuery_IncludesScreenshots(t *testing.T) {
 		t.Fatalf("failed to parse query: %v", err)
 	}
 
-	expected := "createdDate,comment,email,deviceModel,osVersion,appPlatform,devicePlatform,screenshots"
+	expected := "createdDate,comment,email,deviceModel,osVersion,locale,timeZone,architecture,connectionType,pairedAppleWatch,appUptimeInMilliseconds,diskBytesAvailable,diskBytesTotal,batteryPercentage,screenWidthInPoints,screenHeightInPoints,appPlatform,devicePlatform,deviceFamily,buildBundleId,screenshots,build,tester"
 	if got := values.Get("fields[betaFeedbackScreenshotSubmissions]"); got != expected {
 		t.Fatalf("expected fields to be %q, got %q", expected, got)
 	}

--- a/internal/cli/cmdtest/crashes_feedback_include_test.go
+++ b/internal/cli/cmdtest/crashes_feedback_include_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -14,6 +16,8 @@ import (
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
+
+const feedbackScreenshotFields = "createdDate,comment,email,deviceModel,osVersion,locale,timeZone,architecture,connectionType,pairedAppleWatch,appUptimeInMilliseconds,diskBytesAvailable,diskBytesTotal,batteryPercentage,screenWidthInPoints,screenHeightInPoints,appPlatform,devicePlatform,deviceFamily,buildBundleId,screenshots,build,tester"
 
 type betaSubmissionListOutput struct {
 	Data []struct {
@@ -36,6 +40,21 @@ func decodeBetaSubmissionListOutput(t *testing.T, stdout string) betaSubmissionL
 		t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, stdout)
 	}
 	return output
+}
+
+func installDefaultTransportForServer(t *testing.T, server *httptest.Server) {
+	t.Helper()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	}))
 }
 
 // okJSONResponse builds a 200 JSON response for the mock transport.
@@ -184,14 +203,30 @@ func TestFeedbackListIncludeScreenshotsPreservesAllFeedbackFields(t *testing.T) 
 	t.Setenv("ASC_APP_ID", "")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	var gotQuery url.Values
-	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	requestErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaFeedbackScreenshotSubmissions" {
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			requestErr <- fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
 		}
-		gotQuery = req.URL.Query()
-		return okJSONResponse(`{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"fb-1","attributes":{"createdDate":"2026-01-20T00:00:00Z","comment":"Nice","email":"tester@example.com","deviceModel":"iPhone17,1","osVersion":"18.0","locale":"en-US","timeZone":"America/Los_Angeles","architecture":"arm64","connectionType":"WIFI","pairedAppleWatch":"Watch7,1","appUptimeInMilliseconds":1234,"diskBytesAvailable":2000,"diskBytesTotal":4000,"batteryPercentage":85,"screenWidthInPoints":430,"screenHeightInPoints":932,"appPlatform":"IOS","devicePlatform":"IOS","deviceFamily":"IPHONE","buildBundleId":"com.example.app","screenshots":[{"url":"https://example.com/shot.png","width":320,"height":640,"expirationDate":"2026-01-21T00:00:00Z"}]},"relationships":{"build":{"data":{"type":"builds","id":"build-1"}},"tester":{"data":{"type":"betaTesters","id":"tester-1"}}}}]}`), nil
+		query := req.URL.Query()
+		if len(query) != 1 {
+			requestErr <- fmt.Errorf("expected only the feedback sparse fieldset, got %q", query.Encode())
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+			return
+		}
+		if got := query.Get("fields[betaFeedbackScreenshotSubmissions]"); got != feedbackScreenshotFields {
+			requestErr <- fmt.Errorf("feedback fieldset = %q, want %q", got, feedbackScreenshotFields)
+			http.Error(w, "unexpected fieldset", http.StatusBadRequest)
+			return
+		}
+		requestErr <- nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"fb-1","attributes":{"createdDate":"2026-01-20T00:00:00Z","comment":"Nice","email":"tester@example.com","deviceModel":"iPhone17,1","osVersion":"18.0","locale":"en-US","timeZone":"America/Los_Angeles","architecture":"arm64","connectionType":"WIFI","pairedAppleWatch":"Watch7,1","appUptimeInMilliseconds":1234,"diskBytesAvailable":2000,"diskBytesTotal":4000,"batteryPercentage":85,"screenWidthInPoints":430,"screenHeightInPoints":932,"appPlatform":"IOS","devicePlatform":"IOS","deviceFamily":"IPHONE","buildBundleId":"com.example.app","screenshots":[{"url":"https://example.com/shot.png","width":320,"height":640,"expirationDate":"2026-01-21T00:00:00Z"}]},"relationships":{"build":{"data":{"type":"builds","id":"build-1"}},"tester":{"data":{"type":"betaTesters","id":"tester-1"}}}}]}`)
 	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
 
 	var exitCode int
 	stdout, stderr := captureOutput(t, func() {
@@ -201,12 +236,8 @@ func TestFeedbackListIncludeScreenshotsPreservesAllFeedbackFields(t *testing.T) 
 	if exitCode != rootcmd.ExitSuccess {
 		t.Fatalf("exit code = %d, want %d; stderr: %s", exitCode, rootcmd.ExitSuccess, stderr)
 	}
-	if len(gotQuery) != 1 {
-		t.Fatalf("expected only the feedback sparse fieldset, got %q", gotQuery.Encode())
-	}
-	expectedFields := "createdDate,comment,email,deviceModel,osVersion,locale,timeZone,architecture,connectionType,pairedAppleWatch,appUptimeInMilliseconds,diskBytesAvailable,diskBytesTotal,batteryPercentage,screenWidthInPoints,screenHeightInPoints,appPlatform,devicePlatform,deviceFamily,buildBundleId,screenshots,build,tester"
-	if got := gotQuery.Get("fields[betaFeedbackScreenshotSubmissions]"); got != expectedFields {
-		t.Fatalf("feedback fieldset = %q, want %q", got, expectedFields)
+	if err := <-requestErr; err != nil {
+		t.Fatal(err)
 	}
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
@@ -242,6 +273,65 @@ func TestFeedbackListIncludeScreenshotsPreservesAllFeedbackFields(t *testing.T) 
 	}
 	if output.Data[0].Relationships["build"].Data.ID != "build-1" || output.Data[0].Relationships["tester"].Data.ID != "tester-1" {
 		t.Fatalf("JSON output omitted feedback relationships: %+v", output.Data[0].Relationships)
+	}
+}
+
+func TestFeedbackListIncludeScreenshotsWithIncludedRelationships(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	requestErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaFeedbackScreenshotSubmissions" {
+			requestErr <- fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		query := req.URL.Query()
+		if got := query.Get("include"); got != "build,tester" {
+			requestErr <- fmt.Errorf("include query = %q, want %q", got, "build,tester")
+			http.Error(w, "unexpected include", http.StatusBadRequest)
+			return
+		}
+		if got := query.Get("fields[betaFeedbackScreenshotSubmissions]"); got != feedbackScreenshotFields {
+			requestErr <- fmt.Errorf("feedback fieldset = %q, want %q", got, feedbackScreenshotFields)
+			http.Error(w, "unexpected fieldset", http.StatusBadRequest)
+			return
+		}
+		requestErr <- nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"fb-1","attributes":{"screenshots":[{"url":"https://example.com/shot.png","width":320,"height":640,"expirationDate":"2026-01-21T00:00:00Z"}]}}],"included":[{"type":"builds","id":"build-1","attributes":{"version":"1.0"}},{"type":"betaTesters","id":"tester-1","attributes":{"email":"tester@example.com"}}]}`)
+	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
+
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{"testflight", "feedback", "list", "--app", "123", "--include-screenshots", "--include", "build,tester", "--output", "json"}, "1.2.3")
+	})
+
+	if exitCode != rootcmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr: %s", exitCode, rootcmd.ExitSuccess, stderr)
+	}
+	if err := <-requestErr; err != nil {
+		t.Fatal(err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	output := decodeBetaSubmissionListOutput(t, stdout)
+	if len(output.Data) != 1 || output.Data[0].ID != "fb-1" {
+		t.Fatalf("unexpected feedback data: %+v", output.Data)
+	}
+	gotIncluded := make(map[string]bool, len(output.Included))
+	for _, resource := range output.Included {
+		gotIncluded[resource.Type+"/"+resource.ID] = true
+	}
+	for _, identity := range []string{"builds/build-1", "betaTesters/tester-1"} {
+		if !gotIncluded[identity] {
+			t.Fatalf("missing included resource %q: %+v", identity, output.Included)
+		}
 	}
 }
 

--- a/internal/cli/cmdtest/crashes_feedback_include_test.go
+++ b/internal/cli/cmdtest/crashes_feedback_include_test.go
@@ -184,17 +184,14 @@ func TestFeedbackListIncludeScreenshotsPreservesAllFeedbackFields(t *testing.T) 
 	t.Setenv("ASC_APP_ID", "")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
 	var gotQuery url.Values
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaFeedbackScreenshotSubmissions" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 		gotQuery = req.URL.Query()
 		return okJSONResponse(`{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"fb-1","attributes":{"createdDate":"2026-01-20T00:00:00Z","comment":"Nice","email":"tester@example.com","deviceModel":"iPhone17,1","osVersion":"18.0","locale":"en-US","timeZone":"America/Los_Angeles","architecture":"arm64","connectionType":"WIFI","pairedAppleWatch":"Watch7,1","appUptimeInMilliseconds":1234,"diskBytesAvailable":2000,"diskBytesTotal":4000,"batteryPercentage":85,"screenWidthInPoints":430,"screenHeightInPoints":932,"appPlatform":"IOS","devicePlatform":"IOS","deviceFamily":"IPHONE","buildBundleId":"com.example.app","screenshots":[{"url":"https://example.com/shot.png","width":320,"height":640,"expirationDate":"2026-01-21T00:00:00Z"}]},"relationships":{"build":{"data":{"type":"builds","id":"build-1"}},"tester":{"data":{"type":"betaTesters","id":"tester-1"}}}}]}`), nil
-	})
+	}))
 
 	var exitCode int
 	stdout, stderr := captureOutput(t, func() {

--- a/internal/cli/cmdtest/crashes_feedback_include_test.go
+++ b/internal/cli/cmdtest/crashes_feedback_include_test.go
@@ -271,6 +271,35 @@ func TestFeedbackListIncludeScreenshotsPreservesAllFeedbackFields(t *testing.T) 
 			t.Errorf("JSON output omitted feedback attribute %q", name)
 		}
 	}
+	for name, want := range map[string]any{
+		"createdDate":             "2026-01-20T00:00:00Z",
+		"comment":                 "Nice",
+		"appUptimeInMilliseconds": float64(1234),
+		"batteryPercentage":       float64(85),
+		"buildBundleId":           "com.example.app",
+	} {
+		if got := output.Data[0].Attributes[name]; got != want {
+			t.Errorf("feedback attribute %q = %#v, want %#v", name, got, want)
+		}
+	}
+	screenshots, ok := output.Data[0].Attributes["screenshots"].([]any)
+	if !ok || len(screenshots) != 1 {
+		t.Fatalf("feedback screenshots = %#v, want one screenshot", output.Data[0].Attributes["screenshots"])
+	}
+	screenshot, ok := screenshots[0].(map[string]any)
+	if !ok {
+		t.Fatalf("feedback screenshot = %#v, want an object", screenshots[0])
+	}
+	for name, want := range map[string]any{
+		"url":            "https://example.com/shot.png",
+		"width":          float64(320),
+		"height":         float64(640),
+		"expirationDate": "2026-01-21T00:00:00Z",
+	} {
+		if got := screenshot[name]; got != want {
+			t.Errorf("feedback screenshot %q = %#v, want %#v", name, got, want)
+		}
+	}
 	if output.Data[0].Relationships["build"].Data.ID != "build-1" || output.Data[0].Relationships["tester"].Data.ID != "tester-1" {
 		t.Fatalf("JSON output omitted feedback relationships: %+v", output.Data[0].Relationships)
 	}

--- a/internal/cli/cmdtest/crashes_feedback_include_test.go
+++ b/internal/cli/cmdtest/crashes_feedback_include_test.go
@@ -179,6 +179,75 @@ func TestFeedbackListIncludeBuildSendsBuildRelationship(t *testing.T) {
 	}
 }
 
+func TestFeedbackListIncludeScreenshotsPreservesAllFeedbackFields(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var gotQuery url.Values
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/123/betaFeedbackScreenshotSubmissions" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		gotQuery = req.URL.Query()
+		return okJSONResponse(`{"data":[{"type":"betaFeedbackScreenshotSubmissions","id":"fb-1","attributes":{"createdDate":"2026-01-20T00:00:00Z","comment":"Nice","email":"tester@example.com","deviceModel":"iPhone17,1","osVersion":"18.0","locale":"en-US","timeZone":"America/Los_Angeles","architecture":"arm64","connectionType":"WIFI","pairedAppleWatch":"Watch7,1","appUptimeInMilliseconds":1234,"diskBytesAvailable":2000,"diskBytesTotal":4000,"batteryPercentage":85,"screenWidthInPoints":430,"screenHeightInPoints":932,"appPlatform":"IOS","devicePlatform":"IOS","deviceFamily":"IPHONE","buildBundleId":"com.example.app","screenshots":[{"url":"https://example.com/shot.png","width":320,"height":640,"expirationDate":"2026-01-21T00:00:00Z"}]},"relationships":{"build":{"data":{"type":"builds","id":"build-1"}},"tester":{"data":{"type":"betaTesters","id":"tester-1"}}}}]}`), nil
+	})
+
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{"testflight", "feedback", "list", "--app", "123", "--include-screenshots", "--output", "json"}, "1.2.3")
+	})
+
+	if exitCode != rootcmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr: %s", exitCode, rootcmd.ExitSuccess, stderr)
+	}
+	if len(gotQuery) != 1 {
+		t.Fatalf("expected only the feedback sparse fieldset, got %q", gotQuery.Encode())
+	}
+	expectedFields := "createdDate,comment,email,deviceModel,osVersion,locale,timeZone,architecture,connectionType,pairedAppleWatch,appUptimeInMilliseconds,diskBytesAvailable,diskBytesTotal,batteryPercentage,screenWidthInPoints,screenHeightInPoints,appPlatform,devicePlatform,deviceFamily,buildBundleId,screenshots,build,tester"
+	if got := gotQuery.Get("fields[betaFeedbackScreenshotSubmissions]"); got != expectedFields {
+		t.Fatalf("feedback fieldset = %q, want %q", got, expectedFields)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var output struct {
+		Data []struct {
+			Attributes    map[string]any `json:"attributes"`
+			Relationships map[string]struct {
+				Data struct {
+					ID string `json:"id"`
+				} `json:"data"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, stdout)
+	}
+	if len(output.Data) != 1 {
+		t.Fatalf("feedback count = %d, want 1", len(output.Data))
+	}
+	expectedAttributeNames := []string{
+		"createdDate", "comment", "email", "deviceModel", "osVersion", "locale", "timeZone",
+		"architecture", "connectionType", "pairedAppleWatch", "appUptimeInMilliseconds",
+		"diskBytesAvailable", "diskBytesTotal", "batteryPercentage", "screenWidthInPoints",
+		"screenHeightInPoints", "appPlatform", "devicePlatform", "deviceFamily", "buildBundleId",
+		"screenshots",
+	}
+	for _, name := range expectedAttributeNames {
+		if _, ok := output.Data[0].Attributes[name]; !ok {
+			t.Errorf("JSON output omitted feedback attribute %q", name)
+		}
+	}
+	if output.Data[0].Relationships["build"].Data.ID != "build-1" || output.Data[0].Relationships["tester"].Data.ID != "tester-1" {
+		t.Fatalf("JSON output omitted feedback relationships: %+v", output.Data[0].Relationships)
+	}
+}
+
 func TestFeedbackListInvalidIncludeReturnsUsageError(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))


### PR DESCRIPTION
## Summary

- make `testflight feedback list --include-screenshots` request all 20 feedback attributes, screenshot data, and the `build`/`tester` relationship linkages
- retain the existing separate compound-resource behavior for `--include build,tester`
- cover the exact GET path/query and complete JSON response through query-builder, HTTP-client, and built command paths

## Why

PR #20 originally selected every feedback attribute modeled by the client at that time plus `screenshots`. A later model expansion added 13 documented attributes without updating that sparse fieldset, so enabling the flag caused Apple to omit them. Subsequent relationship support also exposed that sparse fieldsets must name `build` and `tester` to retain primary-resource linkages.

Apple's current public endpoint and OpenAPI continue to support this GET workflow and enumerate the complete 23-field set. The maintained AppStoreConnect Swift SDK independently defines the same public resource. There is no history or current contract evidence that the destructive field selection was intentional.

## Verification

- established RED tests showing the old eight-name fieldset
- built the CLI and issued a read-only GET with an explicit disposable app ID and file-backed authentication
  - method: `GET`
  - path: `/v1/apps/{id}/betaFeedbackScreenshotSubmissions`
  - query: exact 23-field `fields[betaFeedbackScreenshotSubmissions]` value
  - result: HTTP 200, exit 0, empty collection
  - mutation/body: none; no resource changed
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- intact pre-commit hooks: docs, format, lint, short tests

The live app had no feedback rows, so field preservation is proven deterministically by the exact HTTP and full-command response regressions; live verification proves Apple accepts the complete current query.

## Compatibility

This is additive. The command, flag, help, output modes, exit codes, and existing `--include` behavior are unchanged.

References: [Apple endpoint documentation](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-apps-_id_-betafeedbackscreenshotsubmissions), [original PR #20](https://github.com/rorkai/App-Store-Connect-CLI/pull/20)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788627925&installation_model_id=10418&pr_number=1876&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1876&signature=96ee3b4243c566d3c65034e7a0b4c535de2878e43e4644092a0ab4d5d70da2b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * `feedback list --include-screenshots` now returns complete feedback details, including device, environment, runtime, screen, battery, and app metadata.
  * Build and tester relationships are preserved in screenshot-inclusive results.
  * JSON output consistently includes all available feedback attributes and screenshot information.

* **Documentation**
  * Added guidance covering screenshot retrieval, supported options, response details, compatibility, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->