### PR TITLE
fix(testflight): deprecate unsupported external state edit

### DIFF
--- a/cmd/boolean_args_test.go
+++ b/cmd/boolean_args_test.go
@@ -55,6 +55,11 @@ func TestNormalizeSpacedBooleanFlags(t *testing.T) {
 			want: []string{"import", "--confirm=false"},
 		},
 		{
+			name: "invalid spaced boolean reaches flag validation",
+			args: []string{"import", "--confirm", "maybe"},
+			want: []string{"import", "--confirm=maybe"},
+		},
+		{
 			name: "modifier false cannot hide later dry run",
 			args: []string{"import", "--confirm", "--invite", "false", "--dry-run"},
 			want: []string{"import", "--confirm", "--invite=false", "--dry-run"},

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -688,6 +688,28 @@ func TestBuildsExpiredFlagsInvalidBooleanExitCode(t *testing.T) {
 	}
 }
 
+func TestTestFlightExternalTestingInvalidBooleanExitCode(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		code := Run([]string{
+			"testflight", "distribution", "edit",
+			"--id", "DETAIL_ID",
+			"--external-testing=maybe",
+		}, "1.0.0")
+		if code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "invalid boolean value") || !strings.Contains(stderr, "external-testing") {
+		t.Fatalf("expected invalid --external-testing boolean diagnostic, got %q", stderr)
+	}
+}
+
 func TestPublishAppStoreDryRunInvalidBooleanExitCode(t *testing.T) {
 	tmpDir := t.TempDir()
 	binaryPath := buildASCBlackboxBinary(t)

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -689,24 +689,34 @@ func TestBuildsExpiredFlagsInvalidBooleanExitCode(t *testing.T) {
 }
 
 func TestTestFlightExternalTestingInvalidBooleanExitCode(t *testing.T) {
-	resetReportFlags(t)
+	for _, test := range []struct {
+		name string
+		flag []string
+	}{
+		{name: "equals", flag: []string{"--external-testing=maybe"}},
+		{name: "space separated", flag: []string{"--external-testing", "maybe"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resetReportFlags(t)
 
-	stdout, stderr := captureCommandOutput(t, func() {
-		code := Run([]string{
-			"testflight", "distribution", "edit",
-			"--id", "DETAIL_ID",
-			"--external-testing=maybe",
-		}, "1.0.0")
-		if code != ExitUsage {
-			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
-		}
-	})
+			args := []string{
+				"testflight", "distribution", "edit",
+				"--id", "DETAIL_ID",
+			}
+			args = append(args, test.flag...)
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
 
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	if !strings.Contains(stderr, "invalid boolean value") || !strings.Contains(stderr, "external-testing") {
-		t.Fatalf("expected invalid --external-testing boolean diagnostic, got %q", stderr)
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "invalid boolean value") || !strings.Contains(stderr, "external-testing") {
+				t.Fatalf("expected invalid --external-testing boolean diagnostic, got %q", stderr)
+			}
+		})
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -222,8 +222,14 @@ func normalizeSpacedBooleanFlags(root *ffcli.Command, args []string) []string {
 				continue
 			}
 			if index+1 < len(args) {
-				if value, err := strconv.ParseBool(strings.TrimSpace(args[index+1])); err == nil {
+				next := strings.TrimSpace(args[index+1])
+				if value, err := strconv.ParseBool(next); err == nil {
 					normalized = append(normalized, token+"="+strconv.FormatBool(value))
+					index++
+					continue
+				}
+				if len(command.Subcommands) == 0 && !strings.HasPrefix(next, "-") {
+					normalized = append(normalized, token+"="+next)
 					index++
 					continue
 				}

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -43,6 +43,11 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - List/get use the v2 API; create/delete use v1 endpoints (may be unavailable on some accounts)
 - Update/clear-history use the v2 API
 
+## TestFlight Distribution
+
+- `asc testflight distribution edit --external-testing` shipped in 0.35.3 but App Store Connect does not allow `externalBuildState` in the build beta detail PATCH request. The flag remains parseable during its deprecation window and fails before HTTP instead of sending an unsupported update.
+- Migrate `--external-testing=true` to `asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm`. Migrate `--external-testing=false` to `asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm`; the old boolean cannot identify which group assignments to remove.
+
 ## Game Center
 
 - Most Game Center endpoints require a Game Center detail ID, resolved via `/v1/apps/{id}/gameCenterDetail`.

--- a/docs/design/testflight-external-testing-deprecation.md
+++ b/docs/design/testflight-external-testing-deprecation.md
@@ -1,0 +1,54 @@
+# TestFlight external-testing deprecation
+
+## Command and API contract
+
+`asc testflight distribution edit` is the canonical command for updating a
+build beta detail. Its supported PATCH shape is:
+
+```console
+asc testflight distribution edit --id "DETAIL_ID" --auto-notify
+```
+
+The offline App Store Connect OpenAPI snapshot defines
+`PATCH /v1/buildBetaDetails/{id}` with
+`BuildBetaDetailUpdateRequest.data.attributes.autoNotifyEnabled` as its only
+update attribute. The response model still includes `internalBuildState` and
+`externalBuildState`; those fields remain available when decoding API
+responses.
+
+Release 0.35.3 exposed `--external-testing`, translating its boolean value to
+`externalBuildState`. Removing that stable parser surface immediately would
+break existing invocations without the repository's required deprecation
+window. The flag therefore remains recognized and is marked deprecated in
+help, but every invocation fails with usage exit code 2 before client creation
+or HTTP. Stdout remains empty; stderr contains a deprecation warning followed
+by value-specific migration guidance.
+
+## Migration
+
+The old boolean does not identify a beta group, cannot decide whether review
+submission is appropriate, and cannot identify which existing group
+assignments should be removed. Callers must use the explicit distribution
+operations instead:
+
+```console
+asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm
+asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm
+```
+
+`--external-testing=true` points to `builds add-groups`; `false` points to
+`builds remove-groups`. Supplying `--auto-notify` together with the deprecated
+flag still fails closed rather than sending a partial PATCH.
+
+## Verification and alternatives
+
+Transition tests cover both boolean values, the mixed-flag case, warning and
+error text, empty stdout, and the no-client/no-transport boundary. The existing
+HTTP contract test continues to assert that `--auto-notify` sends a PATCH whose
+attributes contain only `autoNotifyEnabled`. Built-binary checks cover help,
+invalid boolean parsing, stdout, stderr, and exit codes.
+
+Immediate removal was rejected because the flag shipped as stable. Continuing
+to translate the boolean into `externalBuildState` was rejected because the
+update schema does not allow it. Guessing group assignment or review behavior
+was rejected because a boolean lacks the inputs needed to do either safely.

--- a/internal/asc/build_beta_details.go
+++ b/internal/asc/build_beta_details.go
@@ -15,9 +15,7 @@ type BuildBetaDetailResponse = SingleResponse[BuildBetaDetailAttributes]
 
 // BuildBetaDetailUpdateAttributes describes updateable build beta detail attributes.
 type BuildBetaDetailUpdateAttributes struct {
-	AutoNotifyEnabled  *bool   `json:"autoNotifyEnabled,omitempty"`
-	InternalBuildState *string `json:"internalBuildState,omitempty"`
-	ExternalBuildState *string `json:"externalBuildState,omitempty"`
+	AutoNotifyEnabled *bool `json:"autoNotifyEnabled,omitempty"`
 }
 
 // BuildBetaDetailUpdateData is the data portion of a build beta detail update.

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -9459,7 +9459,7 @@ func TestGetBuildBetaDetails_WithBuildFilter(t *testing.T) {
 }
 
 func TestGetBuildBetaDetail(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":{"type":"buildBetaDetails","id":"detail-1","attributes":{"autoNotifyEnabled":true}}}`)
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"buildBetaDetails","id":"detail-1","attributes":{"autoNotifyEnabled":true,"internalBuildState":"PROCESSING","externalBuildState":"READY_FOR_TESTING"}}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -9470,8 +9470,15 @@ func TestGetBuildBetaDetail(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetBuildBetaDetail(context.Background(), "detail-1"); err != nil {
+	detail, err := client.GetBuildBetaDetail(context.Background(), "detail-1")
+	if err != nil {
 		t.Fatalf("GetBuildBetaDetail() error: %v", err)
+	}
+	if detail.Data.Attributes.InternalBuildState != "PROCESSING" {
+		t.Fatalf("expected internalBuildState to remain available in responses, got %q", detail.Data.Attributes.InternalBuildState)
+	}
+	if detail.Data.Attributes.ExternalBuildState != "READY_FOR_TESTING" {
+		t.Fatalf("expected externalBuildState to remain available in responses, got %q", detail.Data.Attributes.ExternalBuildState)
 	}
 }
 

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3146,12 +3146,12 @@ func TestTestFlightBetaDetailsValidationErrors(t *testing.T) {
 		},
 		{
 			name:    "beta-details update missing id",
-			args:    []string{"testflight", "review", "edit"},
+			args:    []string{"testflight", "distribution", "edit"},
 			wantErr: "--id is required",
 		},
 		{
 			name:    "beta-details update missing updates",
-			args:    []string{"testflight", "review", "edit", "--id", "DETAIL_ID"},
+			args:    []string{"testflight", "distribution", "edit", "--id", "DETAIL_ID"},
 			wantErr: "at least one update flag is required",
 		},
 	}

--- a/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
+++ b/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
@@ -2,6 +2,7 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -122,12 +123,21 @@ func TestTestFlightDistributionEditOutput(t *testing.T) {
 		if req.URL.Path != "/v1/buildBetaDetails/detail-1" {
 			t.Fatalf("expected path /v1/buildBetaDetails/detail-1, got %s", req.URL.Path)
 		}
-		payload, err := io.ReadAll(req.Body)
-		if err != nil {
-			t.Fatalf("read body error: %v", err)
+		var payload struct {
+			Data struct {
+				Type       string         `json:"type"`
+				ID         string         `json:"id"`
+				Attributes map[string]any `json:"attributes"`
+			} `json:"data"`
 		}
-		if !strings.Contains(string(payload), `"autoNotifyEnabled":true`) {
-			t.Fatalf("expected autoNotifyEnabled in body, got %s", string(payload))
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body error: %v", err)
+		}
+		if payload.Data.Type != "buildBetaDetails" || payload.Data.ID != "detail-1" {
+			t.Fatalf("unexpected resource linkage: %#v", payload.Data)
+		}
+		if len(payload.Data.Attributes) != 1 || payload.Data.Attributes["autoNotifyEnabled"] != true {
+			t.Fatalf("expected only autoNotifyEnabled=true, got %#v", payload.Data.Attributes)
 		}
 		body := `{"data":{"type":"buildBetaDetails","id":"detail-1","attributes":{"autoNotifyEnabled":true}}}`
 		return &http.Response{

--- a/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
+++ b/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
@@ -7,9 +7,15 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestTestFlightDistributionViewOutputWithLimit(t *testing.T) {
@@ -111,12 +117,7 @@ func TestTestFlightDistributionEditOutput(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodPatch {
 			t.Fatalf("expected PATCH, got %s", req.Method)
 		}
@@ -139,13 +140,33 @@ func TestTestFlightDistributionEditOutput(t *testing.T) {
 		if len(payload.Data.Attributes) != 1 || payload.Data.Attributes["autoNotifyEnabled"] != true {
 			t.Fatalf("expected only autoNotifyEnabled=true, got %#v", payload.Data.Attributes)
 		}
-		body := `{"data":{"type":"buildBetaDetails","id":"detail-1","attributes":{"autoNotifyEnabled":true}}}`
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"type":"buildBetaDetails","id":"detail-1","attributes":{"autoNotifyEnabled":true}}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
 	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
+++ b/internal/cli/cmdtest/testflight_beta_details_recruitment_test.go
@@ -188,6 +188,67 @@ func TestTestFlightDistributionEditOutput(t *testing.T) {
 	}
 }
 
+func TestTestFlightDistributionEditExternalTestingDeprecation(t *testing.T) {
+	clientFactoryCalled := false
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientFactoryCalled = true
+		return nil, errors.New("client factory must not be called")
+	}))
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantError string
+	}{
+		{
+			name:      "enable",
+			args:      []string{"testflight", "distribution", "edit", "--id", "detail-1", "--external-testing=true"},
+			wantError: `Error: --external-testing=true cannot select a beta group or safely infer review submission. Use asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm.`,
+		},
+		{
+			name:      "disable",
+			args:      []string{"testflight", "distribution", "edit", "--id", "detail-1", "--external-testing=false"},
+			wantError: `Error: --external-testing=false cannot identify which beta groups to remove. Use asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm.`,
+		},
+		{
+			name:      "mixed with supported update",
+			args:      []string{"testflight", "distribution", "edit", "--id", "detail-1", "--auto-notify", "--external-testing=true"},
+			wantError: `Error: --external-testing=true cannot select a beta group or safely infer review submission. Use asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm.`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled = false
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected usage error, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			const warning = "Warning: `--external-testing` is deprecated and cannot be applied safely; App Store Connect does not support editing `externalBuildState`."
+			if !strings.Contains(stderr, warning) {
+				t.Fatalf("expected deprecation warning %q, got %q", warning, stderr)
+			}
+			if !strings.Contains(stderr, test.wantError) {
+				t.Fatalf("expected migration error %q, got %q", test.wantError, stderr)
+			}
+			if clientFactoryCalled {
+				t.Fatal("expected deprecated flag to fail before client creation or HTTP")
+			}
+		})
+	}
+}
+
 func TestTestFlightRecruitmentOptionsOutput(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/testflight/external_testing_deprecation_test.go
+++ b/internal/cli/testflight/external_testing_deprecation_test.go
@@ -1,0 +1,35 @@
+package testflight
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFlightDistributionEditExternalTestingDeprecatedHelp(t *testing.T) {
+	distribution := TestFlightDistributionCommand()
+	var editCommandFound bool
+	for _, subcommand := range distribution.Subcommands {
+		if subcommand.Name != "edit" {
+			continue
+		}
+		editCommandFound = true
+
+		externalTesting := subcommand.FlagSet.Lookup("external-testing")
+		if externalTesting == nil {
+			t.Fatal("expected released --external-testing parser surface to remain available")
+		}
+		if !strings.HasPrefix(externalTesting.Usage, "DEPRECATED:") {
+			t.Fatalf("expected deprecated flag help, got %q", externalTesting.Usage)
+		}
+		if !strings.Contains(subcommand.LongHelp, `asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm`) {
+			t.Fatalf("expected enable migration in canonical help, got %q", subcommand.LongHelp)
+		}
+		if !strings.Contains(subcommand.LongHelp, `asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm`) {
+			t.Fatalf("expected disable migration in canonical help, got %q", subcommand.LongHelp)
+		}
+	}
+
+	if !editCommandFound {
+		t.Fatal("expected testflight distribution edit command")
+	}
+}

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -675,14 +675,8 @@ Examples:
 func TestFlightBetaDetailsUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 
-	const (
-		externalStateEnabled  = "READY_FOR_TESTING"
-		externalStateDisabled = "NOT_READY_FOR_TESTING"
-	)
-
 	id := fs.String("id", "", "Build beta detail ID")
 	autoNotify := fs.Bool("auto-notify", false, "Enable auto-notify for external testers")
-	externalTesting := fs.Bool("external-testing", false, "Enable external testing (maps to externalBuildState)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -692,8 +686,7 @@ func TestFlightBetaDetailsUpdateCommand() *ffcli.Command {
 		LongHelp: `Update build beta details.
 
 Examples:
-  asc testflight beta-details update --id "DETAIL_ID" --auto-notify
-  asc testflight beta-details update --id "DETAIL_ID" --external-testing true`,
+  asc testflight beta-details update --id "DETAIL_ID" --auto-notify`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -708,7 +701,7 @@ Examples:
 				visited[f.Name] = true
 			})
 
-			hasUpdates := visited["auto-notify"] || visited["external-testing"]
+			hasUpdates := visited["auto-notify"]
 			if !hasUpdates {
 				fmt.Fprintln(os.Stderr, "Error: at least one update flag is required")
 				return shared.MissingRequiredUsageError()
@@ -719,14 +712,6 @@ Examples:
 				value := *autoNotify
 				attrs.AutoNotifyEnabled = &value
 			}
-			if visited["external-testing"] {
-				state := externalStateDisabled
-				if *externalTesting {
-					state = externalStateEnabled
-				}
-				attrs.ExternalBuildState = &state
-			}
-
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("testflight beta-details update: %w", err)

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -677,6 +677,7 @@ func TestFlightBetaDetailsUpdateCommand() *ffcli.Command {
 
 	id := fs.String("id", "", "Build beta detail ID")
 	autoNotify := fs.Bool("auto-notify", false, "Enable auto-notify for external testers")
+	externalTesting := fs.Bool("external-testing", false, "DEPRECATED: unsupported; use builds add-groups or builds remove-groups")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -686,20 +687,32 @@ func TestFlightBetaDetailsUpdateCommand() *ffcli.Command {
 		LongHelp: `Update build beta details.
 
 Examples:
-  asc testflight beta-details update --id "DETAIL_ID" --auto-notify`,
+  asc testflight beta-details update --id "DETAIL_ID" --auto-notify
+
+Deprecated:
+  --external-testing is retained only for migration and always exits before HTTP.
+  Use asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm to enable external distribution.
+  Use asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm to remove group assignments.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			visited := map[string]bool{}
+			fs.Visit(func(f *flag.Flag) {
+				visited[f.Name] = true
+			})
+			if visited["external-testing"] {
+				fmt.Fprintln(os.Stderr, "Warning: `--external-testing` is deprecated and cannot be applied safely; App Store Connect does not support editing `externalBuildState`.")
+				if *externalTesting {
+					return shared.UsageError(`--external-testing=true cannot select a beta group or safely infer review submission. Use asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm.`)
+				}
+				return shared.UsageError(`--external-testing=false cannot identify which beta groups to remove. Use asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm.`)
+			}
+
 			detailID := strings.TrimSpace(*id)
 			if detailID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
 				return shared.MissingRequiredUsageError()
 			}
-
-			visited := map[string]bool{}
-			fs.Visit(func(f *flag.Flag) {
-				visited[f.Name] = true
-			})
 
 			hasUpdates := visited["auto-notify"]
 			if !hasUpdates {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -50,29 +50,42 @@ func TestEmitQueuesEventAndSwallowsWorkerStartErrors(t *testing.T) {
 	}
 }
 
-func TestEmitDoesNotWaitForBlockedSender(t *testing.T) {
+func TestEmitQueuesEventWithoutForegroundHTTPDelivery(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv(endpointEnvVar, "https://telemetry.example.test/events")
 
+	transportCalls := 0
 	originalClient := http.DefaultClient
 	http.DefaultClient = &http.Client{
-		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
-			<-request.Context().Done()
-			return nil, request.Context().Err()
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			transportCalls++
+			return nil, errors.New("unexpected foreground telemetry request")
 		}),
 	}
 	t.Cleanup(func() { http.DefaultClient = originalClient })
-	stubMaintenanceWorkerStart(t, func() error { return nil })
+	workerStarted := false
+	stubMaintenanceWorkerStart(t, func() error {
+		workerStarted = true
+		return nil
+	})
 
-	start := time.Now()
 	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
-	elapsed := time.Since(start)
 
-	if elapsed >= 150*time.Millisecond {
-		t.Fatalf("Emit() elapsed = %s, want foreground return before blocked network deadline", elapsed)
+	if transportCalls != 0 {
+		t.Fatalf("foreground HTTP transport calls = %d, want 0", transportCalls)
+	}
+	if !workerStarted {
+		t.Fatal("expected maintenance worker start")
+	}
+	records := readDefaultSpool(t)
+	if len(records) != 1 {
+		t.Fatalf("spool records = %d, want 1", len(records))
+	}
+	if got := records[0].Endpoint; got != "https://telemetry.example.test/events" {
+		t.Fatalf("spooled endpoint = %q, want endpoint override", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep the released `testflight distribution edit --external-testing` parser surface for a deprecation window
- fail both boolean values closed before client creation, with a deprecation warning and value-specific migration error
- remove response-only build-state fields from `BuildBetaDetailUpdateAttributes` while preserving `internalBuildState` and `externalBuildState` on response decoding
- preserve and contract-test supported `--auto-notify` editing
- add release notes, migration guidance, transition tests, and built-binary exit-code coverage

## Why

Apple App Store Connect API 4.4.1 defines `PATCH /v1/buildBetaDetails/{id}` with only nullable `autoNotifyEnabled` in `BuildBetaDetailUpdateRequest.data.attributes`. `internalBuildState` and `externalBuildState` are response state, not update attributes.

The released boolean cannot safely infer the required beta group, which groups should be removed, or whether beta review should be submitted. Keeping it recognized gives existing automation an explicit deprecation path without sending an invalid or ambiguous request.

## Migration

Enable external distribution by assigning an explicit group and, when intended, submitting beta review:

```bash
asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID" --submit --confirm
```

Remove external distribution from an explicit group:

```bash
asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm
```

`testflight distribution edit --auto-notify` remains supported.

## Verification

- RED transition tests proved the flag had been removed before this rework
- focused and adjacent TestFlight, CLI exit-code, and HTTP contract tests pass
- `make format`, `make check-docs`, and `make lint` pass
- `ASC_BYPASS_KEYCHAIN=1 make test` passes
- the intact commit hook passed docs, formatting, lint, and the short suite
- built-binary checks cover help, true, false, mixed supported/deprecated flags, and invalid boolean input, including stdout/stderr/exit behavior
- a prior safe probe against a literal nonexistent beta-detail ID confirmed Apple rejects `externalBuildState`; no real resource was targeted or changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Simplified TestFlight distribution editing to support automatic notification settings.
  * Deprecated `--external-testing` while retaining compatibility and providing value-specific migration guidance.
  * Use dedicated commands to add or remove build group assignments.
* **Bug Fixes**
  * Improved validation for resource identifiers, notification settings, and invalid option values.
  * Improved handling of boolean options provided in separate arguments.
* **Documentation**
  * Updated help and API documentation with revised commands and deprecation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->