### PR TITLE
fix: use BundleIdPlatform for signing endpoints

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -6848,7 +6848,7 @@ func TestGetBundleID_SendsRequest(t *testing.T) {
 }
 
 func TestCreateBundleID_SendsRequest(t *testing.T) {
-	response := jsonResponse(http.StatusCreated, `{"data":{"type":"bundleIds","id":"b1","attributes":{"name":"Demo","identifier":"com.example.demo","platform":"IOS"}}}`)
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"bundleIds","id":"b1","attributes":{"name":"Demo","identifier":"com.example.demo","platform":"UNIVERSAL"}}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
@@ -6870,8 +6870,8 @@ func TestCreateBundleID_SendsRequest(t *testing.T) {
 		if payload.Data.Attributes.Identifier != "com.example.demo" {
 			t.Fatalf("expected identifier com.example.demo, got %q", payload.Data.Attributes.Identifier)
 		}
-		if payload.Data.Attributes.Platform != PlatformIOS {
-			t.Fatalf("expected platform IOS, got %q", payload.Data.Attributes.Platform)
+		if payload.Data.Attributes.Platform != BundleIDPlatformUniversal {
+			t.Fatalf("expected platform UNIVERSAL, got %q", payload.Data.Attributes.Platform)
 		}
 		assertAuthorized(t, req)
 	}, response)
@@ -6879,7 +6879,7 @@ func TestCreateBundleID_SendsRequest(t *testing.T) {
 	attrs := BundleIDCreateAttributes{
 		Name:       "Demo",
 		Identifier: "com.example.demo",
-		Platform:   PlatformIOS,
+		Platform:   BundleIDPlatformUniversal,
 	}
 	if _, err := client.CreateBundleID(context.Background(), attrs); err != nil {
 		t.Fatalf("CreateBundleID() error: %v", err)
@@ -7611,7 +7611,7 @@ func TestGetDevice_SendsRequest(t *testing.T) {
 }
 
 func TestRegisterDevice_SendsRequest(t *testing.T) {
-	response := jsonResponse(http.StatusCreated, `{"data":{"type":"devices","id":"d1","attributes":{"name":"Device","udid":"UDID","platform":"IOS","status":"ENABLED"}}}`)
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"devices","id":"d1","attributes":{"name":"Device","udid":"UDID","platform":"UNIVERSAL","status":"ENABLED"}}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
@@ -7633,8 +7633,8 @@ func TestRegisterDevice_SendsRequest(t *testing.T) {
 		if payload.Data.Attributes.UDID != "UDID" {
 			t.Fatalf("expected udid UDID, got %q", payload.Data.Attributes.UDID)
 		}
-		if payload.Data.Attributes.Platform != DevicePlatformIOS {
-			t.Fatalf("expected platform IOS, got %q", payload.Data.Attributes.Platform)
+		if payload.Data.Attributes.Platform != DevicePlatformUniversal {
+			t.Fatalf("expected platform UNIVERSAL, got %q", payload.Data.Attributes.Platform)
 		}
 		assertAuthorized(t, req)
 	}, response)
@@ -7642,7 +7642,7 @@ func TestRegisterDevice_SendsRequest(t *testing.T) {
 	attrs := DeviceCreateAttributes{
 		Name:     "Device",
 		UDID:     "UDID",
-		Platform: DevicePlatformIOS,
+		Platform: DevicePlatformUniversal,
 	}
 	if _, err := client.RegisterDevice(context.Background(), attrs); err != nil {
 		t.Fatalf("RegisterDevice() error: %v", err)

--- a/internal/asc/devices.go
+++ b/internal/asc/devices.go
@@ -1,11 +1,12 @@
 package asc
 
 // DevicePlatform represents the platform of a device.
-type DevicePlatform string
+type DevicePlatform = BundleIDPlatform
 
 const (
-	DevicePlatformIOS   DevicePlatform = "IOS"
-	DevicePlatformMacOS DevicePlatform = "MAC_OS"
+	DevicePlatformIOS       = BundleIDPlatformIOS
+	DevicePlatformMacOS     = BundleIDPlatformMacOS
+	DevicePlatformUniversal = BundleIDPlatformUniversal
 )
 
 // DeviceStatus represents the status of a device.

--- a/internal/asc/signing.go
+++ b/internal/asc/signing.go
@@ -1,18 +1,27 @@
 package asc
 
+// BundleIDPlatform represents the platform of a bundle ID or registered device.
+type BundleIDPlatform string
+
+const (
+	BundleIDPlatformIOS       BundleIDPlatform = "IOS"
+	BundleIDPlatformMacOS     BundleIDPlatform = "MAC_OS"
+	BundleIDPlatformUniversal BundleIDPlatform = "UNIVERSAL"
+)
+
 // BundleIDAttributes describes a bundle ID resource.
 type BundleIDAttributes struct {
-	Name       string   `json:"name"`
-	Identifier string   `json:"identifier"`
-	Platform   Platform `json:"platform"`
-	SeedID     string   `json:"seedId,omitempty"`
+	Name       string           `json:"name"`
+	Identifier string           `json:"identifier"`
+	Platform   BundleIDPlatform `json:"platform"`
+	SeedID     string           `json:"seedId,omitempty"`
 }
 
 // BundleIDCreateAttributes describes attributes for creating a bundle ID.
 type BundleIDCreateAttributes struct {
-	Name       string   `json:"name"`
-	Identifier string   `json:"identifier"`
-	Platform   Platform `json:"platform"`
+	Name       string           `json:"name"`
+	Identifier string           `json:"identifier"`
+	Platform   BundleIDPlatform `json:"platform"`
 }
 
 // BundleIDUpdateAttributes describes attributes for updating a bundle ID.

--- a/internal/cli/bundleids/bundle_ids.go
+++ b/internal/cli/bundleids/bundle_ids.go
@@ -166,7 +166,7 @@ func BundleIDsCreateCommand() *ffcli.Command {
 
 	identifier := fs.String("identifier", "", "Bundle ID identifier (e.g., com.example.app)")
 	name := fs.String("name", "", "Bundle ID name")
-	platform := fs.String("platform", "IOS", "Platform: "+strings.Join(shared.PlatformList(), ", "))
+	platform := fs.String("platform", "IOS", "Platform: "+strings.Join(shared.BundleIDPlatformList(), ", "))
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -190,9 +190,9 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --name is required")
 				return shared.MissingRequiredUsageError()
 			}
-			platformValue, err := shared.NormalizePlatform(*platform)
+			platformValue, err := shared.NormalizeBundleIDPlatform(*platform)
 			if err != nil {
-				return fmt.Errorf("bundle-ids create: %w", err)
+				return fmt.Errorf("bundle-ids create: %w", shared.UsageError(err.Error()))
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"strings"
 	"testing"
 )
 
@@ -40,6 +41,33 @@ func TestBundleIDsCreateCommand_MissingName(t *testing.T) {
 
 	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --name is missing, got %v", err)
+	}
+}
+
+func TestBundleIDsCreateCommand_UsesBundleIDPlatformContract(t *testing.T) {
+	cmd := BundleIDsCreateCommand()
+	platformFlag := cmd.FlagSet.Lookup("platform")
+	if platformFlag == nil {
+		t.Fatal("expected --platform flag")
+	}
+	if !strings.Contains(platformFlag.Usage, "IOS, MAC_OS, UNIVERSAL") {
+		t.Fatalf("--platform usage = %q, want BundleIdPlatform values", platformFlag.Usage)
+	}
+	if strings.Contains(platformFlag.Usage, "TV_OS") || strings.Contains(platformFlag.Usage, "VISION_OS") {
+		t.Fatalf("--platform usage advertises general app platforms: %q", platformFlag.Usage)
+	}
+
+	if err := cmd.FlagSet.Parse([]string{
+		"--identifier", "com.example.invalid",
+		"--name", "Invalid",
+		"--platform", "TV_OS",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil || err.Error() != "bundle-ids create: --platform must be one of: IOS, MAC_OS, UNIVERSAL" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cli/cmdtest/bundle_id_platform_test.go
+++ b/internal/cli/cmdtest/bundle_id_platform_test.go
@@ -7,29 +7,63 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+func setBundleIDPlatformTestServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create Bundle ID platform test client: %v", err)
+	}
+	restoreClient := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restoreClient)
+}
 
 func TestDevicesListUsesBundleIDPlatformFilter(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	requestCount := 0
+	setBundleIDPlatformTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/devices" {
 			t.Fatalf("expected GET /v1/devices, got %s %s", req.Method, req.URL.Path)
 		}
 		if got := req.URL.Query().Get("filter[platform]"); got != "UNIVERSAL" {
 			t.Fatalf("filter[platform] = %q, want UNIVERSAL", got)
 		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"data":[],"links":{"self":"https://api.appstoreconnect.apple.com/v1/devices"}}`)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[],"links":{"self":"https://api.appstoreconnect.apple.com/v1/devices"}}`)
 	})
 
 	root := RootCommand("1.2.3")
@@ -40,15 +74,18 @@ func TestDevicesListUsesBundleIDPlatformFilter(t *testing.T) {
 	if err := root.Run(context.Background()); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
 }
 
 func TestBundleIDsCreateUsesBundleIDPlatformPayload(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	requestCount := 0
+	setBundleIDPlatformTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
 		if req.Method != http.MethodPost || req.URL.Path != "/v1/bundleIds" {
 			t.Fatalf("expected POST /v1/bundleIds, got %s %s", req.Method, req.URL.Path)
 		}
@@ -68,11 +105,9 @@ func TestBundleIDsCreateUsesBundleIDPlatformPayload(t *testing.T) {
 		if payload.Data.Type != "bundleIds" || payload.Data.Attributes.Identifier != "com.example.universal" || payload.Data.Attributes.Name != "Universal" || payload.Data.Attributes.Platform != "UNIVERSAL" {
 			t.Fatalf("unexpected payload: %+v", payload.Data)
 		}
-		return &http.Response{
-			StatusCode: http.StatusCreated,
-			Body:       io.NopCloser(strings.NewReader(`{"data":{"type":"bundleIds","id":"bundle-1","attributes":{"identifier":"com.example.universal","name":"Universal","platform":"UNIVERSAL"}}}`)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"data":{"type":"bundleIds","id":"bundle-1","attributes":{"identifier":"com.example.universal","name":"Universal","platform":"UNIVERSAL"}}}`)
 	})
 
 	root := RootCommand("1.2.3")
@@ -82,6 +117,9 @@ func TestBundleIDsCreateUsesBundleIDPlatformPayload(t *testing.T) {
 	}
 	if err := root.Run(context.Background()); err != nil {
 		t.Fatalf("run error: %v", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
 	}
 }
 

--- a/internal/cli/cmdtest/bundle_id_platform_test.go
+++ b/internal/cli/cmdtest/bundle_id_platform_test.go
@@ -1,0 +1,120 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDevicesListUsesBundleIDPlatformFilter(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/devices" {
+			t.Fatalf("expected GET /v1/devices, got %s %s", req.Method, req.URL.Path)
+		}
+		if got := req.URL.Query().Get("filter[platform]"); got != "UNIVERSAL" {
+			t.Fatalf("filter[platform] = %q, want UNIVERSAL", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":[],"links":{"self":"https://api.appstoreconnect.apple.com/v1/devices"}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "list", "--platform", "universal"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestBundleIDsCreateUsesBundleIDPlatformPayload(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/bundleIds" {
+			t.Fatalf("expected POST /v1/bundleIds, got %s %s", req.Method, req.URL.Path)
+		}
+		var payload struct {
+			Data struct {
+				Type       string `json:"type"`
+				Attributes struct {
+					Identifier string `json:"identifier"`
+					Name       string `json:"name"`
+					Platform   string `json:"platform"`
+				} `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload.Data.Type != "bundleIds" || payload.Data.Attributes.Identifier != "com.example.universal" || payload.Data.Attributes.Name != "Universal" || payload.Data.Attributes.Platform != "UNIVERSAL" {
+			t.Fatalf("unexpected payload: %+v", payload.Data)
+		}
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"type":"bundleIds","id":"bundle-1","attributes":{"identifier":"com.example.universal","name":"Universal","platform":"UNIVERSAL"}}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"bundle-ids", "create", "--identifier", "com.example.universal", "--name", "Universal", "--platform", "universal"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestBundleIDPlatformCommandsRejectGeneralPlatforms(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "devices list tvOS", args: []string{"devices", "list", "--platform", "TV_OS"}},
+		{name: "devices register visionOS", args: []string{"devices", "register", "--name", "Invalid", "--udid", "INVALID", "--platform", "VISION_OS"}},
+		{name: "bundle ID create tvOS", args: []string{"bundle-ids", "create", "--identifier", "com.example.invalid", "--name", "Invalid", "--platform", "TV_OS"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			if err := root.Parse(tt.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			_, stderr := captureOutput(t, func() {
+				err := root.Run(context.Background())
+				if err == nil || !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want usage error", err)
+				}
+			})
+			const diagnostic = "Error: --platform must be one of: IOS, MAC_OS, UNIVERSAL\n"
+			if count := strings.Count(stderr, diagnostic); count != 1 {
+				t.Fatalf("diagnostic count = %d in stderr %q", count, stderr)
+			}
+			if !strings.Contains(stderr, "USAGE\n") {
+				t.Fatalf("expected usage on stderr, got %q", stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/devices_register_existing_test.go
+++ b/internal/cli/cmdtest/devices_register_existing_test.go
@@ -141,8 +141,8 @@ func TestDevicesRegisterCreatesDeviceWhenNoExistingUDIDMatches(t *testing.T) {
 			if req.URL.Path != "/v1/devices" {
 				t.Fatalf("expected devices list path, got %s", req.URL.Path)
 			}
-			if got := req.URL.Query().Get("filter[platform]"); got != "IOS" {
-				t.Fatalf("expected filter[platform]=IOS, got %q", got)
+			if got := req.URL.Query().Get("filter[platform]"); got != "UNIVERSAL" {
+				t.Fatalf("expected filter[platform]=UNIVERSAL, got %q", got)
 			}
 			body := `{"data":[],"links":{"next":""}}`
 			return &http.Response{
@@ -179,10 +179,10 @@ func TestDevicesRegisterCreatesDeviceWhenNoExistingUDIDMatches(t *testing.T) {
 			if payload.Data.Attributes.UDID != "NEW-UDID" {
 				t.Fatalf("expected UDID NEW-UDID, got %q", payload.Data.Attributes.UDID)
 			}
-			if payload.Data.Attributes.Platform != "IOS" {
-				t.Fatalf("expected platform IOS, got %q", payload.Data.Attributes.Platform)
+			if payload.Data.Attributes.Platform != "UNIVERSAL" {
+				t.Fatalf("expected platform UNIVERSAL, got %q", payload.Data.Attributes.Platform)
 			}
-			body := `{"data":{"type":"devices","id":"device-new","attributes":{"name":"New iPhone","platform":"IOS","udid":"NEW-UDID","status":"ENABLED"}}}`
+			body := `{"data":{"type":"devices","id":"device-new","attributes":{"name":"New iPhone","platform":"UNIVERSAL","udid":"NEW-UDID","status":"ENABLED"}}}`
 			return &http.Response{
 				StatusCode: http.StatusCreated,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -198,7 +198,7 @@ func TestDevicesRegisterCreatesDeviceWhenNoExistingUDIDMatches(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"devices", "register", "--name", "New iPhone", "--udid", "NEW-UDID", "--platform", "IOS"}); err != nil {
+		if err := root.Parse([]string{"devices", "register", "--name", "New iPhone", "--udid", "NEW-UDID", "--platform", "universal"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/devices/devices.go
+++ b/internal/cli/devices/devices.go
@@ -106,7 +106,7 @@ Examples:
 
 			platformValues, err := normalizeDevicePlatforms(shared.SplitCSV(*platform))
 			if err != nil {
-				return fmt.Errorf("devices list: %w", err)
+				return fmt.Errorf("devices list: %w", shared.UsageError(err.Error()))
 			}
 
 			statusValue, err := normalizeDeviceStatus(*status)
@@ -316,7 +316,7 @@ Examples:
 
 			platformValue, err := normalizeDevicePlatform(platformValue)
 			if err != nil {
-				return fmt.Errorf("devices register: %w", err)
+				return fmt.Errorf("devices register: %w", shared.UsageError(err.Error()))
 			}
 
 			client, err := shared.GetASCClient()
@@ -467,11 +467,11 @@ func normalizeDevicePlatform(value string) (string, error) {
 	if trimmed == "" {
 		return "", nil
 	}
-	normalized := strings.ToUpper(trimmed)
-	if slices.Contains(devicePlatformList(), normalized) {
-		return normalized, nil
+	platform, err := shared.NormalizeBundleIDPlatform(trimmed)
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("--platform must be one of: %s", strings.Join(devicePlatformList(), ", "))
+	return string(platform), nil
 }
 
 func normalizeDevicePlatforms(values []string) ([]string, error) {
@@ -527,7 +527,7 @@ func normalizeDeviceFields(value string) ([]string, error) {
 }
 
 func devicePlatformList() []string {
-	return []string{"IOS", "MAC_OS", "TV_OS", "VISION_OS"}
+	return shared.BundleIDPlatformList()
 }
 
 func deviceStatusList() []string {

--- a/internal/cli/devices/devices_test.go
+++ b/internal/cli/devices/devices_test.go
@@ -81,6 +81,43 @@ func TestDevicesUpdateCommand_MissingStatus(t *testing.T) {
 	}
 }
 
+func TestDevicePlatformContract(t *testing.T) {
+	if got := strings.Join(devicePlatformList(), ", "); got != "IOS, MAC_OS, UNIVERSAL" {
+		t.Fatalf("devicePlatformList() = %q, want %q", got, "IOS, MAC_OS, UNIVERSAL")
+	}
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr string
+	}{
+		{name: "iOS", value: " ios ", want: "IOS"},
+		{name: "macOS", value: "mac_os", want: "MAC_OS"},
+		{name: "universal", value: "universal", want: "UNIVERSAL"},
+		{name: "reject tvOS", value: "TV_OS", wantErr: "--platform must be one of: IOS, MAC_OS, UNIVERSAL"},
+		{name: "reject visionOS", value: "VISION_OS", wantErr: "--platform must be one of: IOS, MAC_OS, UNIVERSAL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeDevicePlatform(tt.value)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("normalizeDevicePlatform(%q) error = %v, want %q", tt.value, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeDevicePlatform(%q) error = %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeDevicePlatform(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLocalMacUDID_RejectsNonDarwin(t *testing.T) {
 	prevGOOS := localUDIDGOOS
 	localUDIDGOOS = "linux"

--- a/internal/cli/shared/platform_helpers.go
+++ b/internal/cli/shared/platform_helpers.go
@@ -14,6 +14,12 @@ var platformValues = map[string]asc.Platform{
 	"VISION_OS": asc.PlatformVisionOS,
 }
 
+var bundleIDPlatformValues = map[string]asc.BundleIDPlatform{
+	"IOS":       asc.BundleIDPlatformIOS,
+	"MAC_OS":    asc.BundleIDPlatformMacOS,
+	"UNIVERSAL": asc.BundleIDPlatformUniversal,
+}
+
 // NormalizePlatform validates and normalizes a platform string.
 func NormalizePlatform(value string) (asc.Platform, error) {
 	normalized := strings.ToUpper(strings.TrimSpace(value))
@@ -30,6 +36,24 @@ func NormalizePlatform(value string) (asc.Platform, error) {
 // PlatformList returns the allowed platform values.
 func PlatformList() []string {
 	return platformList()
+}
+
+// NormalizeBundleIDPlatform validates and normalizes a BundleIdPlatform value.
+func NormalizeBundleIDPlatform(value string) (asc.BundleIDPlatform, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	if normalized == "" {
+		return "", fmt.Errorf("--platform is required")
+	}
+	platform, ok := bundleIDPlatformValues[normalized]
+	if !ok {
+		return "", fmt.Errorf("--platform must be one of: %s", strings.Join(BundleIDPlatformList(), ", "))
+	}
+	return platform, nil
+}
+
+// BundleIDPlatformList returns the allowed BundleIdPlatform values.
+func BundleIDPlatformList() []string {
+	return []string{"IOS", "MAC_OS", "UNIVERSAL"}
 }
 
 func platformList() []string {

--- a/internal/cli/web/web_apps.go
+++ b/internal/cli/web/web_apps.go
@@ -85,17 +85,16 @@ func isDuplicateBundleIDError(err error) bool {
 	return false
 }
 
-func bundleIDPlatformForWebApp(platform string) (asc.Platform, error) {
+func bundleIDPlatformForWebApp(platform string) (asc.BundleIDPlatform, error) {
 	switch strings.ToUpper(strings.TrimSpace(platform)) {
 	case "", "IOS":
-		return asc.PlatformIOS, nil
+		return asc.BundleIDPlatformIOS, nil
 	case "MAC_OS":
-		return asc.PlatformMacOS, nil
+		return asc.BundleIDPlatformMacOS, nil
 	case "TV_OS":
-		return asc.PlatformTVOS, nil
+		return asc.BundleIDPlatformIOS, nil
 	case "UNIVERSAL":
-		// Bundle ID creation does not accept UNIVERSAL; IOS is the compatible preflight platform.
-		return asc.PlatformIOS, nil
+		return asc.BundleIDPlatformUniversal, nil
 	default:
 		return "", fmt.Errorf("platform must be one of IOS, MAC_OS, TV_OS, UNIVERSAL")
 	}

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -1149,13 +1149,23 @@ func TestWebAppsCreateSurfacesBundleIDRollbackFailure(t *testing.T) {
 }
 
 func TestBundleIDPlatformForWebApp(t *testing.T) {
-	t.Run("maps UNIVERSAL to IOS for bundle id create", func(t *testing.T) {
+	t.Run("keeps universal bundle id platform", func(t *testing.T) {
 		got, err := bundleIDPlatformForWebApp("UNIVERSAL")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got != asc.PlatformIOS {
-			t.Fatalf("expected %q, got %q", asc.PlatformIOS, got)
+		if got != asc.BundleIDPlatformUniversal {
+			t.Fatalf("expected %q, got %q", asc.BundleIDPlatformUniversal, got)
+		}
+	})
+
+	t.Run("maps tvOS app to iOS bundle id platform", func(t *testing.T) {
+		got, err := bundleIDPlatformForWebApp("TV_OS")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != asc.BundleIDPlatformIOS {
+			t.Fatalf("expected %q, got %q", asc.BundleIDPlatformIOS, got)
 		}
 	})
 
@@ -1164,8 +1174,8 @@ func TestBundleIDPlatformForWebApp(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got != asc.PlatformMacOS {
-			t.Fatalf("expected %q, got %q", asc.PlatformMacOS, got)
+		if got != asc.BundleIDPlatformMacOS {
+			t.Fatalf("expected %q, got %q", asc.BundleIDPlatformMacOS, got)
 		}
 	})
 


### PR DESCRIPTION
## What changed

- Add an endpoint-specific `BundleIDPlatform` model with `IOS`, `MAC_OS`, and `UNIVERSAL`.
- Use that contract for bundle ID and device request/response types, CLI validation, and help text.
- Fix the `web apps create` bundle-ID preflight: preserve `UNIVERSAL`, and encode a tvOS app's provisioning bundle ID as `IOS`.
- Leave the general app/build `Platform` enum alone, so `TV_OS` and `VISION_OS` remain valid on the endpoints that support them.

## Why

Apple's current [BundleIdPlatform documentation](https://developer.apple.com/tutorials/data/documentation/appstoreconnectapi/bundleidplatform.json) and OpenAPI schema define this endpoint enum as `IOS`, `MAC_OS`, `UNIVERSAL`. Device list filtering, device registration, and bundle ID creation all use it. The separate general [Platform enum](https://developer.apple.com/documentation/appstoreconnectapi/platform) contains `TV_OS` and `VISION_OS` instead.

The device drift came from PR #119's merge-resolution commit `259a68c3`, which replaced the original device-specific list from PR #175 with the general app platform list. [Review caught the unsupported registration values](https://github.com/rorkai/App-Store-Connect-CLI/pull/119#discussion_r2729040483), but the follow-up fix closed unmerged. Bundle ID creation in the same PR reused the pre-existing general `asc.Platform` type. [PR #119's live-test record](https://github.com/rorkai/App-Store-Connect-CLI/pull/119#issuecomment-3796297868) says these three operations weren't tested against Apple.

Other App Store Connect clients also keep this provisioning enum separate. One maps tvOS and visionOS device families to the `IOS` API platform, using `deviceClass` to distinguish them.

## Verification

- Established RED coverage for the wrong help/validation and missing `UNIVERSAL` requests before implementation.
- Added HTTP contract checks for `GET /v1/devices`, `POST /v1/devices`, and `POST /v1/bundleIds`, plus the web-app preflight mapping.
- Built the CLI and confirmed invalid provisioning values fail locally with exit code 2.
- Ran `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` successfully. Commit hooks also passed command-doc, format, lint, and short-suite checks.

Live checks used explicit file-backed authentication and discarded resource output:

- `GET /v1/devices?filter[platform]=IOS&limit=1` -> HTTP 200
- `GET /v1/devices?filter[platform]=MAC_OS&limit=1` -> HTTP 200
- `GET /v1/devices?filter[platform]=UNIVERSAL&limit=1` -> HTTP 200
- `TV_OS` and `VISION_OS` filters -> HTTP 400, with Apple naming `IOS, MAC_OS, UNIVERSAL` as the accepted values

For bundle ID creation, a mutation-shaped probe used an identifier containing spaces and `/`, which Apple cannot create. The `UNIVERSAL` request reached identifier validation and returned HTTP 409 solely for the invalid identifier. Exact filtered lookups before and after both returned zero resources, so no bundle ID changed.

## Remaining boundary

No real device was registered, and no valid bundle ID was created. The live evidence covers read-only filtering, local validation, and Apple's request validation without changing an account resource.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629618&installation_model_id=10418&pr_number=1884&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1884&signature=996d3ece2a35334634bfcc83f8fa2bd872080d485296a64216a5b4c4cbf199d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the `UNIVERSAL` platform when creating bundle IDs and registering or listing devices.
  - Platform inputs are normalized consistently, including case and surrounding whitespace.
  - Web app bundle-ID mapping now preserves universal platforms and handles tvOS compatibility.

- **Bug Fixes**
  - Invalid `TV_OS` and `VISION_OS` values now return clear usage errors before requests are submitted.
  - Platform options and validation messages now consistently list supported values: `IOS`, `MAC_OS`, and `UNIVERSAL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
