### PR TITLE
Fix introductory offer view reads

### DIFF
--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -324,21 +324,6 @@ func (c *Client) GetSubscriptionIntroductoryOffers(ctx context.Context, subscrip
 	return &response, nil
 }
 
-// GetSubscriptionIntroductoryOffer retrieves an introductory offer by ID.
-func (c *Client) GetSubscriptionIntroductoryOffer(ctx context.Context, offerID string) (*SubscriptionIntroductoryOfferResponse, error) {
-	path := fmt.Sprintf("/v1/subscriptionIntroductoryOffers/%s", strings.TrimSpace(offerID))
-	data, err := c.do(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var response SubscriptionIntroductoryOfferResponse
-	if err := json.Unmarshal(data, &response); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &response, nil
-}
-
 // CreateSubscriptionIntroductoryOffer creates an introductory offer.
 func (c *Client) CreateSubscriptionIntroductoryOffer(ctx context.Context, subscriptionID string, attrs SubscriptionIntroductoryOfferCreateAttributes, territoryID, pricePointID string) (*SubscriptionIntroductoryOfferResponse, error) {
 	subscriptionID = strings.TrimSpace(subscriptionID)

--- a/internal/asc/subscriptions_resources_http_test.go
+++ b/internal/asc/subscriptions_resources_http_test.go
@@ -573,23 +573,6 @@ func TestDeleteSubscriptionImage(t *testing.T) {
 	}
 }
 
-func TestGetSubscriptionIntroductoryOffer(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"subscriptionIntroductoryOffers","id":"offer-1","attributes":{"duration":"ONE_MONTH","numberOfPeriods":1,"offerMode":"FREE_TRIAL"}}}`)
-	client := newTestClient(t, func(req *http.Request) {
-		if req.Method != http.MethodGet {
-			t.Fatalf("expected GET, got %s", req.Method)
-		}
-		if req.URL.Path != "/v1/subscriptionIntroductoryOffers/offer-1" {
-			t.Fatalf("expected path /v1/subscriptionIntroductoryOffers/offer-1, got %s", req.URL.Path)
-		}
-		assertAuthorized(t, req)
-	}, response)
-
-	if _, err := client.GetSubscriptionIntroductoryOffer(context.Background(), "offer-1"); err != nil {
-		t.Fatalf("GetSubscriptionIntroductoryOffer() error: %v", err)
-	}
-}
-
 func TestCreateSubscriptionIntroductoryOffer(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionIntroductoryOffers","id":"offer-1","attributes":{"duration":"ONE_MONTH","numberOfPeriods":1,"offerMode":"FREE_TRIAL"}}}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1728,6 +1728,16 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 			wantErr: "--subscription-id is required",
 		},
 		{
+			name:    "subscriptions introductory-offers view missing subscription-id",
+			args:    []string{"subscriptions", "offers", "introductory", "view", "--id", "OFFER_ID"},
+			wantErr: "--subscription-id is required",
+		},
+		{
+			name:    "subscriptions introductory-offers view missing offer id",
+			args:    []string{"subscriptions", "offers", "introductory", "view", "--subscription-id", "SUB_ID"},
+			wantErr: "--id is required",
+		},
+		{
 			name:    "subscriptions introductory-offers create missing offer-duration",
 			args:    []string{"subscriptions", "offers", "introductory", "create", "--subscription-id", "SUB_ID", "--offer-mode", "FREE_TRIAL", "--number-of-periods", "1"},
 			wantErr: "--offer-duration is required",

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -133,6 +133,22 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 		}
 	}
 
+	introductoryViewCmd := findSubcommand(root, "subscriptions", "offers", "introductory", "view")
+	if introductoryViewCmd == nil {
+		t.Fatal("expected subscriptions offers introductory view command")
+		return
+	}
+	introductoryViewUsage := introductoryViewCmd.UsageFunc(introductoryViewCmd)
+	if !strings.Contains(introductoryViewUsage, `asc subscriptions offers introductory view --subscription-id "SUB_ID" --id "OFFER_ID"`) {
+		t.Fatalf("expected introductory offer view help to require the parent subscription, got %q", introductoryViewUsage)
+	}
+	if !strings.Contains(introductoryViewUsage, "--app") {
+		t.Fatalf("expected introductory offer view help to document subscription resolution, got %q", introductoryViewUsage)
+	}
+	if strings.Contains(introductoryViewUsage, `asc subscriptions offers introductory view --id "OFFER_ID"`) {
+		t.Fatalf("expected introductory offer view help to drop the unsupported id-only invocation, got %q", introductoryViewUsage)
+	}
+
 	offerCodesCmd := findSubcommand(root, "subscriptions", "offers", "offer-codes")
 	if offerCodesCmd == nil {
 		t.Fatal("expected subscriptions offers offer-codes command")

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
@@ -6,25 +6,24 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestSubscriptionsIntroductoryOffersViewFindsOfferAcrossPages(t *testing.T) {
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
 	const subscriptionID = "1234567890"
 	nextURL := "https://api.appstoreconnect.apple.com/v1/subscriptions/" + subscriptionID + "/introductoryOffers?cursor=next"
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	useIntroductoryOffersViewServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -39,18 +38,17 @@ func TestSubscriptionsIntroductoryOffersViewFindsOfferAcrossPages(t *testing.T) 
 				t.Fatalf("expected first-page limit 200, got %q", got)
 			}
 			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-1"}],"links":{"next":"` + nextURL + `"}}`
-			return jsonHTTPResponse(http.StatusOK, body), nil
+			writeIntroductoryOffersViewJSON(w, body)
 		case 2:
 			if got := req.URL.Query().Get("cursor"); got != "next" {
 				t.Fatalf("expected server-provided next URL, got %q", req.URL.String())
 			}
 			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-2","attributes":{"duration":"ONE_MONTH","offerMode":"FREE_TRIAL","numberOfPeriods":1}}],"links":{"next":""}}`
-			return jsonHTTPResponse(http.StatusOK, body), nil
+			writeIntroductoryOffersViewJSON(w, body)
 		default:
 			t.Fatalf("unexpected request %d: %s", requestCount, req.URL.String())
-			return nil, nil
 		}
-	})
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -93,29 +91,23 @@ func TestSubscriptionsIntroductoryOffersViewFindsOfferAcrossPages(t *testing.T) 
 func TestSubscriptionsIntroductoryOffersViewResolvesSubscriptionSelector(t *testing.T) {
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	useIntroductoryOffersViewServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups":
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}],"links":{"next":""}}`), nil
+			writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}],"links":{"next":""}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
 			if got := req.URL.Query().Get("filter[productId]"); got != "com.example.monthly" {
 				t.Fatalf("expected product ID filter, got %q", got)
 			}
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{"next":""}}`), nil
+			writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{"next":""}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/introductoryOffers":
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-1"}],"links":{"next":""}}`), nil
+			writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-1"}],"links":{"next":""}}`)
 		default:
 			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
-			return nil, nil
 		}
-	})
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -148,17 +140,12 @@ func TestSubscriptionsIntroductoryOffersViewResolvesSubscriptionSelector(t *test
 func TestSubscriptionsIntroductoryOffersViewReturnsNotFoundAfterAllPages(t *testing.T) {
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	useIntroductoryOffersViewServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/1234567890/introductoryOffers" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
-		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other"}],"links":{"next":""}}`), nil
-	})
+		writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other"}],"links":{"next":""}}`)
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -194,22 +181,17 @@ func TestSubscriptionsIntroductoryOffersViewReturnsNotFoundAfterAllPages(t *test
 func TestSubscriptionsIntroductoryOffersViewRejectsRepeatedPaginationURL(t *testing.T) {
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
 	const subscriptionID = "1234567890"
 	nextURL := "https://api.appstoreconnect.apple.com/v1/subscriptions/" + subscriptionID + "/introductoryOffers?cursor=repeated"
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	useIntroductoryOffersViewServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
 		if requestCount > 2 {
-			return nil, errors.New("unexpected third request")
+			t.Fatal("unexpected third request")
 		}
 		body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other"}],"links":{"next":"` + nextURL + `"}}`
-		return jsonHTTPResponse(http.StatusOK, body), nil
-	})
+		writeIntroductoryOffersViewJSON(w, body)
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -228,4 +210,40 @@ func TestSubscriptionsIntroductoryOffersViewRejectsRepeatedPaginationURL(t *test
 	if requestCount != 2 {
 		t.Fatalf("expected two requests before repeated URL detection, got %d", requestCount)
 	}
+}
+
+func useIntroductoryOffersViewServer(t *testing.T, handler http.Handler) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create introductory offers view test client: %v", err)
+	}
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restore)
+}
+
+func writeIntroductoryOffersViewJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, body)
 }

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
@@ -190,3 +190,42 @@ func TestSubscriptionsIntroductoryOffersViewReturnsNotFoundAfterAllPages(t *test
 		t.Fatalf("expected no process output before error reporting, got stdout=%q stderr=%q", stdout, stderr)
 	}
 }
+
+func TestSubscriptionsIntroductoryOffersViewRejectsRepeatedPaginationURL(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	const subscriptionID = "1234567890"
+	nextURL := "https://api.appstoreconnect.apple.com/v1/subscriptions/" + subscriptionID + "/introductoryOffers?cursor=repeated"
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount > 2 {
+			return nil, errors.New("unexpected third request")
+		}
+		body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other"}],"links":{"next":"` + nextURL + `"}}`
+		return jsonHTTPResponse(http.StatusOK, body), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"subscriptions", "offers", "introductory", "view",
+		"--subscription-id", subscriptionID,
+		"--id", "offer-missing",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	runErr := root.Run(context.Background())
+	if !errors.Is(runErr, asc.ErrRepeatedPaginationURL) {
+		t.Fatalf("expected ErrRepeatedPaginationURL, got %v", runErr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two requests before repeated URL detection, got %d", requestCount)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
@@ -137,14 +137,97 @@ func TestSubscriptionsIntroductoryOffersViewResolvesSubscriptionSelector(t *test
 	}
 }
 
+func TestSubscriptionsIntroductoryOffersViewResolvesExactSubscriptionName(t *testing.T) {
+	setupAuth(t)
+
+	groupRequestCount := 0
+	subscriptionRequestCount := 0
+	offerRequestCount := 0
+	useIntroductoryOffersViewServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups":
+			groupRequestCount++
+			writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
+			subscriptionRequestCount++
+			switch subscriptionRequestCount {
+			case 1:
+				if got := req.URL.Query().Get("filter[productId]"); got != "Monthly" {
+					t.Fatalf("expected product ID lookup before name lookup, got %q", got)
+				}
+				writeIntroductoryOffersViewJSON(w, `{"data":[],"links":{"next":""}}`)
+			case 2:
+				if got := req.URL.Query().Get("filter[name]"); got != "Monthly" {
+					t.Fatalf("expected exact name filter, got %q", got)
+				}
+				writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{"next":""}}`)
+			default:
+				t.Fatalf("unexpected subscription lookup request %d: %s", subscriptionRequestCount, req.URL.String())
+			}
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/introductoryOffers":
+			offerRequestCount++
+			writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-1"}],"links":{"next":""}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "view",
+			"--app", "app-1",
+			"--subscription-id", "Monthly",
+			"--id", "offer-1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if groupRequestCount != 2 || subscriptionRequestCount != 2 || offerRequestCount != 1 {
+		t.Fatalf(
+			"expected two group requests, two subscription requests, and one offer request; got groups=%d subscriptions=%d offers=%d",
+			groupRequestCount,
+			subscriptionRequestCount,
+			offerRequestCount,
+		)
+	}
+	if !strings.Contains(stdout, `"id":"offer-1"`) {
+		t.Fatalf("expected selected offer output, got %q", stdout)
+	}
+}
+
 func TestSubscriptionsIntroductoryOffersViewReturnsNotFoundAfterAllPages(t *testing.T) {
 	setupAuth(t)
 
+	const subscriptionID = "1234567890"
+	nextURL := "https://api.appstoreconnect.apple.com/v1/subscriptions/" + subscriptionID + "/introductoryOffers?cursor=next"
+	requestCount := 0
 	useIntroductoryOffersViewServer(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/1234567890/introductoryOffers" {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/"+subscriptionID+"/introductoryOffers" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
-		writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other"}],"links":{"next":""}}`)
+		switch requestCount {
+		case 1:
+			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other-1"}],"links":{"next":"` + nextURL + `"}}`
+			writeIntroductoryOffersViewJSON(w, body)
+		case 2:
+			if got := req.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("expected server-provided next URL, got %q", req.URL.String())
+			}
+			writeIntroductoryOffersViewJSON(w, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other-2"}],"links":{"next":""}}`)
+		default:
+			t.Fatalf("unexpected request %d: %s", requestCount, req.URL.String())
+		}
 	}))
 
 	root := RootCommand("1.2.3")
@@ -154,7 +237,7 @@ func TestSubscriptionsIntroductoryOffersViewReturnsNotFoundAfterAllPages(t *test
 	stdout, stderr := captureOutput(t, func() {
 		if err := root.Parse([]string{
 			"subscriptions", "offers", "introductory", "view",
-			"--subscription-id", "1234567890",
+			"--subscription-id", subscriptionID,
 			"--id", "offer-missing",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
@@ -172,6 +255,9 @@ func TestSubscriptionsIntroductoryOffersViewReturnsNotFoundAfterAllPages(t *test
 	}
 	if !strings.Contains(runErr.Error(), `introductory offer "offer-missing" not found for subscription "1234567890"`) {
 		t.Fatalf("expected contextual not-found error, got %v", runErr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two requests before not-found, got %d", requestCount)
 	}
 	if stdout != "" || stderr != "" {
 		t.Fatalf("expected no process output before error reporting, got stdout=%q stderr=%q", stdout, stderr)

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_view_test.go
@@ -1,0 +1,192 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestSubscriptionsIntroductoryOffersViewFindsOfferAcrossPages(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	const subscriptionID = "1234567890"
+	nextURL := "https://api.appstoreconnect.apple.com/v1/subscriptions/" + subscriptionID + "/introductoryOffers?cursor=next"
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/subscriptions/"+subscriptionID+"/introductoryOffers" {
+			t.Fatalf("unexpected path: %s", req.URL.Path)
+		}
+
+		switch requestCount {
+		case 1:
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Fatalf("expected first-page limit 200, got %q", got)
+			}
+			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-1"}],"links":{"next":"` + nextURL + `"}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		case 2:
+			if got := req.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("expected server-provided next URL, got %q", req.URL.String())
+			}
+			body := `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-2","attributes":{"duration":"ONE_MONTH","offerMode":"FREE_TRIAL","numberOfPeriods":1}}],"links":{"next":""}}`
+			return jsonHTTPResponse(http.StatusOK, body), nil
+		default:
+			t.Fatalf("unexpected request %d: %s", requestCount, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "view",
+			"--subscription-id", subscriptionID,
+			"--id", "offer-2",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two requests, got %d", requestCount)
+	}
+
+	var response struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(strings.NewReader(stdout)).Decode(&response); err != nil {
+		t.Fatalf("decode output: %v\nstdout: %s", err, stdout)
+	}
+	if response.Data.ID != "offer-2" {
+		t.Fatalf("expected offer-2, got %q", response.Data.ID)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersViewResolvesSubscriptionSelector(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/subscriptionGroups":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Premium"}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
+			if got := req.URL.Query().Get("filter[productId]"); got != "com.example.monthly" {
+				t.Fatalf("expected product ID filter, got %q", got)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/introductoryOffers":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-1"}],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s?%s", req.Method, req.URL.Path, req.URL.RawQuery)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "view",
+			"--app", "app-1",
+			"--subscription-id", "com.example.monthly",
+			"--id", "offer-1",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 3 {
+		t.Fatalf("expected three requests, got %d", requestCount)
+	}
+	if !strings.Contains(stdout, `"id":"offer-1"`) {
+		t.Fatalf("expected selected offer output, got %q", stdout)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersViewReturnsNotFoundAfterAllPages(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/1234567890/introductoryOffers" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionIntroductoryOffers","id":"offer-other"}],"links":{"next":""}}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "view",
+			"--subscription-id", "1234567890",
+			"--id", "offer-missing",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected not-found error")
+	}
+	if !errors.Is(runErr, asc.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", runErr)
+	}
+	if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitNotFound {
+		t.Fatalf("expected exit code %d, got %d", rootcmd.ExitNotFound, got)
+	}
+	if !strings.Contains(runErr.Error(), `introductory offer "offer-missing" not found for subscription "1234567890"`) {
+		t.Fatalf("expected contextual not-found error, got %v", runErr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected no process output before error reporting, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -213,27 +214,33 @@ Examples:
 }
 
 func findSubscriptionIntroductoryOffer(ctx context.Context, client *asc.Client, subscriptionID, offerID string) (*asc.SubscriptionIntroductoryOfferResponse, error) {
-	page, err := client.GetSubscriptionIntroductoryOffers(ctx, subscriptionID, asc.WithSubscriptionIntroductoryOffersLimit(200))
+	firstPage, err := client.GetSubscriptionIntroductoryOffers(ctx, subscriptionID, asc.WithSubscriptionIntroductoryOffersLimit(200))
 	if err != nil {
 		return nil, err
 	}
 
-	for {
-		for _, offer := range page.Data {
+	errOfferFound := errors.New("introductory offer found")
+	var found *asc.SubscriptionIntroductoryOfferResponse
+	err = asc.PaginateEach(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetSubscriptionIntroductoryOffers(ctx, subscriptionID, asc.WithSubscriptionIntroductoryOffersNextURL(nextURL))
+	}, func(page asc.PaginatedResponse) error {
+		resp, ok := page.(*asc.SubscriptionIntroductoryOffersResponse)
+		if !ok {
+			return fmt.Errorf("unexpected page type %T", page)
+		}
+		for _, offer := range resp.Data {
 			if offer.ID == offerID {
-				return &asc.SubscriptionIntroductoryOfferResponse{Data: offer}, nil
+				found = &asc.SubscriptionIntroductoryOfferResponse{Data: offer}
+				return errOfferFound
 			}
 		}
-
-		nextURL := strings.TrimSpace(page.Links.Next)
-		if nextURL == "" {
-			break
-		}
-
-		page, err = client.GetSubscriptionIntroductoryOffers(ctx, subscriptionID, asc.WithSubscriptionIntroductoryOffersNextURL(nextURL))
-		if err != nil {
-			return nil, err
-		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errOfferFound) {
+		return nil, err
+	}
+	if found != nil {
+		return found, nil
 	}
 
 	return nil, fmt.Errorf("introductory offer %q not found for subscription %q: %w", offerID, subscriptionID, asc.ErrNotFound)

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -157,20 +157,32 @@ Examples:
 func SubscriptionsIntroductoryOffersGetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("introductory-offers view", flag.ExitOnError)
 
+	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
+	appID := addSubscriptionLookupAppFlag(fs)
 	offerID := fs.String("id", "", "Introductory offer ID")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "view",
-		ShortUsage: "asc subscriptions introductory-offers view --id \"OFFER_ID\"",
-		ShortHelp:  "View an introductory offer by ID.",
-		LongHelp: `View an introductory offer by ID.
+		ShortUsage: "asc subscriptions introductory-offers view --subscription-id \"SUB_ID\" --id \"OFFER_ID\"",
+		ShortHelp:  "View an introductory offer by subscription and offer ID.",
+		LongHelp: `View an introductory offer by subscription and offer ID.
+
+The subscription selector accepts a subscription ID, product ID, or exact current name.
+Product IDs and names require --app to resolve the subscription.
 
 Examples:
-  asc subscriptions introductory-offers view --id "OFFER_ID"`,
+  asc subscriptions introductory-offers view --subscription-id "SUB_ID" --id "OFFER_ID"
+  asc subscriptions introductory-offers view --app "APP_ID" --subscription-id "com.example.monthly" --id "OFFER_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			subID := strings.TrimSpace(*subscriptionID)
+			if subID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
+				return shared.MissingRequiredUsageError()
+			}
+
 			id := strings.TrimSpace(*offerID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -182,10 +194,15 @@ Examples:
 				return fmt.Errorf("subscriptions introductory-offers view: %w", err)
 			}
 
+			subID, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, *appID, subID)
+			if err != nil {
+				return err
+			}
+
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetSubscriptionIntroductoryOffer(requestCtx, id)
+			resp, err := findSubscriptionIntroductoryOffer(requestCtx, client, subID, id)
 			if err != nil {
 				return fmt.Errorf("subscriptions introductory-offers view: failed to fetch: %w", err)
 			}
@@ -193,6 +210,33 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func findSubscriptionIntroductoryOffer(ctx context.Context, client *asc.Client, subscriptionID, offerID string) (*asc.SubscriptionIntroductoryOfferResponse, error) {
+	page, err := client.GetSubscriptionIntroductoryOffers(ctx, subscriptionID, asc.WithSubscriptionIntroductoryOffersLimit(200))
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		for _, offer := range page.Data {
+			if offer.ID == offerID {
+				return &asc.SubscriptionIntroductoryOfferResponse{Data: offer}, nil
+			}
+		}
+
+		nextURL := strings.TrimSpace(page.Links.Next)
+		if nextURL == "" {
+			break
+		}
+
+		page, err = client.GetSubscriptionIntroductoryOffers(ctx, subscriptionID, asc.WithSubscriptionIntroductoryOffersNextURL(nextURL))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, fmt.Errorf("introductory offer %q not found for subscription %q: %w", offerID, subscriptionID, asc.ErrNotFound)
 }
 
 // SubscriptionsIntroductoryOffersCreateCommand returns the introductory offers create subcommand.


### PR DESCRIPTION
## What changed

- Require `--subscription-id` for `subscriptions offers introductory view`, with existing product ID and exact-name resolution through `--app`.
- Read `GET /v1/subscriptions/{id}/introductoryOffers`, request 200 records per page, follow every server-provided `links.next`, and return the matching offer in the existing single-resource output shape.
- Remove the client method and mock for nonexistent `GET /v1/subscriptionIntroductoryOffers/{id}`. Return exit 4 after every page is exhausted without a match.

## Contract and history

Apple App Store Connect OpenAPI 4.4.1 exposes only PATCH and DELETE on `/v1/subscriptionIntroductoryOffers/{id}`. Reads use the parent subscription collection, which has no `filter[id]`. Current generated clients agree: [appstoreconnect-swift-sdk](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/651b56950c917d30d7aaa863baadd290f2e28cb7/Sources/OpenAPI/Generated/Paths/PathsV1SubscriptionsWithIDIntroductoryOffers.swift) and [Bagbutik](https://github.com/MortenGregersen/Bagbutik/blob/e9cb24ce5a4868b813c3d5e40e2004eba4c29460/Sources/Bagbutik-AppStore/Endpoints/Subscription/Relationships/ListIntroductoryOffersForSubscriptionV1.swift) both generate only the parent-scoped read.

The broken instance method came from the mocked parity work in [#324](https://github.com/rorkai/App-Store-Connect-CLI/issues/324) and [#350](https://github.com/rorkai/App-Store-Connect-CLI/pull/350). That work explicitly excluded live credentials, and the repository OpenAPI already omitted the instance GET. No discussion or review claimed undocumented API support.

A safe live probe against a deliberately nonexistent offer confirmed the old path returns HTTP 403 with `GET_INSTANCE` disallowed. The repaired built binary read an explicit subscription on the disposable app through the parent endpoint, received HTTP 200, then returned the expected local not-found result for a deliberately nonexistent offer. Every probe used GET; no resource changed.

## Compatibility

The old ID-only invocation had no successful Apple contract. The corrected form is:

```console
asc subscriptions offers introductory view --subscription-id "SUB_ID" --id "OFFER_ID"
```

Product IDs and exact names also work when `--app` supplies the app context.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built-binary help, pagination, selector resolution, JSON output, usage errors, and not-found exit behavior
- Independent diff review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introductory-offer viewing now requires a subscription ID.
  * Subscriptions can be selected by product ID or exact name, with optional app selection.
  * Offer lookup searches across paginated results and reports when no matching offer is found.
  * Updated command help and usage examples.

* **Bug Fixes**
  * Improved validation for missing subscription and offer identifiers.
  * Prevented repeated pagination results from causing unnecessary requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->