### PR TITLE
Fix pass type pagination and user role validation

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -9044,13 +9044,21 @@ func TestGetUsers_WithFiltersAndLimit(t *testing.T) {
 		if values.Get("filter[username]") != "user@example.com" {
 			t.Fatalf("expected filter[username]=user@example.com, got %q", values.Get("filter[username]"))
 		}
+		if values.Get("filter[roles]") != "DEVELOPER,APP_MANAGER" {
+			t.Fatalf("expected filter[roles]=DEVELOPER,APP_MANAGER, got %q", values.Get("filter[roles]"))
+		}
 		if values.Get("limit") != "5" {
 			t.Fatalf("expected limit=5, got %q", values.Get("limit"))
 		}
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetUsers(context.Background(), WithUsersEmail("user@example.com"), WithUsersLimit(5)); err != nil {
+	if _, err := client.GetUsers(
+		context.Background(),
+		WithUsersEmail("user@example.com"),
+		WithUsersRoles([]string{"developer", " app_manager "}),
+		WithUsersLimit(5),
+	); err != nil {
 		t.Fatalf("GetUsers() error: %v", err)
 	}
 }

--- a/internal/asc/client_query_signing.go
+++ b/internal/asc/client_query_signing.go
@@ -969,7 +969,7 @@ func WithUsersEmail(email string) UsersOption {
 // WithUsersRoles filters users by roles.
 func WithUsersRoles(roles []string) UsersOption {
 	return func(q *usersQuery) {
-		q.roles = normalizeList(roles)
+		q.roles = normalizeUpperList(roles)
 	}
 }
 

--- a/internal/cli/cmdtest/ids_relationships_next_validation_test.go
+++ b/internal/cli/cmdtest/ids_relationships_next_validation_test.go
@@ -2,8 +2,11 @@ package cmdtest
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -102,32 +105,30 @@ func TestPassTypeIDCertificatesListPaginateFromNextWithoutPassTypeID(t *testing.
 	const secondURL = "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/certificates?cursor=BQ&limit=200"
 
 	requestCount := 0
-	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	installAppStoreConnectTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
 		switch requestCount {
 		case 1:
-			if req.Method != http.MethodGet || req.URL.String() != firstURL {
-				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
+			if req.Method != http.MethodGet || req.URL.RequestURI() != "/v1/passTypeIds/pass-1/certificates?cursor=AQ&limit=200" {
+				t.Errorf("unexpected first request: %s %s", req.Method, req.URL.String())
+				http.Error(w, "unexpected request", http.StatusBadRequest)
+				return
 			}
 			body := `{"data":[{"type":"certificates","id":"pass-cert-next-1"}],"links":{"next":"` + secondURL + `"}}`
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(body)),
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-			}, nil
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, body)
 		case 2:
-			if req.Method != http.MethodGet || req.URL.String() != secondURL {
-				t.Fatalf("unexpected second request: %s %s", req.Method, req.URL.String())
+			if req.Method != http.MethodGet || req.URL.RequestURI() != "/v1/passTypeIds/pass-1/certificates?cursor=BQ&limit=200" {
+				t.Errorf("unexpected second request: %s %s", req.Method, req.URL.String())
+				http.Error(w, "unexpected request", http.StatusBadRequest)
+				return
 			}
 			body := `{"data":[{"type":"certificates","id":"pass-cert-next-2"}],"links":{"next":""}}`
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(body)),
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-			}, nil
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, body)
 		default:
-			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			t.Errorf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
 		}
 	}))
 
@@ -210,32 +211,30 @@ func TestPassTypeIDCertificatesGetPaginateFromNextWithoutPassTypeID(t *testing.T
 	const secondURL = "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/relationships/certificates?cursor=BQ&limit=200"
 
 	requestCount := 0
-	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	installAppStoreConnectTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
 		switch requestCount {
 		case 1:
-			if req.Method != http.MethodGet || req.URL.String() != firstURL {
-				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
+			if req.Method != http.MethodGet || req.URL.RequestURI() != "/v1/passTypeIds/pass-1/relationships/certificates?cursor=AQ&limit=200" {
+				t.Errorf("unexpected first request: %s %s", req.Method, req.URL.String())
+				http.Error(w, "unexpected request", http.StatusBadRequest)
+				return
 			}
 			body := `{"data":[{"type":"certificates","id":"pass-rel-next-1"}],"links":{"next":"` + secondURL + `"}}`
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(body)),
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-			}, nil
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, body)
 		case 2:
-			if req.Method != http.MethodGet || req.URL.String() != secondURL {
-				t.Fatalf("unexpected second request: %s %s", req.Method, req.URL.String())
+			if req.Method != http.MethodGet || req.URL.RequestURI() != "/v1/passTypeIds/pass-1/relationships/certificates?cursor=BQ&limit=200" {
+				t.Errorf("unexpected second request: %s %s", req.Method, req.URL.String())
+				http.Error(w, "unexpected request", http.StatusBadRequest)
+				return
 			}
 			body := `{"data":[{"type":"certificates","id":"pass-rel-next-2"}],"links":{"next":""}}`
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(body)),
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-			}, nil
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, body)
 		default:
-			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			t.Errorf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
 		}
 	}))
 
@@ -257,6 +256,30 @@ func TestPassTypeIDCertificatesGetPaginateFromNextWithoutPassTypeID(t *testing.T
 	if !strings.Contains(stdout, `"id":"pass-rel-next-1"`) || !strings.Contains(stdout, `"id":"pass-rel-next-2"`) {
 		t.Fatalf("expected paginated pass type certificate relationships in output, got %q", stdout)
 	}
+}
+
+func installAppStoreConnectTestServer(t *testing.T, handler http.Handler) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Scheme != "https" || req.URL.Host != "api.appstoreconnect.apple.com" {
+			return nil, fmt.Errorf("unexpected App Store Connect URL: %s", req.URL.String())
+		}
+
+		rewritten := req.Clone(req.Context())
+		rewritten.URL.Scheme = serverURL.Scheme
+		rewritten.URL.Host = serverURL.Host
+		rewritten.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(rewritten)
+	}))
 }
 
 func TestMerchantIDCertificatesListRejectsInvalidNextURL(t *testing.T) {

--- a/internal/cli/cmdtest/ids_relationships_next_validation_test.go
+++ b/internal/cli/cmdtest/ids_relationships_next_validation_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestPassTypeIDCertificatesListRejectsInvalidNextURL(t *testing.T) {
@@ -29,34 +31,38 @@ func TestPassTypeIDCertificatesListRejectsInvalidNextURL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			root := RootCommand("1.2.3")
-			root.FlagSet.SetOutput(io.Discard)
-
-			var runErr error
 			stdout, stderr := captureOutput(t, func() {
-				if err := root.Parse([]string{"pass-type-ids", "certificates", "list", "--pass-type-id", "pass-1", "--next", test.next}); err != nil {
-					t.Fatalf("parse error: %v", err)
+				if code := rootcmd.Run([]string{"pass-type-ids", "certificates", "list", "--next", test.next}, "1.2.3"); code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
 				}
-				runErr = root.Run(context.Background())
 			})
-
-			if runErr == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(runErr.Error(), test.wantErr) {
-				t.Fatalf("expected error %q, got %v", test.wantErr, runErr)
-			}
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if stderr != "" {
-				t.Fatalf("expected empty stderr, got %q", stderr)
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr %q, got %q", test.wantErr, stderr)
 			}
 		})
 	}
 }
 
-func TestPassTypeIDCertificatesListPaginateFromNext(t *testing.T) {
+func TestPassTypeIDCertificatesListRejectsWrongNextEndpoint(t *testing.T) {
+	stdout, stderr := captureOutput(t, func() {
+		args := []string{"pass-type-ids", "certificates", "list", "--next", "https://api.appstoreconnect.apple.com/v1/users?cursor=AQ"}
+		if code := rootcmd.Run(args, "1.2.3"); code != rootcmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+		}
+	})
+
+	if !strings.Contains(stderr, "--next must target the pass type ID certificates endpoint") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}
+
+func TestPassTypeIDCertificatesListPaginateFromNextWithoutPassTypeID(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -102,7 +108,7 @@ func TestPassTypeIDCertificatesListPaginateFromNext(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"pass-type-ids", "certificates", "list", "--pass-type-id", "pass-1", "--paginate", "--next", firstURL}); err != nil {
+		if err := root.Parse([]string{"pass-type-ids", "certificates", "list", "--paginate", "--next", firstURL}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {
@@ -138,34 +144,38 @@ func TestPassTypeIDCertificatesGetRejectsInvalidNextURL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			root := RootCommand("1.2.3")
-			root.FlagSet.SetOutput(io.Discard)
-
-			var runErr error
 			stdout, stderr := captureOutput(t, func() {
-				if err := root.Parse([]string{"pass-type-ids", "certificates", "view", "--pass-type-id", "pass-1", "--next", test.next}); err != nil {
-					t.Fatalf("parse error: %v", err)
+				if code := rootcmd.Run([]string{"pass-type-ids", "certificates", "view", "--next", test.next}, "1.2.3"); code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
 				}
-				runErr = root.Run(context.Background())
 			})
-
-			if runErr == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(runErr.Error(), test.wantErr) {
-				t.Fatalf("expected error %q, got %v", test.wantErr, runErr)
-			}
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if stderr != "" {
-				t.Fatalf("expected empty stderr, got %q", stderr)
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr %q, got %q", test.wantErr, stderr)
 			}
 		})
 	}
 }
 
-func TestPassTypeIDCertificatesGetPaginateFromNext(t *testing.T) {
+func TestPassTypeIDCertificatesGetRejectsWrongNextEndpoint(t *testing.T) {
+	stdout, stderr := captureOutput(t, func() {
+		args := []string{"pass-type-ids", "certificates", "view", "--next", "https://api.appstoreconnect.apple.com/v1/users?cursor=AQ"}
+		if code := rootcmd.Run(args, "1.2.3"); code != rootcmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+		}
+	})
+
+	if !strings.Contains(stderr, "--next must target the pass type ID certificates endpoint") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}
+
+func TestPassTypeIDCertificatesGetPaginateFromNextWithoutPassTypeID(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -211,7 +221,7 @@ func TestPassTypeIDCertificatesGetPaginateFromNext(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"pass-type-ids", "certificates", "view", "--pass-type-id", "pass-1", "--paginate", "--next", firstURL}); err != nil {
+		if err := root.Parse([]string{"pass-type-ids", "certificates", "view", "--paginate", "--next", firstURL}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/cmdtest/ids_relationships_next_validation_test.go
+++ b/internal/cli/cmdtest/ids_relationships_next_validation_test.go
@@ -62,6 +62,38 @@ func TestPassTypeIDCertificatesListRejectsWrongNextEndpoint(t *testing.T) {
 	}
 }
 
+func TestPassTypeIDCertificatesRejectsConflictingPassTypeIDAndNext(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "list",
+			args: []string{"pass-type-ids", "certificates", "list", "--pass-type-id", "pass-2", "--next", "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/certificates?cursor=AQ"},
+		},
+		{
+			name: "view",
+			args: []string{"pass-type-ids", "certificates", "view", "--pass-type-id", "pass-2", "--next", "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/relationships/certificates?cursor=AQ"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run(test.args, "1.2.3"); code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "--pass-type-id must match the pass type ID in --next") {
+				t.Fatalf("unexpected stderr: %q", stderr)
+			}
+		})
+	}
+}
+
 func TestPassTypeIDCertificatesListPaginateFromNextWithoutPassTypeID(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -69,13 +101,8 @@ func TestPassTypeIDCertificatesListPaginateFromNextWithoutPassTypeID(t *testing.
 	const firstURL = "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/certificates?cursor=AQ&limit=200"
 	const secondURL = "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/certificates?cursor=BQ&limit=200"
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requestCount++
 		switch requestCount {
 		case 1:
@@ -102,7 +129,7 @@ func TestPassTypeIDCertificatesListPaginateFromNextWithoutPassTypeID(t *testing.
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
 			return nil, nil
 		}
-	})
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -182,13 +209,8 @@ func TestPassTypeIDCertificatesGetPaginateFromNextWithoutPassTypeID(t *testing.T
 	const firstURL = "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/relationships/certificates?cursor=AQ&limit=200"
 	const secondURL = "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/relationships/certificates?cursor=BQ&limit=200"
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requestCount++
 		switch requestCount {
 		case 1:
@@ -215,7 +237,7 @@ func TestPassTypeIDCertificatesGetPaginateFromNextWithoutPassTypeID(t *testing.T
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
 			return nil, nil
 		}
-	})
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
+++ b/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
@@ -519,33 +519,32 @@ func TestSubscriptionsReviewScreenshotCreateUsesFreshTimeoutForEachUploadPart(t 
 	}
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	sequence := make([]string, 0, 7)
-	partTwoAttempts := 0
+	sequence := newRequestLog(7)
+	var partTwoAttempts lockedCounter
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
-			sequence = append(sequence, "read")
+			sequence.Add("read")
 			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponseWithOperations("shot-1", filepath.Base(path), int64(len(content)), operations)), nil
 		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
 			deadline, ok := req.Context().Deadline()
 			if !ok || time.Until(deadline) < 100*time.Millisecond {
 				t.Fatalf("upload part inherited stale deadline: %s", time.Until(deadline))
 			}
-			sequence = append(sequence, req.URL.Path)
+			sequence.Add(req.URL.Path)
 			if req.URL.Path == "/part-1" {
 				time.Sleep(75 * time.Millisecond)
 				return jsonHTTPResponse(http.StatusOK, ``), nil
 			}
-			partTwoAttempts++
-			if partTwoAttempts == 1 {
+			if partTwoAttempts.Inc() == 1 {
 				return jsonHTTPResponse(http.StatusServiceUnavailable, ``), nil
 			}
 			return jsonHTTPResponse(http.StatusOK, ``), nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
-			sequence = append(sequence, "commit")
+			sequence.Add("commit")
 			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "PROCESSING", false)), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAppStoreReviewScreenshots/shot-1":
-			sequence = append(sequence, "poll")
+			sequence.Add("poll")
 			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponse("shot-1", filepath.Base(path), int64(len(content)), checksum, "COMPLETE", false)), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
@@ -554,9 +553,20 @@ func TestSubscriptionsReviewScreenshotCreateUsesFreshTimeoutForEachUploadPart(t 
 	})
 
 	_, _, err := runSubscriptionReviewScreenshotCreate(t, path)
-	want := []string{"read", "/part-1", "/part-2", "/part-2", "commit", "poll"}
-	if err != nil || !reflect.DeepEqual(sequence, want) {
-		t.Fatalf("expected multipart sequence %v, got %v err=%v", want, sequence, err)
+	if err != nil {
+		t.Fatalf("unexpected multipart result: %v", err)
+	}
+	got := sequence.Snapshot()
+	if len(got) != 6 || got[0] != "read" || got[4] != "commit" || got[5] != "poll" {
+		t.Fatalf("unexpected multipart sequence: %v", got)
+	}
+	uploadAttempts := make(map[string]int, 2)
+	for _, step := range got[1:4] {
+		uploadAttempts[step]++
+	}
+	wantUploadAttempts := map[string]int{"/part-1": 1, "/part-2": 2}
+	if !reflect.DeepEqual(uploadAttempts, wantUploadAttempts) {
+		t.Fatalf("upload attempts = %v, want %v", uploadAttempts, wantUploadAttempts)
 	}
 }
 

--- a/internal/cli/cmdtest/users_deprecated_roles_test.go
+++ b/internal/cli/cmdtest/users_deprecated_roles_test.go
@@ -27,7 +27,7 @@ func TestUsersUpdateWarnsDeprecatedAccessToReportsRole(t *testing.T) {
 		if err := root.Parse([]string{
 			"users", "update",
 			"--id", "user-1",
-			"--roles", "ACCESS_TO_REPORTS",
+			"--roles", "access_to_reports",
 			"--output", "json",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -73,7 +73,7 @@ func TestUsersInviteWarnsDeprecatedAccessToReportsRole(t *testing.T) {
 			"--email", "user@example.com",
 			"--first-name", "Jane",
 			"--last-name", "Doe",
-			"--roles", "ACCESS_TO_REPORTS",
+			"--roles", "access_to_reports",
 			"--all-apps",
 			"--output", "json",
 		}); err != nil {

--- a/internal/cli/cmdtest/users_roles_test.go
+++ b/internal/cli/cmdtest/users_roles_test.go
@@ -1,0 +1,118 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestUsersListNormalizesRoles(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/users" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.URL.Query().Get("filter[roles]"); got != "DEVELOPER,APP_MANAGER" {
+			t.Fatalf("filter[roles] = %q, want DEVELOPER,APP_MANAGER", got)
+		}
+		return jsonResponse(http.StatusOK, `{"data":[]}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"users", "list", "--role", " developer, app_manager ", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestUsersUpdateNormalizesRoles(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/users/user-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		var payload asc.UserUpdateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := payload.Data.Attributes.Roles; len(got) != 2 || got[0] != "DEVELOPER" || got[1] != "APP_MANAGER" {
+			t.Fatalf("roles = %#v, want [DEVELOPER APP_MANAGER]", got)
+		}
+		return jsonResponse(http.StatusOK, `{"data":{"type":"users","id":"user-1","attributes":{"roles":["DEVELOPER","APP_MANAGER"]}}}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"users", "update", "--id", "user-1", "--roles", "developer,app_manager", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestUsersInviteNormalizesRoles(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/userInvitations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		var payload asc.UserInvitationCreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := payload.Data.Attributes.Roles; len(got) != 1 || got[0] != "DEVELOPER" {
+			t.Fatalf("roles = %#v, want [DEVELOPER]", got)
+		}
+		return jsonResponse(http.StatusCreated, `{"data":{"type":"userInvitations","id":"invite-1","attributes":{"roles":["DEVELOPER"]}}}`)
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"users", "invite", "--email", "user@example.com", "--first-name", "Jane", "--last-name", "Doe", "--roles", "developer", "--all-apps", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestUsersCommandsRejectInvalidRolesWithUsageExit(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", t.TempDir()+"/config.json")
+
+	tests := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "list", args: []string{"users", "list", "--role", "not_a_role"}, flag: "--role"},
+		{name: "update", args: []string{"users", "update", "--id", "user-1", "--roles", "not_a_role"}, flag: "--roles"},
+		{name: "invite", args: []string{"users", "invite", "--email", "user@example.com", "--first-name", "Jane", "--last-name", "Doe", "--roles", "not_a_role", "--all-apps"}, flag: "--roles"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run(test.args, "1.2.3"); code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.flag+" must be one of: ADMIN, FINANCE, ACCOUNT_HOLDER") {
+				t.Fatalf("unexpected stderr: %q", stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/passtypeids/certificates.go
+++ b/internal/cli/passtypeids/certificates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -42,7 +43,7 @@ Examples:
 func PassTypeIDCertificatesListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
-	passTypeID := fs.String("pass-type-id", "", "Pass type ID")
+	passTypeID := fs.String("pass-type-id", "", "Pass type ID (required unless --next is provided)")
 	displayName := fs.String("display-name", "", "Filter by display name(s), comma-separated")
 	certificateType := fs.String("certificate-type", "", "Filter by certificate type(s), comma-separated")
 	serialNumber := fs.String("serial-number", "", "Filter by serial number(s), comma-separated")
@@ -56,26 +57,36 @@ func PassTypeIDCertificatesListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc pass-type-ids certificates list --pass-type-id \"PASS_ID\" [flags]",
+		ShortUsage: "asc pass-type-ids certificates list [--pass-type-id \"PASS_ID\"] [--next \"URL\"] [flags]",
 		ShortHelp:  "List certificates for a pass type ID.",
 		LongHelp: `List certificates for a pass type ID.
 
 Examples:
   asc pass-type-ids certificates list --pass-type-id "PASS_ID"
+  asc pass-type-ids certificates list --next "https://api.appstoreconnect.apple.com/v1/passTypeIds/PASS_ID/certificates?cursor=CURSOR"
   asc pass-type-ids certificates list --pass-type-id "PASS_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			passTypeIDValue := strings.TrimSpace(*passTypeID)
-			if passTypeIDValue == "" {
-				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required")
-				return shared.MissingRequiredUsageError()
-			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("pass-type-ids certificates list: --limit must be between 1 and 200")
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
-				return fmt.Errorf("pass-type-ids certificates list: %w", err)
+				return shared.UsageErrorf("pass-type-ids certificates list: %v", err)
+			}
+			if strings.TrimSpace(*next) != "" {
+				derivedID, err := passTypeIDFromCertificatesNextURL(*next, false)
+				if err != nil {
+					return shared.UsageErrorf("pass-type-ids certificates list: %v", err)
+				}
+				if passTypeIDValue == "" {
+					passTypeIDValue = derivedID
+				}
+			}
+			if passTypeIDValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required unless --next is provided")
+				return shared.MissingRequiredUsageError()
 			}
 			if err := shared.ValidateSort(*sort, passTypeIDCertificatesSortList()...); err != nil {
 				return fmt.Errorf("pass-type-ids certificates list: %w", err)
@@ -152,7 +163,7 @@ Examples:
 func PassTypeIDCertificatesGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("view", flag.ExitOnError)
 
-	passTypeID := fs.String("pass-type-id", "", "Pass type ID")
+	passTypeID := fs.String("pass-type-id", "", "Pass type ID (required unless --next is provided)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -160,26 +171,36 @@ func PassTypeIDCertificatesGetCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "view",
-		ShortUsage: "asc pass-type-ids certificates view --pass-type-id \"PASS_ID\" [flags]",
+		ShortUsage: "asc pass-type-ids certificates view [--pass-type-id \"PASS_ID\"] [--next \"URL\"] [flags]",
 		ShortHelp:  "View certificate relationships for a pass type ID.",
 		LongHelp: `View certificate relationships for a pass type ID.
 
 Examples:
   asc pass-type-ids certificates view --pass-type-id "PASS_ID"
+  asc pass-type-ids certificates view --next "https://api.appstoreconnect.apple.com/v1/passTypeIds/PASS_ID/relationships/certificates?cursor=CURSOR"
   asc pass-type-ids certificates view --pass-type-id "PASS_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			passTypeIDValue := strings.TrimSpace(*passTypeID)
-			if passTypeIDValue == "" {
-				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required")
-				return shared.MissingRequiredUsageError()
-			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("pass-type-ids certificates view: --limit must be between 1 and 200")
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
-				return fmt.Errorf("pass-type-ids certificates view: %w", err)
+				return shared.UsageErrorf("pass-type-ids certificates view: %v", err)
+			}
+			if strings.TrimSpace(*next) != "" {
+				derivedID, err := passTypeIDFromCertificatesNextURL(*next, true)
+				if err != nil {
+					return shared.UsageErrorf("pass-type-ids certificates view: %v", err)
+				}
+				if passTypeIDValue == "" {
+					passTypeIDValue = derivedID
+				}
+			}
+			if passTypeIDValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --pass-type-id is required unless --next is provided")
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()
@@ -220,4 +241,33 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func passTypeIDFromCertificatesNextURL(nextURL string, relationship bool) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(nextURL))
+	if err != nil {
+		return "", fmt.Errorf("invalid --next URL")
+	}
+
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	wantParts := 4
+	if relationship {
+		wantParts = 5
+	}
+	if len(parts) != wantParts || parts[0] != "v1" || parts[1] != "passTypeIds" {
+		return "", fmt.Errorf("--next must target the pass type ID certificates endpoint")
+	}
+	if relationship {
+		if parts[3] != "relationships" || parts[4] != "certificates" {
+			return "", fmt.Errorf("--next must target the pass type ID certificate relationships endpoint")
+		}
+	} else if parts[3] != "certificates" {
+		return "", fmt.Errorf("--next must target the pass type ID certificates endpoint")
+	}
+
+	passTypeID, err := url.PathUnescape(parts[2])
+	if err != nil || strings.TrimSpace(passTypeID) == "" || strings.Contains(passTypeID, "/") {
+		return "", fmt.Errorf("--next must contain a valid pass type ID")
+	}
+	return passTypeID, nil
 }

--- a/internal/cli/passtypeids/certificates.go
+++ b/internal/cli/passtypeids/certificates.go
@@ -80,6 +80,9 @@ Examples:
 				if err != nil {
 					return shared.UsageErrorf("pass-type-ids certificates list: %v", err)
 				}
+				if passTypeIDValue != "" && passTypeIDValue != derivedID {
+					return shared.UsageError("pass-type-ids certificates list: --pass-type-id must match the pass type ID in --next")
+				}
 				if passTypeIDValue == "" {
 					passTypeIDValue = derivedID
 				}
@@ -193,6 +196,9 @@ Examples:
 				derivedID, err := passTypeIDFromCertificatesNextURL(*next, true)
 				if err != nil {
 					return shared.UsageErrorf("pass-type-ids certificates view: %v", err)
+				}
+				if passTypeIDValue != "" && passTypeIDValue != derivedID {
+					return shared.UsageError("pass-type-ids certificates view: --pass-type-id must match the pass type ID in --next")
 				}
 				if passTypeIDValue == "" {
 					passTypeIDValue = derivedID

--- a/internal/cli/passtypeids/pass_type_ids_test.go
+++ b/internal/cli/passtypeids/pass_type_ids_test.go
@@ -88,3 +88,58 @@ func TestPassTypeIDHelpers(t *testing.T) {
 		t.Fatal("expected fields validation error")
 	}
 }
+
+func TestPassTypeIDFromCertificatesNextURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		next         string
+		relationship bool
+		want         string
+	}{
+		{
+			name: "certificates",
+			next: "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/certificates?cursor=AQ",
+			want: "pass-1",
+		},
+		{
+			name:         "certificate relationships",
+			next:         "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/relationships/certificates?cursor=AQ",
+			relationship: true,
+			want:         "pass-1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := passTypeIDFromCertificatesNextURL(test.next, test.relationship)
+			if err != nil {
+				t.Fatalf("passTypeIDFromCertificatesNextURL() error: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("passTypeIDFromCertificatesNextURL() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPassTypeIDFromCertificatesNextURLRejectsWrongEndpoint(t *testing.T) {
+	tests := []struct {
+		name         string
+		next         string
+		relationship bool
+	}{
+		{name: "users endpoint", next: "https://api.appstoreconnect.apple.com/v1/users?cursor=AQ"},
+		{name: "missing pass type ID", next: "https://api.appstoreconnect.apple.com/v1/passTypeIds//certificates?cursor=AQ"},
+		{name: "relationship passed to list", next: "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/relationships/certificates?cursor=AQ"},
+		{name: "list passed to relationship", next: "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass-1/certificates?cursor=AQ", relationship: true},
+		{name: "encoded slash in ID", next: "https://api.appstoreconnect.apple.com/v1/passTypeIds/pass%2Fone/certificates?cursor=AQ"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := passTypeIDFromCertificatesNextURL(test.next, test.relationship); err == nil {
+				t.Fatalf("expected error for %q", test.next)
+			}
+		})
+	}
+}

--- a/internal/cli/users/roles.go
+++ b/internal/cli/users/roles.go
@@ -1,0 +1,38 @@
+package users
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func userRoleList() []string {
+	return []string{
+		"ADMIN",
+		"FINANCE",
+		"ACCOUNT_HOLDER",
+		"SALES",
+		"MARKETING",
+		"APP_MANAGER",
+		"DEVELOPER",
+		"ACCESS_TO_REPORTS",
+		"CUSTOMER_SUPPORT",
+		"CREATE_APPS",
+		"CLOUD_MANAGED_DEVELOPER_ID",
+		"CLOUD_MANAGED_APP_DISTRIBUTION",
+		"GENERATE_INDIVIDUAL_KEYS",
+	}
+}
+
+func normalizeUserRoles(value string, flagName string) ([]string, error) {
+	roles := shared.SplitCSVUpper(value)
+	allowed := userRoleList()
+	for _, role := range roles {
+		if !slices.Contains(allowed, role) {
+			return nil, fmt.Errorf("%s must be one of: %s", flagName, strings.Join(allowed, ", "))
+		}
+	}
+	return roles, nil
+}

--- a/internal/cli/users/roles_test.go
+++ b/internal/cli/users/roles_test.go
@@ -1,0 +1,30 @@
+package users
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeUserRolesAcceptsExactUserRoleEnumCaseInsensitively(t *testing.T) {
+	input := "admin, finance, account_holder, sales, marketing, app_manager, developer, access_to_reports, customer_support, create_apps, cloud_managed_developer_id, cloud_managed_app_distribution, generate_individual_keys"
+	want := userRoleList()
+
+	got, err := normalizeUserRoles(input, "--roles")
+	if err != nil {
+		t.Fatalf("normalizeUserRoles() error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeUserRoles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeUserRolesRejectsUnknownRole(t *testing.T) {
+	_, err := normalizeUserRoles("developer,not_a_role", "--role")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--role must be one of: ADMIN, FINANCE, ACCOUNT_HOLDER") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -56,7 +56,7 @@ func UsersListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	email := fs.String("email", "", "Filter by email/username")
-	role := fs.String("role", "", "Filter by role (comma-separated): ADMIN, DEVELOPER, APP_MANAGER, etc.")
+	role := fs.String("role", "", "Filter by UserRole (comma-separated): "+strings.Join(userRoleList(), ", "))
 	output := shared.BindOutputFlags(fs)
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -84,6 +84,10 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("users list: %w", err)
 			}
+			roleValues, err := normalizeUserRoles(*role, "--role")
+			if err != nil {
+				return shared.UsageErrorf("users list: %v", err)
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -95,7 +99,7 @@ Examples:
 
 			opts := []asc.UsersOption{
 				asc.WithUsersEmail(*email),
-				asc.WithUsersRoles(shared.SplitCSV(*role)),
+				asc.WithUsersRoles(roleValues),
 				asc.WithUsersLimit(*limit),
 				asc.WithUsersNextURL(*next),
 			}
@@ -186,7 +190,7 @@ func UsersUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 
 	id := fs.String("id", "", "User ID")
-	roles := fs.String("roles", "", "Comma-separated role IDs")
+	roles := fs.String("roles", "", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
 	visibleApps := fs.String("visible-app", "", "Comma-separated app IDs for visible apps")
 	output := shared.BindOutputFlags(fs)
 
@@ -208,7 +212,10 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			roleValues := shared.SplitCSV(*roles)
+			roleValues, err := normalizeUserRoles(*roles, "--roles")
+			if err != nil {
+				return shared.UsageErrorf("users update: %v", err)
+			}
 			if len(roleValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --roles is required")
 				return shared.MissingRequiredUsageError()
@@ -308,7 +315,7 @@ func UsersInviteCommand() *ffcli.Command {
 	email := fs.String("email", "", "Email address to invite")
 	firstName := fs.String("first-name", "", "First name of the invitee (required)")
 	lastName := fs.String("last-name", "", "Last name of the invitee (required)")
-	roles := fs.String("roles", "", "Comma-separated role IDs")
+	roles := fs.String("roles", "", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
 	allApps := fs.Bool("all-apps", false, "Grant access to all apps")
 	visibleApps := fs.String("visible-app", "", "Comma-separated app IDs for visible apps")
 	output := shared.BindOutputFlags(fs)
@@ -343,7 +350,10 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			roleValues := shared.SplitCSV(*roles)
+			roleValues, err := normalizeUserRoles(*roles, "--roles")
+			if err != nil {
+				return shared.UsageErrorf("users invite: %v", err)
+			}
 			if len(roleValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --roles is required")
 				return shared.MissingRequiredUsageError()


### PR DESCRIPTION
## Summary

- allow pass type certificate list and relationship pagination to resume from a validated `links.next` URL without repeating `--pass-type-id`
- restrict continuation URLs to the matching pass type certificate endpoint and return usage exit code 2 for invalid URLs
- normalize UserRole input to uppercase and validate the exact Apple enum for users list, update, and invite
- update command help and add HTTP, query, payload, warning, and exit-code regressions

## Contract and history

Apple OpenAPI 4.4.1 explicitly defines both `GET /v1/passTypeIds/{id}/certificates` and `GET /v1/passTypeIds/{id}/relationships/certificates`, with paged response links. The official current OpenAPI download is byte-identical to the repository snapshot. Issue #250 and PR #289 introduced these supported endpoints; the known live mismatch in that work concerns unsupported include and sparse-field parameters, not pagination or a repeated parent ID. The existing client already treats `links.next` as the complete request path.

The same OpenAPI defines a closed 13-value uppercase UserRole enum for `filter[roles]`, user updates, and invitations. PRs #101 and #136 only verified uppercase role values. The client contract treats opaque continuation links as complete request paths, and the maintained App Store Connect Swift SDK models these roles as uppercase wire values. No history or current contract supports forwarding lowercase or unknown roles to Apple.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built CLI: invalid UserRole exits 2 before auth or HTTP
- live read-only `GET /v1/users?filter[roles]=DEVELOPER&limit=1`: 200 after lowercase CLI input normalization; the baseline sent lowercase and received 400
- live read-only next-only pass type certificate GETs with a deliberately nonexistent pass type ID reached the exact collection and relationship paths and returned the expected 404; no mutation was performed

## Remaining uncertainty

The verification account currently has no pass type IDs, so a successful live next-page response could not be observed. Exact-path HTTP regressions cover multi-page collection and relationship responses, and the read-only probes confirm that the built CLI sends the next-only paths without requiring the parent flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User role filters and role options now accept case-insensitive, comma-separated values.
  * Certificate list and view commands can derive the pass type ID from valid pagination links, so it may be omitted when using `--next`.
* **Bug Fixes**
  * Invalid roles now produce clearer validation errors.
  * Conflicting certificate options and invalid or unrelated pagination links are rejected with helpful usage errors.
  * Deprecated user roles continue to work with appropriate warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
