### PR TITLE
ci: notarize macOS CLI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,152 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Existing release tag to rebuild
+        description: Release tag to build or repair
         required: true
         type: string
+      notarize_existing:
+        description: Notarize an existing release without replacing its assets
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  repair-notarization:
+    if: github.event_name == 'workflow_dispatch' && inputs.notarize_existing
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: refs/tags/${{ inputs.version }}
+
+      - name: Validate release tag
+        env:
+          RELEASE_TAG: ${{ inputs.version }}
+        run: |
+          TAG="${RELEASE_TAG}"
+
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tags must match x.y.z. Got: ${TAG}"
+            exit 1
+          fi
+
+          printf 'VERSION=%s\n' "$TAG" >> "$GITHUB_ENV"
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Validate notarization secrets
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+        run: |
+          missing=0
+          for name in APPLE_DEVELOPER_ID ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY_B64; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Required secret ${name} is not set"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Prepare App Store Connect auth
+        env:
+          ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+        run: |
+          python3 -c 'import base64, os; from pathlib import Path; Path("/tmp/AuthKey.p8").write_bytes(base64.b64decode(os.environ["ASC_PRIVATE_KEY_B64"], validate=True))'
+          chmod 600 /tmp/AuthKey.p8
+          go build -trimpath -ldflags "-s -w" -o /tmp/asc-notary-bootstrap .
+
+      - name: Verify notarization auth
+        env:
+          ASC_BYPASS_KEYCHAIN: "1"
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+        run: /tmp/asc-notary-bootstrap auth status --validate --output json >/dev/null
+
+      - name: Download and verify existing release
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p existing-release
+          gh release download "${VERSION}" --dir existing-release
+          cd existing-release
+          test -f "asc_${VERSION}_checksums.txt"
+          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+          for binary in asc_*_macOS_*; do
+            test -f "$binary"
+            codesign --verify --deep --strict --verbose=2 "$binary"
+            authority=$(codesign -dv --verbose=4 "$binary" 2>&1 | sed -n 's/^Authority=//p' | head -n 1)
+            if [ "$authority" != "$APPLE_DEVELOPER_ID" ]; then
+              echo "::error::$(basename "$binary") is signed by an unexpected Developer ID"
+              exit 1
+            fi
+          done
+
+      - name: Notarize existing macOS binaries
+        env:
+          ASC_BYPASS_KEYCHAIN: "1"
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+        run: |
+          for binary in existing-release/asc_*_macOS_*; do
+            archive="${RUNNER_TEMP}/$(basename "$binary").zip"
+            output="${RUNNER_TEMP}/$(basename "$binary").notarization.json"
+            errors="${RUNNER_TEMP}/$(basename "$binary").notarization.stderr"
+            ditto -c -k --keepParent "$binary" "$archive"
+
+            set +e
+            /tmp/asc-notary-bootstrap notarization submit \
+              --file "$archive" \
+              --wait \
+              --timeout 1h \
+              --output json >"$output" 2>"$errors"
+            status=$?
+            set -e
+
+            cat "$errors" >&2 || true
+            cat "$output"
+            submission_id=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("data", {}).get("id", ""))' "$output" 2>/dev/null || true)
+            if [ "$status" -ne 0 ]; then
+              if [ -n "$submission_id" ]; then
+                /tmp/asc-notary-bootstrap notarization log --id "$submission_id" --output json || true
+              fi
+              exit "$status"
+            fi
+
+            accepted=0
+            for _ in {1..20}; do
+              if spctl --assess --type execute --verbose=4 "$binary"; then
+                accepted=1
+                break
+              fi
+              sleep 15
+            done
+            if [ "$accepted" -ne 1 ]; then
+              echo "::error::Gatekeeper did not accept $(basename "$binary") after notarization"
+              exit 1
+            fi
+          done
+
+      - name: Remove notarization credentials
+        if: always()
+        run: rm -f /tmp/AuthKey.p8
+
   release:
+    if: github.event_name != 'workflow_dispatch' || !inputs.notarize_existing
     runs-on: macos-latest
     permissions:
       contents: write
@@ -35,6 +175,26 @@ jobs:
 
           printf 'VERSION=%s\n' "$TAG" >> "$GITHUB_ENV"
 
+      - name: Validate release secrets
+        env:
+          APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
+          APPLE_DEVELOPER_ID_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_PASSWORD }}
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+        run: |
+          missing=0
+          for name in APPLE_DEVELOPER_ID_CERT APPLE_DEVELOPER_ID_PASSWORD APPLE_DEVELOPER_ID ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY_B64; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Required secret ${name} is not set"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
@@ -43,6 +203,22 @@ jobs:
 
       - name: Install tooling
         run: make tools
+
+      - name: Prepare App Store Connect auth
+        env:
+          ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+        run: |
+          python3 -c 'import base64, os; from pathlib import Path; Path("/tmp/AuthKey.p8").write_bytes(base64.b64decode(os.environ["ASC_PRIVATE_KEY_B64"], validate=True))'
+          chmod 600 /tmp/AuthKey.p8
+          go build -trimpath -ldflags "-s -w" -o /tmp/asc-notary-bootstrap .
+
+      - name: Verify notarization auth
+        env:
+          ASC_BYPASS_KEYCHAIN: "1"
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+        run: /tmp/asc-notary-bootstrap auth status --validate --output json >/dev/null
 
       - name: Self-test docs validators
         run: python3 scripts/test_check_docs.py
@@ -98,6 +274,56 @@ jobs:
             codesign --force --sign "${APPLE_DEVELOPER_ID}" --timestamp --options=runtime "$binary"
             codesign --verify --deep --strict --verbose=2 "$binary"
           done
+
+      - name: Notarize macOS binaries
+        env:
+          ASC_BYPASS_KEYCHAIN: "1"
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+        run: |
+          for binary in release/asc_*_macOS_*; do
+            archive="${RUNNER_TEMP}/$(basename "$binary").zip"
+            output="${RUNNER_TEMP}/$(basename "$binary").notarization.json"
+            errors="${RUNNER_TEMP}/$(basename "$binary").notarization.stderr"
+            ditto -c -k --keepParent "$binary" "$archive"
+
+            set +e
+            /tmp/asc-notary-bootstrap notarization submit \
+              --file "$archive" \
+              --wait \
+              --timeout 1h \
+              --output json >"$output" 2>"$errors"
+            status=$?
+            set -e
+
+            cat "$errors" >&2 || true
+            cat "$output"
+            submission_id=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("data", {}).get("id", ""))' "$output" 2>/dev/null || true)
+            if [ "$status" -ne 0 ]; then
+              if [ -n "$submission_id" ]; then
+                /tmp/asc-notary-bootstrap notarization log --id "$submission_id" --output json || true
+              fi
+              exit "$status"
+            fi
+
+            accepted=0
+            for _ in {1..20}; do
+              if spctl --assess --type execute --verbose=4 "$binary"; then
+                accepted=1
+                break
+              fi
+              sleep 15
+            done
+            if [ "$accepted" -ne 1 ]; then
+              echo "::error::Gatekeeper did not accept $(basename "$binary") after notarization"
+              exit 1
+            fi
+          done
+
+      - name: Remove notarization credentials
+        if: always()
+        run: rm -f /tmp/AuthKey.p8
 
       - name: Create checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ inputs.version }}
+          persist-credentials: false
 
       - name: Validate release tag
         env:
@@ -69,8 +70,8 @@ jobs:
         env:
           ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
         run: |
-          python3 -c 'import base64, os; from pathlib import Path; Path("/tmp/AuthKey.p8").write_bytes(base64.b64decode(os.environ["ASC_PRIVATE_KEY_B64"], validate=True))'
-          chmod 600 /tmp/AuthKey.p8
+          install -m 600 /dev/null "$RUNNER_TEMP/AuthKey.p8"
+          python3 -c 'import base64, os; from pathlib import Path; Path(os.environ["RUNNER_TEMP"], "AuthKey.p8").write_bytes(base64.b64decode(os.environ["ASC_PRIVATE_KEY_B64"], validate=True))'
           go build -trimpath -ldflags "-s -w" -o /tmp/asc-notary-bootstrap .
 
       - name: Verify notarization auth
@@ -78,8 +79,8 @@ jobs:
           ASC_BYPASS_KEYCHAIN: "1"
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
-        run: /tmp/asc-notary-bootstrap auth status --validate --output json >/dev/null
+          ASC_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+        run: /tmp/asc-notary-bootstrap notarization list --limit 1 --output json >/dev/null
 
       - name: Download and verify existing release
         env:
@@ -106,7 +107,7 @@ jobs:
           ASC_BYPASS_KEYCHAIN: "1"
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+          ASC_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
         run: |
           for binary in existing-release/asc_*_macOS_*; do
             archive="${RUNNER_TEMP}/$(basename "$binary").zip"
@@ -133,23 +134,23 @@ jobs:
               exit "$status"
             fi
 
-            accepted=0
+            ticket_available=0
             for _ in {1..20}; do
-              if spctl --assess --type execute --verbose=4 "$binary"; then
-                accepted=1
+              if codesign -vvvv -R="notarized" --check-notarization "$binary"; then
+                ticket_available=1
                 break
               fi
               sleep 15
             done
-            if [ "$accepted" -ne 1 ]; then
-              echo "::error::Gatekeeper did not accept $(basename "$binary") after notarization"
+            if [ "$ticket_available" -ne 1 ]; then
+              echo "::error::Notarization ticket is not available for $(basename "$binary")"
               exit 1
             fi
           done
 
       - name: Remove notarization credentials
         if: always()
-        run: rm -f /tmp/AuthKey.p8
+        run: rm -f "$RUNNER_TEMP/AuthKey.p8"
 
   release:
     if: github.event_name != 'workflow_dispatch' || !inputs.notarize_existing
@@ -161,6 +162,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
+          persist-credentials: false
 
       - name: Validate release tag
         env:
@@ -208,8 +210,8 @@ jobs:
         env:
           ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
         run: |
-          python3 -c 'import base64, os; from pathlib import Path; Path("/tmp/AuthKey.p8").write_bytes(base64.b64decode(os.environ["ASC_PRIVATE_KEY_B64"], validate=True))'
-          chmod 600 /tmp/AuthKey.p8
+          install -m 600 /dev/null "$RUNNER_TEMP/AuthKey.p8"
+          python3 -c 'import base64, os; from pathlib import Path; Path(os.environ["RUNNER_TEMP"], "AuthKey.p8").write_bytes(base64.b64decode(os.environ["ASC_PRIVATE_KEY_B64"], validate=True))'
           go build -trimpath -ldflags "-s -w" -o /tmp/asc-notary-bootstrap .
 
       - name: Verify notarization auth
@@ -217,8 +219,8 @@ jobs:
           ASC_BYPASS_KEYCHAIN: "1"
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
-        run: /tmp/asc-notary-bootstrap auth status --validate --output json >/dev/null
+          ASC_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+        run: /tmp/asc-notary-bootstrap notarization list --limit 1 --output json >/dev/null
 
       - name: Self-test docs validators
         run: python3 scripts/test_check_docs.py
@@ -280,7 +282,7 @@ jobs:
           ASC_BYPASS_KEYCHAIN: "1"
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY_PATH: /tmp/AuthKey.p8
+          ASC_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
         run: |
           for binary in release/asc_*_macOS_*; do
             archive="${RUNNER_TEMP}/$(basename "$binary").zip"
@@ -307,23 +309,23 @@ jobs:
               exit "$status"
             fi
 
-            accepted=0
+            ticket_available=0
             for _ in {1..20}; do
-              if spctl --assess --type execute --verbose=4 "$binary"; then
-                accepted=1
+              if codesign -vvvv -R="notarized" --check-notarization "$binary"; then
+                ticket_available=1
                 break
               fi
               sleep 15
             done
-            if [ "$accepted" -ne 1 ]; then
-              echo "::error::Gatekeeper did not accept $(basename "$binary") after notarization"
+            if [ "$ticket_available" -ne 1 ]; then
+              echo "::error::Notarization ticket is not available for $(basename "$binary")"
               exit 1
             fi
           done
 
       - name: Remove notarization credentials
         if: always()
-        run: rm -f /tmp/AuthKey.p8
+        run: rm -f "$RUNNER_TEMP/AuthKey.p8"
 
       - name: Create checksums
         run: |

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -218,7 +218,11 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 		`shasum -a 256 -c`,
 		`codesign --verify --deep --strict --verbose=2`,
 		`is signed by an unexpected Developer ID`,
+		`ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}`,
+		`ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}`,
+		`ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}`,
 		`ASC_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8`,
+		`ASC_BYPASS_KEYCHAIN: "1"`,
 		`notarization list --limit 1 --output json`,
 		`notarization submit`,
 		`codesign -vvvv -R="notarized" --check-notarization`,
@@ -258,8 +262,9 @@ func TestReleaseWorkflowCreatesPrivateKeyWithRestrictedModeInRunnerTemp(t *testi
 	if got := strings.Count(workflow, `install -m 600 /dev/null "$RUNNER_TEMP/AuthKey.p8"`); got != 2 {
 		t.Fatalf("release workflow must securely create both temporary keys, got %d sites", got)
 	}
-	if got := strings.Count(workflow, `run: rm -f "$RUNNER_TEMP/AuthKey.p8"`); got != 2 {
-		t.Fatalf("release workflow must clean up both temporary keys, got %d sites", got)
+	cleanup := "- name: Remove notarization credentials\n        if: always()\n        run: rm -f \"$RUNNER_TEMP/AuthKey.p8\""
+	if got := strings.Count(workflow, cleanup); got != 2 {
+		t.Fatalf("release workflow must unconditionally clean up both temporary keys, got %d sites", got)
 	}
 	if strings.Contains(workflow, "/tmp/AuthKey.p8") {
 		t.Fatal("release workflow must not store private keys in shared /tmp")

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -154,21 +154,33 @@ func TestReleaseWorkflowNotarizesMacOSBinariesBeforePublishing(t *testing.T) {
 	}
 
 	workflow := string(data)
+	releaseStart := strings.Index(workflow, "\n  release:\n")
+	if releaseStart == -1 {
+		t.Fatal("release workflow missing release job")
+	}
+	releaseJob := workflow[releaseStart:]
 	for _, want := range []string{
 		`ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}`,
 		`ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}`,
 		`ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}`,
+		`ASC_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8`,
 		`ASC_BYPASS_KEYCHAIN: "1"`,
-		`auth status --validate --output json`,
+		`notarization list --limit 1 --output json`,
 		`notarization submit`,
 		`--wait`,
 		`--timeout 1h`,
 		`notarization log --id`,
-		`spctl --assess --type execute`,
+		`codesign -vvvv -R="notarized" --check-notarization`,
 	} {
-		if !strings.Contains(workflow, want) {
+		if !strings.Contains(releaseJob, want) {
 			t.Errorf("release workflow missing notarization contract %q", want)
 		}
+	}
+	if strings.Contains(releaseJob, `auth status --validate`) {
+		t.Fatal("release workflow must validate the environment credentials with a Notary API request")
+	}
+	if strings.Contains(releaseJob, `spctl --assess`) {
+		t.Fatal("release workflow must not assess standalone binaries with spctl")
 	}
 
 	notarizeIndex := strings.Index(workflow, "- name: Notarize macOS binaries")
@@ -201,15 +213,26 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 	repairJob := workflow[start:end]
 
 	for _, want := range []string{
+		`persist-credentials: false`,
 		`gh release download "${VERSION}"`,
 		`shasum -a 256 -c`,
 		`codesign --verify --deep --strict --verbose=2`,
 		`is signed by an unexpected Developer ID`,
+		`ASC_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8`,
+		`notarization list --limit 1 --output json`,
 		`notarization submit`,
-		`spctl --assess --type execute`,
+		`codesign -vvvv -R="notarized" --check-notarization`,
 	} {
 		if !strings.Contains(repairJob, want) {
 			t.Errorf("repair-notarization job missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{
+		`auth status --validate`,
+		`spctl --assess`,
+	} {
+		if strings.Contains(repairJob, unwanted) {
+			t.Errorf("repair-notarization job contains invalid verification %q", unwanted)
 		}
 	}
 
@@ -222,5 +245,23 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 		if strings.Contains(repairJob, unwanted) {
 			t.Errorf("repair-notarization job must not replace release assets; found %q", unwanted)
 		}
+	}
+}
+
+func TestReleaseWorkflowCreatesPrivateKeyWithRestrictedModeInRunnerTemp(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	if got := strings.Count(workflow, `install -m 600 /dev/null "$RUNNER_TEMP/AuthKey.p8"`); got != 2 {
+		t.Fatalf("release workflow must securely create both temporary keys, got %d sites", got)
+	}
+	if got := strings.Count(workflow, `run: rm -f "$RUNNER_TEMP/AuthKey.p8"`); got != 2 {
+		t.Fatalf("release workflow must clean up both temporary keys, got %d sites", got)
+	}
+	if strings.Contains(workflow, "/tmp/AuthKey.p8") {
+		t.Fatal("release workflow must not store private keys in shared /tmp")
 	}
 }

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -146,3 +146,81 @@ func TestReleaseWorkflowDoesNotInterpolateDispatchInputIntoShell(t *testing.T) {
 		}
 	}
 }
+
+func TestReleaseWorkflowNotarizesMacOSBinariesBeforePublishing(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	for _, want := range []string{
+		`ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}`,
+		`ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}`,
+		`ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}`,
+		`ASC_BYPASS_KEYCHAIN: "1"`,
+		`auth status --validate --output json`,
+		`notarization submit`,
+		`--wait`,
+		`--timeout 1h`,
+		`notarization log --id`,
+		`spctl --assess --type execute`,
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("release workflow missing notarization contract %q", want)
+		}
+	}
+
+	notarizeIndex := strings.Index(workflow, "- name: Notarize macOS binaries")
+	checksumIndex := strings.Index(workflow, "- name: Create checksums")
+	publishIndex := strings.Index(workflow, "- name: Create or update GitHub Release")
+	if notarizeIndex == -1 || checksumIndex == -1 || publishIndex == -1 {
+		t.Fatalf("release workflow must contain notarization, checksum, and publish steps")
+	}
+	if notarizeIndex >= checksumIndex || checksumIndex >= publishIndex {
+		t.Fatalf("release workflow must notarize before checksums and publish: notarize=%d checksum=%d publish=%d", notarizeIndex, checksumIndex, publishIndex)
+	}
+}
+
+func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	if !strings.Contains(workflow, "notarize_existing:") {
+		t.Fatal("release workflow missing notarize_existing dispatch input")
+	}
+
+	start := strings.Index(workflow, "\n  repair-notarization:\n")
+	end := strings.Index(workflow, "\n  release:\n")
+	if start == -1 || end == -1 || start >= end {
+		t.Fatal("release workflow must define repair-notarization before release")
+	}
+	repairJob := workflow[start:end]
+
+	for _, want := range []string{
+		`gh release download "${VERSION}"`,
+		`shasum -a 256 -c`,
+		`codesign --verify --deep --strict --verbose=2`,
+		`is signed by an unexpected Developer ID`,
+		`notarization submit`,
+		`spctl --assess --type execute`,
+	} {
+		if !strings.Contains(repairJob, want) {
+			t.Errorf("repair-notarization job missing %q", want)
+		}
+	}
+
+	for _, unwanted := range []string{
+		`gh release upload`,
+		`gh release create`,
+		`codesign --force`,
+		`--clobber`,
+	} {
+		if strings.Contains(repairJob, unwanted) {
+			t.Errorf("repair-notarization job must not replace release assets; found %q", unwanted)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- validate the Developer ID and App Store Connect secrets before release work starts
- build a native bootstrap `asc`, validate its environment-only auth, and notarize both signed macOS binaries before checksums or publication
- print the Apple notarization log on rejection and require `spctl` acceptance
- add a manual `notarize_existing` repair path that verifies every published checksum and the expected signer without rebuilding, resigning, or replacing release assets

## Why

Developer ID signing alone doesn't give Gatekeeper an Apple notarization ticket. This makes future macOS release binaries fail closed before publication and gives 3.6.0 a byte-preserving repair path.

## Verification

- RED: focused workflow tests failed on the missing auth, notarization, ordering, repair, and Gatekeeper contracts
- GREEN: `ASC_BYPASS_KEYCHAIN=1 go test . -run 'TestReleaseWorkflow' -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- intact pre-commit hook

After merge, the existing 3.6.0 assets can be repaired by dispatching `Release CLI` with `version=3.6.0` and `notarize_existing=true`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788766123&installation_model_id=10418&pr_number=1898&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1898&signature=1b8aa090bda1c07c08f45fbb4abf897bf1ff30aaeebc8bbe52b921ef0a9a5d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS notarization to standard releases, including Gatekeeper validation before publishing.
  * Added a repair option to notarize existing macOS release binaries without replacing published assets.
  * Added validation for signing and notarization credentials during releases.

* **Bug Fixes**
  * Improved release reliability by verifying notarization and authentication before publication.
  * Added secure handling and cleanup of temporary authentication credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->