### PR TITLE
fix(bundle-ids): validate capability settings

### DIFF
--- a/commands/bundle-ids.mdx
+++ b/commands/bundle-ids.mdx
@@ -186,18 +186,20 @@ asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
 * `MULTIPATH` - Multipath networking
 * `NFC_TAG_READING` - NFC tag reading
 
-**Capabilities with schema-defined settings:**
+**Capabilities with settings documented in Apple's current schema:**
 
 * `ICLOUD` - iCloud (CloudKit/Documents)
 * `DATA_PROTECTION` - Data Protection
 * `APPLE_ID_AUTH` - Sign in with Apple consent
 
-The public API accepts only `ICLOUD_VERSION`,
-`DATA_PROTECTION_PERMISSION_LEVEL`, and `APPLE_ID_AUTH_APP_CONSENT` setting
-keys. Allowed option keys are `XCODE_5`, `XCODE_6`, `COMPLETE_PROTECTION`,
+The published schema lists `ICLOUD_VERSION`,
+`DATA_PROTECTION_PERMISSION_LEVEL`, and `APPLE_ID_AUTH_APP_CONSENT`, but Apple
+can return newer setting and option keys before they appear in that schema.
+`--settings` requires exact JSON field names and value types, then sends key
+strings and nonempty `allowedInstances` values unchanged. Current documented
+examples include `XCODE_5`, `XCODE_6`, `COMPLETE_PROTECTION`,
 `PROTECTED_UNLESS_OPEN`, `PROTECTED_UNTIL_FIRST_USER_AUTH`, and
-`PRIMARY_APP_CONSENT`. If supplied, `allowedInstances` must be `ENTRY`,
-`SINGLE`, or `MULTIPLE`. Other capabilities are enabled without `--settings`.
+`PRIMARY_APP_CONSENT`.
 
 ### iCloud Capability
 

--- a/commands/bundle-ids.mdx
+++ b/commands/bundle-ids.mdx
@@ -168,7 +168,7 @@ asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
 # Capability with settings (iCloud)
 asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
   --capability ICLOUD \
-  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'
+  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
 ```
 
 ### Common Capability Types
@@ -182,19 +182,22 @@ asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
 * `SIRIKIT` - SiriKit
 * `PERSONAL_VPN` - Personal VPN
 * `NETWORK_EXTENSIONS` - Network Extensions
-* `HOTSPOT` - Hotspot Configuration
+* `HOT_SPOT` - Hotspot Configuration
 * `MULTIPATH` - Multipath networking
 * `NFC_TAG_READING` - NFC tag reading
 
-**Settings required:**
+**Capabilities with schema-defined settings:**
 
 * `ICLOUD` - iCloud (CloudKit/Documents)
-* `APP_GROUPS` - App Groups
-* `ASSOCIATED_DOMAINS` - Associated Domains
 * `DATA_PROTECTION` - Data Protection
-* `HEALTHKIT` - HealthKit
-* `HOMEKIT` - HomeKit
-* `WIRELESS_ACCESSORY_CONFIGURATION` - Wireless Accessory
+* `APPLE_ID_AUTH` - Sign in with Apple consent
+
+The public API accepts only `ICLOUD_VERSION`,
+`DATA_PROTECTION_PERMISSION_LEVEL`, and `APPLE_ID_AUTH_APP_CONSENT` setting
+keys. Allowed option keys are `XCODE_5`, `XCODE_6`, `COMPLETE_PROTECTION`,
+`PROTECTED_UNLESS_OPEN`, `PROTECTED_UNTIL_FIRST_USER_AUTH`, and
+`PRIMARY_APP_CONSENT`. If supplied, `allowedInstances` must be `ENTRY`,
+`SINGLE`, or `MULTIPLE`. Other capabilities are enabled without `--settings`.
 
 ### iCloud Capability
 
@@ -202,21 +205,23 @@ asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
 # Enable iCloud with CloudKit
 asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
   --capability ICLOUD \
-  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'
+  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
 
 # Enable legacy iCloud (documents)
 asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
   --capability ICLOUD \
-  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_9","enabled":true}]}]'
+  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_5","enabled":true}]}]'
 ```
 
 ### App Groups Capability
 
 ```bash  theme={null}
 asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
-  --capability APP_GROUPS \
-  --settings '[{"key":"APP_GROUP_IDS","options":[{"key":"group.com.example.shared","enabled":true}]}]'
+  --capability APP_GROUPS
 ```
+
+App group membership is not configured through capability settings. Configure
+the group association separately in Certificates, Identifiers & Profiles.
 
 ### Update Capability
 
@@ -224,7 +229,7 @@ Modify capability settings:
 
 ```bash  theme={null}
 asc bundle-ids capabilities update --id "CAPABILITY_ID" \
-  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'
+  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
 
 # Change capability type
 asc bundle-ids capabilities update --id "CAPABILITY_ID" \
@@ -264,7 +269,7 @@ asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
 # 4. Add iCloud
 asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
   --capability ICLOUD \
-  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'
+  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
 
 # 5. Verify capabilities
 asc bundle-ids capabilities list --bundle "BUNDLE_ID" --output table
@@ -307,27 +312,26 @@ asc bundle-ids list --output json | grep "com.example.app"
 
 # 2. Add App Groups to main app
 asc bundle-ids capabilities add --bundle "MAIN_BUNDLE_ID" \
-  --capability APP_GROUPS \
-  --settings '[{"key":"APP_GROUP_IDS","options":[{"key":"group.com.example.shared","enabled":true}]}]'
+  --capability APP_GROUPS
 
 # 3. Add App Groups to widget
 asc bundle-ids capabilities add --bundle "WIDGET_BUNDLE_ID" \
-  --capability APP_GROUPS \
-  --settings '[{"key":"APP_GROUP_IDS","options":[{"key":"group.com.example.shared","enabled":true}]}]'
+  --capability APP_GROUPS
 
 # 4. Add App Groups to share extension
 asc bundle-ids capabilities add --bundle "SHARE_BUNDLE_ID" \
-  --capability APP_GROUPS \
-  --settings '[{"key":"APP_GROUP_IDS","options":[{"key":"group.com.example.shared","enabled":true}]}]'
+  --capability APP_GROUPS
 ```
 
 ### Associated Domains (Universal Links)
 
 ```bash  theme={null}
 asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
-  --capability ASSOCIATED_DOMAINS \
-  --settings '[{"key":"ASSOCIATED_DOMAIN_IDS","options":[{"key":"applinks:example.com","enabled":true},{"key":"applinks:www.example.com","enabled":true}]}]'
+  --capability ASSOCIATED_DOMAINS
 ```
+
+Associated domain values are app entitlements and are not configured through
+the bundle ID capability settings payload.
 
 ### HealthKit and HomeKit
 
@@ -411,13 +415,13 @@ JSON settings must be properly formatted:
 # Correct format
 asc bundle-ids capabilities add --bundle "BUNDLE_ID" \
   --capability ICLOUD \
-  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'
+  --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
 ```
 
 Validate JSON:
 
 ```bash  theme={null}
-echo '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]' | jq .
+echo '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]' | jq .
 ```
 
 ### Provisioning Profiles Invalid After Capability Change

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -7235,6 +7235,13 @@ func TestCreateBundleIDCapability_SendsRequest(t *testing.T) {
 		if payload.Data.Attributes.CapabilityType != "ICLOUD" {
 			t.Fatalf("expected capability ICLOUD, got %q", payload.Data.Attributes.CapabilityType)
 		}
+		if len(payload.Data.Attributes.Settings) != 1 || payload.Data.Attributes.Settings[0].Key != "ICLOUD_VERSION" {
+			t.Fatalf("expected ICLOUD_VERSION setting, got %+v", payload.Data.Attributes.Settings)
+		}
+		options := payload.Data.Attributes.Settings[0].Options
+		if len(options) != 1 || options[0].Key != "XCODE_6" || options[0].Enabled == nil || !*options[0].Enabled {
+			t.Fatalf("expected enabled XCODE_6 option, got %+v", options)
+		}
 		if payload.Data.Relationships == nil || payload.Data.Relationships.BundleID == nil {
 			t.Fatalf("expected bundleId relationship")
 		}
@@ -7251,7 +7258,7 @@ func TestCreateBundleIDCapability_SendsRequest(t *testing.T) {
 			{
 				Key: "ICLOUD_VERSION",
 				Options: []CapabilityOption{
-					{Key: "XCODE_13", Enabled: &enabled},
+					{Key: "XCODE_6", Enabled: &enabled},
 				},
 			},
 		},
@@ -7279,7 +7286,7 @@ func TestDeleteBundleIDCapability_SendsRequest(t *testing.T) {
 }
 
 func TestUpdateBundleIDCapability_UsesPatchPath(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD","settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]}}}`)
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD","settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]}}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodPatch {
 			t.Fatalf("expected PATCH, got %s", req.Method)
@@ -7313,8 +7320,8 @@ func TestUpdateBundleIDCapability_UsesPatchPath(t *testing.T) {
 		if len(payload.Data.Attributes.Settings[0].Options) != 1 {
 			t.Fatalf("expected 1 option, got %d", len(payload.Data.Attributes.Settings[0].Options))
 		}
-		if payload.Data.Attributes.Settings[0].Options[0].Key != "XCODE_13" {
-			t.Fatalf("expected option key XCODE_13, got %q", payload.Data.Attributes.Settings[0].Options[0].Key)
+		if payload.Data.Attributes.Settings[0].Options[0].Key != "XCODE_6" {
+			t.Fatalf("expected option key XCODE_6, got %q", payload.Data.Attributes.Settings[0].Options[0].Key)
 		}
 		if payload.Data.Attributes.Settings[0].Options[0].Enabled == nil || !*payload.Data.Attributes.Settings[0].Options[0].Enabled {
 			t.Fatalf("expected option enabled true")
@@ -7328,7 +7335,7 @@ func TestUpdateBundleIDCapability_UsesPatchPath(t *testing.T) {
 			{
 				Key: "ICLOUD_VERSION",
 				Options: []CapabilityOption{
-					{Key: "XCODE_13", Enabled: &enabled},
+					{Key: "XCODE_6", Enabled: &enabled},
 				},
 			},
 		},

--- a/internal/asc/signing.go
+++ b/internal/asc/signing.go
@@ -57,17 +57,24 @@ type BundleIDCapabilityCreateAttributes struct {
 
 // CapabilitySetting describes a capability setting.
 type CapabilitySetting struct {
-	Key     string             `json:"key"`
-	Name    string             `json:"name,omitempty"`
-	Options []CapabilityOption `json:"options,omitempty"`
+	Key              string             `json:"key"`
+	Name             string             `json:"name,omitempty"`
+	Description      string             `json:"description,omitempty"`
+	EnabledByDefault *bool              `json:"enabledByDefault,omitempty"`
+	Visible          *bool              `json:"visible,omitempty"`
+	AllowedInstances string             `json:"allowedInstances,omitempty"`
+	MinInstances     *int               `json:"minInstances,omitempty"`
+	Options          []CapabilityOption `json:"options,omitempty"`
 }
 
 // CapabilityOption describes a capability option.
 type CapabilityOption struct {
-	Key         string `json:"key"`
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	Enabled     *bool  `json:"enabled,omitempty"`
+	Key              string `json:"key"`
+	Name             string `json:"name,omitempty"`
+	Description      string `json:"description,omitempty"`
+	EnabledByDefault *bool  `json:"enabledByDefault,omitempty"`
+	Enabled          *bool  `json:"enabled,omitempty"`
+	SupportsWildcard *bool  `json:"supportsWildcard,omitempty"`
 }
 
 // BundleIDCapabilityRelationships describes relationships for bundle ID capabilities.

--- a/internal/cli/bundleids/bundle_ids_capabilities.go
+++ b/internal/cli/bundleids/bundle_ids_capabilities.go
@@ -364,9 +364,10 @@ func validateCapabilitySettingsJSON(value any) error {
 				return fmt.Errorf("unknown field %q at setting index %d", field, settingIndex)
 			}
 		}
-		if allowedInstances, present := setting["allowedInstances"]; present {
-			if value, ok := allowedInstances.(string); ok && value == "" {
-				return fmt.Errorf("allowedInstances at setting index %d must not be empty", settingIndex)
+		settingLocation := fmt.Sprintf("setting index %d", settingIndex)
+		for _, field := range []string{"allowedInstances", "description", "name"} {
+			if err := validateCapabilityOptionalString(setting, field, settingLocation); err != nil {
+				return err
 			}
 		}
 		options, ok := setting["options"].([]any)
@@ -383,7 +384,31 @@ func validateCapabilitySettingsJSON(value any) error {
 					return fmt.Errorf("unknown field %q at setting index %d, option index %d", field, settingIndex, optionIndex)
 				}
 			}
+			optionLocation := fmt.Sprintf("setting index %d, option index %d", settingIndex, optionIndex)
+			for _, field := range []string{"description", "name"} {
+				if err := validateCapabilityOptionalString(option, field, optionLocation); err != nil {
+					return err
+				}
+			}
 		}
+	}
+	return nil
+}
+
+func validateCapabilityOptionalString(object map[string]any, field, location string) error {
+	raw, present := object[field]
+	if !present {
+		return nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return nil
+	}
+	if value == "" {
+		return fmt.Errorf("%s at %s must not be empty", field, location)
+	}
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s at %s must not be blank", field, location)
 	}
 	return nil
 }

--- a/internal/cli/bundleids/bundle_ids_capabilities.go
+++ b/internal/cli/bundleids/bundle_ids_capabilities.go
@@ -320,6 +320,9 @@ func parseCapabilitySettings(value string) ([]asc.CapabilitySetting, error) {
 	if err := rejectCapabilitySettingsNulls(rawSettings, "settings"); err != nil {
 		return nil, fmt.Errorf("--settings: %w", err)
 	}
+	if err := validateCapabilitySettingsJSON(rawSettings); err != nil {
+		return nil, fmt.Errorf("--settings: %w", err)
+	}
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
 		return nil, fmt.Errorf("--settings must contain one JSON array")
@@ -328,6 +331,65 @@ func parseCapabilitySettings(value string) ([]asc.CapabilitySetting, error) {
 		return nil, fmt.Errorf("--settings: %w", err)
 	}
 	return settings, nil
+}
+
+var capabilitySettingFields = []string{
+	"allowedInstances",
+	"description",
+	"enabledByDefault",
+	"key",
+	"minInstances",
+	"name",
+	"options",
+	"visible",
+}
+
+var capabilityOptionFields = []string{
+	"description",
+	"enabled",
+	"enabledByDefault",
+	"key",
+	"name",
+	"supportsWildcard",
+}
+
+func validateCapabilitySettingsJSON(value any) error {
+	settings, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	for settingIndex, item := range settings {
+		setting, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for field := range setting {
+			if !slices.Contains(capabilitySettingFields, field) {
+				return fmt.Errorf("unknown field %q at setting index %d", field, settingIndex)
+			}
+		}
+		if allowedInstances, present := setting["allowedInstances"]; present {
+			if value, ok := allowedInstances.(string); ok && !slices.Contains(capabilityAllowedInstances, value) {
+				return fmt.Errorf("unsupported allowedInstances %q at setting index %d (must be one of: %s)", value, settingIndex, strings.Join(capabilityAllowedInstances, ", "))
+			}
+		}
+		options, ok := setting["options"].([]any)
+		if !ok {
+			continue
+		}
+		for optionIndex, item := range options {
+			option, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			for field := range option {
+				if !slices.Contains(capabilityOptionFields, field) {
+					return fmt.Errorf("unknown field %q at setting index %d, option index %d", field, settingIndex, optionIndex)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func rejectCapabilitySettingsNulls(value any, path string) error {
@@ -356,13 +418,19 @@ var capabilitySettingKeys = []string{
 	"ICLOUD_VERSION",
 }
 
-var capabilityOptionKeys = []string{
-	"COMPLETE_PROTECTION",
-	"PRIMARY_APP_CONSENT",
-	"PROTECTED_UNLESS_OPEN",
-	"PROTECTED_UNTIL_FIRST_USER_AUTH",
-	"XCODE_5",
-	"XCODE_6",
+var capabilityOptionKeysBySetting = map[string][]string{
+	"APPLE_ID_AUTH_APP_CONSENT": {
+		"PRIMARY_APP_CONSENT",
+	},
+	"DATA_PROTECTION_PERMISSION_LEVEL": {
+		"COMPLETE_PROTECTION",
+		"PROTECTED_UNLESS_OPEN",
+		"PROTECTED_UNTIL_FIRST_USER_AUTH",
+	},
+	"ICLOUD_VERSION": {
+		"XCODE_5",
+		"XCODE_6",
+	},
 }
 
 var capabilityAllowedInstances = []string{"ENTRY", "MULTIPLE", "SINGLE"}
@@ -372,12 +440,10 @@ func validateCapabilitySettings(settings []asc.CapabilitySetting) error {
 		if !slices.Contains(capabilitySettingKeys, setting.Key) {
 			return fmt.Errorf("unsupported capability setting key %q at index %d (must be one of: %s)", setting.Key, settingIndex, strings.Join(capabilitySettingKeys, ", "))
 		}
-		if setting.AllowedInstances != "" && !slices.Contains(capabilityAllowedInstances, setting.AllowedInstances) {
-			return fmt.Errorf("unsupported allowedInstances %q at setting index %d (must be one of: %s)", setting.AllowedInstances, settingIndex, strings.Join(capabilityAllowedInstances, ", "))
-		}
+		allowedOptionKeys := capabilityOptionKeysBySetting[setting.Key]
 		for optionIndex, option := range setting.Options {
-			if !slices.Contains(capabilityOptionKeys, option.Key) {
-				return fmt.Errorf("unsupported capability option key %q at setting index %d, option index %d (must be one of: %s)", option.Key, settingIndex, optionIndex, strings.Join(capabilityOptionKeys, ", "))
+			if !slices.Contains(allowedOptionKeys, option.Key) {
+				return fmt.Errorf("unsupported capability option key %q for setting %q at setting index %d, option index %d (must be one of: %s)", option.Key, setting.Key, settingIndex, optionIndex, strings.Join(allowedOptionKeys, ", "))
 			}
 		}
 	}

--- a/internal/cli/bundleids/bundle_ids_capabilities.go
+++ b/internal/cli/bundleids/bundle_ids_capabilities.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -27,7 +29,7 @@ func BundleIDsCapabilitiesCommand() *ffcli.Command {
 Examples:
   asc bundle-ids capabilities list --bundle "BUNDLE_ID"
   asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD
-  asc bundle-ids capabilities update --id "CAPABILITY_ID" --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'
+  asc bundle-ids capabilities update --id "CAPABILITY_ID" --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
   asc bundle-ids capabilities remove --id "CAPABILITY_ID" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -121,7 +123,7 @@ func BundleIDsCapabilitiesAddCommand() *ffcli.Command {
 
 	bundleID := fs.String("bundle", "", "Bundle ID")
 	capability := fs.String("capability", "", "Capability type (e.g., ICLOUD, IN_APP_PURCHASE)")
-	settings := fs.String("settings", "", "Capability settings as JSON array (optional)")
+	settings := fs.String("settings", "", "Capability settings as a schema-validated JSON array (optional)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -130,9 +132,14 @@ func BundleIDsCapabilitiesAddCommand() *ffcli.Command {
 		ShortHelp:  "Add a capability to a bundle ID.",
 		LongHelp: `Add a capability to a bundle ID.
 
+Setting keys must be ICLOUD_VERSION, DATA_PROTECTION_PERMISSION_LEVEL, or
+APPLE_ID_AUTH_APP_CONSENT. Option keys must be XCODE_5, XCODE_6,
+COMPLETE_PROTECTION, PROTECTED_UNLESS_OPEN, PROTECTED_UNTIL_FIRST_USER_AUTH,
+or PRIMARY_APP_CONSENT.
+
 Examples:
   asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD
-  asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'`,
+  asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -149,7 +156,7 @@ Examples:
 
 			settingsValue, err := parseCapabilitySettings(*settings)
 			if err != nil {
-				return fmt.Errorf("bundle-ids capabilities add: %w", err)
+				return shared.UsageErrorf("bundle-ids capabilities add: %v", err)
 			}
 
 			client, err := shared.GetASCClient()
@@ -180,7 +187,7 @@ func BundleIDsCapabilitiesUpdateCommand() *ffcli.Command {
 
 	id := fs.String("id", "", "Capability ID")
 	capabilityType := fs.String("capability", "", "Capability type (e.g., ICLOUD, IN_APP_PURCHASE)")
-	settings := fs.String("settings", "", "Capability settings as JSON array")
+	settings := fs.String("settings", "", "Capability settings as a schema-validated JSON array")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -189,8 +196,13 @@ func BundleIDsCapabilitiesUpdateCommand() *ffcli.Command {
 		ShortHelp:  "Update a bundle ID capability.",
 		LongHelp: `Update a bundle ID capability.
 
+Setting keys must be ICLOUD_VERSION, DATA_PROTECTION_PERMISSION_LEVEL, or
+APPLE_ID_AUTH_APP_CONSENT. Option keys must be XCODE_5, XCODE_6,
+COMPLETE_PROTECTION, PROTECTED_UNLESS_OPEN, PROTECTED_UNTIL_FIRST_USER_AUTH,
+or PRIMARY_APP_CONSENT.
+
 Examples:
-  asc bundle-ids capabilities update --id "CAPABILITY_ID" --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'
+  asc bundle-ids capabilities update --id "CAPABILITY_ID" --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
   asc bundle-ids capabilities update --id "CAPABILITY_ID" --capability PUSH_NOTIFICATIONS
   asc bundle-ids capabilities update --id "CAPABILITY_ID" --output table`,
 		FlagSet:   fs,
@@ -205,8 +217,7 @@ Examples:
 			capabilityValue := strings.ToUpper(strings.TrimSpace(*capabilityType))
 			settingsValue, err := parseCapabilitySettings(*settings)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				return flag.ErrHelp
+				return shared.UsageErrorf("bundle-ids capabilities update: %v", err)
 			}
 
 			// Treat empty settings arrays as no-op updates.
@@ -294,8 +305,81 @@ func parseCapabilitySettings(value string) ([]asc.CapabilitySetting, error) {
 		return nil, nil
 	}
 	var settings []asc.CapabilitySetting
-	if err := json.Unmarshal([]byte(trimmed), &settings); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&settings); err != nil {
 		return nil, fmt.Errorf("--settings must be valid JSON array: %w", err)
 	}
+	if settings == nil {
+		return nil, fmt.Errorf("--settings must be a JSON array, got null")
+	}
+	var rawSettings any
+	if err := json.Unmarshal([]byte(trimmed), &rawSettings); err != nil {
+		return nil, fmt.Errorf("--settings must be valid JSON array: %w", err)
+	}
+	if err := rejectCapabilitySettingsNulls(rawSettings, "settings"); err != nil {
+		return nil, fmt.Errorf("--settings: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("--settings must contain one JSON array")
+	}
+	if err := validateCapabilitySettings(settings); err != nil {
+		return nil, fmt.Errorf("--settings: %w", err)
+	}
 	return settings, nil
+}
+
+func rejectCapabilitySettingsNulls(value any, path string) error {
+	switch typed := value.(type) {
+	case nil:
+		return fmt.Errorf("%s must not be null", path)
+	case []any:
+		for index, item := range typed {
+			if err := rejectCapabilitySettingsNulls(item, fmt.Sprintf("%s[%d]", path, index)); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		for key, item := range typed {
+			if err := rejectCapabilitySettingsNulls(item, path+"."+key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+var capabilitySettingKeys = []string{
+	"APPLE_ID_AUTH_APP_CONSENT",
+	"DATA_PROTECTION_PERMISSION_LEVEL",
+	"ICLOUD_VERSION",
+}
+
+var capabilityOptionKeys = []string{
+	"COMPLETE_PROTECTION",
+	"PRIMARY_APP_CONSENT",
+	"PROTECTED_UNLESS_OPEN",
+	"PROTECTED_UNTIL_FIRST_USER_AUTH",
+	"XCODE_5",
+	"XCODE_6",
+}
+
+var capabilityAllowedInstances = []string{"ENTRY", "MULTIPLE", "SINGLE"}
+
+func validateCapabilitySettings(settings []asc.CapabilitySetting) error {
+	for settingIndex, setting := range settings {
+		if !slices.Contains(capabilitySettingKeys, setting.Key) {
+			return fmt.Errorf("unsupported capability setting key %q at index %d (must be one of: %s)", setting.Key, settingIndex, strings.Join(capabilitySettingKeys, ", "))
+		}
+		if setting.AllowedInstances != "" && !slices.Contains(capabilityAllowedInstances, setting.AllowedInstances) {
+			return fmt.Errorf("unsupported allowedInstances %q at setting index %d (must be one of: %s)", setting.AllowedInstances, settingIndex, strings.Join(capabilityAllowedInstances, ", "))
+		}
+		for optionIndex, option := range setting.Options {
+			if !slices.Contains(capabilityOptionKeys, option.Key) {
+				return fmt.Errorf("unsupported capability option key %q at setting index %d, option index %d (must be one of: %s)", option.Key, settingIndex, optionIndex, strings.Join(capabilityOptionKeys, ", "))
+			}
+		}
+	}
+	return nil
 }

--- a/internal/cli/bundleids/bundle_ids_capabilities.go
+++ b/internal/cli/bundleids/bundle_ids_capabilities.go
@@ -123,7 +123,7 @@ func BundleIDsCapabilitiesAddCommand() *ffcli.Command {
 
 	bundleID := fs.String("bundle", "", "Bundle ID")
 	capability := fs.String("capability", "", "Capability type (e.g., ICLOUD, IN_APP_PURCHASE)")
-	settings := fs.String("settings", "", "Capability settings as a schema-validated JSON array (optional)")
+	settings := fs.String("settings", "", "Capability settings as a structure-validated JSON array (optional)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -132,10 +132,8 @@ func BundleIDsCapabilitiesAddCommand() *ffcli.Command {
 		ShortHelp:  "Add a capability to a bundle ID.",
 		LongHelp: `Add a capability to a bundle ID.
 
-Setting keys must be ICLOUD_VERSION, DATA_PROTECTION_PERMISSION_LEVEL, or
-APPLE_ID_AUTH_APP_CONSENT. Option keys must be XCODE_5, XCODE_6,
-COMPLETE_PROTECTION, PROTECTED_UNLESS_OPEN, PROTECTED_UNTIL_FIRST_USER_AUTH,
-or PRIMARY_APP_CONSENT.
+Settings require exact JSON field names and value types. Setting and option key
+strings are sent unchanged so values newer than Apple's published schema work.
 
 Examples:
   asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD
@@ -187,7 +185,7 @@ func BundleIDsCapabilitiesUpdateCommand() *ffcli.Command {
 
 	id := fs.String("id", "", "Capability ID")
 	capabilityType := fs.String("capability", "", "Capability type (e.g., ICLOUD, IN_APP_PURCHASE)")
-	settings := fs.String("settings", "", "Capability settings as a schema-validated JSON array")
+	settings := fs.String("settings", "", "Capability settings as a structure-validated JSON array")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -196,10 +194,8 @@ func BundleIDsCapabilitiesUpdateCommand() *ffcli.Command {
 		ShortHelp:  "Update a bundle ID capability.",
 		LongHelp: `Update a bundle ID capability.
 
-Setting keys must be ICLOUD_VERSION, DATA_PROTECTION_PERMISSION_LEVEL, or
-APPLE_ID_AUTH_APP_CONSENT. Option keys must be XCODE_5, XCODE_6,
-COMPLETE_PROTECTION, PROTECTED_UNLESS_OPEN, PROTECTED_UNTIL_FIRST_USER_AUTH,
-or PRIMARY_APP_CONSENT.
+Settings require exact JSON field names and value types. Setting and option key
+strings are sent unchanged so values newer than Apple's published schema work.
 
 Examples:
   asc bundle-ids capabilities update --id "CAPABILITY_ID" --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'
@@ -369,8 +365,8 @@ func validateCapabilitySettingsJSON(value any) error {
 			}
 		}
 		if allowedInstances, present := setting["allowedInstances"]; present {
-			if value, ok := allowedInstances.(string); ok && !slices.Contains(capabilityAllowedInstances, value) {
-				return fmt.Errorf("unsupported allowedInstances %q at setting index %d (must be one of: %s)", value, settingIndex, strings.Join(capabilityAllowedInstances, ", "))
+			if value, ok := allowedInstances.(string); ok && value == "" {
+				return fmt.Errorf("allowedInstances at setting index %d must not be empty", settingIndex)
 			}
 		}
 		options, ok := setting["options"].([]any)
@@ -412,38 +408,14 @@ func rejectCapabilitySettingsNulls(value any, path string) error {
 	return nil
 }
 
-var capabilitySettingKeys = []string{
-	"APPLE_ID_AUTH_APP_CONSENT",
-	"DATA_PROTECTION_PERMISSION_LEVEL",
-	"ICLOUD_VERSION",
-}
-
-var capabilityOptionKeysBySetting = map[string][]string{
-	"APPLE_ID_AUTH_APP_CONSENT": {
-		"PRIMARY_APP_CONSENT",
-	},
-	"DATA_PROTECTION_PERMISSION_LEVEL": {
-		"COMPLETE_PROTECTION",
-		"PROTECTED_UNLESS_OPEN",
-		"PROTECTED_UNTIL_FIRST_USER_AUTH",
-	},
-	"ICLOUD_VERSION": {
-		"XCODE_5",
-		"XCODE_6",
-	},
-}
-
-var capabilityAllowedInstances = []string{"ENTRY", "MULTIPLE", "SINGLE"}
-
 func validateCapabilitySettings(settings []asc.CapabilitySetting) error {
 	for settingIndex, setting := range settings {
-		if !slices.Contains(capabilitySettingKeys, setting.Key) {
-			return fmt.Errorf("unsupported capability setting key %q at index %d (must be one of: %s)", setting.Key, settingIndex, strings.Join(capabilitySettingKeys, ", "))
+		if strings.TrimSpace(setting.Key) == "" {
+			return fmt.Errorf("capability setting key at index %d must not be empty", settingIndex)
 		}
-		allowedOptionKeys := capabilityOptionKeysBySetting[setting.Key]
 		for optionIndex, option := range setting.Options {
-			if !slices.Contains(allowedOptionKeys, option.Key) {
-				return fmt.Errorf("unsupported capability option key %q for setting %q at setting index %d, option index %d (must be one of: %s)", option.Key, setting.Key, settingIndex, optionIndex, strings.Join(allowedOptionKeys, ", "))
+			if strings.TrimSpace(option.Key) == "" {
+				return fmt.Errorf("capability option key at setting index %d, option index %d must not be empty", settingIndex, optionIndex)
 			}
 		}
 	}

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -135,6 +135,16 @@ func TestParseCapabilitySettingsRejectsUnsupportedInput(t *testing.T) {
 			wantErr: `unknown field "unexpected"`,
 		},
 		{
+			name:    "incorrect setting field casing",
+			value:   `[{"KEY":"ICLOUD_VERSION"}]`,
+			wantErr: `unknown field "KEY"`,
+		},
+		{
+			name:    "incorrect option field casing",
+			value:   `[{"key":"ICLOUD_VERSION","Options":[{"key":"XCODE_6"}]}]`,
+			wantErr: `unknown field "Options"`,
+		},
+		{
 			name:    "unsupported setting key",
 			value:   `[{"key":"APP_GROUP_IDS"}]`,
 			wantErr: `unsupported capability setting key "APP_GROUP_IDS"`,
@@ -145,9 +155,19 @@ func TestParseCapabilitySettingsRejectsUnsupportedInput(t *testing.T) {
 			wantErr: `unsupported capability option key "XCODE_13"`,
 		},
 		{
+			name:    "option key for different setting",
+			value:   `[{"key":"ICLOUD_VERSION","options":[{"key":"COMPLETE_PROTECTION"}]}]`,
+			wantErr: `unsupported capability option key "COMPLETE_PROTECTION" for setting "ICLOUD_VERSION"`,
+		},
+		{
 			name:    "unsupported allowed instances",
 			value:   `[{"key":"ICLOUD_VERSION","allowedInstances":"MANY"}]`,
 			wantErr: `unsupported allowedInstances "MANY"`,
+		},
+		{
+			name:    "empty allowed instances",
+			value:   `[{"key":"ICLOUD_VERSION","allowedInstances":""}]`,
+			wantErr: `unsupported allowedInstances ""`,
 		},
 		{
 			name:    "null is not an array",

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -150,6 +150,21 @@ func TestParseCapabilitySettingsRejectsInvalidStructure(t *testing.T) {
 			wantErr: `allowedInstances at setting index 0 must not be empty`,
 		},
 		{
+			name:    "whitespace allowed instances",
+			value:   `[{"key":"ICLOUD_VERSION","allowedInstances":" \t"}]`,
+			wantErr: `allowedInstances at setting index 0 must not be blank`,
+		},
+		{
+			name:    "empty setting description",
+			value:   `[{"key":"ICLOUD_VERSION","description":""}]`,
+			wantErr: `description at setting index 0 must not be empty`,
+		},
+		{
+			name:    "whitespace option name",
+			value:   `[{"key":"FUTURE_SETTING","options":[{"key":"FUTURE_OPTION","name":"  "}]}]`,
+			wantErr: `name at setting index 0, option index 0 must not be blank`,
+		},
+		{
 			name:    "missing setting key",
 			value:   `[{"options":[]}]`,
 			wantErr: `capability setting key at index 0 must not be empty`,

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -118,7 +118,7 @@ func TestBundleIDsCapabilitiesAddCommand_MissingCapability(t *testing.T) {
 	}
 }
 
-func TestParseCapabilitySettingsRejectsUnsupportedInput(t *testing.T) {
+func TestParseCapabilitySettingsRejectsInvalidStructure(t *testing.T) {
 	tests := []struct {
 		name    string
 		value   string
@@ -145,29 +145,34 @@ func TestParseCapabilitySettingsRejectsUnsupportedInput(t *testing.T) {
 			wantErr: `unknown field "Options"`,
 		},
 		{
-			name:    "unsupported setting key",
-			value:   `[{"key":"APP_GROUP_IDS"}]`,
-			wantErr: `unsupported capability setting key "APP_GROUP_IDS"`,
-		},
-		{
-			name:    "unsupported option key",
-			value:   `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]`,
-			wantErr: `unsupported capability option key "XCODE_13"`,
-		},
-		{
-			name:    "option key for different setting",
-			value:   `[{"key":"ICLOUD_VERSION","options":[{"key":"COMPLETE_PROTECTION"}]}]`,
-			wantErr: `unsupported capability option key "COMPLETE_PROTECTION" for setting "ICLOUD_VERSION"`,
-		},
-		{
-			name:    "unsupported allowed instances",
-			value:   `[{"key":"ICLOUD_VERSION","allowedInstances":"MANY"}]`,
-			wantErr: `unsupported allowedInstances "MANY"`,
-		},
-		{
 			name:    "empty allowed instances",
 			value:   `[{"key":"ICLOUD_VERSION","allowedInstances":""}]`,
-			wantErr: `unsupported allowedInstances ""`,
+			wantErr: `allowedInstances at setting index 0 must not be empty`,
+		},
+		{
+			name:    "missing setting key",
+			value:   `[{"options":[]}]`,
+			wantErr: `capability setting key at index 0 must not be empty`,
+		},
+		{
+			name:    "missing option key",
+			value:   `[{"key":"FUTURE_SETTING","options":[{"enabled":true}]}]`,
+			wantErr: `capability option key at setting index 0, option index 0 must not be empty`,
+		},
+		{
+			name:    "setting key has wrong type",
+			value:   `[{"key":42}]`,
+			wantErr: `cannot unmarshal number into Go struct field CapabilitySetting.key of type string`,
+		},
+		{
+			name:    "options has wrong shape",
+			value:   `[{"key":"FUTURE_SETTING","options":{}}]`,
+			wantErr: `cannot unmarshal object into Go struct field CapabilitySetting.options of type []asc.CapabilityOption`,
+		},
+		{
+			name:    "option has wrong shape",
+			value:   `[{"key":"FUTURE_SETTING","options":[true]}]`,
+			wantErr: `cannot unmarshal bool into Go struct field CapabilitySetting.options of type asc.CapabilityOption`,
 		},
 		{
 			name:    "null is not an array",
@@ -191,24 +196,21 @@ func TestParseCapabilitySettingsRejectsUnsupportedInput(t *testing.T) {
 	}
 }
 
-func TestParseCapabilitySettingsAcceptsExactOpenAPIEnumsAndFields(t *testing.T) {
+func TestParseCapabilitySettingsAcceptsForwardCompatibleKeysAndExactFields(t *testing.T) {
 	settings, err := parseCapabilitySettings(`[
 		{"key":"ICLOUD_VERSION","name":"iCloud","description":"version","enabledByDefault":true,"visible":true,"allowedInstances":"SINGLE","minInstances":1,"options":[
 			{"key":"XCODE_5","name":"Xcode 5","description":"legacy","enabledByDefault":false,"enabled":false,"supportsWildcard":true},
 			{"key":"XCODE_6","enabled":true}
 		]},
-		{"key":"DATA_PROTECTION_PERMISSION_LEVEL","allowedInstances":"ENTRY","options":[
-			{"key":"COMPLETE_PROTECTION"},
-			{"key":"PROTECTED_UNLESS_OPEN"},
-			{"key":"PROTECTED_UNTIL_FIRST_USER_AUTH"}
-		]},
-		{"key":"APPLE_ID_AUTH_APP_CONSENT","allowedInstances":"MULTIPLE","options":[{"key":"PRIMARY_APP_CONSENT"}]}
+		{"key":"ENABLED_FOR_MAC_APP_SETUP","options":[{"key":"USE_IOS_APPID","enabled":true}]},
+		{"key":"APP_GROUP_IDENTIFIERS","options":[{"key":"group.com.example.shared","enabled":true}]},
+		{"key":"FUTURE_SETTING","allowedInstances":"FUTURE_INSTANCE_MODE","options":[{"key":"FUTURE_OPTION"}]}
 	]`)
 	if err != nil {
 		t.Fatalf("parse settings: %v", err)
 	}
-	if len(settings) != 3 {
-		t.Fatalf("settings count = %d, want 3", len(settings))
+	if len(settings) != 4 {
+		t.Fatalf("settings count = %d, want 4", len(settings))
 	}
 	if settings[0].MinInstances == nil || *settings[0].MinInstances != 1 {
 		t.Fatalf("minInstances = %v, want 1", settings[0].MinInstances)
@@ -218,6 +220,15 @@ func TestParseCapabilitySettingsAcceptsExactOpenAPIEnumsAndFields(t *testing.T) 
 	}
 	if settings[0].Options[0].SupportsWildcard == nil || !*settings[0].Options[0].SupportsWildcard {
 		t.Fatalf("supportsWildcard=true was not preserved: %+v", settings[0].Options[0].SupportsWildcard)
+	}
+	if settings[1].Key != "ENABLED_FOR_MAC_APP_SETUP" || settings[1].Options[0].Key != "USE_IOS_APPID" {
+		t.Fatalf("live Apple setting/option pair was not preserved: %+v", settings[1])
+	}
+	if settings[2].Key != "APP_GROUP_IDENTIFIERS" || settings[2].Options[0].Key != "group.com.example.shared" {
+		t.Fatalf("app group setting/option pair was not preserved: %+v", settings[2])
+	}
+	if settings[3].Key != "FUTURE_SETTING" || settings[3].AllowedInstances != "FUTURE_INSTANCE_MODE" || settings[3].Options[0].Key != "FUTURE_OPTION" {
+		t.Fatalf("future setting values were not preserved: %+v", settings[3])
 	}
 }
 

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"strings"
 	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
 func TestBundleIDsGetCommand_MissingID(t *testing.T) {
@@ -112,6 +115,104 @@ func TestBundleIDsCapabilitiesAddCommand_MissingCapability(t *testing.T) {
 
 	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --capability is missing, got %v", err)
+	}
+}
+
+func TestParseCapabilitySettingsRejectsUnsupportedInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{
+			name:    "unknown setting field",
+			value:   `[{"key":"ICLOUD_VERSION","unexpected":true}]`,
+			wantErr: `unknown field "unexpected"`,
+		},
+		{
+			name:    "unknown option field",
+			value:   `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","unexpected":true}]}]`,
+			wantErr: `unknown field "unexpected"`,
+		},
+		{
+			name:    "unsupported setting key",
+			value:   `[{"key":"APP_GROUP_IDS"}]`,
+			wantErr: `unsupported capability setting key "APP_GROUP_IDS"`,
+		},
+		{
+			name:    "unsupported option key",
+			value:   `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]`,
+			wantErr: `unsupported capability option key "XCODE_13"`,
+		},
+		{
+			name:    "unsupported allowed instances",
+			value:   `[{"key":"ICLOUD_VERSION","allowedInstances":"MANY"}]`,
+			wantErr: `unsupported allowedInstances "MANY"`,
+		},
+		{
+			name:    "null is not an array",
+			value:   `null`,
+			wantErr: `must be a JSON array, got null`,
+		},
+		{
+			name:    "null nested field",
+			value:   `[{"key":"ICLOUD_VERSION","options":null}]`,
+			wantErr: `settings[0].options must not be null`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseCapabilitySettings(tc.value)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestParseCapabilitySettingsAcceptsExactOpenAPIEnumsAndFields(t *testing.T) {
+	settings, err := parseCapabilitySettings(`[
+		{"key":"ICLOUD_VERSION","name":"iCloud","description":"version","enabledByDefault":true,"visible":true,"allowedInstances":"SINGLE","minInstances":1,"options":[
+			{"key":"XCODE_5","name":"Xcode 5","description":"legacy","enabledByDefault":false,"enabled":false,"supportsWildcard":true},
+			{"key":"XCODE_6","enabled":true}
+		]},
+		{"key":"DATA_PROTECTION_PERMISSION_LEVEL","allowedInstances":"ENTRY","options":[
+			{"key":"COMPLETE_PROTECTION"},
+			{"key":"PROTECTED_UNLESS_OPEN"},
+			{"key":"PROTECTED_UNTIL_FIRST_USER_AUTH"}
+		]},
+		{"key":"APPLE_ID_AUTH_APP_CONSENT","allowedInstances":"MULTIPLE","options":[{"key":"PRIMARY_APP_CONSENT"}]}
+	]`)
+	if err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	if len(settings) != 3 {
+		t.Fatalf("settings count = %d, want 3", len(settings))
+	}
+	if settings[0].MinInstances == nil || *settings[0].MinInstances != 1 {
+		t.Fatalf("minInstances = %v, want 1", settings[0].MinInstances)
+	}
+	if settings[0].Options[0].Enabled == nil || *settings[0].Options[0].Enabled {
+		t.Fatalf("explicit enabled=false was not preserved: %+v", settings[0].Options[0].Enabled)
+	}
+	if settings[0].Options[0].SupportsWildcard == nil || !*settings[0].Options[0].SupportsWildcard {
+		t.Fatalf("supportsWildcard=true was not preserved: %+v", settings[0].Options[0].SupportsWildcard)
+	}
+}
+
+func TestBundleIDsCapabilitiesHelpUsesSupportedSettings(t *testing.T) {
+	for _, cmd := range []*ffcli.Command{
+		BundleIDsCapabilitiesCommand(),
+		BundleIDsCapabilitiesAddCommand(),
+		BundleIDsCapabilitiesUpdateCommand(),
+	} {
+		if strings.Contains(cmd.LongHelp, "XCODE_9") || strings.Contains(cmd.LongHelp, "XCODE_13") {
+			t.Fatalf("%s help advertises an unsupported Xcode capability option: %q", cmd.Name, cmd.LongHelp)
+		}
+		if !strings.Contains(cmd.LongHelp, "XCODE_6") {
+			t.Fatalf("%s help does not include supported XCODE_6 option: %q", cmd.Name, cmd.LongHelp)
+		}
 	}
 }
 

--- a/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
+++ b/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
@@ -140,6 +140,21 @@ func TestBundleIDCapabilitiesSettingsValidationStopsBeforeHTTP(t *testing.T) {
 			wantErr: `unsupported capability option key "XCODE_13"`,
 		},
 		{
+			name:    "update rejects option for different setting",
+			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"COMPLETE_PROTECTION"}]}]`},
+			wantErr: `unsupported capability option key "COMPLETE_PROTECTION" for setting "ICLOUD_VERSION"`,
+		},
+		{
+			name:    "add rejects incorrectly cased field",
+			args:    []string{"bundle-ids", "capabilities", "add", "--bundle", "bundle1", "--capability", "ICLOUD", "--settings", `[{"KEY":"ICLOUD_VERSION"}]`},
+			wantErr: `unknown field "KEY"`,
+		},
+		{
+			name:    "update rejects empty allowed instances",
+			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","allowedInstances":""}]`},
+			wantErr: `unsupported allowedInstances ""`,
+		},
+		{
 			name:    "add rejects null schema field",
 			args:    []string{"bundle-ids", "capabilities", "add", "--bundle", "bundle1", "--capability", "ICLOUD", "--settings", `[{"key":"ICLOUD_VERSION","options":null}]`},
 			wantErr: `settings[0].options must not be null`,

--- a/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
+++ b/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestBundleIDCapabilitiesUpdateMissingID(t *testing.T) {
@@ -17,7 +19,7 @@ func TestBundleIDCapabilitiesUpdateMissingID(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"bundle-ids", "capabilities", "update", "--settings", `[{"key":"K"}]`}); err != nil {
+		if err := root.Parse([]string{"bundle-ids", "capabilities", "update", "--settings", `[{"key":"ICLOUD_VERSION"}]`}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		err := root.Run(context.Background())
@@ -100,6 +102,152 @@ func TestBundleIDCapabilitiesUpdateInvalidSettingsJSON(t *testing.T) {
 	}
 }
 
+func TestBundleIDCapabilitiesSettingsValidationStopsBeforeHTTP(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		status := http.StatusOK
+		if req.Method == http.MethodPost {
+			status = http.StatusCreated
+		}
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD"}}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "add rejects unknown field",
+			args:    []string{"bundle-ids", "capabilities", "add", "--bundle", "bundle1", "--capability", "ICLOUD", "--settings", `[{"key":"ICLOUD_VERSION","typo":true}]`},
+			wantErr: `unknown field "typo"`,
+		},
+		{
+			name:    "update rejects unsupported option",
+			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]`},
+			wantErr: `unsupported capability option key "XCODE_13"`,
+		},
+		{
+			name:    "add rejects null schema field",
+			args:    []string{"bundle-ids", "capabilities", "add", "--bundle", "bundle1", "--capability", "ICLOUD", "--settings", `[{"key":"ICLOUD_VERSION","options":null}]`},
+			wantErr: `settings[0].options must not be null`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requestCount = 0
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(tc.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, tc.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", tc.wantErr, stderr)
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, runErr)
+			}
+			if requestCount != 0 {
+				t.Fatalf("HTTP request count = %d, want 0", requestCount)
+			}
+		})
+	}
+}
+
+func TestBundleIDCapabilitiesAddWithSettings(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/bundleIdCapabilities" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var body struct {
+			Data struct {
+				Attributes struct {
+					Settings []struct {
+						Key     string `json:"key"`
+						Options []struct {
+							Key     string `json:"key"`
+							Enabled *bool  `json:"enabled"`
+						} `json:"options"`
+					} `json:"settings"`
+				} `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(payload, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		settings := body.Data.Attributes.Settings
+		if len(settings) != 1 || settings[0].Key != "ICLOUD_VERSION" || len(settings[0].Options) != 1 {
+			t.Fatalf("unexpected settings payload: %+v", settings)
+		}
+		option := settings[0].Options[0]
+		if option.Key != "XCODE_6" || option.Enabled == nil || !*option.Enabled {
+			t.Fatalf("unexpected option payload: %+v", option)
+		}
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: io.NopCloser(strings.NewReader(
+				`{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD","settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]}}}`,
+			)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"bundle-ids", "capabilities", "add",
+			"--bundle", "bundle1", "--capability", "ICLOUD",
+			"--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]`,
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"cap1"`) {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+}
+
 func TestBundleIDCapabilitiesUpdateSuccessOutput(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -143,7 +291,7 @@ func TestBundleIDCapabilitiesUpdateSuccessOutput(t *testing.T) {
 			t.Fatalf("expected 1 setting, got %v", attrs["settings"])
 		}
 
-		respBody := `{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD","settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]}}}`
+		respBody := `{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD","settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]}}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(respBody)),
@@ -155,7 +303,7 @@ func TestBundleIDCapabilitiesUpdateSuccessOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]`}); err != nil {
+		if err := root.Parse([]string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]`}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
+++ b/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
@@ -144,6 +144,16 @@ func TestBundleIDCapabilitiesSettingsValidationStopsBeforeHTTP(t *testing.T) {
 			wantErr: `allowedInstances at setting index 0 must not be empty`,
 		},
 		{
+			name:    "update rejects whitespace allowed instances",
+			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","allowedInstances":" \t"}]`},
+			wantErr: `allowedInstances at setting index 0 must not be blank`,
+		},
+		{
+			name:    "add rejects empty description",
+			args:    []string{"bundle-ids", "capabilities", "add", "--bundle", "bundle1", "--capability", "ICLOUD", "--settings", `[{"key":"ICLOUD_VERSION","description":""}]`},
+			wantErr: `description at setting index 0 must not be empty`,
+		},
+		{
 			name:    "update rejects missing setting key",
 			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"options":[]}]`},
 			wantErr: `capability setting key at index 0 must not be empty`,

--- a/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
+++ b/internal/cli/cmdtest/bundle_ids_capabilities_update_test.go
@@ -2,7 +2,6 @@ package cmdtest
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -135,16 +134,6 @@ func TestBundleIDCapabilitiesSettingsValidationStopsBeforeHTTP(t *testing.T) {
 			wantErr: `unknown field "typo"`,
 		},
 		{
-			name:    "update rejects unsupported option",
-			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]`},
-			wantErr: `unsupported capability option key "XCODE_13"`,
-		},
-		{
-			name:    "update rejects option for different setting",
-			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"COMPLETE_PROTECTION"}]}]`},
-			wantErr: `unsupported capability option key "COMPLETE_PROTECTION" for setting "ICLOUD_VERSION"`,
-		},
-		{
 			name:    "add rejects incorrectly cased field",
 			args:    []string{"bundle-ids", "capabilities", "add", "--bundle", "bundle1", "--capability", "ICLOUD", "--settings", `[{"KEY":"ICLOUD_VERSION"}]`},
 			wantErr: `unknown field "KEY"`,
@@ -152,7 +141,17 @@ func TestBundleIDCapabilitiesSettingsValidationStopsBeforeHTTP(t *testing.T) {
 		{
 			name:    "update rejects empty allowed instances",
 			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","allowedInstances":""}]`},
-			wantErr: `unsupported allowedInstances ""`,
+			wantErr: `allowedInstances at setting index 0 must not be empty`,
+		},
+		{
+			name:    "update rejects missing setting key",
+			args:    []string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"options":[]}]`},
+			wantErr: `capability setting key at index 0 must not be empty`,
+		},
+		{
+			name:    "add rejects malformed options",
+			args:    []string{"bundle-ids", "capabilities", "add", "--bundle", "bundle1", "--capability", "ICLOUD", "--settings", `[{"key":"FUTURE_SETTING","options":{}}]`},
+			wantErr: `cannot unmarshal object into Go struct field CapabilitySetting.options`,
 		},
 		{
 			name:    "add rejects null schema field",
@@ -207,34 +206,14 @@ func TestBundleIDCapabilitiesAddWithSettings(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		var body struct {
-			Data struct {
-				Attributes struct {
-					Settings []struct {
-						Key     string `json:"key"`
-						Options []struct {
-							Key     string `json:"key"`
-							Enabled *bool  `json:"enabled"`
-						} `json:"options"`
-					} `json:"settings"`
-				} `json:"attributes"`
-			} `json:"data"`
-		}
-		if err := json.Unmarshal(payload, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-		settings := body.Data.Attributes.Settings
-		if len(settings) != 1 || settings[0].Key != "ICLOUD_VERSION" || len(settings[0].Options) != 1 {
-			t.Fatalf("unexpected settings payload: %+v", settings)
-		}
-		option := settings[0].Options[0]
-		if option.Key != "XCODE_6" || option.Enabled == nil || !*option.Enabled {
-			t.Fatalf("unexpected option payload: %+v", option)
+		wantPayload := `{"data":{"type":"bundleIdCapabilities","attributes":{"capabilityType":"MARZIPAN","settings":[{"key":"ENABLED_FOR_MAC_APP_SETUP","options":[{"key":"USE_IOS_APPID","enabled":true}]}]},"relationships":{"bundleId":{"data":{"type":"bundleIds","id":"bundle1"}}}}}` + "\n"
+		if string(payload) != wantPayload {
+			t.Fatalf("request body = %q, want %q", payload, wantPayload)
 		}
 		return &http.Response{
 			StatusCode: http.StatusCreated,
 			Body: io.NopCloser(strings.NewReader(
-				`{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD","settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]}}}`,
+				`{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"MARZIPAN","settings":[{"key":"ENABLED_FOR_MAC_APP_SETUP","options":[{"key":"USE_IOS_APPID","enabled":true}]}]}}}`,
 			)),
 			Header: http.Header{"Content-Type": []string{"application/json"}},
 		}, nil
@@ -245,8 +224,8 @@ func TestBundleIDCapabilitiesAddWithSettings(t *testing.T) {
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"bundle-ids", "capabilities", "add",
-			"--bundle", "bundle1", "--capability", "ICLOUD",
-			"--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]`,
+			"--bundle", "bundle1", "--capability", "MARZIPAN",
+			"--settings", `[{"key":"ENABLED_FOR_MAC_APP_SETUP","options":[{"key":"USE_IOS_APPID","enabled":true}]}]`,
 			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -260,6 +239,11 @@ func TestBundleIDCapabilitiesAddWithSettings(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"id":"cap1"`) {
 		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"capabilityType":"MARZIPAN"`) ||
+		!strings.Contains(stdout, `"key":"ENABLED_FOR_MAC_APP_SETUP"`) ||
+		!strings.Contains(stdout, `"key":"USE_IOS_APPID"`) {
+		t.Fatalf("forward-compatible response fields were not preserved: %q", stdout)
 	}
 }
 
@@ -283,30 +267,12 @@ func TestBundleIDCapabilitiesUpdateSuccessOutput(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body error: %v", err)
 		}
-		var body map[string]any
-		if err := json.Unmarshal(payload, &body); err != nil {
-			t.Fatalf("decode body error: %v", err)
-		}
-		data, ok := body["data"].(map[string]any)
-		if !ok {
-			t.Fatalf("expected data object in body")
-		}
-		if data["type"] != "bundleIdCapabilities" {
-			t.Fatalf("expected type bundleIdCapabilities, got %v", data["type"])
-		}
-		if data["id"] != "cap1" {
-			t.Fatalf("expected id cap1, got %v", data["id"])
-		}
-		attrs, ok := data["attributes"].(map[string]any)
-		if !ok {
-			t.Fatalf("expected attributes object in body")
-		}
-		settings, ok := attrs["settings"].([]any)
-		if !ok || len(settings) != 1 {
-			t.Fatalf("expected 1 setting, got %v", attrs["settings"])
+		wantPayload := `{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"settings":[{"key":"APP_GROUP_IDENTIFIERS","allowedInstances":"FUTURE_INSTANCE_MODE","options":[{"key":"group.com.example.shared","enabled":true}]}]}}}` + "\n"
+		if string(payload) != wantPayload {
+			t.Fatalf("request body = %q, want %q", payload, wantPayload)
 		}
 
-		respBody := `{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"ICLOUD","settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]}}}`
+		respBody := `{"data":{"type":"bundleIdCapabilities","id":"cap1","attributes":{"capabilityType":"APP_GROUPS","settings":[{"key":"APP_GROUP_IDENTIFIERS","allowedInstances":"FUTURE_INSTANCE_MODE","options":[{"key":"group.com.example.shared","enabled":true}]}]}}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(respBody)),
@@ -318,7 +284,7 @@ func TestBundleIDCapabilitiesUpdateSuccessOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]`}); err != nil {
+		if err := root.Parse([]string{"bundle-ids", "capabilities", "update", "--id", "cap1", "--settings", `[{"key":"APP_GROUP_IDENTIFIERS","allowedInstances":"FUTURE_INSTANCE_MODE","options":[{"key":"group.com.example.shared","enabled":true}]}]`}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -332,8 +298,13 @@ func TestBundleIDCapabilitiesUpdateSuccessOutput(t *testing.T) {
 	if !strings.Contains(stdout, `"id":"cap1"`) {
 		t.Fatalf("expected capability id in output, got %q", stdout)
 	}
-	if !strings.Contains(stdout, `"capabilityType":"ICLOUD"`) {
+	if !strings.Contains(stdout, `"capabilityType":"APP_GROUPS"`) {
 		t.Fatalf("expected capabilityType in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"key":"APP_GROUP_IDENTIFIERS"`) ||
+		!strings.Contains(stdout, `"allowedInstances":"FUTURE_INSTANCE_MODE"`) ||
+		!strings.Contains(stdout, `"key":"group.com.example.shared"`) {
+		t.Fatalf("forward-compatible response fields were not preserved: %q", stdout)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Complete the public `CapabilitySetting` and `CapabilityOption` models so every field in Apple OpenAPI 4.4.1 can round-trip.
- Validate `--settings` structure for capability add and update: exact field-name casing, JSON types, array/object shape, nulls, required nonblank setting and option keys, and blank optional strings that `omitempty` would discard.
- Pass unknown nonempty setting, option, and `allowedInstances` strings through unchanged. The client neither rewrites them nor blocks values missing from Apple's published schema.
- Replace invalid `XCODE_9` and `XCODE_13` examples with `XCODE_5` and `XCODE_6`; remove the invented `APP_GROUP_IDS` and `ASSOCIATED_DOMAIN_IDS` payloads, correct `HOT_SPOT`, and update request fixtures.

## Why the enum values stay open

Apple documents both [`POST /v1/bundleIdCapabilities`](https://developer.apple.com/documentation/appstoreconnectapi/post-v1-bundleidcapabilities) and [`PATCH /v1/bundleIdCapabilities/{id}`](https://developer.apple.com/documentation/appstoreconnectapi/patch-v1-bundleidcapabilities-_id_). The current OpenAPI file accurately describes the setting and option fields, but its enum lists lag live behavior.

Read-only Apple responses returned capability type `MARZIPAN` with `ENABLED_FOR_MAC_APP_SETUP => USE_IOS_APPID`, none of which appears in the current OpenAPI snapshot. [Bitrise go-xcode](https://github.com/bitrise-io/go-xcode/blob/0a9bec060ac77b4dd3ebb75c4cbdf5cb5b7f92b9/autocodesign/devportalclient/appstoreconnect/capabilities.go#L109-L136) also declares `APP_GROUP_IDENTIFIERS`. A local allowlist would reject valid Apple values whenever the schema falls behind, while runtime discovery would make request validation network-dependent. Structural validation is the stable boundary.

App Group and Associated Domain documentation remains conservative. The old `APP_GROUP_IDS` and `ASSOCIATED_DOMAIN_IDS` examples had no supporting API evidence, so this PR doesn't restore them.

## Compatibility

The command names, flags, output formats, and exit codes do not change. Malformed settings still fail before authentication or HTTP with usage exit `2`; well-formed unknown strings now reach Apple exactly as supplied. Existing documented values behave as before.

## Verification

- RED tests reproduced rejection of the live Apple pair, Bitrise's app-group setting, and synthetic future values.
- Parser and command regressions cover field casing, JSON types, malformed arrays/objects, nulls, empty or whitespace-only values, trailing JSON, byte-exact POST/PATCH bodies, zero HTTP on invalid input, and response round-tripping.
- A built binary accepts future setting values before authentication; incorrectly cased fields return exit `2`, leave stdout empty, and make no request.
- Read-only live listing confirmed `MARZIPAN` and `ENABLED_FOR_MAC_APP_SETUP => USE_IOS_APPID` on current Apple data. No live mutation ran for this rework.
- `make format`, `make check-docs`, serialized `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Capability settings now validate supported fields, values, options, and instance limits.
  * Invalid or malformed settings are rejected before requests are sent.
  * Optional capability values and supported response fields are preserved during updates.
  * App Groups and Associated Domains are configured without settings payloads.
  * Updated iCloud examples to use `XCODE_6`.

* **Documentation**
  * Expanded guidance for capability settings, options, instance limits, and command examples.
  * Improved CLI help text for capability configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->