### PR TITLE
Fix App Clip inline localization usage exit codes

### DIFF
--- a/internal/cli/appclips/advanced_experiences.go
+++ b/internal/cli/appclips/advanced_experiences.go
@@ -306,12 +306,12 @@ Examples:
 
 			inlineLocalizations, err := parseInlineLocalizations(inlineLocalizationJSON)
 			if err != nil {
-				return fmt.Errorf("app-clips advanced-experiences create: %w", err)
+				return shared.UsageErrorf("app-clips advanced-experiences create: %v", err)
 			}
 			if languageValue != "" && titleValue != "" {
 				parsedLanguage, err := normalizeAppClipLanguage(languageValue)
 				if err != nil {
-					return fmt.Errorf("app-clips advanced-experiences create: %w", err)
+					return shared.UsageErrorf("app-clips advanced-experiences create: %v", err)
 				}
 				inlineLocalizations = append(inlineLocalizations, asc.AppClipAdvancedExperienceLocalizationCreateAttributes{
 					Language: parsedLanguage,

--- a/internal/cli/cmdtest/appclips_advanced_experiences_rework_test.go
+++ b/internal/cli/cmdtest/appclips_advanced_experiences_rework_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"testing"
 
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	appclipscli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/appclips"
 )
@@ -92,26 +93,71 @@ func TestAppClipsAdvancedExperiencesCreateSupportsMultipleInlineLocalizations(t 
 	}
 }
 
-func TestAppClipsAdvancedExperiencesCreateRejectsUnknownInlineLocalizationFields(t *testing.T) {
-	root := RootCommand("1.2.3")
-	if err := root.Parse([]string{
-		"app-clips", "advanced-experiences", "create",
-		"--app-clip-id", "clip-1",
-		"--link", "https://example.com",
-		"--default-language", "EN",
-		"--is-powered-by",
-		"--header-image-id", "img-1",
-		"--inline-localization", `{"locale":"en-US","title":"Order ahead"}`,
-	}); err != nil {
-		t.Fatalf("parse error: %v", err)
+func TestAppClipsAdvancedExperiencesCreateRejectsInvalidInlineLocalizationsAsUsage(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "unknown JSON field",
+			args:    []string{"--inline-localization", `{"locale":"en-US","title":"Order ahead"}`},
+			wantErr: `unknown field "locale"`,
+		},
+		{
+			name:    "multiple JSON objects",
+			args:    []string{"--inline-localization", `{"language":"EN","title":"Order ahead"}{"language":"FR","title":"Commander"}`},
+			wantErr: "must contain exactly one JSON object",
+		},
+		{
+			name:    "missing JSON language",
+			args:    []string{"--inline-localization", `{"title":"Order ahead"}`},
+			wantErr: "language is required",
+		},
+		{
+			name:    "unsupported JSON language",
+			args:    []string{"--inline-localization", `{"language":"en-US","title":"Order ahead"}`},
+			wantErr: `invalid default language "en-US"`,
+		},
+		{
+			name:    "missing JSON title",
+			args:    []string{"--inline-localization", `{"language":"EN"}`},
+			wantErr: "title is required",
+		},
+		{
+			name:    "unsupported singular language",
+			args:    []string{"--language", "en-US", "--title", "Order ahead"},
+			wantErr: `invalid default language "en-US"`,
+		},
 	}
 
-	var runErr error
-	_, _ = captureOutput(t, func() {
-		runErr = root.Run(context.Background())
-	})
-	if runErr == nil || !strings.Contains(runErr.Error(), `unknown field "locale"`) {
-		t.Fatalf("expected unknown inline localization field error, got %v", runErr)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{
+				"app-clips", "advanced-experiences", "create",
+				"--app-clip-id", "clip-1",
+				"--link", "https://example.com",
+				"--default-language", "EN",
+				"--is-powered-by",
+				"--header-image-id", "img-1",
+			}
+			args = append(args, test.args...)
+
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				code = rootcmd.Run(args, "1.2.3")
+			})
+
+			if code != rootcmd.ExitUsage {
+				t.Fatalf("expected exit code %d, got %d", rootcmd.ExitUsage, code)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify invalid advanced-experience inline-localization JSON as usage errors
- classify invalid paired `--language` input as a usage error
- assert exit 2, empty stdout, and preserved diagnostics at the root CLI boundary

## Provenance

Follow-up to the late exact-head [review on #1886](https://github.com/rorkai/App-Store-Connect-CLI/pull/1886#pullrequestreview-4880728948). The CLI emitted the right diagnostics for invalid user input but exited 1; these paths now exit 2.

## Validation

- focused boundary test: 100 repetitions
- focused race test: 25 repetitions
- built executable probes for all six covered inputs
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- intact pre-commit hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788679719&installation_model_id=10418&pr_number=1892&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1892&signature=8fbcf142e0eab6161f4245f3c191734835bb8b6ed36492ed7791439eb0972f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation feedback when creating advanced experiences with invalid inline localizations or unsupported language options.
  * Validation errors now clearly identify usage-related issues and return the appropriate command-line exit status.
* **Tests**
  * Expanded coverage for malformed localization data, unsupported languages, missing titles, and multiple localization objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->