### PR TITLE
Fix review contracts and pre-order confirmation

### DIFF
--- a/commands/reviews.mdx
+++ b/commands/reviews.mdx
@@ -55,6 +55,7 @@ List App Store review summarizations for an app:
 ```bash  theme={null}
 asc reviews summarizations --app "APP_ID" --platform IOS
 asc reviews summarizations --app "APP_ID" --platform IOS --territory USA
+asc reviews summarizations --next "<links.next>"
 ```
 
 ### Manage existing review responses

--- a/commands/reviews.mdx
+++ b/commands/reviews.mdx
@@ -53,7 +53,7 @@ asc reviews ratings --app APP_ID
 List App Store review summarizations for an app:
 
 ```bash  theme={null}
-asc reviews summarizations --app "APP_ID"
+asc reviews summarizations --app "APP_ID" --platform IOS
 asc reviews summarizations --app "APP_ID" --platform IOS --territory USA
 ```
 

--- a/internal/asc/customer_review_summarizations.go
+++ b/internal/asc/customer_review_summarizations.go
@@ -50,6 +50,9 @@ func (c *Client) GetCustomerReviewSummarizations(ctx context.Context, appID stri
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("customerReviewSummarizations: %w", err)
 		}
+		if appID != "" || buildCustomerReviewSummarizationsQuery(query) != "" {
+			return nil, fmt.Errorf("customerReviewSummarizations: next URL cannot be combined with appID or query options")
+		}
 		path = query.nextURL
 	} else {
 		if appID == "" {

--- a/internal/asc/customer_review_summarizations_test.go
+++ b/internal/asc/customer_review_summarizations_test.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -64,7 +65,40 @@ func TestGetCustomerReviewSummarizations_UsesNextURL(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetCustomerReviewSummarizations(context.Background(), "app-1", WithCustomerReviewSummarizationsNextURL(next)); err != nil {
+	if _, err := client.GetCustomerReviewSummarizations(context.Background(), "", WithCustomerReviewSummarizationsNextURL(next)); err != nil {
 		t.Fatalf("GetCustomerReviewSummarizations() error: %v", err)
+	}
+}
+
+func TestGetCustomerReviewSummarizations_RejectsNextURLWithSelectorsOrQueryOptions(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviewSummarizations?cursor=abc"
+	tests := []struct {
+		name  string
+		appID string
+		opts  []CustomerReviewSummarizationsOption
+	}{
+		{name: "app ID", appID: "app-1"},
+		{name: "platform", opts: []CustomerReviewSummarizationsOption{WithCustomerReviewSummarizationsPlatforms([]string{"IOS"})}},
+		{name: "territory", opts: []CustomerReviewSummarizationsOption{WithCustomerReviewSummarizationsTerritories([]string{"USA"})}},
+		{name: "fields", opts: []CustomerReviewSummarizationsOption{WithCustomerReviewSummarizationsFields([]string{"text"})}},
+		{name: "territory fields", opts: []CustomerReviewSummarizationsOption{WithCustomerReviewSummarizationsTerritoryFields([]string{"currency"})}},
+		{name: "include", opts: []CustomerReviewSummarizationsOption{WithCustomerReviewSummarizationsInclude([]string{"territory"})}},
+		{name: "limit", opts: []CustomerReviewSummarizationsOption{WithCustomerReviewSummarizationsLimit(25)}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requests := 0
+			client := newTestClient(t, func(*http.Request) { requests++ }, jsonResponse(http.StatusOK, `{"data":[]}`))
+			opts := append([]CustomerReviewSummarizationsOption{WithCustomerReviewSummarizationsNextURL(next)}, test.opts...)
+
+			_, err := client.GetCustomerReviewSummarizations(context.Background(), test.appID, opts...)
+			if err == nil || !strings.Contains(err.Error(), "next URL cannot be combined with") {
+				t.Fatalf("error = %v, want next URL conflict", err)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d, want 0", requests)
+			}
+		})
 	}
 }

--- a/internal/asc/review_attachments.go
+++ b/internal/asc/review_attachments.go
@@ -83,6 +83,9 @@ func (c *Client) GetAppStoreReviewAttachmentsForReviewDetail(ctx context.Context
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("app-store-review-attachments: %w", err)
 		}
+		if reviewDetailID != "" || buildAppStoreReviewAttachmentsQuery(query) != "" {
+			return nil, fmt.Errorf("app-store-review-attachments: next URL cannot be combined with reviewDetailID or query options")
+		}
 		path = query.nextURL
 	} else {
 		if reviewDetailID == "" {

--- a/internal/asc/review_attachments.go
+++ b/internal/asc/review_attachments.go
@@ -72,24 +72,25 @@ type AppStoreReviewAttachmentDeleteResult struct {
 
 // GetAppStoreReviewAttachmentsForReviewDetail lists attachments for a review detail.
 func (c *Client) GetAppStoreReviewAttachmentsForReviewDetail(ctx context.Context, reviewDetailID string, opts ...AppStoreReviewAttachmentsOption) (*AppStoreReviewAttachmentsResponse, error) {
-	reviewDetailID = strings.TrimSpace(reviewDetailID)
-	if reviewDetailID == "" {
-		return nil, fmt.Errorf("reviewDetailID is required")
-	}
-
 	query := &appStoreReviewAttachmentsQuery{}
 	for _, opt := range opts {
 		opt(query)
 	}
 
+	reviewDetailID = strings.TrimSpace(reviewDetailID)
 	path := fmt.Sprintf("/v1/appStoreReviewDetails/%s/appStoreReviewAttachments", reviewDetailID)
 	if query.nextURL != "" {
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("app-store-review-attachments: %w", err)
 		}
 		path = query.nextURL
-	} else if queryString := buildAppStoreReviewAttachmentsQuery(query); queryString != "" {
-		path += "?" + queryString
+	} else {
+		if reviewDetailID == "" {
+			return nil, fmt.Errorf("reviewDetailID is required")
+		}
+		if queryString := buildAppStoreReviewAttachmentsQuery(query); queryString != "" {
+			path += "?" + queryString
+		}
 	}
 
 	data, err := c.do(ctx, http.MethodGet, path, nil)

--- a/internal/asc/review_attachments_test.go
+++ b/internal/asc/review_attachments_test.go
@@ -1,0 +1,28 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetAppStoreReviewAttachmentsForReviewDetail_UsesNextURLWithoutReviewDetail(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appStoreReviewDetails/detail-1/appStoreReviewAttachments?cursor=abc"
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.String() != next {
+			t.Fatalf("expected URL %q, got %q", next, req.URL.String())
+		}
+		assertAuthorized(t, req)
+	}, jsonResponse(http.StatusOK, `{"data":[],"links":{"self":"`+next+`"}}`))
+
+	if _, err := client.GetAppStoreReviewAttachmentsForReviewDetail(
+		context.Background(),
+		"",
+		WithAppStoreReviewAttachmentsNextURL(next),
+	); err != nil {
+		t.Fatalf("GetAppStoreReviewAttachmentsForReviewDetail() error: %v", err)
+	}
+}

--- a/internal/asc/review_attachments_test.go
+++ b/internal/asc/review_attachments_test.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -24,5 +25,36 @@ func TestGetAppStoreReviewAttachmentsForReviewDetail_UsesNextURLWithoutReviewDet
 		WithAppStoreReviewAttachmentsNextURL(next),
 	); err != nil {
 		t.Fatalf("GetAppStoreReviewAttachmentsForReviewDetail() error: %v", err)
+	}
+}
+
+func TestGetAppStoreReviewAttachmentsForReviewDetail_RejectsNextURLWithSelectorOrQueryOptions(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/appStoreReviewDetails/detail-1/appStoreReviewAttachments?cursor=abc"
+	tests := []struct {
+		name           string
+		reviewDetailID string
+		opts           []AppStoreReviewAttachmentsOption
+	}{
+		{name: "review detail ID", reviewDetailID: "detail-1"},
+		{name: "fields", opts: []AppStoreReviewAttachmentsOption{WithAppStoreReviewAttachmentsFields([]string{"fileName"})}},
+		{name: "review detail fields", opts: []AppStoreReviewAttachmentsOption{WithAppStoreReviewAttachmentReviewDetailFields([]string{"notes"})}},
+		{name: "include", opts: []AppStoreReviewAttachmentsOption{WithAppStoreReviewAttachmentsInclude([]string{"appStoreReviewDetail"})}},
+		{name: "limit", opts: []AppStoreReviewAttachmentsOption{WithAppStoreReviewAttachmentsLimit(25)}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requests := 0
+			client := newTestClient(t, func(*http.Request) { requests++ }, jsonResponse(http.StatusOK, `{"data":[]}`))
+			opts := append([]AppStoreReviewAttachmentsOption{WithAppStoreReviewAttachmentsNextURL(next)}, test.opts...)
+
+			_, err := client.GetAppStoreReviewAttachmentsForReviewDetail(context.Background(), test.reviewDetailID, opts...)
+			if err == nil || !strings.Contains(err.Error(), "next URL cannot be combined with") {
+				t.Fatalf("error = %v, want next URL conflict", err)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d, want 0", requests)
+			}
+		})
 	}
 }

--- a/internal/cli/cmdtest/pre_orders_end_confirm_test.go
+++ b/internal/cli/cmdtest/pre_orders_end_confirm_test.go
@@ -1,0 +1,89 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestPreOrdersEndWithConfirmPostsExpectedPayload(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/endAppAvailabilityPreOrders" {
+			t.Fatalf("expected /v1/endAppAvailabilityPreOrders, got %s", req.URL.Path)
+		}
+
+		var payload struct {
+			Data struct {
+				Type          string `json:"type"`
+				Relationships struct {
+					TerritoryAvailabilities struct {
+						Data []struct {
+							Type string `json:"type"`
+							ID   string `json:"id"`
+						} `json:"data"`
+					} `json:"territoryAvailabilities"`
+				} `json:"relationships"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload.Data.Type != "endAppAvailabilityPreOrders" {
+			t.Fatalf("unexpected data type %q", payload.Data.Type)
+		}
+		linkages := payload.Data.Relationships.TerritoryAvailabilities.Data
+		if len(linkages) != 2 || linkages[0].Type != "territoryAvailabilities" || linkages[0].ID != "ta-1" || linkages[1].ID != "ta-2" {
+			t.Fatalf("unexpected territory availability linkages: %+v", linkages)
+		}
+
+		return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"endAppAvailabilityPreOrders","id":"end-1"},"links":{"self":"https://api.appstoreconnect.apple.com/v1/endAppAvailabilityPreOrders/end-1"}}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"pre-orders", "end",
+		"--territory-availability", "ta-1,ta-2",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if requestCount != 1 {
+		t.Fatalf("expected one request, got %d", requestCount)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var output struct {
+		Data struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode stdout: %v; stdout=%q", err, stdout)
+	}
+	if output.Data.Type != "endAppAvailabilityPreOrders" || output.Data.ID != "end-1" {
+		t.Fatalf("unexpected output: %+v", output.Data)
+	}
+}

--- a/internal/cli/cmdtest/pre_orders_end_confirm_test.go
+++ b/internal/cli/cmdtest/pre_orders_end_confirm_test.go
@@ -5,23 +5,26 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
 func TestPreOrdersEndWithConfirmPostsExpectedPayload(t *testing.T) {
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
 	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestCount++
 		if req.Method != http.MethodPost {
-			t.Fatalf("expected POST, got %s", req.Method)
+			t.Errorf("expected POST, got %s", req.Method)
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
 		}
 		if req.URL.Path != "/v1/endAppAvailabilityPreOrders" {
-			t.Fatalf("expected /v1/endAppAvailabilityPreOrders, got %s", req.URL.Path)
+			t.Errorf("expected /v1/endAppAvailabilityPreOrders, got %s", req.URL.Path)
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
 		}
 
 		var payload struct {
@@ -38,18 +41,38 @@ func TestPreOrdersEndWithConfirmPostsExpectedPayload(t *testing.T) {
 			} `json:"data"`
 		}
 		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode request: %v", err)
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
 		}
 		if payload.Data.Type != "endAppAvailabilityPreOrders" {
-			t.Fatalf("unexpected data type %q", payload.Data.Type)
+			t.Errorf("unexpected data type %q", payload.Data.Type)
+			http.Error(w, "unexpected data type", http.StatusBadRequest)
+			return
 		}
 		linkages := payload.Data.Relationships.TerritoryAvailabilities.Data
-		if len(linkages) != 2 || linkages[0].Type != "territoryAvailabilities" || linkages[0].ID != "ta-1" || linkages[1].ID != "ta-2" {
-			t.Fatalf("unexpected territory availability linkages: %+v", linkages)
+		if len(linkages) != 2 || linkages[0].Type != "territoryAvailabilities" || linkages[0].ID != "ta-1" || linkages[1].Type != "territoryAvailabilities" || linkages[1].ID != "ta-2" {
+			t.Errorf("unexpected territory availability linkages: %+v", linkages)
+			http.Error(w, "unexpected linkages", http.StatusBadRequest)
+			return
 		}
 
-		return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"endAppAvailabilityPreOrders","id":"end-1"},"links":{"self":"https://api.appstoreconnect.apple.com/v1/endAppAvailabilityPreOrders/end-1"}}`), nil
-	})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"data":{"type":"endAppAvailabilityPreOrders","id":"end-1"},"links":{"self":"https://api.appstoreconnect.apple.com/v1/endAppAvailabilityPreOrders/end-1"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/remaining_next_validation_phase63_test.go
+++ b/internal/cli/cmdtest/remaining_next_validation_phase63_test.go
@@ -448,7 +448,7 @@ func TestReviewAttachmentsListPaginateFromNextWithoutReviewDetailPhase63(t *test
 
 	runGameCenterAchievementsPaginateFromNext(
 		t,
-		[]string{"review", "attachments-list", "--review-detail", "review-detail-1"},
+		[]string{"review", "attachments-list"},
 		firstURL,
 		secondURL,
 		firstBody,

--- a/internal/cli/cmdtest/reviews_next_conflicts_test.go
+++ b/internal/cli/cmdtest/reviews_next_conflicts_test.go
@@ -1,0 +1,240 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestReviewContinuationsRejectServerQueryFlagsBeforeAuth(t *testing.T) {
+	t.Cleanup(func() { shared.SetSelectedProfile("") })
+
+	const summariesNext = "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviewSummarizations?cursor=next"
+	const attachmentsNext = "https://api.appstoreconnect.apple.com/v1/appStoreReviewDetails/detail-1/appStoreReviewAttachments?cursor=next"
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "summarizations app before next",
+			args:    []string{"reviews", "summarizations", "--app", "app-1", "--next", summariesNext},
+			wantErr: "reviews summarizations: --next cannot be combined with --app",
+		},
+		{
+			name:    "summarizations app after next with root flag before subcommands",
+			args:    []string{"--profile", "ci", "reviews", "summarizations", "--next", summariesNext, "--app", "app-1"},
+			wantErr: "reviews summarizations: --next cannot be combined with --app",
+		},
+		{
+			name:    "summarizations platform after next",
+			args:    []string{"reviews", "summarizations", "--next", summariesNext, "--platform", "IOS"},
+			wantErr: "reviews summarizations: --next cannot be combined with --platform",
+		},
+		{
+			name:    "summarizations territory before next",
+			args:    []string{"reviews", "summarizations", "--territory", "USA", "--next", summariesNext},
+			wantErr: "reviews summarizations: --next cannot be combined with --territory",
+		},
+		{
+			name:    "summarizations fields after next",
+			args:    []string{"reviews", "summarizations", "--next", summariesNext, "--fields", "text"},
+			wantErr: "reviews summarizations: --next cannot be combined with --fields",
+		},
+		{
+			name:    "summarizations explicit empty territory fields",
+			args:    []string{"reviews", "summarizations", "--territory-fields", "", "--next", summariesNext},
+			wantErr: "reviews summarizations: --next cannot be combined with --territory-fields",
+		},
+		{
+			name:    "summarizations include after next",
+			args:    []string{"reviews", "summarizations", "--next", summariesNext, "--include", "territory"},
+			wantErr: "reviews summarizations: --next cannot be combined with --include",
+		},
+		{
+			name:    "summarizations explicit zero limit",
+			args:    []string{"reviews", "summarizations", "--limit", "0", "--next", summariesNext},
+			wantErr: "reviews summarizations: --next cannot be combined with --limit",
+		},
+		{
+			name:    "attachments review detail before next",
+			args:    []string{"review", "attachments-list", "--review-detail", "detail-1", "--next", attachmentsNext},
+			wantErr: "review attachments-list: --next cannot be combined with --review-detail",
+		},
+		{
+			name:    "attachments review detail after next with root flag before subcommands",
+			args:    []string{"--profile", "ci", "review", "attachments-list", "--next", attachmentsNext, "--review-detail", "detail-1"},
+			wantErr: "review attachments-list: --next cannot be combined with --review-detail",
+		},
+		{
+			name:    "attachments fields after next",
+			args:    []string{"review", "attachments-list", "--next", attachmentsNext, "--fields", "fileName"},
+			wantErr: "review attachments-list: --next cannot be combined with --fields",
+		},
+		{
+			name:    "attachments explicit empty detail fields",
+			args:    []string{"review", "attachments-list", "--detail-fields", "", "--next", attachmentsNext},
+			wantErr: "review attachments-list: --next cannot be combined with --detail-fields",
+		},
+		{
+			name:    "attachments include before next",
+			args:    []string{"review", "attachments-list", "--include", "appStoreReviewDetail", "--next", attachmentsNext},
+			wantErr: "review attachments-list: --next cannot be combined with --include",
+		},
+		{
+			name:    "attachments explicit zero limit",
+			args:    []string{"review", "attachments-list", "--next", attachmentsNext, "--limit", "0"},
+			wantErr: "review attachments-list: --next cannot be combined with --limit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during validation")
+			})
+			defer restore()
+
+			assertUsageExit(t, test.args, test.wantErr)
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before --next conflict validation")
+			}
+		})
+	}
+}
+
+func TestReviewsSummarizationsPaginationFollowsNextWithoutInitialSelectors(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviewSummarizations?cursor=next"
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/customerReviewSummarizations" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount {
+		case 1:
+			if got := req.URL.Query().Get("filter[platform]"); got != "IOS" {
+				t.Errorf("first request platform = %q, want IOS", got)
+			}
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Errorf("first request limit = %q, want 200", got)
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"customerReviewSummarizations","id":"summary-1"}],"links":{"next":"`+nextURL+`"}}`)
+		case 2:
+			if got := req.URL.Query().Get("cursor"); got != "next" {
+				t.Errorf("second request cursor = %q, want next", got)
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"customerReviewSummarizations","id":"summary-2"}],"links":{"next":""}}`)
+		default:
+			t.Errorf("unexpected request count %d", requestCount)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	installReviewNextTestTransport(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "summarizations", "--app", "app-1", "--platform", "IOS", "--paginate", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"summary-1"`) || !strings.Contains(stdout, `"id":"summary-2"`) {
+		t.Fatalf("stdout = %q, want both pages", stdout)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+}
+
+func TestReviewAttachmentsPaginationFollowsNextWithoutInitialSelector(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/appStoreReviewDetails/detail-1/appStoreReviewAttachments?cursor=next"
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreReviewDetails/detail-1/appStoreReviewAttachments" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount {
+		case 1:
+			if got := req.URL.Query().Get("limit"); got != "200" {
+				t.Errorf("first request limit = %q, want 200", got)
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreReviewAttachments","id":"attachment-1"}],"links":{"next":"`+nextURL+`"}}`)
+		case 2:
+			if got := req.URL.Query().Get("cursor"); got != "next" {
+				t.Errorf("second request cursor = %q, want next", got)
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreReviewAttachments","id":"attachment-2"}],"links":{"next":""}}`)
+		default:
+			t.Errorf("unexpected request count %d", requestCount)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	installReviewNextTestTransport(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"review", "attachments-list", "--review-detail", "detail-1", "--paginate", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"attachment-1"`) || !strings.Contains(stdout, `"id":"attachment-2"`) {
+		t.Fatalf("stdout = %q, want both pages", stdout)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+}
+
+func installReviewNextTestTransport(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		cloned.Host = req.URL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	}))
+}

--- a/internal/cli/cmdtest/reviews_summarizations_test.go
+++ b/internal/cli/cmdtest/reviews_summarizations_test.go
@@ -78,6 +78,7 @@ func TestReviewsSummarizationsRequiresPlatformWithoutNext(t *testing.T) {
 
 func TestReviewsSummarizationsNextDoesNotRequirePlatform(t *testing.T) {
 	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "ambient-app-must-not-affect-continuation")
 
 	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviewSummarizations?cursor=abc"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/internal/cli/cmdtest/reviews_summarizations_test.go
+++ b/internal/cli/cmdtest/reviews_summarizations_test.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -78,14 +80,29 @@ func TestReviewsSummarizationsNextDoesNotRequirePlatform(t *testing.T) {
 	setupAuth(t)
 
 	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviewSummarizations?cursor=abc"
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method != http.MethodGet || req.URL.String() != nextURL {
-			t.Fatalf("expected GET %s, got %s %s", nextURL, req.Method, req.URL.String())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		actualURL := "https://" + req.Host + req.URL.RequestURI()
+		if req.Method != http.MethodGet || actualURL != nextURL {
+			t.Errorf("expected GET %s, got %s %s", nextURL, req.Method, actualURL)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
 		}
-		return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"self":"`+nextURL+`"}}`), nil
-	})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[],"links":{"self":"`+nextURL+`"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		cloned.Host = req.URL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/reviews_summarizations_test.go
+++ b/internal/cli/cmdtest/reviews_summarizations_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -45,5 +47,61 @@ func TestReviewsSummarizationsLimitValidation(t *testing.T) {
 
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+}
+
+func TestReviewsSummarizationsRequiresPlatformWithoutNext(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"reviews", "summarizations", "--app", "app-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --platform is required") {
+		t.Fatalf("expected platform-required error on stderr, got %q", stderr)
+	}
+}
+
+func TestReviewsSummarizationsNextDoesNotRequirePlatform(t *testing.T) {
+	setupAuth(t)
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/customerReviewSummarizations?cursor=abc"
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.String() != nextURL {
+			t.Fatalf("expected GET %s, got %s %s", nextURL, req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"self":"`+nextURL+`"}}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"reviews", "summarizations", "--next", nextURL, "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `"data":[]`) {
+		t.Fatalf("expected JSON response on stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
 }

--- a/internal/cli/preorders/pre_orders.go
+++ b/internal/cli/preorders/pre_orders.go
@@ -28,7 +28,7 @@ Examples:
   asc pre-orders enable --app "123456789" --territory "US,France" --release-date "2026-06-01"
   asc pre-orders update --territory-availability "TERRITORY_AVAILABILITY_ID" --pre-order-enabled true --release-date "2026-03-01"
   asc pre-orders disable --territory-availability "TERRITORY_AVAILABILITY_ID"
-  asc pre-orders end --territory-availability "TA_1,TA_2"`,
+  asc pre-orders end --territory-availability "TA_1,TA_2" --confirm`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			PreOrdersGetCommand(),
@@ -404,22 +404,27 @@ func PreOrdersEndCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("pre-orders end", flag.ExitOnError)
 
 	territoryAvailabilityIDs := fs.String("territory-availability", "", "Territory availability IDs (comma-separated)")
+	confirm := fs.Bool("confirm", false, "Confirm ending pre-orders (required)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "end",
-		ShortUsage: "asc pre-orders end --territory-availability TERRITORY_AVAILABILITY_ID[,ID...]",
+		ShortUsage: "asc pre-orders end --territory-availability TERRITORY_AVAILABILITY_ID[,ID...] --confirm",
 		ShortHelp:  "End pre-orders for territory availabilities.",
 		LongHelp: `End pre-orders for territory availabilities.
 
 Examples:
-  asc pre-orders end --territory-availability "TA_1,TA_2"`,
+  asc pre-orders end --territory-availability "TA_1,TA_2" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			ids := shared.SplitCSV(*territoryAvailabilityIDs)
 			if len(ids) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --territory-availability is required")
+				return shared.MissingRequiredUsageError()
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
 				return shared.MissingRequiredUsageError()
 			}
 

--- a/internal/cli/preorders/pre_orders_test.go
+++ b/internal/cli/preorders/pre_orders_test.go
@@ -148,6 +148,27 @@ func TestPreOrdersEndCommand_MissingIDs(t *testing.T) {
 	}
 }
 
+func TestPreOrdersEndCommand_RequiresConfirmationBeforeClient(t *testing.T) {
+	clientRequested := false
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientRequested = true
+		return nil, errors.New("client must not be created")
+	})
+	t.Cleanup(restore)
+
+	cmd := PreOrdersEndCommand()
+	if err := cmd.FlagSet.Parse([]string{"--territory-availability", "ta-1"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
+	}
+	if clientRequested {
+		t.Fatal("expected missing confirmation to fail before client creation")
+	}
+}
+
 func TestPreOrdersCommand_FlagDefinitions(t *testing.T) {
 	getCmd := PreOrdersGetCommand()
 	for _, name := range []string{"app", "output", "pretty"} {
@@ -185,7 +206,7 @@ func TestPreOrdersCommand_FlagDefinitions(t *testing.T) {
 	}
 
 	endCmd := PreOrdersEndCommand()
-	for _, name := range []string{"territory-availability", "output", "pretty"} {
+	for _, name := range []string{"territory-availability", "confirm", "output", "pretty"} {
 		if endCmd.FlagSet.Lookup(name) == nil {
 			t.Errorf("end: expected flag --%s to be defined", name)
 		}

--- a/internal/cli/reviews/review_attachments.go
+++ b/internal/cli/reviews/review_attachments.go
@@ -30,14 +30,15 @@ func ReviewDetailsAttachmentsListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "attachments-list",
-		ShortUsage: "asc review attachments-list --review-detail \"REVIEW_DETAIL_ID\"",
+		ShortUsage: "asc review attachments-list (--review-detail REVIEW_DETAIL_ID | --next URL) [flags]",
 		ShortHelp:  "List review attachments for a review detail.",
 		LongHelp: `List review attachments for a review detail.
 
 Examples:
   asc review attachments-list --review-detail "REVIEW_DETAIL_ID"
   asc review attachments-list --review-detail "REVIEW_DETAIL_ID" --fields "fileName,fileSize" --limit 50
-  asc review attachments-list --review-detail "REVIEW_DETAIL_ID" --paginate`,
+  asc review attachments-list --review-detail "REVIEW_DETAIL_ID" --paginate
+  asc review attachments-list --next "<links.next>"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/reviews/review_attachments.go
+++ b/internal/cli/reviews/review_attachments.go
@@ -42,11 +42,18 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("review attachments-list: --limit must be between 1 and 200")
-			}
+			nextValue := strings.TrimSpace(*next)
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("review attachments-list: %w", err)
+			}
+			if err := rejectReviewNextFlagConflicts(
+				fs, *next, "review attachments-list",
+				"review-detail", "fields", "detail-fields", "include", "limit",
+			); err != nil {
+				return err
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("review attachments-list: --limit must be between 1 and 200")
 			}
 
 			fieldsValue, err := normalizeReviewAttachmentFields(*fields)
@@ -63,7 +70,7 @@ Examples:
 			}
 
 			reviewDetailValue := strings.TrimSpace(*reviewDetailID)
-			if reviewDetailValue == "" && strings.TrimSpace(*next) == "" {
+			if reviewDetailValue == "" && nextValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --review-detail is required")
 				return shared.MissingRequiredUsageError()
 			}
@@ -85,7 +92,10 @@ Examples:
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithAppStoreReviewAttachmentsLimit(200))
+				paginateOpts := opts
+				if nextValue == "" {
+					paginateOpts = append(paginateOpts, asc.WithAppStoreReviewAttachmentsLimit(200))
+				}
 				pages, err := shared.PaginateWithSpinner(
 					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
@@ -96,7 +106,7 @@ Examples:
 						return asc.RedactAppStoreReviewDetailIncludesInListResponse(resp)
 					},
 					func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-						resp, err := client.GetAppStoreReviewAttachmentsForReviewDetail(ctx, reviewDetailValue, asc.WithAppStoreReviewAttachmentsNextURL(nextURL))
+						resp, err := client.GetAppStoreReviewAttachmentsForReviewDetail(ctx, "", asc.WithAppStoreReviewAttachmentsNextURL(nextURL))
 						if err != nil || *includeSensitive {
 							return resp, err
 						}

--- a/internal/cli/reviews/reviews_summarizations.go
+++ b/internal/cli/reviews/reviews_summarizations.go
@@ -43,17 +43,26 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			nextValue := strings.TrimSpace(*next)
-			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("reviews summarizations: --limit must be between 1 and 200")
-			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("reviews summarizations: %w", err)
+			}
+			if err := rejectReviewNextFlagConflicts(
+				fs, *next, "reviews summarizations",
+				"app", "platform", "territory", "fields", "territory-fields", "include", "limit",
+			); err != nil {
+				return err
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("reviews summarizations: --limit must be between 1 and 200")
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" && nextValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError()
+			}
+			if nextValue != "" {
+				resolvedAppID = ""
 			}
 
 			fieldsValue, err := normalizeReviewSummarizationFields(*fields)
@@ -89,14 +98,17 @@ Examples:
 			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithCustomerReviewSummarizationsLimit(200))
+				paginateOpts := opts
+				if nextValue == "" {
+					paginateOpts = append(paginateOpts, asc.WithCustomerReviewSummarizationsLimit(200))
+				}
 				summaries, err := shared.PaginateWithSpinner(
 					requestCtx,
 					func(ctx context.Context) (asc.PaginatedResponse, error) {
 						return client.GetCustomerReviewSummarizations(ctx, resolvedAppID, paginateOpts...)
 					},
 					func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-						return client.GetCustomerReviewSummarizations(ctx, resolvedAppID, asc.WithCustomerReviewSummarizationsNextURL(nextURL))
+						return client.GetCustomerReviewSummarizations(ctx, "", asc.WithCustomerReviewSummarizationsNextURL(nextURL))
 					},
 				)
 				if err != nil {

--- a/internal/cli/reviews/reviews_summarizations.go
+++ b/internal/cli/reviews/reviews_summarizations.go
@@ -30,18 +30,19 @@ func ReviewsSummarizationsCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "summarizations",
-		ShortUsage: "asc reviews summarizations [flags]",
+		ShortUsage: "asc reviews summarizations (--app APP_ID --platform PLATFORM[,PLATFORM...] | --next URL) [flags]",
 		ShortHelp:  "List App Store review summarizations.",
 		LongHelp: `List App Store review summarizations for an app.
 
 Examples:
-  asc reviews summarizations --app "APP_ID"
+  asc reviews summarizations --app "APP_ID" --platform IOS
   asc reviews summarizations --app "APP_ID" --platform IOS --territory USA
-  asc reviews summarizations --app "APP_ID" --limit 50
+  asc reviews summarizations --app "APP_ID" --platform IOS --limit 50
   asc reviews summarizations --next "<links.next>"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			nextValue := strings.TrimSpace(*next)
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return fmt.Errorf("reviews summarizations: --limit must be between 1 and 200")
 			}
@@ -50,7 +51,7 @@ Examples:
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
-			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
+			if resolvedAppID == "" && nextValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError()
 			}
@@ -63,6 +64,10 @@ Examples:
 			platformValues, err := shared.NormalizeAppStoreVersionPlatforms(shared.SplitCSVUpper(*platforms))
 			if err != nil {
 				return fmt.Errorf("reviews summarizations: %w", err)
+			}
+			if len(platformValues) == 0 && nextValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --platform is required")
+				return shared.MissingRequiredUsageError()
 			}
 
 			client, err := shared.GetASCClient()


### PR DESCRIPTION
## Summary

- require `--platform` for initial customer-review summarization requests while preserving self-contained `--next` continuations
- allow review-attachment pagination to follow `links.next` without re-requiring the original review-detail ID
- require `--confirm` before `pre-orders end` constructs a client or sends its destructive POST
- correct help, website examples, and the mocks that previously hid the continuation/confirmation defects

## Contract and history

All three surfaces remain supported and should be repaired rather than removed. Apple's current App Store Connect OpenAPI 4.4.1 archive is byte-identical to the repository snapshot.

- [`GET /v1/apps/{id}/customerReviewSummarizations`](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-apps-_id_-customerreviewsummarizations) requires `filter[platform]`. The command was introduced in #363 even though the checked-in schema already marked this filter required; there was no evidence of intentional undocumented behavior.
- [`GET /v1/appStoreReviewDetails/{id}/appStoreReviewAttachments`](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-appstorereviewdetails-_id_-appstorereviewattachments) returns paged links. The CLI originally accepted `--next` without `--review-detail`, but the client rejected the missing parent ID before it inspected the continuation URL. A maintained generated client likewise follows the absolute next URL directly: [appstoreconnect-swift-sdk pagination](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/651b56950c917d30d7aaa863baadd290f2e28cb7/Sources/APIProvider.swift#L457-L482).
- [`POST /v1/endAppAvailabilityPreOrders`](https://developer.apple.com/documentation/appstoreconnectapi/post-v1-endappavailabilitypreorders) is a supported operation that immediately ends pre-order availability. Issue #199 explicitly required `--confirm`, but #225 omitted that guard. The existing client payload already matches Apple's request schema, so this change adds the missing fail-closed CLI boundary rather than replacing the operation.

## Behavior

```console
asc reviews summarizations --app APP_ID --platform IOS
asc reviews summarizations --next NEXT_URL
asc review attachments-list --next NEXT_URL
asc pre-orders end --territory-availability TA_1,TA_2 --confirm
```

Missing `--platform` on an initial summarization request and missing `--confirm` on `pre-orders end` now exit with usage code 2 before authentication or HTTP. Existing valid calls and `--paginate --next` remain compatible.

## Verification

- RED reproduced Apple's live `400` for a summarization GET without `filter[platform]`
- GREEN live read-only summarization GET with `filter[platform]=IOS`: `200`
- GREEN live read-only attachment continuation GET with a deliberately nonexistent review-detail ID: the request reached Apple and returned the expected `404` resource-not-found response instead of the former local `reviewDetailID is required` error
- built CLI: both new fail-closed validations exit `2` with empty stdout
- no live pre-order POST was sent; both live probes were GET requests, so no resource was changed
- `make format`
- `make check-docs`
- `GOLANGCI_LINT_CACHE=/tmp/asc-lint-reviews make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- full commit-hook suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629596&installation_model_id=10418&pr_number=1883&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1883&signature=078f99dd392027d87a1e8956d6356f5f79e54d034489657aeb7078927df1481d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination for review attachments and review summarizations using `--next` URLs without initial identifiers.
  - Added confirmation protection to `pre-orders end`, requiring `--confirm` before submission.
  - Review summarizations now require a platform for initial requests while supporting independent pagination.

- **Bug Fixes**
  - Improved validation for conflicting pagination, selector, and query options.
  - Preserved pagination limits and correctly followed subsequent-page links.

- **Documentation**
  - Updated command examples and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->