### PR TITLE
test(capabilities): catch all Asset Library spellings

### DIFF
--- a/internal/cli/capabilities/asset_library_unexposed_test.go
+++ b/internal/cli/capabilities/asset_library_unexposed_test.go
@@ -3,6 +3,7 @@ package capabilities
 import (
 	"strings"
 	"testing"
+	"unicode"
 )
 
 func TestAssetLibraryIsNotInPublicCapabilities(t *testing.T) {
@@ -16,8 +17,38 @@ func TestAssetLibraryIsNotInPublicCapabilities(t *testing.T) {
 			capability.NextAction,
 		}
 		row := strings.ToLower(strings.Join(fields, " "))
-		if strings.Contains(row, "asset library") || strings.Contains(row, "creative asset") {
+		if containsAssetLibraryTerm(row) {
 			t.Fatalf("Asset Library must remain absent from public capabilities, got %+v", capability)
 		}
 	}
+}
+
+func TestContainsAssetLibraryTerm(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{value: "asset library", want: true},
+		{value: "asc asset-library", want: true},
+		{value: "creative-assets", want: true},
+		{value: "assetLibraryItems", want: true},
+		{value: "asset catalog", want: false},
+		{value: "creative tools", want: false},
+	}
+
+	for _, test := range tests {
+		if got := containsAssetLibraryTerm(test.value); got != test.want {
+			t.Errorf("containsAssetLibraryTerm(%q) = %t, want %t", test.value, got, test.want)
+		}
+	}
+}
+
+func containsAssetLibraryTerm(value string) bool {
+	normalized := strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return unicode.ToLower(r)
+		}
+		return -1
+	}, value)
+	return strings.Contains(normalized, "assetlibrary") || strings.Contains(normalized, "creativeasset")
 }


### PR DESCRIPTION
## What changed

The public-capability guard now strips punctuation and casing before it checks for Asset Library terms. Regression cases cover the space-separated name, the asset-library command spelling, creative-assets, camelCase API resources, and two unrelated names that must stay allowed.

## Why

PR #1871 only checked space-separated phrases, so all three review bots correctly pointed out that the exact command and resource spellings could slip through the test. The command is still absent from the public registry; this closes the test hole they found.

## Verification

- RED: the new cases failed for asset-library, creative-assets, and assetLibraryItems
- GREEN: focused capability, asset-library, and registry tests pass
- make format, make check-docs, make lint, make build
- ASC_BYPASS_KEYCHAIN=1 go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788757682&installation_model_id=10418&pr_number=1897&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1897&signature=2522e2b9208d792f964c2353a4098687330fcd7878806a96a166a7af2eb3e818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Asset Library term detection to handle differences in spacing, punctuation, capitalization, and Unicode characters more reliably.
  - Reduced the risk of incorrectly identifying unrelated terms as Asset Library references.

- **Tests**
  - Added broader coverage for valid and invalid term variations to help ensure consistent detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->