### PR TITLE
Stabilize build upload timeout regression test

### DIFF
--- a/internal/cli/cmdtest/builds_upload_wait_test.go
+++ b/internal/cli/cmdtest/builds_upload_wait_test.go
@@ -252,7 +252,7 @@ func TestBuildsUploadWithoutWaitSkipsPostCommitVerificationByDefault(t *testing.
 func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-	t.Setenv("ASC_TIMEOUT", "1ms")
+	t.Setenv("ASC_TIMEOUT", "250ms")
 
 	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
 
@@ -262,16 +262,24 @@ func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) 
 	})
 
 	buildUploadChecks := 0
+	initialRequestDeadline := make(chan time.Time, 1)
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			deadline, ok := req.Context().Deadline()
+			if !ok {
+				t.Fatal("expected initial request context deadline")
+			}
+			initialRequestDeadline <- deadline
 			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
 			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":4,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":4,"offset":0,"requestHeaders":[{"name":"Content-Type","value":"application/octet-stream"}]}]}}}`)
 		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
-			time.Sleep(5 * time.Millisecond)
+			if delay := time.Until((<-initialRequestDeadline).Add(50 * time.Millisecond)); delay > 0 {
+				time.Sleep(delay)
+			}
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader("")),
@@ -316,7 +324,7 @@ func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) 
 			"--version", "1.0.0",
 			"--build-number", "42",
 			"--poll-interval", "1ms",
-			"--verify-timeout", "10ms",
+			"--verify-timeout", "250ms",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -326,7 +334,7 @@ func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) 
 	if runErr != nil {
 		t.Fatalf("expected builds upload to succeed, got %v", runErr)
 	}
-	if !strings.Contains(stderr, "Verifying initial App Store Connect processing for up to 10ms...") {
+	if !strings.Contains(stderr, "Verifying initial App Store Connect processing for up to 250ms...") {
 		t.Fatalf("expected verification progress output, got %q", stderr)
 	}
 	if !strings.Contains(stdout, `"uploadId":"upload-1"`) {


### PR DESCRIPTION
## Summary

- give build upload reservation setup a scheduler-safe request window
- wait until the captured original request deadline has elapsed before commit verification
- keep post-commit verification on its own fresh timeout window

## Why

The prior 1ms reservation budget could expire before the first or second mocked mutation, producing a false limiter timeout. The test now derives the upload wait from the request deadline, preserving the regression's causal guarantee without changing production behavior.

## Verification

- RED: `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run '^TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow$' -count=500` (failed on the unmodified test with an expired reservation context)
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run '^TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow$' -count=100`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run '^TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow$' -count=50`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788668249&installation_model_id=10418&pr_number=1891&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1891&signature=4f463d48c7d1e4fc5bc52c0860c97ee73241e02da6a7fc3756841ac63cc5c8db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated timeout verification coverage to use more realistic timeout windows.
  * Confirmed post-upload verification receives a fresh timeout period, even when the upload request is delayed beyond the initial deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->