### PR TITLE
Fix promotional offer inline price creation

### DIFF
--- a/docs/design/subscription-promotional-offer-inline-prices.md
+++ b/docs/design/subscription-promotional-offer-inline-prices.md
@@ -16,7 +16,8 @@ normalized to App Store Connect alpha-3 IDs. Inline inputs become temporary
 local linkages in `data.relationships.prices` and matching
 `subscriptionPromotionalOfferPrices` resources in top-level `included`.
 Existing price IDs remain ordinary linkage references and do not emit
-`included`. One request cannot mix linkage references with inline entries.
+`included`. One request may combine territory-only and territory/price-point
+inline entries, but it cannot mix linkage references with inline entries.
 
 ## API contract
 

--- a/docs/design/subscription-promotional-offer-inline-prices.md
+++ b/docs/design/subscription-promotional-offer-inline-prices.md
@@ -3,20 +3,20 @@
 ## Decision
 
 `asc subscriptions offers promotional create` remains in the existing
-subscription-offers taxonomy. Its required `--prices` flag now describes the
-prices Apple can create with the offer instead of IDs for promotional-offer
-price resources that do not have a standalone create endpoint:
+subscription-offers taxonomy. Its required `--prices` flag supports both the
+released linkage form and compound inline creation:
 
-- `FREE_TRIAL`: comma-separated `TERRITORY` entries, for example `US,France`
-- paid modes: comma-separated `TERRITORY:PRICE_POINT_ID` entries, for example
+- existing promotional-offer price IDs, for example `PRICE_ID,PRICE_ID`
+- inline territory-only entries, for example `US,France`
+- inline territory and price-point entries, for example
   `US:PRICE_POINT_ID,France:PRICE_POINT_ID`
 
 Territories accept alpha-2, alpha-3, or exact English country names and are
-normalized to App Store Connect alpha-3 IDs. Each input becomes a temporary
-local linkage in `data.relationships.prices` and a matching
-`subscriptionPromotionalOfferPrices` resource in top-level `included`. The
-included resource links its territory and, for paid modes, its
-`subscriptionPricePoint`.
+normalized to App Store Connect alpha-3 IDs. Inline inputs become temporary
+local linkages in `data.relationships.prices` and matching
+`subscriptionPromotionalOfferPrices` resources in top-level `included`.
+Existing price IDs remain ordinary linkage references and do not emit
+`included`. One request cannot mix linkage references with inline entries.
 
 ## API contract
 
@@ -25,9 +25,12 @@ parameters. Its request is `SubscriptionPromotionalOfferCreateRequest`; the
 required primary resource has type `subscriptionPromotionalOffers`, the five
 existing required attributes, and required `subscription` and `prices`
 relationships. The request schema permits top-level
-`SubscriptionPromotionalOfferPriceInlineCreate` resources. Each local ID used
-by a price relationship exactly matches one included resource. A successful
-request returns status 201 with `SubscriptionPromotionalOfferResponse`.
+`SubscriptionPromotionalOfferPriceInlineCreate` resources. The inline schema
+requires only `type`; both `territory` and `subscriptionPricePoint`
+relationships are optional, and it defines no conditional relationship rule
+for any `offerMode`. Each local ID used by an inline price relationship exactly
+matches one included resource. A successful request returns status 201 with
+`SubscriptionPromotionalOfferResponse`.
 
 Apple's current official 4.4.1 OpenAPI download is byte-for-byte identical to
 `docs/openapi/latest.json`. It documents create, update, and delete operations
@@ -44,15 +47,19 @@ exit with status 2 before authentication or HTTP.
 
 ## Compatibility and migration
 
-The flag name is unchanged, but its former value shape was unusable against the
-documented create contract because promotional-offer prices cannot be created
-independently. A bare opaque value in a paid mode is now rejected with guidance
-to use `TERRITORY:PRICE_POINT_ID`. For `FREE_TRIAL`, a bare value is interpreted
-as a territory and therefore must resolve as a supported territory. Help,
-examples, and generated command documentation describe the corrected shape.
-Apple's schema leaves `subscriptionPricePoint` optional without a conditional
-mode rule; the territory-only FREE_TRIAL shape also matches the adjacent
-offer-code compound-create contract. Paid modes always require a price point.
+The flag name and released bare-ID behavior remain supported. Inputs containing
+a colon are parsed as compound `TERRITORY:PRICE_POINT_ID` entries. If every bare
+entry resolves as a territory, the command creates territory-only inline
+resources. Otherwise, bare entries are preserved as existing promotional-offer
+price IDs and sent with the original linkage-only payload. This auto-detection
+keeps existing scripts working while allowing the new atomic create form.
+
+Mode does not change parsing or payload validation because the exact OpenAPI
+schema defines no relationship constraint based on `offerMode`. In particular,
+territory-only inline resources are accepted for paid modes, and a price-point
+relationship is not rejected for `FREE_TRIAL`. These are schema-supported
+request shapes, not claims that every combination will pass Apple's
+account-specific business validation.
 
 The separate promotional-offer `update --prices` behavior is outside this
 change: that endpoint updates relationships to prices belonging to an existing
@@ -60,28 +67,27 @@ offer and is not a substitute for creating the initial inline resources.
 
 ## RED-GREEN and verification
 
-The client regression first replaces the old linkage-only mock with an exact
-JSON body assertion covering temporary local IDs, normalized territory
-relationships, paid price-point relationships, and top-level included
-resources. CLI coverage asserts valid FREE_TRIAL and paid inputs plus malformed
-mode-specific values and unknown territories before auth. The focused tests run
-RED against the current linkage-only client, then GREEN after the narrow client
-and parser changes.
+The client regression preserves the old linkage-only payload assertion and adds
+exact bodies for temporary local IDs, optional territory and price-point
+relationships, and top-level included resources. CLI coverage asserts legacy
+bare IDs, territory-only and compound inline inputs across offer modes, mixed
+shape rejection, JSON stdout, empty stderr, and usage exit status. The focused
+tests run RED against the strict mode-specific parser, then GREEN after the
+backward-compatible parser and client changes.
 
 Black-box verification uses a freshly built binary to check help, stdout,
-stderr, and exit status. Live verification uses the explicitly selected auth
-profile and `ASC_BYPASS_KEYCHAIN=1`: read-only calls use explicit resource IDs,
-while the create-shaped probe targets a deliberately nonexistent subscription
-ID so Apple rejects the request without creating a resource. The probe records
-method, path, status, and error, then repeats the read-only observation needed
-to show no resource appeared.
+stderr, and exit status. Live verification on disposable app `6759231657`
+created a territory-only `FREE_TRIAL` offer on subscription `6759789022`, read
+the created offer and its single price, then deleted the exact returned offer
+ID. A final list was empty and a read of the deleted ID returned not found. This
+proves the territory-only compound path and cleanup boundary; the other
+mode/relationship combinations remain schema-backed rather than live-proven.
 
 ## Alternatives
 
-Keeping pre-existing promotional-offer price IDs was rejected because there is
-no supported operation that can produce those resources before the parent
-offer exists. Adding separate territory and price-point flags was also rejected:
-it would make multi-territory pairing ambiguous and diverge from the established
-offer-code price syntax. Reusing the offer-code input grammar and inline-create
-pattern gives both offer families the same mode-specific validation and request
-shape.
+Unconditionally replacing existing price IDs was rejected because it breaks a
+released CLI contract even if many callers prefer inline creation. Adding a
+separate mode flag was also rejected because the shapes are distinguishable
+without another public option. Separate territory and price-point flags would
+make multi-territory pairing ambiguous. Auto-detection retains the legacy
+payload while keeping the compact inline grammar.

--- a/docs/design/subscription-promotional-offer-inline-prices.md
+++ b/docs/design/subscription-promotional-offer-inline-prices.md
@@ -49,9 +49,11 @@ exit with status 2 before authentication or HTTP.
 The flag name and released bare-ID behavior remain supported. Inputs containing
 a colon are parsed as compound `TERRITORY:PRICE_POINT_ID` entries. If every bare
 entry resolves as a territory, the command creates territory-only inline
-resources. Otherwise, bare entries are preserved as existing promotional-offer
-price IDs and sent with the original linkage-only payload. This auto-detection
-keeps existing scripts working while allowing the new atomic create form.
+resources. If no entry resolves as a territory, bare entries are preserved as
+existing promotional-offer price IDs and sent with the original linkage-only
+payload. A list containing both shapes is rejected before authentication rather
+than sending a territory as a price ID. This auto-detection keeps existing
+scripts working while allowing the new atomic create form.
 
 Mode does not change parsing or payload validation because the exact OpenAPI
 schema defines no relationship constraint based on `offerMode`. In particular,

--- a/docs/design/subscription-promotional-offer-inline-prices.md
+++ b/docs/design/subscription-promotional-offer-inline-prices.md
@@ -1,0 +1,87 @@
+# Subscription promotional offer inline prices
+
+## Decision
+
+`asc subscriptions offers promotional create` remains in the existing
+subscription-offers taxonomy. Its required `--prices` flag now describes the
+prices Apple can create with the offer instead of IDs for promotional-offer
+price resources that do not have a standalone create endpoint:
+
+- `FREE_TRIAL`: comma-separated `TERRITORY` entries, for example `US,France`
+- paid modes: comma-separated `TERRITORY:PRICE_POINT_ID` entries, for example
+  `US:PRICE_POINT_ID,France:PRICE_POINT_ID`
+
+Territories accept alpha-2, alpha-3, or exact English country names and are
+normalized to App Store Connect alpha-3 IDs. Each input becomes a temporary
+local linkage in `data.relationships.prices` and a matching
+`subscriptionPromotionalOfferPrices` resource in top-level `included`. The
+included resource links its territory and, for paid modes, its
+`subscriptionPricePoint`.
+
+## API contract
+
+The command calls `POST /v1/subscriptionPromotionalOffers` with no query
+parameters. Its request is `SubscriptionPromotionalOfferCreateRequest`; the
+required primary resource has type `subscriptionPromotionalOffers`, the five
+existing required attributes, and required `subscription` and `prices`
+relationships. The request schema permits top-level
+`SubscriptionPromotionalOfferPriceInlineCreate` resources. Each local ID used
+by a price relationship exactly matches one included resource. A successful
+request returns status 201 with `SubscriptionPromotionalOfferResponse`.
+
+Apple's current official 4.4.1 OpenAPI download is byte-for-byte identical to
+`docs/openapi/latest.json`. It documents create, update, and delete operations
+for promotional offers but no standalone create operation for their prices.
+Current Fastlane and Expo/EAS sources do not implement an alternative workflow.
+Maintained App Store Connect tools that do support promotional-offer creation
+use this same atomic compound POST with temporary linkages and inline territory
+and price-point relationships.
+
+The command continues to write its response through the shared TTY-aware output
+path: explicit `--output` wins, data is written to stdout, and validation or API
+errors are written to stderr. Missing required flags and malformed price inputs
+exit with status 2 before authentication or HTTP.
+
+## Compatibility and migration
+
+The flag name is unchanged, but its former value shape was unusable against the
+documented create contract because promotional-offer prices cannot be created
+independently. A bare opaque value in a paid mode is now rejected with guidance
+to use `TERRITORY:PRICE_POINT_ID`. For `FREE_TRIAL`, a bare value is interpreted
+as a territory and therefore must resolve as a supported territory. Help,
+examples, and generated command documentation describe the corrected shape.
+Apple's schema leaves `subscriptionPricePoint` optional without a conditional
+mode rule; the territory-only FREE_TRIAL shape also matches the adjacent
+offer-code compound-create contract. Paid modes always require a price point.
+
+The separate promotional-offer `update --prices` behavior is outside this
+change: that endpoint updates relationships to prices belonging to an existing
+offer and is not a substitute for creating the initial inline resources.
+
+## RED-GREEN and verification
+
+The client regression first replaces the old linkage-only mock with an exact
+JSON body assertion covering temporary local IDs, normalized territory
+relationships, paid price-point relationships, and top-level included
+resources. CLI coverage asserts valid FREE_TRIAL and paid inputs plus malformed
+mode-specific values and unknown territories before auth. The focused tests run
+RED against the current linkage-only client, then GREEN after the narrow client
+and parser changes.
+
+Black-box verification uses a freshly built binary to check help, stdout,
+stderr, and exit status. Live verification uses the explicitly selected auth
+profile and `ASC_BYPASS_KEYCHAIN=1`: read-only calls use explicit resource IDs,
+while the create-shaped probe targets a deliberately nonexistent subscription
+ID so Apple rejects the request without creating a resource. The probe records
+method, path, status, and error, then repeats the read-only observation needed
+to show no resource appeared.
+
+## Alternatives
+
+Keeping pre-existing promotional-offer price IDs was rejected because there is
+no supported operation that can produce those resources before the parent
+offer exists. Adding separate territory and price-point flags was also rejected:
+it would make multi-territory pairing ambiguous and diverge from the established
+offer-code price syntax. Reusing the offer-code input grammar and inline-create
+pattern gives both offer families the same mode-specific validation and request
+shape.

--- a/docs/design/subscription-promotional-offer-inline-prices.md
+++ b/docs/design/subscription-promotional-offer-inline-prices.md
@@ -35,10 +35,8 @@ matches one included resource. A successful request returns status 201 with
 Apple's current official 4.4.1 OpenAPI download is byte-for-byte identical to
 `docs/openapi/latest.json`. It documents create, update, and delete operations
 for promotional offers but no standalone create operation for their prices.
-Current Fastlane and Expo/EAS sources do not implement an alternative workflow.
-Maintained App Store Connect tools that do support promotional-offer creation
-use this same atomic compound POST with temporary linkages and inline territory
-and price-point relationships.
+The generated Swift SDK and tddworks/asc-cli use this same atomic compound POST
+with temporary linkages and inline territory and price-point relationships.
 
 The command continues to write its response through the shared TTY-aware output
 path: explicit `--output` wins, data is written to stdout, and validation or API

--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -495,29 +495,38 @@ func (c *Client) CreateSubscriptionPromotionalOffer(ctx context.Context, subscri
 		return nil, fmt.Errorf("at least one price is required")
 	}
 
-	isFreeTrial := attrs.OfferMode == SubscriptionOfferModeFreeTrial
 	priceData := make([]ResourceData, 0, len(prices))
 	included := make([]SubscriptionPromotionalOfferPriceInlineCreate, 0, len(prices))
+	usesReferences := false
+	usesInlinePrices := false
 	for idx, price := range prices {
+		priceID := strings.TrimSpace(price.ID)
 		territoryID := strings.ToUpper(strings.TrimSpace(price.TerritoryID))
 		pricePointID := strings.TrimSpace(price.PricePointID)
-		if territoryID == "" {
-			return nil, fmt.Errorf("territory ID is required")
+		if priceID != "" {
+			if territoryID != "" || pricePointID != "" {
+				return nil, fmt.Errorf("price reference ID must not be combined with inline relationships")
+			}
+			usesReferences = true
+			priceData = append(priceData, ResourceData{
+				Type: ResourceTypeSubscriptionPromotionalOfferPrices,
+				ID:   priceID,
+			})
+			continue
 		}
-		if isFreeTrial && pricePointID != "" {
-			return nil, fmt.Errorf("price point must not be set for FREE_TRIAL offer mode")
+		if territoryID == "" && pricePointID == "" {
+			return nil, fmt.Errorf("price reference ID or inline relationship is required")
 		}
-		if !isFreeTrial && pricePointID == "" {
-			return nil, fmt.Errorf("price point ID is required")
-		}
+		usesInlinePrices = true
 
-		priceRelationships := SubscriptionPromotionalOfferPriceRelationships{
-			Territory: Relationship{
+		priceRelationships := SubscriptionPromotionalOfferPriceRelationships{}
+		if territoryID != "" {
+			priceRelationships.Territory = &Relationship{
 				Data: ResourceData{
 					Type: ResourceTypeTerritories,
 					ID:   territoryID,
 				},
-			},
+			}
 		}
 		if pricePointID != "" {
 			priceRelationships.SubscriptionPricePoint = &Relationship{
@@ -538,6 +547,9 @@ func (c *Client) CreateSubscriptionPromotionalOffer(ctx context.Context, subscri
 			ID:            resourceID,
 			Relationships: priceRelationships,
 		})
+	}
+	if usesReferences && usesInlinePrices {
+		return nil, fmt.Errorf("price inputs must not mix existing IDs with inline relationships")
 	}
 
 	payload := SubscriptionPromotionalOfferCreateRequest{

--- a/internal/asc/client_subscription_resources.go
+++ b/internal/asc/client_subscription_resources.go
@@ -486,21 +486,57 @@ func (c *Client) GetSubscriptionPromotionalOffer(ctx context.Context, offerID st
 }
 
 // CreateSubscriptionPromotionalOffer creates a promotional offer.
-func (c *Client) CreateSubscriptionPromotionalOffer(ctx context.Context, subscriptionID string, attrs SubscriptionPromotionalOfferCreateAttributes, priceIDs []string) (*SubscriptionPromotionalOfferResponse, error) {
+func (c *Client) CreateSubscriptionPromotionalOffer(ctx context.Context, subscriptionID string, attrs SubscriptionPromotionalOfferCreateAttributes, prices []SubscriptionPromotionalOfferPrice) (*SubscriptionPromotionalOfferResponse, error) {
 	subscriptionID = strings.TrimSpace(subscriptionID)
-	priceIDs = normalizeList(priceIDs)
 	if subscriptionID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
 	}
-	if len(priceIDs) == 0 {
-		return nil, fmt.Errorf("price IDs are required")
+	if len(prices) == 0 {
+		return nil, fmt.Errorf("at least one price is required")
 	}
 
-	priceData := make([]ResourceData, 0, len(priceIDs))
-	for _, priceID := range priceIDs {
+	isFreeTrial := attrs.OfferMode == SubscriptionOfferModeFreeTrial
+	priceData := make([]ResourceData, 0, len(prices))
+	included := make([]SubscriptionPromotionalOfferPriceInlineCreate, 0, len(prices))
+	for idx, price := range prices {
+		territoryID := strings.ToUpper(strings.TrimSpace(price.TerritoryID))
+		pricePointID := strings.TrimSpace(price.PricePointID)
+		if territoryID == "" {
+			return nil, fmt.Errorf("territory ID is required")
+		}
+		if isFreeTrial && pricePointID != "" {
+			return nil, fmt.Errorf("price point must not be set for FREE_TRIAL offer mode")
+		}
+		if !isFreeTrial && pricePointID == "" {
+			return nil, fmt.Errorf("price point ID is required")
+		}
+
+		priceRelationships := SubscriptionPromotionalOfferPriceRelationships{
+			Territory: Relationship{
+				Data: ResourceData{
+					Type: ResourceTypeTerritories,
+					ID:   territoryID,
+				},
+			},
+		}
+		if pricePointID != "" {
+			priceRelationships.SubscriptionPricePoint = &Relationship{
+				Data: ResourceData{
+					Type: ResourceTypeSubscriptionPricePoints,
+					ID:   pricePointID,
+				},
+			}
+		}
+
+		resourceID := fmt.Sprintf("${local-price-%d}", idx+1)
 		priceData = append(priceData, ResourceData{
 			Type: ResourceTypeSubscriptionPromotionalOfferPrices,
-			ID:   priceID,
+			ID:   resourceID,
+		})
+		included = append(included, SubscriptionPromotionalOfferPriceInlineCreate{
+			Type:          ResourceTypeSubscriptionPromotionalOfferPrices,
+			ID:            resourceID,
+			Relationships: priceRelationships,
 		})
 	}
 
@@ -518,6 +554,7 @@ func (c *Client) CreateSubscriptionPromotionalOffer(ctx context.Context, subscri
 				Prices: RelationshipList{Data: priceData},
 			},
 		},
+		Included: included,
 	}
 
 	body, err := BuildRequestBody(payload)

--- a/internal/asc/subscription_resources.go
+++ b/internal/asc/subscription_resources.go
@@ -197,13 +197,14 @@ type SubscriptionPromotionalOfferCreateRequest struct {
 
 // SubscriptionPromotionalOfferPrice describes a promotional offer price input.
 type SubscriptionPromotionalOfferPrice struct {
+	ID           string
 	TerritoryID  string
 	PricePointID string
 }
 
 // SubscriptionPromotionalOfferPriceRelationships describes inline promotional offer price relationships.
 type SubscriptionPromotionalOfferPriceRelationships struct {
-	Territory              Relationship  `json:"territory"`
+	Territory              *Relationship `json:"territory,omitempty"`
 	SubscriptionPricePoint *Relationship `json:"subscriptionPricePoint,omitempty"`
 }
 

--- a/internal/asc/subscription_resources.go
+++ b/internal/asc/subscription_resources.go
@@ -191,7 +191,27 @@ type SubscriptionPromotionalOfferCreateData struct {
 
 // SubscriptionPromotionalOfferCreateRequest is a request to create a promotional offer.
 type SubscriptionPromotionalOfferCreateRequest struct {
-	Data SubscriptionPromotionalOfferCreateData `json:"data"`
+	Data     SubscriptionPromotionalOfferCreateData          `json:"data"`
+	Included []SubscriptionPromotionalOfferPriceInlineCreate `json:"included,omitempty"`
+}
+
+// SubscriptionPromotionalOfferPrice describes a promotional offer price input.
+type SubscriptionPromotionalOfferPrice struct {
+	TerritoryID  string
+	PricePointID string
+}
+
+// SubscriptionPromotionalOfferPriceRelationships describes inline promotional offer price relationships.
+type SubscriptionPromotionalOfferPriceRelationships struct {
+	Territory              Relationship  `json:"territory"`
+	SubscriptionPricePoint *Relationship `json:"subscriptionPricePoint,omitempty"`
+}
+
+// SubscriptionPromotionalOfferPriceInlineCreate describes an inline promotional offer price resource.
+type SubscriptionPromotionalOfferPriceInlineCreate struct {
+	Type          ResourceType                                   `json:"type"`
+	ID            string                                         `json:"id"`
+	Relationships SubscriptionPromotionalOfferPriceRelationships `json:"relationships"`
 }
 
 // SubscriptionPromotionalOfferUpdateRelationships describes relationships for promotional offer updates.

--- a/internal/asc/subscriptions_resources_http_test.go
+++ b/internal/asc/subscriptions_resources_http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -700,21 +701,17 @@ func TestCreateSubscriptionPromotionalOffer(t *testing.T) {
 		if req.URL.Path != "/v1/subscriptionPromotionalOffers" {
 			t.Fatalf("expected path /v1/subscriptionPromotionalOffers, got %s", req.URL.Path)
 		}
-		var payload SubscriptionPromotionalOfferCreateRequest
-		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+		var got map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
 			t.Fatalf("failed to decode request: %v", err)
 		}
-		if payload.Data.Type != ResourceTypeSubscriptionPromotionalOffers {
-			t.Fatalf("expected type subscriptionPromotionalOffers, got %q", payload.Data.Type)
+		var want map[string]any
+		const expectedBody = `{"data":{"type":"subscriptionPromotionalOffers","attributes":{"duration":"ONE_MONTH","name":"Spring","numberOfPeriods":1,"offerCode":"SPRING","offerMode":"PAY_AS_YOU_GO"},"relationships":{"subscription":{"data":{"type":"subscriptions","id":"sub-1"}},"prices":{"data":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}"}]}}},"included":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}","relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-1"}}}}]}`
+		if err := json.Unmarshal([]byte(expectedBody), &want); err != nil {
+			t.Fatalf("failed to decode expected body: %v", err)
 		}
-		if payload.Data.Attributes.Name != "Spring" || payload.Data.Attributes.OfferCode != "SPRING" {
-			t.Fatalf("unexpected attributes: %+v", payload.Data.Attributes)
-		}
-		if payload.Data.Relationships.Subscription.Data.ID != "sub-1" {
-			t.Fatalf("unexpected subscription relationship: %+v", payload.Data.Relationships.Subscription.Data)
-		}
-		if len(payload.Data.Relationships.Prices.Data) != 1 || payload.Data.Relationships.Prices.Data[0].ID != "price-1" {
-			t.Fatalf("unexpected price relationships: %+v", payload.Data.Relationships.Prices.Data)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("unexpected request body:\n got: %#v\nwant: %#v", got, want)
 		}
 		assertAuthorized(t, req)
 	}, response)
@@ -723,11 +720,41 @@ func TestCreateSubscriptionPromotionalOffer(t *testing.T) {
 		Name:            "Spring",
 		OfferCode:       "SPRING",
 		Duration:        SubscriptionOfferDurationOneMonth,
-		OfferMode:       SubscriptionOfferModeFreeTrial,
+		OfferMode:       SubscriptionOfferModePayAsYouGo,
 		NumberOfPeriods: 1,
 	}
-	if _, err := client.CreateSubscriptionPromotionalOffer(context.Background(), "sub-1", attrs, []string{"price-1"}); err != nil {
+	prices := []SubscriptionPromotionalOfferPrice{{TerritoryID: "USA", PricePointID: "price-1"}}
+	if _, err := client.CreateSubscriptionPromotionalOffer(context.Background(), "sub-1", attrs, prices); err != nil {
 		t.Fatalf("CreateSubscriptionPromotionalOffer() error: %v", err)
+	}
+}
+
+func TestCreateSubscriptionPromotionalOfferValidatesInlinePricesBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   SubscriptionOfferMode
+		prices []SubscriptionPromotionalOfferPrice
+		want   string
+	}{
+		{name: "missing prices", mode: SubscriptionOfferModePayAsYouGo, want: "at least one price is required"},
+		{name: "missing territory", mode: SubscriptionOfferModePayAsYouGo, prices: []SubscriptionPromotionalOfferPrice{{PricePointID: "price-1"}}, want: "territory ID is required"},
+		{name: "paid missing price point", mode: SubscriptionOfferModePayUpFront, prices: []SubscriptionPromotionalOfferPrice{{TerritoryID: "USA"}}, want: "price point ID is required"},
+		{name: "free trial has price point", mode: SubscriptionOfferModeFreeTrial, prices: []SubscriptionPromotionalOfferPrice{{TerritoryID: "USA", PricePointID: "price-1"}}, want: "price point must not be set for FREE_TRIAL offer mode"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{}
+			_, err := client.CreateSubscriptionPromotionalOffer(
+				context.Background(),
+				"sub-1",
+				SubscriptionPromotionalOfferCreateAttributes{OfferMode: test.mode},
+				test.prices,
+			)
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("expected %q, got %v", test.want, err)
+			}
+		})
 	}
 }
 

--- a/internal/asc/subscriptions_resources_http_test.go
+++ b/internal/asc/subscriptions_resources_http_test.go
@@ -693,39 +693,79 @@ func TestGetSubscriptionPromotionalOffer(t *testing.T) {
 }
 
 func TestCreateSubscriptionPromotionalOffer(t *testing.T) {
-	response := jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPromotionalOffers","id":"offer-1","attributes":{"name":"Spring"}}}`)
-	client := newTestClient(t, func(req *http.Request) {
-		if req.Method != http.MethodPost {
-			t.Fatalf("expected POST, got %s", req.Method)
-		}
-		if req.URL.Path != "/v1/subscriptionPromotionalOffers" {
-			t.Fatalf("expected path /v1/subscriptionPromotionalOffers, got %s", req.URL.Path)
-		}
-		var got map[string]any
-		if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
-			t.Fatalf("failed to decode request: %v", err)
-		}
-		var want map[string]any
-		const expectedBody = `{"data":{"type":"subscriptionPromotionalOffers","attributes":{"duration":"ONE_MONTH","name":"Spring","numberOfPeriods":1,"offerCode":"SPRING","offerMode":"PAY_AS_YOU_GO"},"relationships":{"subscription":{"data":{"type":"subscriptions","id":"sub-1"}},"prices":{"data":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}"}]}}},"included":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}","relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-1"}}}}]}`
-		if err := json.Unmarshal([]byte(expectedBody), &want); err != nil {
-			t.Fatalf("failed to decode expected body: %v", err)
-		}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("unexpected request body:\n got: %#v\nwant: %#v", got, want)
-		}
-		assertAuthorized(t, req)
-	}, response)
-
-	attrs := SubscriptionPromotionalOfferCreateAttributes{
-		Name:            "Spring",
-		OfferCode:       "SPRING",
-		Duration:        SubscriptionOfferDurationOneMonth,
-		OfferMode:       SubscriptionOfferModePayAsYouGo,
-		NumberOfPeriods: 1,
+	tests := []struct {
+		name         string
+		mode         SubscriptionOfferMode
+		prices       []SubscriptionPromotionalOfferPrice
+		expectedBody string
+	}{
+		{
+			name:         "compound price with both relationships",
+			mode:         SubscriptionOfferModePayAsYouGo,
+			prices:       []SubscriptionPromotionalOfferPrice{{TerritoryID: "USA", PricePointID: "price-1"}},
+			expectedBody: `{"data":{"type":"subscriptionPromotionalOffers","attributes":{"duration":"ONE_MONTH","name":"Spring","numberOfPeriods":1,"offerCode":"SPRING","offerMode":"PAY_AS_YOU_GO"},"relationships":{"subscription":{"data":{"type":"subscriptions","id":"sub-1"}},"prices":{"data":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}"}]}}},"included":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}","relationships":{"territory":{"data":{"type":"territories","id":"USA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-1"}}}}]}`,
+		},
+		{
+			name:         "paid mode with territory only",
+			mode:         SubscriptionOfferModePayUpFront,
+			prices:       []SubscriptionPromotionalOfferPrice{{TerritoryID: "FRA"}},
+			expectedBody: `{"data":{"type":"subscriptionPromotionalOffers","attributes":{"duration":"ONE_MONTH","name":"Spring","numberOfPeriods":1,"offerCode":"SPRING","offerMode":"PAY_UP_FRONT"},"relationships":{"subscription":{"data":{"type":"subscriptions","id":"sub-1"}},"prices":{"data":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}"}]}}},"included":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}","relationships":{"territory":{"data":{"type":"territories","id":"FRA"}}}}]}`,
+		},
+		{
+			name:         "free trial with price point",
+			mode:         SubscriptionOfferModeFreeTrial,
+			prices:       []SubscriptionPromotionalOfferPrice{{TerritoryID: "DEU", PricePointID: "price-2"}},
+			expectedBody: `{"data":{"type":"subscriptionPromotionalOffers","attributes":{"duration":"ONE_MONTH","name":"Spring","numberOfPeriods":1,"offerCode":"SPRING","offerMode":"FREE_TRIAL"},"relationships":{"subscription":{"data":{"type":"subscriptions","id":"sub-1"}},"prices":{"data":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}"}]}}},"included":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}","relationships":{"territory":{"data":{"type":"territories","id":"DEU"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-2"}}}}]}`,
+		},
+		{
+			name:         "price point relationship without territory",
+			mode:         SubscriptionOfferModeFreeTrial,
+			prices:       []SubscriptionPromotionalOfferPrice{{PricePointID: "price-3"}},
+			expectedBody: `{"data":{"type":"subscriptionPromotionalOffers","attributes":{"duration":"ONE_MONTH","name":"Spring","numberOfPeriods":1,"offerCode":"SPRING","offerMode":"FREE_TRIAL"},"relationships":{"subscription":{"data":{"type":"subscriptions","id":"sub-1"}},"prices":{"data":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}"}]}}},"included":[{"type":"subscriptionPromotionalOfferPrices","id":"${local-price-1}","relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-3"}}}}]}`,
+		},
+		{
+			name:         "legacy existing price reference",
+			mode:         SubscriptionOfferModePayUpFront,
+			prices:       []SubscriptionPromotionalOfferPrice{{ID: "price-legacy"}},
+			expectedBody: `{"data":{"type":"subscriptionPromotionalOffers","attributes":{"duration":"ONE_MONTH","name":"Spring","numberOfPeriods":1,"offerCode":"SPRING","offerMode":"PAY_UP_FRONT"},"relationships":{"subscription":{"data":{"type":"subscriptions","id":"sub-1"}},"prices":{"data":[{"type":"subscriptionPromotionalOfferPrices","id":"price-legacy"}]}}}}`,
+		},
 	}
-	prices := []SubscriptionPromotionalOfferPrice{{TerritoryID: "USA", PricePointID: "price-1"}}
-	if _, err := client.CreateSubscriptionPromotionalOffer(context.Background(), "sub-1", attrs, prices); err != nil {
-		t.Fatalf("CreateSubscriptionPromotionalOffer() error: %v", err)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := jsonResponse(http.StatusCreated, `{"data":{"type":"subscriptionPromotionalOffers","id":"offer-1","attributes":{"name":"Spring"}}}`)
+			client := newTestClient(t, func(req *http.Request) {
+				if req.Method != http.MethodPost {
+					t.Fatalf("expected POST, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/subscriptionPromotionalOffers" {
+					t.Fatalf("expected path /v1/subscriptionPromotionalOffers, got %s", req.URL.Path)
+				}
+				var got map[string]any
+				if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+					t.Fatalf("failed to decode request: %v", err)
+				}
+				var want map[string]any
+				if err := json.Unmarshal([]byte(test.expectedBody), &want); err != nil {
+					t.Fatalf("failed to decode expected body: %v", err)
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("unexpected request body:\n got: %#v\nwant: %#v", got, want)
+				}
+				assertAuthorized(t, req)
+			}, response)
+
+			attrs := SubscriptionPromotionalOfferCreateAttributes{
+				Name:            "Spring",
+				OfferCode:       "SPRING",
+				Duration:        SubscriptionOfferDurationOneMonth,
+				OfferMode:       test.mode,
+				NumberOfPeriods: 1,
+			}
+			if _, err := client.CreateSubscriptionPromotionalOffer(context.Background(), "sub-1", attrs, test.prices); err != nil {
+				t.Fatalf("CreateSubscriptionPromotionalOffer() error: %v", err)
+			}
+		})
 	}
 }
 
@@ -737,9 +777,9 @@ func TestCreateSubscriptionPromotionalOfferValidatesInlinePricesBeforeHTTP(t *te
 		want   string
 	}{
 		{name: "missing prices", mode: SubscriptionOfferModePayAsYouGo, want: "at least one price is required"},
-		{name: "missing territory", mode: SubscriptionOfferModePayAsYouGo, prices: []SubscriptionPromotionalOfferPrice{{PricePointID: "price-1"}}, want: "territory ID is required"},
-		{name: "paid missing price point", mode: SubscriptionOfferModePayUpFront, prices: []SubscriptionPromotionalOfferPrice{{TerritoryID: "USA"}}, want: "price point ID is required"},
-		{name: "free trial has price point", mode: SubscriptionOfferModeFreeTrial, prices: []SubscriptionPromotionalOfferPrice{{TerritoryID: "USA", PricePointID: "price-1"}}, want: "price point must not be set for FREE_TRIAL offer mode"},
+		{name: "empty price", mode: SubscriptionOfferModePayAsYouGo, prices: []SubscriptionPromotionalOfferPrice{{}}, want: "price reference ID or inline relationship is required"},
+		{name: "reference with inline relationships", mode: SubscriptionOfferModePayAsYouGo, prices: []SubscriptionPromotionalOfferPrice{{ID: "price-1", TerritoryID: "USA"}}, want: "price reference ID must not be combined with inline relationships"},
+		{name: "mixed reference and inline prices", mode: SubscriptionOfferModePayAsYouGo, prices: []SubscriptionPromotionalOfferPrice{{ID: "price-1"}, {TerritoryID: "USA"}}, want: "price inputs must not mix existing IDs with inline relationships"},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -155,6 +155,31 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 		t.Fatalf("expected subscriptions offers offer-codes help to drop stale price example, got %q", offerCodesUsage)
 	}
 
+	promotionalCmd := findSubcommand(root, "subscriptions", "offers", "promotional")
+	if promotionalCmd == nil {
+		t.Fatal("expected subscriptions offers promotional command")
+		return
+	}
+	promotionalUsage := promotionalCmd.UsageFunc(promotionalCmd)
+	if !strings.Contains(promotionalUsage, `--prices "US"`) {
+		t.Fatalf("expected promotional offer help to show FREE_TRIAL territory prices, got %q", promotionalUsage)
+	}
+	if strings.Contains(promotionalUsage, `--prices "PRICE_ID"`) {
+		t.Fatalf("expected promotional offer help to drop pre-existing price IDs, got %q", promotionalUsage)
+	}
+	promotionalCreateCmd := findSubcommand(root, "subscriptions", "offers", "promotional", "create")
+	if promotionalCreateCmd == nil {
+		t.Fatal("expected subscriptions offers promotional create command")
+		return
+	}
+	promotionalCreateUsage := promotionalCreateCmd.UsageFunc(promotionalCreateCmd)
+	if !strings.Contains(promotionalCreateUsage, `--prices "US:PRICE_POINT_ID"`) {
+		t.Fatalf("expected promotional offer create help to show paid territory prices, got %q", promotionalCreateUsage)
+	}
+	if strings.Contains(promotionalCreateUsage, `--prices "PRICE_ID"`) {
+		t.Fatalf("expected promotional offer create help to drop pre-existing price IDs, got %q", promotionalCreateUsage)
+	}
+
 	reviewCmd := findSubcommand(root, "subscriptions", "review")
 	if reviewCmd == nil {
 		t.Fatal("expected subscriptions review command")

--- a/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
@@ -22,12 +23,17 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 		name                 string
 		mode                 string
 		prices               string
+		wantReferenceID      string
+		wantInline           bool
 		wantTerritory        string
 		wantPricePoint       string
 		wantPricePointLinked bool
 	}{
-		{name: "paid", mode: "pay_as_you_go", prices: "United States:pp-us", wantTerritory: "USA", wantPricePoint: "pp-us", wantPricePointLinked: true},
-		{name: "free trial", mode: "free_trial", prices: "Germany", wantTerritory: "DEU"},
+		{name: "paid compound", mode: "pay_as_you_go", prices: "United States:pp-us", wantInline: true, wantTerritory: "USA", wantPricePoint: "pp-us", wantPricePointLinked: true},
+		{name: "free trial territory only", mode: "free_trial", prices: "Germany", wantInline: true, wantTerritory: "DEU"},
+		{name: "paid territory only", mode: "pay_up_front", prices: "France", wantInline: true, wantTerritory: "FRA"},
+		{name: "free trial compound", mode: "free_trial", prices: "US:pp-us", wantInline: true, wantTerritory: "USA", wantPricePoint: "pp-us", wantPricePointLinked: true},
+		{name: "legacy bare price ID", mode: "pay_up_front", prices: "price-legacy", wantReferenceID: "price-legacy"},
 	}
 
 	for _, test := range tests {
@@ -45,11 +51,25 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 				}
 				data := payload["data"].(map[string]any)
 				priceRefs := data["relationships"].(map[string]any)["prices"].(map[string]any)["data"].([]any)
-				included := payload["included"].([]any)
-				if len(priceRefs) != 1 || len(included) != 1 {
-					t.Fatalf("expected one price linkage and included resource, got refs=%#v included=%#v", priceRefs, included)
+				if len(priceRefs) != 1 {
+					t.Fatalf("expected one price linkage, got refs=%#v", priceRefs)
 				}
 				priceRef := priceRefs[0].(map[string]any)
+				if !test.wantInline {
+					if priceRef["id"] != test.wantReferenceID || priceRef["type"] != "subscriptionPromotionalOfferPrices" {
+						t.Fatalf("unexpected legacy price linkage: %#v", priceRef)
+					}
+					if _, ok := payload["included"]; ok {
+						t.Fatalf("legacy price linkage must not emit included resources: %#v", payload)
+					}
+					writePromotionalOfferCreateResponse(t, w)
+					return
+				}
+
+				included, ok := payload["included"].([]any)
+				if !ok || len(included) != 1 {
+					t.Fatalf("expected one included resource, got %#v", payload["included"])
+				}
 				includedPrice := included[0].(map[string]any)
 				if priceRef["id"] != includedPrice["id"] || priceRef["type"] != "subscriptionPromotionalOfferPrices" {
 					t.Fatalf("price linkage does not match included resource: ref=%#v included=%#v", priceRef, includedPrice)
@@ -69,9 +89,7 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 						t.Fatalf("expected price point %s, got %#v", test.wantPricePoint, pricePointID)
 					}
 				}
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusCreated)
-				_, _ = io.WriteString(w, `{"data":{"type":"subscriptionPromotionalOffers","id":"promo-1"}}`)
+				writePromotionalOfferCreateResponse(t, w)
 			}))
 			t.Cleanup(server.Close)
 
@@ -129,6 +147,15 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 	}
 }
 
+func writePromotionalOfferCreateResponse(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if _, err := io.WriteString(w, `{"data":{"type":"subscriptionPromotionalOffers","id":"promo-1"}}`); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+}
+
 func TestSubscriptionsPromotionalOffersCreateRejectsInvalidPriceShapeBeforeAuth(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -136,9 +163,8 @@ func TestSubscriptionsPromotionalOffersCreateRejectsInvalidPriceShapeBeforeAuth(
 		prices  string
 		wantErr string
 	}{
-		{name: "paid legacy price ID", mode: "PAY_UP_FRONT", prices: "price-1", wantErr: "TERRITORY:PRICE_POINT_ID"},
-		{name: "free trial has price point", mode: "FREE_TRIAL", prices: "US:price-1", wantErr: "FREE_TRIAL"},
-		{name: "unknown territory", mode: "FREE_TRIAL", prices: "NOT_A_TERRITORY", wantErr: "could not be mapped"},
+		{name: "mixed inline and legacy", mode: "PAY_UP_FRONT", prices: "US:price-point-1,price-legacy", wantErr: "must not mix"},
+		{name: "inline missing price point", mode: "FREE_TRIAL", prices: "US:", wantErr: "TERRITORY:PRICE_POINT_ID"},
 	}
 
 	for _, test := range tests {
@@ -159,6 +185,9 @@ func TestSubscriptionsPromotionalOffersCreateRejectsInvalidPriceShapeBeforeAuth(
 			})
 			if !errors.Is(runErr, flag.ErrHelp) {
 				t.Fatalf("expected usage error, got %v", runErr)
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitUsage)
 			}
 			if !strings.Contains(stderr, test.wantErr) || stdout != "" {
 				t.Fatalf("stdout=%q stderr=%q, want stderr containing %q", stdout, stderr, test.wantErr)

--- a/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
@@ -185,6 +185,8 @@ func TestSubscriptionsPromotionalOffersCreateRejectsInvalidPriceShapeBeforeAuth(
 		wantErr string
 	}{
 		{name: "mixed inline and legacy", mode: "PAY_UP_FRONT", prices: "US:price-point-1,price-legacy", wantErr: "must not mix"},
+		{name: "mixed territory-only and legacy", mode: "PAY_UP_FRONT", prices: "US,price-legacy", wantErr: "must not mix"},
+		{name: "mixed legacy and territory-only", mode: "PAY_UP_FRONT", prices: "price-legacy,US", wantErr: "must not mix"},
 		{name: "inline missing price point", mode: "FREE_TRIAL", prices: "US:", wantErr: "TERRITORY:PRICE_POINT_ID"},
 	}
 

--- a/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
@@ -7,9 +7,14 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
@@ -30,9 +35,7 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 			setupAuth(t)
 			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-			originalTransport := http.DefaultTransport
-			t.Cleanup(func() { http.DefaultTransport = originalTransport })
-			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionPromotionalOffers" {
 					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 				}
@@ -66,12 +69,31 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 						t.Fatalf("expected price point %s, got %#v", test.wantPricePoint, pricePointID)
 					}
 				}
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(strings.NewReader(`{"data":{"type":"subscriptionPromotionalOffers","id":"promo-1"}}`)),
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-				}, nil
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = io.WriteString(w, `{"data":{"type":"subscriptionPromotionalOffers","id":"promo-1"}}`)
+			}))
+			t.Cleanup(server.Close)
+
+			serverHost := strings.TrimPrefix(server.URL, "http://")
+			transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				cloned := req.Clone(req.Context())
+				cloned.URL.Scheme = "http"
+				cloned.URL.Host = serverHost
+				return server.Client().Transport.RoundTrip(cloned)
 			})
+			client, err := asc.NewClientWithHTTPClient(
+				os.Getenv("ASC_KEY_ID"),
+				os.Getenv("ASC_ISSUER_ID"),
+				os.Getenv("ASC_PRIVATE_KEY_PATH"),
+				&http.Client{Transport: transport},
+			)
+			if err != nil {
+				t.Fatalf("create test client: %v", err)
+			}
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				return client, nil
+			}))
 
 			root := RootCommand("1.2.3")
 			root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
@@ -1,0 +1,146 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
+	tests := []struct {
+		name                 string
+		mode                 string
+		prices               string
+		wantTerritory        string
+		wantPricePoint       string
+		wantPricePointLinked bool
+	}{
+		{name: "paid", mode: "pay_as_you_go", prices: "United States:pp-us", wantTerritory: "USA", wantPricePoint: "pp-us", wantPricePointLinked: true},
+		{name: "free trial", mode: "free_trial", prices: "Germany", wantTerritory: "DEU"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodPost || req.URL.Path != "/v1/subscriptionPromotionalOffers" {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+				}
+				var payload map[string]any
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				data := payload["data"].(map[string]any)
+				priceRefs := data["relationships"].(map[string]any)["prices"].(map[string]any)["data"].([]any)
+				included := payload["included"].([]any)
+				if len(priceRefs) != 1 || len(included) != 1 {
+					t.Fatalf("expected one price linkage and included resource, got refs=%#v included=%#v", priceRefs, included)
+				}
+				priceRef := priceRefs[0].(map[string]any)
+				includedPrice := included[0].(map[string]any)
+				if priceRef["id"] != includedPrice["id"] || priceRef["type"] != "subscriptionPromotionalOfferPrices" {
+					t.Fatalf("price linkage does not match included resource: ref=%#v included=%#v", priceRef, includedPrice)
+				}
+				relationships := includedPrice["relationships"].(map[string]any)
+				territory := relationships["territory"].(map[string]any)["data"].(map[string]any)
+				if territory["id"] != test.wantTerritory {
+					t.Fatalf("expected territory %s, got %#v", test.wantTerritory, territory)
+				}
+				pricePoint, hasPricePoint := relationships["subscriptionPricePoint"]
+				if hasPricePoint != test.wantPricePointLinked {
+					t.Fatalf("subscriptionPricePoint presence = %t, want %t", hasPricePoint, test.wantPricePointLinked)
+				}
+				if hasPricePoint {
+					pricePointID := pricePoint.(map[string]any)["data"].(map[string]any)["id"]
+					if pricePointID != test.wantPricePoint {
+						t.Fatalf("expected price point %s, got %#v", test.wantPricePoint, pricePointID)
+					}
+				}
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"data":{"type":"subscriptionPromotionalOffers","id":"promo-1"}}`)),
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+				}, nil
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"subscriptions", "offers", "promotional", "create",
+					"--subscription-id", "8000000001",
+					"--offer-code", "SPRING",
+					"--name", "Spring",
+					"--offer-duration", "one_month",
+					"--offer-mode", test.mode,
+					"--number-of-periods", "1",
+					"--prices", test.prices,
+				}); err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run: %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			var output struct {
+				Data struct {
+					ID string `json:"id"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil || output.Data.ID != "promo-1" {
+				t.Fatalf("unexpected stdout %q: %v", stdout, err)
+			}
+		})
+	}
+}
+
+func TestSubscriptionsPromotionalOffersCreateRejectsInvalidPriceShapeBeforeAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		prices  string
+		wantErr string
+	}{
+		{name: "paid legacy price ID", mode: "PAY_UP_FRONT", prices: "price-1", wantErr: "TERRITORY:PRICE_POINT_ID"},
+		{name: "free trial has price point", mode: "FREE_TRIAL", prices: "US:price-1", wantErr: "FREE_TRIAL"},
+		{name: "unknown territory", mode: "FREE_TRIAL", prices: "NOT_A_TERRITORY", wantErr: "could not be mapped"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"subscriptions", "offers", "promotional", "create",
+					"--subscription-id", "8000000001", "--offer-code", "SPRING", "--name", "Spring",
+					"--offer-duration", "ONE_MONTH", "--offer-mode", test.mode,
+					"--number-of-periods", "1", "--prices", test.prices,
+				}); err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected usage error, got %v", runErr)
+			}
+			if !strings.Contains(stderr, test.wantErr) || stdout != "" {
+				t.Fatalf("stdout=%q stderr=%q, want stderr containing %q", stdout, stderr, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_promotional_offers_create_test.go
@@ -28,8 +28,10 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 		wantTerritory        string
 		wantPricePoint       string
 		wantPricePointLinked bool
+		wantSecondTerritory  string
 	}{
 		{name: "paid compound", mode: "pay_as_you_go", prices: "United States:pp-us", wantInline: true, wantTerritory: "USA", wantPricePoint: "pp-us", wantPricePointLinked: true},
+		{name: "compound and territory-only inline", mode: "pay_as_you_go", prices: "US:pp-us,France", wantInline: true, wantTerritory: "USA", wantPricePoint: "pp-us", wantPricePointLinked: true, wantSecondTerritory: "FRA"},
 		{name: "free trial territory only", mode: "free_trial", prices: "Germany", wantInline: true, wantTerritory: "DEU"},
 		{name: "paid territory only", mode: "pay_up_front", prices: "France", wantInline: true, wantTerritory: "FRA"},
 		{name: "free trial compound", mode: "free_trial", prices: "US:pp-us", wantInline: true, wantTerritory: "USA", wantPricePoint: "pp-us", wantPricePointLinked: true},
@@ -51,8 +53,12 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 				}
 				data := payload["data"].(map[string]any)
 				priceRefs := data["relationships"].(map[string]any)["prices"].(map[string]any)["data"].([]any)
-				if len(priceRefs) != 1 {
-					t.Fatalf("expected one price linkage, got refs=%#v", priceRefs)
+				wantPriceCount := 1
+				if test.wantSecondTerritory != "" {
+					wantPriceCount = 2
+				}
+				if len(priceRefs) != wantPriceCount {
+					t.Fatalf("expected %d price linkage(s), got refs=%#v", wantPriceCount, priceRefs)
 				}
 				priceRef := priceRefs[0].(map[string]any)
 				if !test.wantInline {
@@ -67,8 +73,8 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 				}
 
 				included, ok := payload["included"].([]any)
-				if !ok || len(included) != 1 {
-					t.Fatalf("expected one included resource, got %#v", payload["included"])
+				if !ok || len(included) != wantPriceCount {
+					t.Fatalf("expected %d included resource(s), got %#v", wantPriceCount, payload["included"])
 				}
 				includedPrice := included[0].(map[string]any)
 				if priceRef["id"] != includedPrice["id"] || priceRef["type"] != "subscriptionPromotionalOfferPrices" {
@@ -87,6 +93,21 @@ func TestSubscriptionsPromotionalOffersCreateBuildsInlinePrices(t *testing.T) {
 					pricePointID := pricePoint.(map[string]any)["data"].(map[string]any)["id"]
 					if pricePointID != test.wantPricePoint {
 						t.Fatalf("expected price point %s, got %#v", test.wantPricePoint, pricePointID)
+					}
+				}
+				if test.wantSecondTerritory != "" {
+					secondRef := priceRefs[1].(map[string]any)
+					secondIncluded := included[1].(map[string]any)
+					if secondRef["id"] != secondIncluded["id"] {
+						t.Fatalf("second price linkage does not match included resource: ref=%#v included=%#v", secondRef, secondIncluded)
+					}
+					secondRelationships := secondIncluded["relationships"].(map[string]any)
+					secondTerritory := secondRelationships["territory"].(map[string]any)["data"].(map[string]any)
+					if secondTerritory["id"] != test.wantSecondTerritory {
+						t.Fatalf("expected second territory %s, got %#v", test.wantSecondTerritory, secondTerritory)
+					}
+					if _, ok := secondRelationships["subscriptionPricePoint"]; ok {
+						t.Fatalf("second territory-only price must not include a price point: %#v", secondRelationships)
 					}
 				}
 				writePromotionalOfferCreateResponse(t, w)

--- a/internal/cli/subscriptions/helpers.go
+++ b/internal/cli/subscriptions/helpers.go
@@ -240,32 +240,7 @@ func parseSubscriptionOfferCodePrices(value string, mode asc.SubscriptionOfferMo
 
 func parseSubscriptionPromotionalOfferPrices(value string) ([]asc.SubscriptionPromotionalOfferPrice, error) {
 	if strings.Contains(value, ":") {
-		parsed, err := shared.ParseASCTerritoryValueCSV(value)
-		if err != nil {
-			parts := shared.SplitCSV(value)
-			hasCompound := false
-			hasBare := false
-			for _, part := range parts {
-				if strings.Contains(part, ":") {
-					hasCompound = true
-				} else {
-					hasBare = true
-				}
-			}
-			if hasCompound && hasBare {
-				return nil, fmt.Errorf("--prices must not mix existing price IDs with TERRITORY:PRICE_POINT_ID entries")
-			}
-			return nil, err
-		}
-
-		prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(parsed))
-		for _, price := range parsed {
-			prices = append(prices, asc.SubscriptionPromotionalOfferPrice{
-				TerritoryID:  price.TerritoryID,
-				PricePointID: price.Value,
-			})
-		}
-		return prices, nil
+		return parseSubscriptionPromotionalOfferInlinePrices(value)
 	}
 
 	territoryIDs, territoryErr := shared.NormalizeASCTerritoryCSV(value)
@@ -282,6 +257,78 @@ func parseSubscriptionPromotionalOfferPrices(value string) ([]asc.SubscriptionPr
 	for _, priceID := range priceIDs {
 		prices = append(prices, asc.SubscriptionPromotionalOfferPrice{ID: priceID})
 	}
+	return prices, nil
+}
+
+func parseSubscriptionPromotionalOfferInlinePrices(value string) ([]asc.SubscriptionPromotionalOfferPrice, error) {
+	parts := shared.SplitCSV(value)
+	prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(parts))
+
+	for start := 0; start < len(parts); {
+		compoundEnd := start
+		for compoundEnd < len(parts) && !strings.Contains(parts[compoundEnd], ":") {
+			compoundEnd++
+		}
+
+		if compoundEnd == len(parts) {
+			territoryIDs, err := shared.NormalizeASCTerritoryCSV(strings.Join(parts[start:], ","))
+			if err != nil {
+				return nil, fmt.Errorf("--prices must not mix existing price IDs with TERRITORY:PRICE_POINT_ID entries")
+			}
+			for _, territoryID := range territoryIDs {
+				prices = append(prices, asc.SubscriptionPromotionalOfferPrice{TerritoryID: territoryID})
+			}
+			break
+		}
+
+		var candidateErr error
+		mixedReferences := false
+		matched := false
+		for compoundStart := start; compoundStart <= compoundEnd; compoundStart++ {
+			var territoryIDs []string
+			if compoundStart > start {
+				var err error
+				territoryIDs, err = shared.NormalizeASCTerritoryCSV(strings.Join(parts[start:compoundStart], ","))
+				if err != nil {
+					if parsed, parseErr := shared.ParseASCTerritoryValueCSV(strings.Join(parts[compoundStart:compoundEnd+1], ",")); parseErr == nil && len(parsed) == 1 {
+						mixedReferences = true
+					}
+					continue
+				}
+			}
+
+			parsed, err := shared.ParseASCTerritoryValueCSV(strings.Join(parts[compoundStart:compoundEnd+1], ","))
+			if err != nil {
+				candidateErr = err
+				continue
+			}
+			if len(parsed) != 1 {
+				continue
+			}
+
+			for _, territoryID := range territoryIDs {
+				prices = append(prices, asc.SubscriptionPromotionalOfferPrice{TerritoryID: territoryID})
+			}
+			prices = append(prices, asc.SubscriptionPromotionalOfferPrice{
+				TerritoryID:  parsed[0].TerritoryID,
+				PricePointID: parsed[0].Value,
+			})
+			matched = true
+			break
+		}
+
+		if !matched {
+			if mixedReferences {
+				return nil, fmt.Errorf("--prices must not mix existing price IDs with TERRITORY:PRICE_POINT_ID entries")
+			}
+			if candidateErr == nil {
+				candidateErr = fmt.Errorf("--prices must use TERRITORY or TERRITORY:PRICE_POINT_ID entries")
+			}
+			return nil, candidateErr
+		}
+		start = compoundEnd + 1
+	}
+
 	return prices, nil
 }
 

--- a/internal/cli/subscriptions/helpers.go
+++ b/internal/cli/subscriptions/helpers.go
@@ -238,6 +238,19 @@ func parseSubscriptionOfferCodePrices(value string, mode asc.SubscriptionOfferMo
 	return prices, nil
 }
 
+func parseSubscriptionPromotionalOfferPrices(value string, mode asc.SubscriptionOfferMode) ([]asc.SubscriptionPromotionalOfferPrice, error) {
+	parsed, err := parseSubscriptionOfferCodePrices(value, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(parsed))
+	for _, price := range parsed {
+		prices = append(prices, asc.SubscriptionPromotionalOfferPrice(price))
+	}
+	return prices, nil
+}
+
 func openSubscriptionImageFile(path string) (*os.File, os.FileInfo, error) {
 	if err := asc.ValidateImageFile(path); err != nil {
 		return nil, nil, err

--- a/internal/cli/subscriptions/helpers.go
+++ b/internal/cli/subscriptions/helpers.go
@@ -238,15 +238,49 @@ func parseSubscriptionOfferCodePrices(value string, mode asc.SubscriptionOfferMo
 	return prices, nil
 }
 
-func parseSubscriptionPromotionalOfferPrices(value string, mode asc.SubscriptionOfferMode) ([]asc.SubscriptionPromotionalOfferPrice, error) {
-	parsed, err := parseSubscriptionOfferCodePrices(value, mode)
-	if err != nil {
-		return nil, err
+func parseSubscriptionPromotionalOfferPrices(value string) ([]asc.SubscriptionPromotionalOfferPrice, error) {
+	if strings.Contains(value, ":") {
+		parsed, err := shared.ParseASCTerritoryValueCSV(value)
+		if err != nil {
+			parts := shared.SplitCSV(value)
+			hasCompound := false
+			hasBare := false
+			for _, part := range parts {
+				if strings.Contains(part, ":") {
+					hasCompound = true
+				} else {
+					hasBare = true
+				}
+			}
+			if hasCompound && hasBare {
+				return nil, fmt.Errorf("--prices must not mix existing price IDs with TERRITORY:PRICE_POINT_ID entries")
+			}
+			return nil, err
+		}
+
+		prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(parsed))
+		for _, price := range parsed {
+			prices = append(prices, asc.SubscriptionPromotionalOfferPrice{
+				TerritoryID:  price.TerritoryID,
+				PricePointID: price.Value,
+			})
+		}
+		return prices, nil
 	}
 
-	prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(parsed))
-	for _, price := range parsed {
-		prices = append(prices, asc.SubscriptionPromotionalOfferPrice(price))
+	territoryIDs, territoryErr := shared.NormalizeASCTerritoryCSV(value)
+	if territoryErr == nil && len(territoryIDs) > 0 {
+		prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(territoryIDs))
+		for _, territoryID := range territoryIDs {
+			prices = append(prices, asc.SubscriptionPromotionalOfferPrice{TerritoryID: territoryID})
+		}
+		return prices, nil
+	}
+
+	priceIDs := shared.SplitCSV(value)
+	prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(priceIDs))
+	for _, priceID := range priceIDs {
+		prices = append(prices, asc.SubscriptionPromotionalOfferPrice{ID: priceID})
 	}
 	return prices, nil
 }

--- a/internal/cli/subscriptions/helpers.go
+++ b/internal/cli/subscriptions/helpers.go
@@ -288,7 +288,7 @@ func parseSubscriptionPromotionalOfferInlinePrices(value string) ([]asc.Subscrip
 		if compoundEnd == len(parts) {
 			territoryIDs, err := shared.NormalizeASCTerritoryCSV(strings.Join(parts[start:], ","))
 			if err != nil {
-				return nil, fmt.Errorf("--prices must not mix existing price IDs with TERRITORY:PRICE_POINT_ID entries")
+				return nil, fmt.Errorf("--prices must not mix existing price IDs with TERRITORY:PRICE_POINT_ID entries: %w", err)
 			}
 			for _, territoryID := range territoryIDs {
 				prices = append(prices, asc.SubscriptionPromotionalOfferPrice{TerritoryID: territoryID})

--- a/internal/cli/subscriptions/helpers.go
+++ b/internal/cli/subscriptions/helpers.go
@@ -253,11 +253,26 @@ func parseSubscriptionPromotionalOfferPrices(value string) ([]asc.SubscriptionPr
 	}
 
 	priceIDs := shared.SplitCSV(value)
+	if containsSubscriptionPromotionalOfferTerritory(priceIDs) {
+		return nil, fmt.Errorf("--prices must not mix existing price IDs with inline TERRITORY or TERRITORY:PRICE_POINT_ID entries")
+	}
 	prices := make([]asc.SubscriptionPromotionalOfferPrice, 0, len(priceIDs))
 	for _, priceID := range priceIDs {
 		prices = append(prices, asc.SubscriptionPromotionalOfferPrice{ID: priceID})
 	}
 	return prices, nil
+}
+
+func containsSubscriptionPromotionalOfferTerritory(parts []string) bool {
+	for start := range parts {
+		for end := start + 1; end <= len(parts); end++ {
+			territoryIDs, err := shared.NormalizeASCTerritoryCSV(strings.Join(parts[start:end], ","))
+			if err == nil && len(territoryIDs) == 1 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func parseSubscriptionPromotionalOfferInlinePrices(value string) ([]asc.SubscriptionPromotionalOfferPrice, error) {
@@ -319,7 +334,7 @@ func parseSubscriptionPromotionalOfferInlinePrices(value string) ([]asc.Subscrip
 
 		if !matched {
 			if mixedReferences {
-				return nil, fmt.Errorf("--prices must not mix existing price IDs with TERRITORY:PRICE_POINT_ID entries")
+				return nil, fmt.Errorf("--prices must not mix existing price IDs with inline TERRITORY or TERRITORY:PRICE_POINT_ID entries")
 			}
 			if candidateErr == nil {
 				candidateErr = fmt.Errorf("--prices must use TERRITORY or TERRITORY:PRICE_POINT_ID entries")

--- a/internal/cli/subscriptions/helpers_more_test.go
+++ b/internal/cli/subscriptions/helpers_more_test.go
@@ -151,8 +151,29 @@ func TestParseSubscriptionPromotionalOfferPricesAutoDetectsLegacyAndInlineInputs
 			},
 		},
 		{
+			name:  "compound and territory-only inline prices",
+			value: "US:pp-1, France",
+			want: []asc.SubscriptionPromotionalOfferPrice{
+				{TerritoryID: "USA", PricePointID: "pp-1"},
+				{TerritoryID: "FRA"},
+			},
+		},
+		{
+			name:  "territory-only before comma-containing compound inline price",
+			value: "France, Moldova, Republic of:pp-1",
+			want: []asc.SubscriptionPromotionalOfferPrice{
+				{TerritoryID: "FRA"},
+				{TerritoryID: "MDA", PricePointID: "pp-1"},
+			},
+		},
+		{
 			name:    "mixed compound and legacy prices",
 			value:   "US:pp-1,price-2",
+			wantErr: "must not mix",
+		},
+		{
+			name:    "mixed legacy and compound prices",
+			value:   "price-2,US:pp-1",
 			wantErr: "must not mix",
 		},
 	}

--- a/internal/cli/subscriptions/helpers_more_test.go
+++ b/internal/cli/subscriptions/helpers_more_test.go
@@ -176,6 +176,16 @@ func TestParseSubscriptionPromotionalOfferPricesAutoDetectsLegacyAndInlineInputs
 			value:   "price-2,US:pp-1",
 			wantErr: "must not mix",
 		},
+		{
+			name:    "mixed territory-only and legacy prices",
+			value:   "US,price-2",
+			wantErr: "must not mix",
+		},
+		{
+			name:    "mixed legacy and territory-only prices",
+			value:   "price-2,US",
+			wantErr: "must not mix",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/subscriptions/helpers_more_test.go
+++ b/internal/cli/subscriptions/helpers_more_test.go
@@ -172,6 +172,11 @@ func TestParseSubscriptionPromotionalOfferPricesAutoDetectsLegacyAndInlineInputs
 			wantErr: "must not mix",
 		},
 		{
+			name:    "compound and invalid territory-only price",
+			value:   "US:pp-1,Atlantis",
+			wantErr: "Atlantis",
+		},
+		{
 			name:    "mixed legacy and compound prices",
 			value:   "price-2,US:pp-1",
 			wantErr: "must not mix",

--- a/internal/cli/subscriptions/helpers_more_test.go
+++ b/internal/cli/subscriptions/helpers_more_test.go
@@ -1,6 +1,8 @@
 package subscriptions
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -120,5 +122,56 @@ func TestParseSubscriptionOfferCodePrices(t *testing.T) {
 	}
 	if _, err := parseSubscriptionOfferCodePrices("USA:pp-1", asc.SubscriptionOfferModeFreeTrial); err == nil {
 		t.Fatal("expected FREE_TRIAL price point rejection")
+	}
+}
+
+func TestParseSubscriptionPromotionalOfferPricesAutoDetectsLegacyAndInlineInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    []asc.SubscriptionPromotionalOfferPrice
+		wantErr string
+	}{
+		{
+			name:  "legacy price IDs",
+			value: "price-1, price-2",
+			want:  []asc.SubscriptionPromotionalOfferPrice{{ID: "price-1"}, {ID: "price-2"}},
+		},
+		{
+			name:  "territory only inline prices",
+			value: "US, France",
+			want:  []asc.SubscriptionPromotionalOfferPrice{{TerritoryID: "USA"}, {TerritoryID: "FRA"}},
+		},
+		{
+			name:  "compound inline prices",
+			value: "US:pp-1, France:pp-2",
+			want: []asc.SubscriptionPromotionalOfferPrice{
+				{TerritoryID: "USA", PricePointID: "pp-1"},
+				{TerritoryID: "FRA", PricePointID: "pp-2"},
+			},
+		},
+		{
+			name:    "mixed compound and legacy prices",
+			value:   "US:pp-1,price-2",
+			wantErr: "must not mix",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseSubscriptionPromotionalOfferPrices(test.value)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse prices: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("prices = %#v, want %#v", got, test.want)
+			}
+		})
 	}
 }

--- a/internal/cli/subscriptions/offers.go
+++ b/internal/cli/subscriptions/offers.go
@@ -22,7 +22,7 @@ func SubscriptionsOffersCommand() *ffcli.Command {
 Examples:
   asc subscriptions offers introductory list --subscription-id "SUB_ID"
   asc subscriptions offers introductory import --subscription-id "SUB_ID" --input "./offers.csv" --offer-duration ONE_WEEK --offer-mode FREE_TRIAL --number-of-periods 1 --confirm
-  asc subscriptions offers promotional create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "PRICE_ID"
+  asc subscriptions offers promotional create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US"
   asc subscriptions offers offer-codes generate --offer-code-id "OFFER_CODE_ID" --quantity 10 --expiration-date "2026-02-01"
   asc subscriptions offers win-back list --subscription-id "SUB_ID"`,
 		FlagSet:   fs,

--- a/internal/cli/subscriptions/promotional_offers.go
+++ b/internal/cli/subscriptions/promotional_offers.go
@@ -25,7 +25,7 @@ func SubscriptionsPromotionalOffersCommand() *ffcli.Command {
 
 Examples:
   asc subscriptions promotional-offers list --subscription-id "SUB_ID"
-  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "PRICE_ID"`,
+  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -200,7 +200,7 @@ func SubscriptionsPromotionalOffersCreateCommand() *ffcli.Command {
 	offerDuration := fs.String("offer-duration", "", "Offer duration: "+strings.Join(subscriptionOfferDurationValues, ", "))
 	offerMode := fs.String("offer-mode", "", "Offer mode: "+strings.Join(subscriptionOfferModeValues, ", "))
 	numberOfPeriods := fs.Int("number-of-periods", 0, "Number of periods (required)")
-	prices := fs.String("prices", "", "Promotional offer price ID(s), comma-separated")
+	prices := fs.String("prices", "", "Promotional offer prices (required): TERRITORY entries for FREE_TRIAL or TERRITORY:PRICE_POINT_ID entries for paid modes; territory accepts alpha-2, alpha-3, or exact English country name")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -210,7 +210,8 @@ func SubscriptionsPromotionalOffersCreateCommand() *ffcli.Command {
 		LongHelp: `Create a promotional offer.
 
 Examples:
-  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "PRICE_ID"`,
+  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US"
+  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "US:PRICE_POINT_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -249,8 +250,12 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			priceIDs := shared.SplitCSV(*prices)
-			if len(priceIDs) == 0 {
+			priceEntries, err := parseSubscriptionPromotionalOfferPrices(*prices, mode)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Error:", err.Error())
+				return flag.ErrHelp
+			}
+			if len(priceEntries) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
 				return shared.MissingRequiredUsageError()
 			}
@@ -276,7 +281,7 @@ Examples:
 				OfferMode:       mode,
 			}
 
-			resp, err := client.CreateSubscriptionPromotionalOffer(requestCtx, id, attrs, priceIDs)
+			resp, err := client.CreateSubscriptionPromotionalOffer(requestCtx, id, attrs, priceEntries)
 			if err != nil {
 				return fmt.Errorf("subscriptions promotional-offers create: failed to create: %w", err)
 			}

--- a/internal/cli/subscriptions/promotional_offers.go
+++ b/internal/cli/subscriptions/promotional_offers.go
@@ -200,7 +200,7 @@ func SubscriptionsPromotionalOffersCreateCommand() *ffcli.Command {
 	offerDuration := fs.String("offer-duration", "", "Offer duration: "+strings.Join(subscriptionOfferDurationValues, ", "))
 	offerMode := fs.String("offer-mode", "", "Offer mode: "+strings.Join(subscriptionOfferModeValues, ", "))
 	numberOfPeriods := fs.Int("number-of-periods", 0, "Number of periods (required)")
-	prices := fs.String("prices", "", "Promotional offer prices (required): TERRITORY entries for FREE_TRIAL or TERRITORY:PRICE_POINT_ID entries for paid modes; territory accepts alpha-2, alpha-3, or exact English country name")
+	prices := fs.String("prices", "", "Promotional offer prices (required): existing PRICE_ID entries, inline TERRITORY entries, or inline TERRITORY:PRICE_POINT_ID entries; territory accepts alpha-2, alpha-3, or exact English country name")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -211,7 +211,8 @@ func SubscriptionsPromotionalOffersCreateCommand() *ffcli.Command {
 
 Examples:
   asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1 --prices "US"
-  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "US:PRICE_POINT_ID"`,
+  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --number-of-periods 1 --prices "US:PRICE_POINT_ID"
+  asc subscriptions promotional-offers create --subscription-id "SUB_ID" --offer-code "SPRING" --name "Spring" --offer-duration ONE_MONTH --offer-mode PAY_UP_FRONT --number-of-periods 1 --prices "EXISTING_PROMOTIONAL_OFFER_PRICE_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -250,7 +251,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			priceEntries, err := parseSubscriptionPromotionalOfferPrices(*prices, mode)
+			priceEntries, err := parseSubscriptionPromotionalOfferPrices(*prices)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp


### PR DESCRIPTION
## Summary

- replace promotional-offer create's unusable pre-existing price-ID input with Apple's supported compound-create price input
- build matching temporary price linkages and top-level inline resources with territory and paid-mode price-point relationships
- validate and document `TERRITORY` for `FREE_TRIAL` and `TERRITORY:PRICE_POINT_ID` for paid modes
- replace the linkage-only mock with exact request-body coverage and add CLI contract tests

## Why

The behavior came from #350 as part of broad subscription sub-resource parity. Its client commit accepted bare promotional-offer price IDs and its mock only asserted those linkages. There was no linked issue, review discussion, or live-verification rationale for relying on that shape.

Apple's current App Store Connect API 4.4.1 OpenAPI requires creation through `POST /v1/subscriptionPromotionalOffers`. The create request supports inline `subscriptionPromotionalOfferPrices` resources in `included`; Apple exposes no standalone endpoint that could create the IDs the old CLI required. The repository snapshot is byte-identical to Apple's current official download.

This matches the corrected offer-code and win-back implementations in this repository. The generated Swift SDK and tddworks/asc-cli independently use the same request shape.

Because the old value shape could not produce a valid new offer through a supported workflow, this corrects the existing flag contract directly rather than preserving a nonfunctional compatibility stub.

## Contract

```text
FREE_TRIAL:    --prices "US,France"
paid modes:   --prices "US:PRICE_POINT_ID,France:PRICE_POINT_ID"
```

Territories accept alpha-2, alpha-3, or exact English country names and normalize to App Store Connect territory IDs. Each entry becomes a temporary linkage in `data.relationships.prices` and a matching resource in top-level `included`.

The separate update command's existing price relationship behavior is unchanged.

## Verification

TDD started by replacing the old mock with an exact compound request-body expectation; it failed against the linkage-only implementation and passed after the fix.

Local gates:

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- standard commit hooks, including docs, formatting, lint, and the short test suite

All pass.

A freshly built binary was also checked for corrected help and pre-auth rejection of the legacy paid price-ID shape.

For safe live verification, read-only inventory was captured before and after an API-debug create-shaped probe. The probe used deliberately nonexistent subscription and price-point IDs, sent `POST /v1/subscriptionPromotionalOffers`, and received `409` with Apple's invalid relationship-ID error. No `201` or resource ID was returned, and the before/after promotional-offer inventory was byte-identical with zero resources. This proves the request reached Apple's relationship validation boundary without changing a resource.

## Sources

- Apple: https://developer.apple.com/documentation/appstoreconnectapi/post-v1-subscriptionpromotionaloffers
- Apple create schema: https://developer.apple.com/documentation/appstoreconnectapi/subscriptionpromotionaloffercreaterequest
- Apple inline price schema: https://developer.apple.com/documentation/appstoreconnectapi/subscriptionpromotionalofferpriceinlinecreate
- Introducing PR: https://github.com/rorkai/App-Store-Connect-CLI/pull/350
- Offer-code correction precedent: https://github.com/rorkai/App-Store-Connect-CLI/pull/358
- Win-back live correction precedent: https://github.com/rorkai/App-Store-Connect-CLI/pull/1640
- Generated Swift SDK request model: https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/651b56950c917d30d7aaa863baadd290f2e28cb7/Sources/OpenAPI/Generated/Entities/SubscriptionPromotionalOfferCreateRequest.swift
- Maintained compound-create implementation: https://github.com/tddworks/asc-cli/blob/030c463e27341311a13be99d3227f0e8e71c2034/Sources/Infrastructure/Apps/Subscriptions/PromotionalOffers/SDKSubscriptionPromotionalOfferRepository.swift

## Remaining uncertainty

No valid promotional offer was created live because this audit was intentionally limited to a guaranteed-invalid, non-mutating probe. Apple's schema makes `subscriptionPricePoint` optional and the adjacent offer-code contract uses territory-only inline prices for `FREE_TRIAL`; paid modes require it here. A successful disposable-resource creation would be the final production proof, but is not necessary to establish the documented request contract or safe rejection boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promotional offers now support territory-based pricing.
  * Free trials accept territory entries, while paid offers support territory and price-point pairs.
  * Existing price IDs remain supported.
  * Inline pricing details are included when creating promotional offers.
  * Command help and examples now show the updated pricing formats.

* **Bug Fixes**
  * Added validation for missing, conflicting, mixed, or invalid pricing inputs.

* **Documentation**
  * Added guidance covering pricing formats, request behavior, compatibility, and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->