### PR TITLE
ci: make CLI releases retry-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,8 +227,8 @@ jobs:
         run: |
           artifact_name="candidate-release-${VERSION}"
           release_commit=$(git rev-parse HEAD)
-          artifact_id=$(gh api "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" \
-            --jq "[.artifacts[] | select(.name == \"${artifact_name}\" and .expired == false)][0].id // empty")
+          artifact_id=$(gh api --paginate "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" | \
+            jq -sr --arg name "$artifact_name" '[.[].artifacts[] | select(.name == $name and .expired == false)][0].id // empty')
           if [ -n "$artifact_id" ]; then
             echo "Reusing immutable build artifact ${artifact_name}."
             echo "reused=true" >> "$GITHUB_OUTPUT"
@@ -307,10 +307,10 @@ jobs:
             echo "reused=true" >> "$GITHUB_OUTPUT"
             echo "cross_run=true" >> "$GITHUB_OUTPUT"
             exit 0
-          done < <(gh api -X GET "repos/${GH_REPO}/actions/artifacts" \
+          done < <(gh api --paginate -X GET "repos/${GH_REPO}/actions/artifacts" \
             -f name="$artifact_name" \
-            -f per_page=100 \
-            --jq '.artifacts | sort_by(.created_at) | reverse[] | select(.expired == false) | [.id, .workflow_run.id] | @tsv')
+            -f per_page=100 | \
+            jq -sr '[.[].artifacts[]] | sort_by(.created_at) | reverse[] | select(.expired == false) | [.id, .workflow_run.id] | @tsv')
 
           if [ "$draft_has_assets" -eq 1 ]; then
             echo "::error::No retained candidate artifact matches the existing draft assets"
@@ -356,7 +356,7 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Install tooling
         if: steps.candidate_artifact.outputs.reused != 'true'
@@ -406,29 +406,28 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_ID_PASSWORD }}
 
-      - parallel:
-          - name: Build macOS binaries
-            if: steps.candidate_artifact.outputs.reused != 'true'
-            run: |
-              COMMIT=$(git rev-parse --short HEAD)
-              DATE=$(git show -s --format=%cI HEAD)
-              GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_macOS_amd64 .
-              GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_macOS_arm64 .
+      - name: Build macOS binaries
+        if: steps.candidate_artifact.outputs.reused != 'true'
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(git show -s --format=%cI HEAD)
+          GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o "release/asc_${VERSION}_macOS_amd64" .
+          GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o "release/asc_${VERSION}_macOS_arm64" .
 
-          - name: Build for Linux
-            if: steps.candidate_artifact.outputs.reused != 'true'
-            run: |
-              COMMIT=$(git rev-parse --short HEAD)
-              DATE=$(git show -s --format=%cI HEAD)
-              GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_linux_amd64 .
-              GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_linux_arm64 .
+      - name: Build for Linux
+        if: steps.candidate_artifact.outputs.reused != 'true'
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(git show -s --format=%cI HEAD)
+          GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o "release/asc_${VERSION}_linux_amd64" .
+          GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o "release/asc_${VERSION}_linux_arm64" .
 
-          - name: Build for Windows
-            if: steps.candidate_artifact.outputs.reused != 'true'
-            run: |
-              COMMIT=$(git rev-parse --short HEAD)
-              DATE=$(git show -s --format=%cI HEAD)
-              GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_windows_amd64.exe .
+      - name: Build for Windows
+        if: steps.candidate_artifact.outputs.reused != 'true'
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(git show -s --format=%cI HEAD)
+          GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o "release/asc_${VERSION}_windows_amd64.exe" .
 
       - name: Sign and verify macOS binaries
         if: steps.candidate_artifact.outputs.reused != 'true'
@@ -552,8 +551,8 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           artifact_name="published-release-${VERSION}"
-          artifact_id=$(gh api "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" \
-            --jq "[.artifacts[] | select(.name == \"${artifact_name}\" and .expired == false)][0].id // empty")
+          artifact_id=$(gh api --paginate "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" | \
+            jq -sr --arg name "$artifact_name" '[.[].artifacts[] | select(.name == $name and .expired == false)][0].id // empty')
           if [ -n "$artifact_id" ]; then
             echo "Reusing immutable published artifact ${artifact_name}."
             echo "reused=true" >> "$GITHUB_OUTPUT"
@@ -578,9 +577,10 @@ jobs:
         if: steps.published_artifact.outputs.reused != 'true' && needs.prepare.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           mkdir -p published-release
-          gh release download "${VERSION}" --dir published-release
+          gh release download "${VERSION}" --repo "${GH_REPO}" --dir published-release
           python3 workflow-source/scripts/verify_release_assets.py --release-dir published-release --version "${VERSION}"
 
       - name: Create, resume, or verify GitHub Release
@@ -821,13 +821,13 @@ jobs:
           python3 scripts/generate_winget_manifests.py \
             --version "${VERSION}" \
             --release-dir release \
-            --output-dir release/winget
+            --output-dir winget-output
 
       - name: Upload WinGet manifests artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: winget-manifests-${{ needs.publish.outputs.version }}-${{ github.run_attempt }}
-          path: release/winget/manifests/r/Rorkai/ASC/${{ needs.publish.outputs.version }}
+          path: winget-output/manifests/r/Rorkai/ASC/${{ needs.publish.outputs.version }}
           if-no-files-found: error
 
       - name: Submit WinGet package PR
@@ -846,7 +846,7 @@ jobs:
           fi
 
           BRANCH="rorkai-asc-${VERSION}"
-          MANIFEST_SOURCE="${PWD}/release/winget/manifests/r/Rorkai/ASC/${VERSION}"
+          MANIFEST_SOURCE="${PWD}/winget-output/manifests/r/Rorkai/ASC/${VERSION}"
 
           if ! gh repo view "${WINGET_FORK_OWNER}/winget-pkgs" >/dev/null 2>&1; then
             if [ "${WINGET_FORK_OWNER}" = "${AUTH_LOGIN}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.notarize_existing
     runs-on: macos-latest
     permissions:
-      actions: read
       contents: read
     steps:
       - name: Checkout release tag
@@ -162,6 +161,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || !inputs.notarize_existing
     runs-on: macos-latest
     permissions:
+      actions: read
       contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -498,6 +498,10 @@ jobs:
               diff -u "$expected_names" "$published_names" || true
               exit 1
             fi
+            (
+              cd published-release
+              shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+            )
             gh release edit "${VERSION}" --draft=false
           else
             if ! cmp -s "$expected_names" "$published_names"; then
@@ -506,10 +510,11 @@ jobs:
               exit 1
             fi
             gh release download "${VERSION}" --dir published-release
+            (
+              cd published-release
+              shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+            )
           fi
-
-          cd published-release
-          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
 
       - name: Pack immutable published artifact
         if: steps.published_artifact.outputs.reused != 'true'
@@ -532,6 +537,7 @@ jobs:
     needs: publish
     runs-on: macos-latest
     permissions:
+      actions: read
       contents: read
     env:
       VERSION: ${{ needs.publish.outputs.version }}
@@ -627,6 +633,7 @@ jobs:
     needs: publish
     runs-on: macos-latest
     permissions:
+      actions: read
       contents: read
     env:
       VERSION: ${{ needs.publish.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,14 +194,98 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           artifact_name="candidate-release-${VERSION}"
+          release_commit=$(git rev-parse HEAD)
           artifact_id=$(gh api "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" \
             --jq "[.artifacts[] | select(.name == \"${artifact_name}\" and .expired == false)][0].id // empty")
           if [ -n "$artifact_id" ]; then
             echo "Reusing immutable build artifact ${artifact_name}."
             echo "reused=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "reused=false" >> "$GITHUB_OUTPUT"
+            echo "cross_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          draft_dir="${RUNNER_TEMP}/existing-release-draft"
+          draft_has_assets=0
+          release_is_draft=$(gh release view "${VERSION}" --json isDraft --jq '.isDraft' 2>/dev/null || true)
+          if [ "$release_is_draft" = "true" ]; then
+            draft_asset_count=$(gh release view "${VERSION}" --json assets --jq '.assets | length')
+            if [ "$draft_asset_count" -gt 0 ]; then
+              mkdir -p "$draft_dir"
+              gh release download "${VERSION}" --dir "$draft_dir"
+              draft_has_assets=1
+            fi
+          fi
+
+          mkdir -p workflow-artifact
+          while IFS=$'\t' read -r artifact_id artifact_run_id; do
+            [ -n "$artifact_id" ] || continue
+            IFS=$'\t' read -r run_path run_head_sha < <(gh api "repos/${GH_REPO}/actions/runs/${artifact_run_id}" \
+              --jq '[.path, .head_sha] | @tsv' 2>/dev/null || true)
+            if [ "$run_path" != ".github/workflows/release.yml" ] || [ "$run_head_sha" != "$release_commit" ]; then
+              continue
+            fi
+            artifact_dir="${RUNNER_TEMP}/candidate-artifact-${artifact_id}"
+            archive_zip="${artifact_dir}/artifact.zip"
+            archive_dir="${artifact_dir}/download"
+            candidate_dir="${artifact_dir}/candidate"
+            mkdir -p "$archive_dir" "$candidate_dir"
+            if ! gh api "repos/${GH_REPO}/actions/artifacts/${artifact_id}/zip" > "$archive_zip"; then
+              continue
+            fi
+            if ! ditto -x -k "$archive_zip" "$archive_dir"; then
+              continue
+            fi
+            archive="${archive_dir}/candidate-release-${VERSION}.tar"
+            provenance="${archive_dir}/candidate-release-${VERSION}.commit"
+            if [ ! -f "$archive" ] || [ ! -f "$provenance" ] || ! test "$(cat "$provenance")" = "$release_commit"; then
+              continue
+            fi
+
+            if [ "$draft_has_assets" -eq 1 ]; then
+              if ! tar -xf "$archive" -C "$candidate_dir"; then
+                continue
+              fi
+              candidate_matches=1
+              while IFS= read -r -d '' draft_asset; do
+                name=$(basename "$draft_asset")
+                if [ ! -f "$candidate_dir/release/$name" ] || ! cmp -s "$draft_asset" "$candidate_dir/release/$name"; then
+                  candidate_matches=0
+                  break
+                fi
+              done < <(find "$draft_dir" -maxdepth 1 -type f -print0)
+              if [ "$candidate_matches" -ne 1 ]; then
+                continue
+              fi
+            fi
+
+            cp "$archive" "workflow-artifact/candidate-release-${VERSION}.tar"
+            cp "$provenance" "workflow-artifact/candidate-release-${VERSION}.commit"
+            echo "Recovered immutable build artifact ${artifact_name} (${artifact_id})."
+            echo "reused=true" >> "$GITHUB_OUTPUT"
+            echo "cross_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          done < <(gh api -X GET "repos/${GH_REPO}/actions/artifacts" \
+            -f name="$artifact_name" \
+            -f per_page=100 \
+            --jq '.artifacts | sort_by(.created_at) | reverse[] | select(.expired == false) | [.id, .workflow_run.id] | @tsv')
+
+          if [ "$draft_has_assets" -eq 1 ]; then
+            echo "::error::No retained candidate artifact matches the existing draft assets"
+            exit 1
+          fi
+          echo "reused=false" >> "$GITHUB_OUTPUT"
+          echo "cross_run=false" >> "$GITHUB_OUTPUT"
+
+      - name: Materialize recovered immutable release artifact
+        if: steps.candidate_artifact.outputs.cross_run == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: candidate-release-${{ steps.version.outputs.version }}
+          path: |
+            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.tar
+            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.commit
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Validate release secrets
         if: steps.candidate_artifact.outputs.reused != 'true'
@@ -380,13 +464,16 @@ jobs:
         run: |
           mkdir -p workflow-artifact
           tar -cf "workflow-artifact/candidate-release-${VERSION}.tar" release
+          git rev-parse HEAD > "workflow-artifact/candidate-release-${VERSION}.commit"
 
       - name: Upload immutable release artifact
         if: steps.candidate_artifact.outputs.reused != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: candidate-release-${{ steps.version.outputs.version }}
-          path: workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.tar
+          path: |
+            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.tar
+            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.commit
           if-no-files-found: error
           retention-days: 14
 
@@ -712,7 +799,7 @@ jobs:
             BRANCH_EXISTS=1
             git checkout -B "${BRANCH}" "origin/${BRANCH}"
           else
-            git checkout -b "${BRANCH}" origin/master
+            git checkout -b "${BRANCH}" upstream/master
           fi
           git sparse-checkout set "manifests/r/Rorkai/ASC"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,13 @@ jobs:
           ref: refs/tags/${{ inputs.version }}
           persist-credentials: false
 
+      - name: Checkout workflow verification tools
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-source
+          persist-credentials: false
+
       - name: Validate release tag
         env:
           RELEASE_TAG: ${{ inputs.version }}
@@ -93,10 +100,8 @@ jobs:
         run: |
           mkdir -p existing-release
           gh release download "${VERSION}" --dir existing-release
-          cd existing-release
-          test -f "asc_${VERSION}_checksums.txt"
-          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
-          for binary in asc_*_macOS_*; do
+          python3 workflow-source/scripts/verify_release_assets.py --release-dir existing-release --version "${VERSION}"
+          for binary in existing-release/asc_*_macOS_*; do
             test -f "$binary"
             codesign --verify --deep --strict --verbose=2 "$binary"
             authority=$(codesign -dv --verbose=4 "$binary" 2>&1 | sed -n 's/^Authority=//p' | head -n 1)
@@ -156,36 +161,63 @@ jobs:
         if: always()
         run: rm -f "$RUNNER_TEMP/AuthKey.p8"
 
-  build:
-    name: Build, sign, and notarize
+  prepare:
+    name: Resolve release state
     if: github.event_name != 'workflow_dispatch' || !inputs.notarize_existing
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
+      published: ${{ steps.release.outputs.published }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
-          persist-credentials: false
-
       - name: Validate release tag
         id: version
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
         run: |
           TAG="${RELEASE_TAG}"
-
           if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Release tags must match x.y.z. Got: ${TAG}"
             exit 1
           fi
-
           printf 'VERSION=%s\n' "$TAG" >> "$GITHUB_ENV"
           printf 'version=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Detect published GitHub release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          release_error="${RUNNER_TEMP}/release-state.stderr"
+          if release_is_draft=$(gh api "repos/${GH_REPO}/releases/tags/${VERSION}" --jq '.draft' 2>"$release_error"); then
+            if [ "$release_is_draft" = "false" ]; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          elif ! grep -Fq "HTTP 404" "$release_error"; then
+            cat "$release_error" >&2
+            exit 1
+          fi
+          echo "published=false" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build, sign, and notarize
+    needs: prepare
+    if: needs.prepare.outputs.published != 'true'
+    runs-on: macos-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
+          persist-credentials: false
 
       - name: Check for existing immutable build artifact
         id: candidate_artifact
@@ -280,10 +312,10 @@ jobs:
         if: steps.candidate_artifact.outputs.cross_run == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: candidate-release-${{ steps.version.outputs.version }}
+          name: candidate-release-${{ needs.prepare.outputs.version }}
           path: |
-            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.tar
-            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.commit
+            workflow-artifact/candidate-release-${{ needs.prepare.outputs.version }}.tar
+            workflow-artifact/candidate-release-${{ needs.prepare.outputs.version }}.commit
           if-no-files-found: error
           retention-days: 14
 
@@ -470,25 +502,38 @@ jobs:
         if: steps.candidate_artifact.outputs.reused != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: candidate-release-${{ steps.version.outputs.version }}
+          name: candidate-release-${{ needs.prepare.outputs.version }}
           path: |
-            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.tar
-            workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.commit
+            workflow-artifact/candidate-release-${{ needs.prepare.outputs.version }}.tar
+            workflow-artifact/candidate-release-${{ needs.prepare.outputs.version }}.commit
           if-no-files-found: error
           retention-days: 14
 
   publish:
     name: Publish GitHub release
-    needs: build
+    needs:
+      - prepare
+      - build
+    if: >-
+      always() &&
+      needs.prepare.result == 'success' &&
+      (needs.prepare.outputs.published == 'true' || needs.build.result == 'success')
     runs-on: macos-latest
     permissions:
       actions: read
       contents: write
     outputs:
-      version: ${{ needs.build.outputs.version }}
+      version: ${{ needs.prepare.outputs.version }}
     env:
-      VERSION: ${{ needs.build.outputs.version }}
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
+      - name: Checkout workflow release tools
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-source
+          persist-credentials: false
+
       - name: Check for existing published artifact
         id: published_artifact
         env:
@@ -506,21 +551,29 @@ jobs:
           fi
 
       - name: Download immutable release artifact
-        if: steps.published_artifact.outputs.reused != 'true'
+        if: steps.published_artifact.outputs.reused != 'true' && needs.prepare.outputs.published != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: candidate-release-${{ needs.build.outputs.version }}
+          name: candidate-release-${{ needs.prepare.outputs.version }}
           path: workflow-artifact
 
       - name: Unpack and verify release artifact
-        if: steps.published_artifact.outputs.reused != 'true'
+        if: steps.published_artifact.outputs.reused != 'true' && needs.prepare.outputs.published != 'true'
         run: |
           tar -xf "workflow-artifact/candidate-release-${VERSION}.tar"
-          cd release
-          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+          python3 workflow-source/scripts/verify_release_assets.py --release-dir release --version "${VERSION}"
+
+      - name: Recover and verify existing published release
+        if: steps.published_artifact.outputs.reused != 'true' && needs.prepare.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p published-release
+          gh release download "${VERSION}" --dir published-release
+          python3 workflow-source/scripts/verify_release_assets.py --release-dir published-release --version "${VERSION}"
 
       - name: Create, resume, or verify GitHub Release
-        if: steps.published_artifact.outputs.reused != 'true'
+        if: steps.published_artifact.outputs.reused != 'true' && needs.prepare.outputs.published != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -585,11 +638,6 @@ jobs:
               diff -u "$expected_names" "$published_names" || true
               exit 1
             fi
-            (
-              cd published-release
-              shasum -a 256 -c "asc_${VERSION}_checksums.txt"
-            )
-            gh release edit "${VERSION}" --draft=false
           else
             if ! cmp -s "$expected_names" "$published_names"; then
               echo "::error::Published release has an unexpected asset set"
@@ -597,10 +645,11 @@ jobs:
               exit 1
             fi
             gh release download "${VERSION}" --dir published-release
-            (
-              cd published-release
-              shasum -a 256 -c "asc_${VERSION}_checksums.txt"
-            )
+          fi
+
+          python3 workflow-source/scripts/verify_release_assets.py --release-dir published-release --version "${VERSION}"
+          if [ "$release_is_draft" = "true" ]; then
+            gh release edit "${VERSION}" --draft=false
           fi
 
       - name: Pack immutable published artifact
@@ -614,8 +663,8 @@ jobs:
         if: steps.published_artifact.outputs.reused != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: published-release-${{ needs.build.outputs.version }}
-          path: workflow-artifact/published-release-${{ needs.build.outputs.version }}.tar
+          name: published-release-${{ needs.prepare.outputs.version }}
+          path: workflow-artifact/published-release-${{ needs.prepare.outputs.version }}.tar
           if-no-files-found: error
           retention-days: 14
 
@@ -629,6 +678,13 @@ jobs:
     env:
       VERSION: ${{ needs.publish.outputs.version }}
     steps:
+      - name: Checkout workflow release tools
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-source
+          persist-credentials: false
+
       - name: Download immutable release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -638,8 +694,7 @@ jobs:
       - name: Unpack and verify release artifact
         run: |
           tar -xf "workflow-artifact/published-release-${VERSION}.tar"
-          cd release
-          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+          python3 workflow-source/scripts/verify_release_assets.py --release-dir release --version "${VERSION}"
 
       - name: Update Homebrew tap
         env:
@@ -731,6 +786,13 @@ jobs:
           ref: refs/tags/${{ needs.publish.outputs.version }}
           persist-credentials: false
 
+      - name: Checkout workflow verification tools
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-source
+          persist-credentials: false
+
       - name: Download immutable release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -740,8 +802,7 @@ jobs:
       - name: Unpack and verify release artifact
         run: |
           tar -xf "workflow-artifact/published-release-${VERSION}.tar"
-          cd release
-          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+          python3 workflow-source/scripts/verify_release_assets.py --release-dir release --version "${VERSION}"
 
       - name: Generate WinGet manifests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -703,10 +703,6 @@ jobs:
           BRANCH_EXISTS=0
           if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
             BRANCH_EXISTS=1
-            if ! git merge-base --is-ancestor origin/master "origin/${BRANCH}"; then
-              echo "::error::The existing WinGet release branch does not descend from the fork master branch"
-              exit 1
-            fi
             git checkout -B "${BRANCH}" "origin/${BRANCH}"
           else
             git checkout -b "${BRANCH}" origin/master
@@ -714,10 +710,16 @@ jobs:
           git sparse-checkout set "manifests/r/Rorkai/ASC"
 
           verify_winget_scope() {
-            unexpected_paths=$(git diff --name-only upstream/master...HEAD | grep -Ev "^manifests/r/Rorkai/ASC/${VERSION}/" || true)
-            if [ -n "$unexpected_paths" ]; then
+            unexpected_paths=()
+            while IFS= read -r -d '' changed_path; do
+              case "$changed_path" in
+                "manifests/r/Rorkai/ASC/${VERSION}/"*) ;;
+                *) unexpected_paths+=("$changed_path") ;;
+              esac
+            done < <(git diff --name-only -z upstream/master...HEAD)
+            if [ "${#unexpected_paths[@]}" -ne 0 ]; then
               echo "::error::WinGet branch contains changes outside the ${VERSION} manifest directory"
-              echo "$unexpected_paths"
+              printf '%s\n' "${unexpected_paths[@]}"
               exit 1
             fi
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -610,7 +610,7 @@ jobs:
                 end
 
                 test do
-                  assert_match "asc is a fast, lightweight CLI for App Store Connect", shell_output("#{{bin}}/asc --help")
+                  assert_match version.to_s, shell_output("#{{bin}}/asc --version")
                 end
               end
               """

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
 
 concurrency:
-  group: release-cli-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
+  group: release-cli-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -25,6 +25,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.notarize_existing
     runs-on: macos-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - name: Checkout release tag
@@ -186,7 +187,24 @@ jobs:
           printf 'VERSION=%s\n' "$TAG" >> "$GITHUB_ENV"
           printf 'version=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
 
+      - name: Check for existing immutable build artifact
+        id: candidate_artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          artifact_name="candidate-release-${VERSION}"
+          artifact_id=$(gh api "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" \
+            --jq "[.artifacts[] | select(.name == \"${artifact_name}\" and .expired == false)][0].id // empty")
+          if [ -n "$artifact_id" ]; then
+            echo "Reusing immutable build artifact ${artifact_name}."
+            echo "reused=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "reused=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Validate release secrets
+        if: steps.candidate_artifact.outputs.reused != 'true'
         env:
           APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
           APPLE_DEVELOPER_ID_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_PASSWORD }}
@@ -207,15 +225,18 @@ jobs:
           fi
 
       - name: Set up Go
+        if: steps.candidate_artifact.outputs.reused != 'true'
         uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Install tooling
+        if: steps.candidate_artifact.outputs.reused != 'true'
         run: make tools
 
       - name: Prepare App Store Connect auth
+        if: steps.candidate_artifact.outputs.reused != 'true'
         env:
           ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
         run: |
@@ -224,6 +245,7 @@ jobs:
           go build -trimpath -ldflags "-s -w" -o /tmp/asc-notary-bootstrap .
 
       - name: Verify notarization auth
+        if: steps.candidate_artifact.outputs.reused != 'true'
         env:
           ASC_BYPASS_KEYCHAIN: "1"
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -232,9 +254,11 @@ jobs:
         run: /tmp/asc-notary-bootstrap notarization list --limit 1 --output json >/dev/null
 
       - name: Self-test docs validators
+        if: steps.candidate_artifact.outputs.reused != 'true'
         run: python3 scripts/test_check_docs.py
 
       - name: Run release guardrails
+        if: steps.candidate_artifact.outputs.reused != 'true'
         run: |
           PATH_VALUE="$(go env GOPATH)/bin:$PATH"
           export PATH="$PATH_VALUE"
@@ -245,9 +269,11 @@ jobs:
           ASC_BYPASS_KEYCHAIN=1 make test
 
       - name: Create release directory
+        if: steps.candidate_artifact.outputs.reused != 'true'
         run: mkdir -p release
 
       - name: Import Apple certificate
+        if: steps.candidate_artifact.outputs.reused != 'true'
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
@@ -255,6 +281,7 @@ jobs:
 
       - parallel:
           - name: Build macOS binaries
+            if: steps.candidate_artifact.outputs.reused != 'true'
             run: |
               COMMIT=$(git rev-parse --short HEAD)
               DATE=$(git show -s --format=%cI HEAD)
@@ -262,6 +289,7 @@ jobs:
               GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_macOS_arm64 .
 
           - name: Build for Linux
+            if: steps.candidate_artifact.outputs.reused != 'true'
             run: |
               COMMIT=$(git rev-parse --short HEAD)
               DATE=$(git show -s --format=%cI HEAD)
@@ -269,12 +297,14 @@ jobs:
               GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_linux_arm64 .
 
           - name: Build for Windows
+            if: steps.candidate_artifact.outputs.reused != 'true'
             run: |
               COMMIT=$(git rev-parse --short HEAD)
               DATE=$(git show -s --format=%cI HEAD)
               GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_windows_amd64.exe .
 
       - name: Sign and verify macOS binaries
+        if: steps.candidate_artifact.outputs.reused != 'true'
         env:
           APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
         run: |
@@ -284,6 +314,7 @@ jobs:
           done
 
       - name: Notarize macOS binaries
+        if: steps.candidate_artifact.outputs.reused != 'true'
         env:
           ASC_BYPASS_KEYCHAIN: "1"
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -334,24 +365,28 @@ jobs:
         run: rm -f "$RUNNER_TEMP/AuthKey.p8"
 
       - name: Create checksums
+        if: steps.candidate_artifact.outputs.reused != 'true'
         run: |
           cd release
           assets=(asc_*)
           shasum -a 256 "${assets[@]}" > "asc_${VERSION}_checksums.txt"
 
       - name: Display files
+        if: steps.candidate_artifact.outputs.reused != 'true'
         run: ls -la release/
 
       - name: Pack immutable release artifact
+        if: steps.candidate_artifact.outputs.reused != 'true'
         run: |
           mkdir -p workflow-artifact
-          tar -cf "workflow-artifact/release-${VERSION}.tar" release
+          tar -cf "workflow-artifact/candidate-release-${VERSION}.tar" release
 
       - name: Upload immutable release artifact
+        if: steps.candidate_artifact.outputs.reused != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: release-${{ steps.version.outputs.version }}
-          path: workflow-artifact/release-${{ steps.version.outputs.version }}.tar
+          name: candidate-release-${{ steps.version.outputs.version }}
+          path: workflow-artifact/candidate-release-${{ steps.version.outputs.version }}.tar
           if-no-files-found: error
           retention-days: 14
 
@@ -360,70 +395,156 @@ jobs:
     needs: build
     runs-on: macos-latest
     permissions:
+      actions: read
       contents: write
+    outputs:
+      version: ${{ needs.build.outputs.version }}
     env:
       VERSION: ${{ needs.build.outputs.version }}
     steps:
-      - name: Download immutable release artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: release-${{ needs.build.outputs.version }}
-          path: workflow-artifact
-
-      - name: Unpack and verify release artifact
-        run: |
-          tar -xf "workflow-artifact/release-${VERSION}.tar"
-          cd release
-          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
-
-      - name: Create or verify GitHub Release
+      - name: Check for existing published artifact
+        id: published_artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          if gh release view "${VERSION}" >/dev/null 2>&1; then
-            expected_names="${RUNNER_TEMP}/expected-release-assets.txt"
-            published_names="${RUNNER_TEMP}/published-release-assets.txt"
-            find release -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort > "$expected_names"
-            gh release view "${VERSION}" --json assets --jq '.assets[].name' | LC_ALL=C sort > "$published_names"
-            if ! cmp -s "$expected_names" "$published_names"; then
-              echo "::error::Published release assets differ from this run"
-              diff -u "$expected_names" "$published_names" || true
+          artifact_name="published-release-${VERSION}"
+          artifact_id=$(gh api "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" \
+            --jq "[.artifacts[] | select(.name == \"${artifact_name}\" and .expired == false)][0].id // empty")
+          if [ -n "$artifact_id" ]; then
+            echo "Reusing immutable published artifact ${artifact_name}."
+            echo "reused=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "reused=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download immutable release artifact
+        if: steps.published_artifact.outputs.reused != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: candidate-release-${{ needs.build.outputs.version }}
+          path: workflow-artifact
+
+      - name: Unpack and verify release artifact
+        if: steps.published_artifact.outputs.reused != 'true'
+        run: |
+          tar -xf "workflow-artifact/candidate-release-${VERSION}.tar"
+          cd release
+          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+
+      - name: Create, resume, or verify GitHub Release
+        if: steps.published_artifact.outputs.reused != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          expected_names="${RUNNER_TEMP}/expected-release-assets.txt"
+          published_names="${RUNNER_TEMP}/published-release-assets.txt"
+          checksum_name="asc_${VERSION}_checksums.txt"
+          find release -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort > "$expected_names"
+          mkdir -p published-release
+
+          if ! gh release view "${VERSION}" >/dev/null 2>&1; then
+            gh release create "${VERSION}" --draft --generate-notes --verify-tag
+          fi
+
+          release_is_draft=$(gh release view "${VERSION}" --json isDraft --jq '.isDraft')
+          gh release view "${VERSION}" --json assets --jq '.assets[].name' | LC_ALL=C sort > "$published_names"
+
+          if [ "$release_is_draft" = "true" ]; then
+            unexpected_names=$(comm -13 "$expected_names" "$published_names" || true)
+            if [ -n "$unexpected_names" ]; then
+              echo "::error::Draft release contains unexpected assets"
+              echo "$unexpected_names"
               exit 1
             fi
 
-            published=$(mktemp -d)
-            gh release download "${VERSION}" --dir "$published"
-            for asset in release/asc_*; do
-              name=$(basename "$asset")
-              if ! cmp -s "$asset" "$published/$name"; then
-                echo "::error::Published release assets differ from this run: ${name}"
+            if grep -Fxq "$checksum_name" "$published_names"; then
+              if ! cmp -s "$expected_names" "$published_names"; then
+                echo "::error::Draft release has a checksum but is missing required assets"
+                diff -u "$expected_names" "$published_names" || true
                 exit 1
               fi
-            done
-            echo "Published release assets match the immutable build artifact."
+              gh release download "${VERSION}" --dir published-release
+            else
+              for asset in release/asc_*; do
+                name=$(basename "$asset")
+                if [ "$name" = "$checksum_name" ]; then
+                  continue
+                fi
+                if grep -Fxq "$name" "$published_names"; then
+                  gh release download "${VERSION}" --pattern "$name" --dir published-release
+                  if ! cmp -s "$asset" "published-release/$name"; then
+                    echo "::error::Draft asset ${name} differs from the immutable build artifact"
+                    exit 1
+                  fi
+                else
+                  gh release upload "${VERSION}" "$asset"
+                  cp "$asset" published-release/
+                fi
+              done
+
+              (
+                cd published-release
+                binaries=(asc_*)
+                shasum -a 256 "${binaries[@]}" > "$checksum_name"
+              )
+              gh release upload "${VERSION}" "published-release/${checksum_name}"
+            fi
+
+            gh release view "${VERSION}" --json assets --jq '.assets[].name' | LC_ALL=C sort > "$published_names"
+            if ! cmp -s "$expected_names" "$published_names"; then
+              echo "::error::Draft release does not contain the exact expected assets"
+              diff -u "$expected_names" "$published_names" || true
+              exit 1
+            fi
+            gh release edit "${VERSION}" --draft=false
           else
-            gh release create "${VERSION}" release/asc_* --generate-notes --verify-tag
+            if ! cmp -s "$expected_names" "$published_names"; then
+              echo "::error::Published release has an unexpected asset set"
+              diff -u "$expected_names" "$published_names" || true
+              exit 1
+            fi
+            gh release download "${VERSION}" --dir published-release
           fi
+
+          cd published-release
+          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+
+      - name: Pack immutable published artifact
+        if: steps.published_artifact.outputs.reused != 'true'
+        run: |
+          rm -rf release
+          mv published-release release
+          tar -cf "workflow-artifact/published-release-${VERSION}.tar" release
+
+      - name: Upload immutable published artifact
+        if: steps.published_artifact.outputs.reused != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: published-release-${{ needs.build.outputs.version }}
+          path: workflow-artifact/published-release-${{ needs.build.outputs.version }}.tar
+          if-no-files-found: error
+          retention-days: 14
 
   homebrew:
     name: Update Homebrew tap
-    needs: [build, publish]
+    needs: publish
     runs-on: macos-latest
     permissions:
       contents: read
     env:
-      VERSION: ${{ needs.build.outputs.version }}
+      VERSION: ${{ needs.publish.outputs.version }}
     steps:
       - name: Download immutable release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: release-${{ needs.build.outputs.version }}
+          name: published-release-${{ needs.publish.outputs.version }}
           path: workflow-artifact
 
       - name: Unpack and verify release artifact
         run: |
-          tar -xf "workflow-artifact/release-${VERSION}.tar"
+          tar -xf "workflow-artifact/published-release-${VERSION}.tar"
           cd release
           shasum -a 256 -c "asc_${VERSION}_checksums.txt"
 
@@ -503,27 +624,28 @@ jobs:
 
   winget:
     name: Submit WinGet package
-    needs: [build, publish]
+    needs: publish
     runs-on: macos-latest
     permissions:
       contents: read
     env:
-      VERSION: ${{ needs.build.outputs.version }}
+      VERSION: ${{ needs.publish.outputs.version }}
     steps:
       - name: Checkout release source
         uses: actions/checkout@v7
         with:
-          ref: refs/tags/${{ needs.build.outputs.version }}
+          ref: refs/tags/${{ needs.publish.outputs.version }}
+          persist-credentials: false
 
       - name: Download immutable release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: release-${{ needs.build.outputs.version }}
+          name: published-release-${{ needs.publish.outputs.version }}
           path: workflow-artifact
 
       - name: Unpack and verify release artifact
         run: |
-          tar -xf "workflow-artifact/release-${VERSION}.tar"
+          tar -xf "workflow-artifact/published-release-${VERSION}.tar"
           cd release
           shasum -a 256 -c "asc_${VERSION}_checksums.txt"
 
@@ -537,8 +659,8 @@ jobs:
       - name: Upload WinGet manifests artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: winget-manifests-${{ needs.build.outputs.version }}
-          path: release/winget/manifests/r/Rorkai/ASC/${{ needs.build.outputs.version }}
+          name: winget-manifests-${{ needs.publish.outputs.version }}-${{ github.run_attempt }}
+          path: release/winget/manifests/r/Rorkai/ASC/${{ needs.publish.outputs.version }}
           if-no-files-found: error
 
       - name: Submit WinGet package PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: release-cli-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   repair-notarization:
     if: github.event_name == 'workflow_dispatch' && inputs.notarize_existing
@@ -151,11 +155,14 @@ jobs:
         if: always()
         run: rm -f /tmp/AuthKey.p8
 
-  release:
+  build:
+    name: Build, sign, and notarize
     if: github.event_name != 'workflow_dispatch' || !inputs.notarize_existing
     runs-on: macos-latest
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -163,6 +170,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
 
       - name: Validate release tag
+        id: version
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
         run: |
@@ -174,6 +182,7 @@ jobs:
           fi
 
           printf 'VERSION=%s\n' "$TAG" >> "$GITHUB_ENV"
+          printf 'version=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Validate release secrets
         env:
@@ -225,7 +234,8 @@ jobs:
 
       - name: Run release guardrails
         run: |
-          export PATH="$(go env GOPATH)/bin:$PATH"
+          PATH_VALUE="$(go env GOPATH)/bin:$PATH"
+          export PATH="$PATH_VALUE"
           make format-check
           make check-docs
           make check-wall-of-apps
@@ -245,31 +255,27 @@ jobs:
           - name: Build macOS binaries
             run: |
               COMMIT=$(git rev-parse --short HEAD)
-              DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+              DATE=$(git show -s --format=%cI HEAD)
               GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_macOS_amd64 .
               GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_macOS_arm64 .
 
           - name: Build for Linux
             run: |
               COMMIT=$(git rev-parse --short HEAD)
-              DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+              DATE=$(git show -s --format=%cI HEAD)
               GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_linux_amd64 .
               GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_linux_arm64 .
 
           - name: Build for Windows
             run: |
               COMMIT=$(git rev-parse --short HEAD)
-              DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+              DATE=$(git show -s --format=%cI HEAD)
               GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o release/asc_${VERSION}_windows_amd64.exe .
 
       - name: Sign and verify macOS binaries
         env:
           APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
         run: |
-          if [ -z "${APPLE_DEVELOPER_ID}" ]; then
-            echo "::error::APPLE_DEVELOPER_ID not set"
-            exit 1
-          fi
           for binary in release/asc_*_macOS_*; do
             codesign --force --sign "${APPLE_DEVELOPER_ID}" --timestamp --options=runtime "$binary"
             codesign --verify --deep --strict --verbose=2 "$binary"
@@ -328,20 +334,96 @@ jobs:
       - name: Create checksums
         run: |
           cd release
-          shasum -a 256 * > asc_${VERSION}_checksums.txt
+          assets=(asc_*)
+          shasum -a 256 "${assets[@]}" > "asc_${VERSION}_checksums.txt"
 
       - name: Display files
         run: ls -la release/
 
-      - name: Create or update GitHub Release
+      - name: Pack immutable release artifact
+        run: |
+          mkdir -p workflow-artifact
+          tar -cf "workflow-artifact/release-${VERSION}.tar" release
+
+      - name: Upload immutable release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-${{ steps.version.outputs.version }}
+          path: workflow-artifact/release-${{ steps.version.outputs.version }}.tar
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish GitHub release
+    needs: build
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-${{ needs.build.outputs.version }}
+          path: workflow-artifact
+
+      - name: Unpack and verify release artifact
+        run: |
+          tar -xf "workflow-artifact/release-${VERSION}.tar"
+          cd release
+          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
+
+      - name: Create or verify GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           if gh release view "${VERSION}" >/dev/null 2>&1; then
-            gh release upload "${VERSION}" release/* --clobber
+            expected_names="${RUNNER_TEMP}/expected-release-assets.txt"
+            published_names="${RUNNER_TEMP}/published-release-assets.txt"
+            find release -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort > "$expected_names"
+            gh release view "${VERSION}" --json assets --jq '.assets[].name' | LC_ALL=C sort > "$published_names"
+            if ! cmp -s "$expected_names" "$published_names"; then
+              echo "::error::Published release assets differ from this run"
+              diff -u "$expected_names" "$published_names" || true
+              exit 1
+            fi
+
+            published=$(mktemp -d)
+            gh release download "${VERSION}" --dir "$published"
+            for asset in release/asc_*; do
+              name=$(basename "$asset")
+              if ! cmp -s "$asset" "$published/$name"; then
+                echo "::error::Published release assets differ from this run: ${name}"
+                exit 1
+              fi
+            done
+            echo "Published release assets match the immutable build artifact."
           else
-            gh release create "${VERSION}" release/* --generate-notes --verify-tag
+            gh release create "${VERSION}" release/asc_* --generate-notes --verify-tag
           fi
+
+  homebrew:
+    name: Update Homebrew tap
+    needs: [build, publish]
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-${{ needs.build.outputs.version }}
+          path: workflow-artifact
+
+      - name: Unpack and verify release artifact
+        run: |
+          tar -xf "workflow-artifact/release-${VERSION}.tar"
+          cd release
+          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
 
       - name: Update Homebrew tap
         env:
@@ -352,14 +434,13 @@ jobs:
             exit 1
           fi
 
-          export SHA256_AMD64=$(shasum -a 256 release/asc_${VERSION}_macOS_amd64 | cut -d ' ' -f 1)
-          export SHA256=$(shasum -a 256 release/asc_${VERSION}_macOS_arm64 | cut -d ' ' -f 1)
+          SHA256_AMD64=$(shasum -a 256 "release/asc_${VERSION}_macOS_amd64" | cut -d ' ' -f 1)
+          SHA256=$(shasum -a 256 "release/asc_${VERSION}_macOS_arm64" | cut -d ' ' -f 1)
+          export SHA256_AMD64 SHA256
 
-          # Clone the tap repo
-          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/rorkai/homebrew-tap.git homebrew-tap
+          git clone "https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/rorkai/homebrew-tap.git" homebrew-tap
           cd homebrew-tap
 
-          # Update the formula
           python3 - <<'PY'
           import os
           from pathlib import Path
@@ -408,12 +489,41 @@ jobs:
           Path("Formula/asc.rb").write_text(formula, encoding="utf-8")
           PY
 
-          # Commit and push
           git config user.name "Rudrank Riyam"
           git config user.email "rudrankriyam@gmail.com"
           git add Formula/asc.rb
-          git commit -m "Update asc to ${VERSION}" || echo "No changes to commit"
-          git push
+          if git diff --cached --quiet; then
+            echo "Homebrew formula is already current."
+          else
+            git commit -m "Update asc to ${VERSION}"
+            git push
+          fi
+
+  winget:
+    name: Submit WinGet package
+    needs: [build, publish]
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v7
+        with:
+          ref: refs/tags/${{ needs.build.outputs.version }}
+
+      - name: Download immutable release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-${{ needs.build.outputs.version }}
+          path: workflow-artifact
+
+      - name: Unpack and verify release artifact
+        run: |
+          tar -xf "workflow-artifact/release-${VERSION}.tar"
+          cd release
+          shasum -a 256 -c "asc_${VERSION}_checksums.txt"
 
       - name: Generate WinGet manifests
         run: |
@@ -423,10 +533,11 @@ jobs:
             --output-dir release/winget
 
       - name: Upload WinGet manifests artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: winget-manifests-${{ env.VERSION }}
-          path: release/winget/manifests/r/Rorkai/ASC/${{ env.VERSION }}
+          name: winget-manifests-${{ needs.build.outputs.version }}
+          path: release/winget/manifests/r/Rorkai/ASC/${{ needs.build.outputs.version }}
+          if-no-files-found: error
 
       - name: Submit WinGet package PR
         env:
@@ -438,7 +549,7 @@ jobs:
             exit 1
           fi
 
-          AUTH_LOGIN="$(gh api user --jq .login)"
+          AUTH_LOGIN=$(gh api user --jq .login)
           if [ -z "$WINGET_FORK_OWNER" ]; then
             WINGET_FORK_OWNER="${AUTH_LOGIN}"
           fi
@@ -457,22 +568,42 @@ jobs:
           git clone --filter=blob:none --sparse "https://x-access-token:${GH_TOKEN}@github.com/${WINGET_FORK_OWNER}/winget-pkgs.git" winget-pkgs
           cd winget-pkgs
           git remote add upstream https://github.com/microsoft/winget-pkgs.git
-          git fetch upstream master --depth 1
-          git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}" --depth 1 || true
+          git fetch origin master
+          git fetch upstream master
+          if ! git merge-base --is-ancestor origin/master upstream/master; then
+            echo "::error::The WinGet fork master branch is not an ancestor of upstream/master"
+            exit 1
+          fi
+
+          git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}" || true
           BRANCH_EXISTS=0
           if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
             BRANCH_EXISTS=1
+            if ! git merge-base --is-ancestor origin/master "origin/${BRANCH}"; then
+              echo "::error::The existing WinGet release branch does not descend from the fork master branch"
+              exit 1
+            fi
             git checkout -B "${BRANCH}" "origin/${BRANCH}"
           else
-            git checkout -B "${BRANCH}" upstream/master
+            git checkout -b "${BRANCH}" origin/master
           fi
           git sparse-checkout set "manifests/r/Rorkai/ASC"
+
+          verify_winget_scope() {
+            unexpected_paths=$(git diff --name-only upstream/master...HEAD | grep -Ev "^manifests/r/Rorkai/ASC/${VERSION}/" || true)
+            if [ -n "$unexpected_paths" ]; then
+              echo "::error::WinGet branch contains changes outside the ${VERSION} manifest directory"
+              echo "$unexpected_paths"
+              exit 1
+            fi
+          }
+          verify_winget_scope
 
           PR_KIND="New package"
           if [ -d manifests/r/Rorkai/ASC ] && find manifests/r/Rorkai/ASC -mindepth 1 -maxdepth 1 -type d | grep -q .; then
             PR_KIND="New version"
           fi
-          OPEN_PACKAGE_PRS="$(gh pr list --repo microsoft/winget-pkgs --state open --search "Rorkai.ASC in:title" --json headRefName --jq "[.[] | select(.headRefName != \"${BRANCH}\")] | length" || echo "0")"
+          OPEN_PACKAGE_PRS=$(gh pr list --repo microsoft/winget-pkgs --state open --search "Rorkai.ASC in:title" --json headRefName --jq "[.[] | select(.headRefName != \"${BRANCH}\")] | length" || echo "0")
           if [ "${PR_KIND}" = "New package" ] && [ "${OPEN_PACKAGE_PRS}" != "0" ]; then
             PR_KIND="New version"
           fi
@@ -491,7 +622,12 @@ jobs:
             echo "WinGet manifests for ${VERSION} already exist on ${BRANCH}; checking for an open PR."
           else
             git commit -m "${PR_KIND}: Rorkai.ASC version ${VERSION}"
-            git push --force-with-lease origin "${BRANCH}"
+            verify_winget_scope
+            if [ "${BRANCH_EXISTS}" = "1" ]; then
+              git push origin "${BRANCH}"
+            else
+              git push --set-upstream origin "${BRANCH}"
+            fi
           fi
 
           if gh pr list --repo microsoft/winget-pkgs --state open --search "Rorkai.ASC version ${VERSION} in:title" --json number --jq '.[0].number // empty' | grep -q .; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,13 +249,24 @@ jobs:
           fi
 
           mkdir -p workflow-artifact
+          default_branch=$(gh api "repos/${GH_REPO}" --jq '.default_branch')
           while IFS=$'\t' read -r artifact_id artifact_run_id; do
             [ -n "$artifact_id" ] || continue
-            IFS=$'\t' read -r run_path run_head_sha < <(gh api "repos/${GH_REPO}/actions/runs/${artifact_run_id}" \
-              --jq '[.path, .head_sha] | @tsv' 2>/dev/null || true)
-            if [ "$run_path" != ".github/workflows/release.yml" ] || [ "$run_head_sha" != "$release_commit" ]; then
+            run_path=""
+            run_head_sha=""
+            run_event=""
+            run_repository=""
+            run_head_branch=""
+            IFS=$'\t' read -r run_path run_head_sha run_event run_repository run_head_branch < <(gh api "repos/${GH_REPO}/actions/runs/${artifact_run_id}" \
+              --jq '[.path, .head_sha, .event, .head_repository.full_name, .head_branch] | @tsv' 2>/dev/null || true)
+            if [ "$run_path" != ".github/workflows/release.yml" ] || [ "$run_repository" != "$GH_REPO" ]; then
               continue
             fi
+            case "$run_event" in
+              push) [ "$run_head_sha" = "$release_commit" ] || continue ;;
+              workflow_dispatch) [ "$run_head_branch" = "$default_branch" ] || continue ;;
+              *) continue ;;
+            esac
             artifact_dir="${RUNNER_TEMP}/candidate-artifact-${artifact_id}"
             archive_zip="${artifact_dir}/artifact.zip"
             archive_dir="${artifact_dir}/download"
@@ -655,6 +666,7 @@ jobs:
       - name: Pack immutable published artifact
         if: steps.published_artifact.outputs.reused != 'true'
         run: |
+          mkdir -p workflow-artifact
           rm -rf release
           mv published-release release
           tar -cf "workflow-artifact/published-release-${VERSION}.tar" release

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -46,21 +46,21 @@ func TestReleaseWorkflowExportsHomebrewChecksumsBeforeFormulaGeneration(t *testi
 	}
 }
 
-func TestReleaseWorkflowPreservesRubyBinInterpolationInFormulaTest(t *testing.T) {
+func TestReleaseWorkflowTestsHomebrewFormulaUsingVersionStdout(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
 
 	workflow := string(data)
-	want := `shell_output("#{{bin}}/asc --help")`
+	want := `assert_match version.to_s, shell_output("#{{bin}}/asc --version")`
 	if !strings.Contains(workflow, want) {
-		t.Fatalf("release workflow missing escaped Ruby interpolation %q", want)
+		t.Fatalf("release workflow missing stdout-based Homebrew formula test %q", want)
 	}
 
-	unwanted := `shell_output("#{bin}/asc --help")`
+	unwanted := `shell_output("#{{bin}}/asc --help")`
 	if strings.Contains(workflow, unwanted) {
-		t.Fatalf("release workflow still contains unescaped Ruby interpolation %q", unwanted)
+		t.Fatalf("release workflow still tests help output from stderr with %q", unwanted)
 	}
 }
 

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -212,7 +216,7 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 	}
 
 	start := strings.Index(workflow, "\n  repair-notarization:\n")
-	end := strings.Index(workflow, "\n  build:\n")
+	end := strings.Index(workflow, "\n  prepare:\n")
 	if start == -1 || end == -1 || start >= end {
 		t.Fatal("release workflow must define repair-notarization before release")
 	}
@@ -221,7 +225,7 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 	for _, want := range []string{
 		`persist-credentials: false`,
 		`gh release download "${VERSION}"`,
-		`shasum -a 256 -c`,
+		`python3 workflow-source/scripts/verify_release_assets.py --release-dir existing-release --version "${VERSION}"`,
 		`codesign --verify --deep --strict --verbose=2`,
 		`is signed by an unexpected Developer ID`,
 		`ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}`,
@@ -285,6 +289,7 @@ func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
 
 	workflow := string(data)
 	for _, want := range []string{
+		"\n  prepare:\n",
 		"\n  build:\n",
 		"\n  publish:\n",
 		"\n  homebrew:\n",
@@ -292,7 +297,7 @@ func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
 		"outputs:\n      version: ${{ steps.version.outputs.version }}",
 		"actions/upload-artifact@",
 		"actions/download-artifact@",
-		"name: candidate-release-${{ needs.build.outputs.version }}",
+		"name: candidate-release-${{ needs.prepare.outputs.version }}",
 		"name: published-release-${{ needs.publish.outputs.version }}",
 		`tar -cf "workflow-artifact/candidate-release-${VERSION}.tar" release`,
 		`tar -cf "workflow-artifact/published-release-${VERSION}.tar" release`,
@@ -302,8 +307,8 @@ func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
 		}
 	}
 
-	if got := strings.Count(workflow, "name: candidate-release-${{ steps.version.outputs.version }}"); got != 2 {
-		t.Fatalf("release workflow must define mutually exclusive fresh and recovered artifact uploads, got %d", got)
+	if got := strings.Count(workflow, "name: candidate-release-${{ needs.prepare.outputs.version }}"); got != 3 {
+		t.Fatalf("release workflow must define two mutually exclusive uploads and one download for the candidate artifact, got %d references", got)
 	}
 	if got := strings.Count(workflow, "actions/download-artifact@"); got != 3 {
 		t.Fatalf("publishers must consume the candidate and published artifacts in three downloads, got %d", got)
@@ -342,6 +347,85 @@ func TestReleaseWorkflowReusesArtifactsAcrossRerunAttempts(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowRepairsPackageManagersWithoutRebuildingPublishedRelease(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	for _, want := range []string{
+		"\n  prepare:\n",
+		`published: ${{ steps.release.outputs.published }}`,
+		`gh api "repos/${GH_REPO}/releases/tags/${VERSION}" --jq '.draft'`,
+		`elif ! grep -Fq "HTTP 404" "$release_error"`,
+		`needs: prepare`,
+		`needs.prepare.outputs.published != 'true'`,
+		"needs:\n      - prepare\n      - build",
+		`needs.prepare.outputs.published == 'true' || needs.build.result == 'success'`,
+		`if: steps.published_artifact.outputs.reused != 'true' && needs.prepare.outputs.published == 'true'`,
+		`gh release download "${VERSION}" --dir published-release`,
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("release workflow missing published-release repair contract %q", want)
+		}
+	}
+}
+
+func TestVerifyReleaseAssetsRequiresExactChecksumCoverage(t *testing.T) {
+	workflowData, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+	if got := strings.Count(string(workflowData), "verify_release_assets.py"); got != 6 {
+		t.Fatalf("every release consumer must run exact checksum coverage verification, got %d verifier calls", got)
+	}
+
+	const version = "1.2.3"
+	const assetName = "asc_1.2.3_macOS_arm64"
+	asset := []byte("signed binary bytes")
+	assetSum := sha256.Sum256(asset)
+	validLine := fmt.Sprintf("%x  %s\n", assetSum, assetName)
+
+	tests := []struct {
+		name          string
+		manifest      string
+		extraAsset    bool
+		wantSucceeded bool
+	}{
+		{name: "complete", manifest: validLine, wantSucceeded: true},
+		{name: "omitted asset", manifest: validLine, extraAsset: true},
+		{name: "wrong digest", manifest: strings.Repeat("0", 64) + "  " + assetName + "\n"},
+		{name: "path traversal", manifest: fmt.Sprintf("%x  ../%s\n", assetSum, assetName)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			releaseDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(releaseDir, assetName), asset, 0o600); err != nil {
+				t.Fatalf("write asset: %v", err)
+			}
+			if tt.extraAsset {
+				if err := os.WriteFile(filepath.Join(releaseDir, "asc_1.2.3_linux_arm64"), []byte("extra"), 0o600); err != nil {
+					t.Fatalf("write extra asset: %v", err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(releaseDir, "asc_1.2.3_checksums.txt"), []byte(tt.manifest), 0o600); err != nil {
+				t.Fatalf("write checksum manifest: %v", err)
+			}
+
+			cmd := exec.Command("python3", "scripts/verify_release_assets.py", "--release-dir", releaseDir, "--version", version)
+			err := cmd.Run()
+			if tt.wantSucceeded && err != nil {
+				t.Fatalf("verify release assets: %v", err)
+			}
+			if !tt.wantSucceeded && err == nil {
+				t.Fatal("verification unexpectedly accepted incomplete or unsafe checksum coverage")
+			}
+		})
+	}
+}
+
 func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
@@ -360,7 +444,7 @@ func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T
 		`cmp -s "$asset" "published-release/$name"`,
 		`gh release edit "${VERSION}" --draft=false`,
 		`gh release download "${VERSION}"`,
-		`shasum -a 256 -c "asc_${VERSION}_checksums.txt"`,
+		`python3 workflow-source/scripts/verify_release_assets.py --release-dir published-release --version "${VERSION}"`,
 		`published-release-${VERSION}.tar`,
 	} {
 		if !strings.Contains(workflow, want) {
@@ -375,7 +459,7 @@ func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T
 	}
 	publishStep := workflow[stepStart:stepEnd]
 	draftStart := strings.Index(publishStep, `if [ "$release_is_draft" = "true" ]`)
-	checksumIndex := strings.Index(publishStep[draftStart:], `shasum -a 256 -c "asc_${VERSION}_checksums.txt"`)
+	checksumIndex := strings.Index(publishStep[draftStart:], `python3 workflow-source/scripts/verify_release_assets.py --release-dir published-release --version "${VERSION}"`)
 	publishIndex := strings.Index(publishStep[draftStart:], `gh release edit "${VERSION}" --draft=false`)
 	if draftStart == -1 || checksumIndex == -1 || publishIndex == -1 {
 		t.Fatal("release workflow must checksum-verify and publish a completed draft")

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -315,6 +315,24 @@ func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowUsesValidSecureReleaseSteps(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	if strings.Contains(workflow, "- parallel:") {
+		t.Fatal("release workflow must use valid run or uses steps")
+	}
+	if !strings.Contains(workflow, "go-version-file: go.mod\n          cache: false") {
+		t.Fatal("release build must not restore a shared Go build cache")
+	}
+	if !strings.Contains(workflow, `gh release download "${VERSION}" --repo "${GH_REPO}" --dir published-release`) {
+		t.Fatal("published-release recovery must select the repository explicitly")
+	}
+}
+
 func TestReleaseWorkflowReusesArtifactsAcrossRerunAttempts(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
@@ -398,6 +416,9 @@ func TestVerifyReleaseAssetsRequiresExactChecksumCoverage(t *testing.T) {
 	if got := strings.Count(string(workflowData), "verify_release_assets.py"); got != 6 {
 		t.Fatalf("every release consumer must run exact checksum coverage verification, got %d verifier calls", got)
 	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Fatalf("python3 is required for release asset verification tests: %v", err)
+	}
 
 	const version = "1.2.3"
 	canonicalNames := []string{
@@ -461,12 +482,12 @@ func TestVerifyReleaseAssetsRequiresExactChecksumCoverage(t *testing.T) {
 			}
 
 			cmd := exec.Command("python3", "scripts/verify_release_assets.py", "--release-dir", releaseDir, "--version", version)
-			err := cmd.Run()
+			output, err := cmd.CombinedOutput()
 			if tt.wantSucceeded && err != nil {
-				t.Fatalf("verify release assets: %v", err)
+				t.Fatalf("verify release assets: %v\n%s", err, output)
 			}
 			if !tt.wantSucceeded && err == nil {
-				t.Fatal("verification unexpectedly accepted incomplete or unsafe checksum coverage")
+				t.Fatalf("verification unexpectedly accepted incomplete or unsafe checksum coverage\n%s", output)
 			}
 		})
 	}
@@ -505,9 +526,12 @@ func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T
 	}
 	publishStep := workflow[stepStart:stepEnd]
 	draftStart := strings.Index(publishStep, `if [ "$release_is_draft" = "true" ]`)
+	if draftStart == -1 {
+		t.Fatal("release workflow must checksum-verify and publish a completed draft")
+	}
 	checksumIndex := strings.Index(publishStep[draftStart:], `python3 workflow-source/scripts/verify_release_assets.py --release-dir published-release --version "${VERSION}"`)
 	publishIndex := strings.Index(publishStep[draftStart:], `gh release edit "${VERSION}" --draft=false`)
-	if draftStart == -1 || checksumIndex == -1 || publishIndex == -1 {
+	if checksumIndex == -1 || publishIndex == -1 {
 		t.Fatal("release workflow must checksum-verify and publish a completed draft")
 	}
 	if checksumIndex >= publishIndex {

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -400,35 +400,63 @@ func TestVerifyReleaseAssetsRequiresExactChecksumCoverage(t *testing.T) {
 	}
 
 	const version = "1.2.3"
-	const assetName = "asc_1.2.3_macOS_arm64"
-	asset := []byte("signed binary bytes")
-	assetSum := sha256.Sum256(asset)
-	validLine := fmt.Sprintf("%x  %s\n", assetSum, assetName)
+	canonicalNames := []string{
+		"asc_1.2.3_macOS_amd64",
+		"asc_1.2.3_macOS_arm64",
+		"asc_1.2.3_linux_amd64",
+		"asc_1.2.3_linux_arm64",
+		"asc_1.2.3_windows_amd64.exe",
+	}
 
 	tests := []struct {
-		name          string
-		manifest      string
-		extraAsset    bool
-		wantSucceeded bool
+		name             string
+		omitCanonical    string
+		addUnlistedAsset bool
+		emptyAsset       string
+		wrongDigest      bool
+		pathTraversal    bool
+		wantSucceeded    bool
 	}{
-		{name: "complete", manifest: validLine, wantSucceeded: true},
-		{name: "omitted asset", manifest: validLine, extraAsset: true},
-		{name: "wrong digest", manifest: strings.Repeat("0", 64) + "  " + assetName + "\n"},
-		{name: "path traversal", manifest: fmt.Sprintf("%x  ../%s\n", assetSum, assetName)},
+		{name: "complete", wantSucceeded: true},
+		{name: "missing canonical asset", omitCanonical: "asc_1.2.3_windows_amd64.exe"},
+		{name: "unlisted asset", addUnlistedAsset: true},
+		{name: "empty canonical asset", emptyAsset: "asc_1.2.3_macOS_arm64"},
+		{name: "wrong digest", wrongDigest: true},
+		{name: "path traversal", pathTraversal: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			releaseDir := t.TempDir()
-			if err := os.WriteFile(filepath.Join(releaseDir, assetName), asset, 0o600); err != nil {
-				t.Fatalf("write asset: %v", err)
+			var manifest strings.Builder
+			for index, name := range canonicalNames {
+				if name == tt.omitCanonical {
+					continue
+				}
+				asset := []byte("signed binary bytes for " + name)
+				if name == tt.emptyAsset {
+					asset = nil
+				}
+				if err := os.WriteFile(filepath.Join(releaseDir, name), asset, 0o600); err != nil {
+					t.Fatalf("write asset: %v", err)
+				}
+				digest := sha256.Sum256(asset)
+				digestText := fmt.Sprintf("%x", digest)
+				manifestName := name
+				if tt.wrongDigest && index == 0 {
+					digestText = strings.Repeat("0", 64)
+				}
+				if tt.pathTraversal && index == 0 {
+					manifestName = "../" + name
+				}
+				fmt.Fprintf(&manifest, "%s  %s\n", digestText, manifestName)
 			}
-			if tt.extraAsset {
-				if err := os.WriteFile(filepath.Join(releaseDir, "asc_1.2.3_linux_arm64"), []byte("extra"), 0o600); err != nil {
+			if tt.addUnlistedAsset {
+				if err := os.WriteFile(filepath.Join(releaseDir, "asc_1.2.3_extra"), []byte("extra"), 0o600); err != nil {
 					t.Fatalf("write extra asset: %v", err)
 				}
 			}
-			if err := os.WriteFile(filepath.Join(releaseDir, "asc_1.2.3_checksums.txt"), []byte(tt.manifest), 0o600); err != nil {
+			if err := os.WriteFile(filepath.Join(releaseDir, "asc_1.2.3_checksums.txt"), []byte(manifest.String()), 0o600); err != nil {
 				t.Fatalf("write checksum manifest: %v", err)
 			}
 

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -191,7 +191,7 @@ func TestReleaseWorkflowNotarizesMacOSBinariesBeforePublishing(t *testing.T) {
 
 	notarizeIndex := strings.Index(workflow, "- name: Notarize macOS binaries")
 	checksumIndex := strings.Index(workflow, "- name: Create checksums")
-	publishIndex := strings.Index(workflow, "- name: Create or verify GitHub Release")
+	publishIndex := strings.Index(workflow, "- name: Create, resume, or verify GitHub Release")
 	if notarizeIndex == -1 || checksumIndex == -1 || publishIndex == -1 {
 		t.Fatalf("release workflow must contain notarization, checksum, and publish steps")
 	}
@@ -292,43 +292,84 @@ func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
 		"outputs:\n      version: ${{ steps.version.outputs.version }}",
 		"actions/upload-artifact@",
 		"actions/download-artifact@",
-		"name: release-${{ needs.build.outputs.version }}",
-		`tar -cf "workflow-artifact/release-${VERSION}.tar" release`,
-		`tar -xf "workflow-artifact/release-${VERSION}.tar"`,
+		"name: candidate-release-${{ needs.build.outputs.version }}",
+		"name: published-release-${{ needs.publish.outputs.version }}",
+		`tar -cf "workflow-artifact/candidate-release-${VERSION}.tar" release`,
+		`tar -cf "workflow-artifact/published-release-${VERSION}.tar" release`,
 	} {
 		if !strings.Contains(workflow, want) {
 			t.Errorf("release workflow missing split-job contract %q", want)
 		}
 	}
 
-	if got := strings.Count(workflow, "name: release-${{ steps.version.outputs.version }}"); got != 1 {
+	if got := strings.Count(workflow, "name: candidate-release-${{ steps.version.outputs.version }}"); got != 1 {
 		t.Fatalf("release workflow must upload exactly one immutable release artifact, got %d", got)
 	}
 	if got := strings.Count(workflow, "actions/download-artifact@"); got != 3 {
-		t.Fatalf("each publisher must download the same build artifact, got %d downloads", got)
+		t.Fatalf("publishers must consume the candidate and published artifacts in three downloads, got %d", got)
 	}
 }
 
-func TestReleaseWorkflowNeverClobbersPublishedAssets(t *testing.T) {
+func TestReleaseWorkflowReusesArtifactsAcrossRerunAttempts(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
 
 	workflow := string(data)
-	for _, unwanted := range []string{"gh release upload", "--clobber"} {
-		if strings.Contains(workflow, unwanted) {
-			t.Errorf("release workflow must not replace published assets; found %q", unwanted)
-		}
-	}
 	for _, want := range []string{
-		`gh release download "${VERSION}"`,
-		`cmp -s "$asset" "$published/$name"`,
-		`Published release assets differ from this run`,
+		`actions/runs/${GITHUB_RUN_ID}/artifacts`,
+		`artifact_name="candidate-release-${VERSION}"`,
+		`artifact_name="published-release-${VERSION}"`,
+		`if: steps.candidate_artifact.outputs.reused != 'true'`,
+		`if: steps.published_artifact.outputs.reused != 'true'`,
 	} {
 		if !strings.Contains(workflow, want) {
-			t.Errorf("release workflow missing published-asset verification %q", want)
+			t.Errorf("release workflow missing rerun artifact contract %q", want)
 		}
+	}
+}
+
+func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	if strings.Contains(workflow, "--clobber") {
+		t.Fatal("release workflow must not replace a published asset")
+	}
+	for _, want := range []string{
+		`--json isDraft`,
+		`gh release create "${VERSION}" --draft --generate-notes --verify-tag`,
+		`if [ "$release_is_draft" = "true" ]`,
+		`gh release upload "${VERSION}" "$asset"`,
+		`cmp -s "$asset" "published-release/$name"`,
+		`gh release edit "${VERSION}" --draft=false`,
+		`gh release download "${VERSION}"`,
+		`shasum -a 256 -c "asc_${VERSION}_checksums.txt"`,
+		`published-release-${VERSION}.tar`,
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("release workflow missing retry-safe publication contract %q", want)
+		}
+	}
+}
+
+func TestReleaseWorkflowSerializesTagAndDispatchForSameVersion(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	want := "group: release-cli-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}"
+	if !strings.Contains(workflow, want) {
+		t.Fatalf("release workflow missing normalized concurrency group %q", want)
+	}
+	if strings.Contains(workflow, "inputs.version || github.ref }}") {
+		t.Fatal("release workflow splits tag and dispatch concurrency groups")
 	}
 }
 

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -395,7 +395,12 @@ func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
 	}
 
 	workflow := string(data)
-	for _, unwanted := range []string{"--force-with-lease", "git push --force"} {
+	for _, unwanted := range []string{
+		"--force-with-lease",
+		"git push --force",
+		`git merge-base --is-ancestor origin/master "origin/${BRANCH}"`,
+		`grep -Ev "^manifests/r/Rorkai/ASC/${VERSION}/"`,
+	} {
 		if strings.Contains(workflow, unwanted) {
 			t.Errorf("WinGet publication must not rewrite branch history; found %q", unwanted)
 		}
@@ -404,6 +409,9 @@ func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
 		`git merge-base --is-ancestor origin/master upstream/master`,
 		`git checkout -b "${BRANCH}" origin/master`,
 		`git push --set-upstream origin "${BRANCH}"`,
+		`git diff --name-only -z upstream/master...HEAD`,
+		`case "$changed_path" in`,
+		`"manifests/r/Rorkai/ASC/${VERSION}/"*)`,
 		`WinGet branch contains changes outside the ${VERSION} manifest directory`,
 	} {
 		if !strings.Contains(workflow, want) {

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -355,6 +355,57 @@ func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T
 			t.Errorf("release workflow missing retry-safe publication contract %q", want)
 		}
 	}
+
+	stepStart := strings.Index(workflow, "- name: Create, resume, or verify GitHub Release")
+	stepEnd := strings.Index(workflow, "- name: Pack immutable published artifact")
+	if stepStart == -1 || stepEnd == -1 || stepStart >= stepEnd {
+		t.Fatal("release workflow missing publication step boundaries")
+	}
+	publishStep := workflow[stepStart:stepEnd]
+	draftStart := strings.Index(publishStep, `if [ "$release_is_draft" = "true" ]`)
+	checksumIndex := strings.Index(publishStep[draftStart:], `shasum -a 256 -c "asc_${VERSION}_checksums.txt"`)
+	publishIndex := strings.Index(publishStep[draftStart:], `gh release edit "${VERSION}" --draft=false`)
+	if draftStart == -1 || checksumIndex == -1 || publishIndex == -1 {
+		t.Fatal("release workflow must checksum-verify and publish a completed draft")
+	}
+	if checksumIndex >= publishIndex {
+		t.Fatal("release workflow must verify draft checksums before making the release public")
+	}
+}
+
+func TestReleaseWorkflowGrantsArtifactReadPermissionToArtifactJobs(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	jobs := []struct {
+		name string
+		next string
+	}{
+		{name: "build", next: "publish"},
+		{name: "publish", next: "homebrew"},
+		{name: "homebrew", next: "winget"},
+		{name: "winget", next: ""},
+	}
+	for _, job := range jobs {
+		start := strings.Index(workflow, "\n  "+job.name+":\n")
+		if start == -1 {
+			t.Fatalf("release workflow missing %s job", job.name)
+		}
+		end := len(workflow)
+		if job.next != "" {
+			next := strings.Index(workflow[start+1:], "\n  "+job.next+":\n")
+			if next == -1 {
+				t.Fatalf("release workflow missing %s job boundary", job.next)
+			}
+			end = start + 1 + next
+		}
+		if !strings.Contains(workflow[start:end], "permissions:\n      actions: read") {
+			t.Errorf("%s job must have actions read permission for artifact access", job.name)
+		}
+	}
 }
 
 func TestReleaseWorkflowSerializesTagAndDispatchForSameVersion(t *testing.T) {

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -13,18 +13,24 @@ func TestReleaseWorkflowExportsHomebrewChecksumsBeforeFormulaGeneration(t *testi
 	}
 
 	workflow := string(data)
-	exportAMD64 := "export SHA256_AMD64="
-	exportArm64 := "export SHA256="
+	assignAMD64 := "SHA256_AMD64=$(shasum"
+	assignArm64 := "SHA256=$(shasum"
+	exportChecksums := "export SHA256_AMD64 SHA256"
 	pythonStep := "python3 - <<'PY'"
 
-	exportAMD64Index := strings.Index(workflow, exportAMD64)
-	if exportAMD64Index == -1 {
-		t.Fatalf("release workflow missing %q", exportAMD64)
+	assignAMD64Index := strings.Index(workflow, assignAMD64)
+	if assignAMD64Index == -1 {
+		t.Fatalf("release workflow missing %q", assignAMD64)
 	}
 
-	exportArm64Index := strings.Index(workflow, exportArm64)
-	if exportArm64Index == -1 {
-		t.Fatalf("release workflow missing %q", exportArm64)
+	assignArm64Index := strings.Index(workflow, assignArm64)
+	if assignArm64Index == -1 {
+		t.Fatalf("release workflow missing %q", assignArm64)
+	}
+
+	exportIndex := strings.Index(workflow, exportChecksums)
+	if exportIndex == -1 {
+		t.Fatalf("release workflow missing %q", exportChecksums)
 	}
 
 	pythonIndex := strings.Index(workflow, pythonStep)
@@ -32,11 +38,11 @@ func TestReleaseWorkflowExportsHomebrewChecksumsBeforeFormulaGeneration(t *testi
 		t.Fatalf("release workflow missing %q", pythonStep)
 	}
 
-	if exportAMD64Index > pythonIndex {
-		t.Fatalf("%q must appear before %q", exportAMD64, pythonStep)
+	if assignAMD64Index > exportIndex || exportIndex > pythonIndex {
+		t.Fatalf("%q must be assigned and exported before %q", assignAMD64, pythonStep)
 	}
-	if exportArm64Index > pythonIndex {
-		t.Fatalf("%q must appear before %q", exportArm64, pythonStep)
+	if assignArm64Index > exportIndex || exportIndex > pythonIndex {
+		t.Fatalf("%q must be assigned and exported before %q", assignArm64, pythonStep)
 	}
 }
 
@@ -173,7 +179,7 @@ func TestReleaseWorkflowNotarizesMacOSBinariesBeforePublishing(t *testing.T) {
 
 	notarizeIndex := strings.Index(workflow, "- name: Notarize macOS binaries")
 	checksumIndex := strings.Index(workflow, "- name: Create checksums")
-	publishIndex := strings.Index(workflow, "- name: Create or update GitHub Release")
+	publishIndex := strings.Index(workflow, "- name: Create or verify GitHub Release")
 	if notarizeIndex == -1 || checksumIndex == -1 || publishIndex == -1 {
 		t.Fatalf("release workflow must contain notarization, checksum, and publish steps")
 	}
@@ -194,7 +200,7 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 	}
 
 	start := strings.Index(workflow, "\n  repair-notarization:\n")
-	end := strings.Index(workflow, "\n  release:\n")
+	end := strings.Index(workflow, "\n  build:\n")
 	if start == -1 || end == -1 || start >= end {
 		t.Fatal("release workflow must define repair-notarization before release")
 	}
@@ -221,6 +227,100 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 	} {
 		if strings.Contains(repairJob, unwanted) {
 			t.Errorf("repair-notarization job must not replace release assets; found %q", unwanted)
+		}
+	}
+}
+
+func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	for _, want := range []string{
+		"\n  build:\n",
+		"\n  publish:\n",
+		"\n  homebrew:\n",
+		"\n  winget:\n",
+		"outputs:\n      version: ${{ steps.version.outputs.version }}",
+		"actions/upload-artifact@",
+		"actions/download-artifact@",
+		"name: release-${{ needs.build.outputs.version }}",
+		`tar -cf "workflow-artifact/release-${VERSION}.tar" release`,
+		`tar -xf "workflow-artifact/release-${VERSION}.tar"`,
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("release workflow missing split-job contract %q", want)
+		}
+	}
+
+	if got := strings.Count(workflow, "name: release-${{ steps.version.outputs.version }}"); got != 1 {
+		t.Fatalf("release workflow must upload exactly one immutable release artifact, got %d", got)
+	}
+	if got := strings.Count(workflow, "actions/download-artifact@"); got != 3 {
+		t.Fatalf("each publisher must download the same build artifact, got %d downloads", got)
+	}
+}
+
+func TestReleaseWorkflowNeverClobbersPublishedAssets(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	for _, unwanted := range []string{"gh release upload", "--clobber"} {
+		if strings.Contains(workflow, unwanted) {
+			t.Errorf("release workflow must not replace published assets; found %q", unwanted)
+		}
+	}
+	for _, want := range []string{
+		`gh release download "${VERSION}"`,
+		`cmp -s "$asset" "$published/$name"`,
+		`Published release assets differ from this run`,
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("release workflow missing published-asset verification %q", want)
+		}
+	}
+}
+
+func TestReleaseWorkflowUsesCommitTimestampForBuildMetadata(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	if !strings.Contains(workflow, `DATE=$(git show -s --format=%cI HEAD)`) {
+		t.Fatal("release workflow must derive build metadata from the release commit")
+	}
+	if strings.Contains(workflow, `DATE=$(date -u`) {
+		t.Fatal("release workflow must not embed the wall-clock build time")
+	}
+}
+
+func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	workflow := string(data)
+	for _, unwanted := range []string{"--force-with-lease", "git push --force"} {
+		if strings.Contains(workflow, unwanted) {
+			t.Errorf("WinGet publication must not rewrite branch history; found %q", unwanted)
+		}
+	}
+	for _, want := range []string{
+		`git merge-base --is-ancestor origin/master upstream/master`,
+		`git checkout -b "${BRANCH}" origin/master`,
+		`git push --set-upstream origin "${BRANCH}"`,
+		`WinGet branch contains changes outside the ${VERSION} manifest directory`,
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("release workflow missing fast-forward-only WinGet contract %q", want)
 		}
 	}
 }

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -330,8 +330,17 @@ func TestReleaseWorkflowReusesArtifactsAcrossRerunAttempts(t *testing.T) {
 		`artifact_name="candidate-release-${VERSION}"`,
 		`artifact_name="published-release-${VERSION}"`,
 		`candidate-release-${VERSION}.commit`,
+		`run_path=""`,
+		`run_head_sha=""`,
+		`run_event=""`,
+		`run_repository=""`,
+		`run_head_branch=""`,
 		`run_path" != ".github/workflows/release.yml`,
-		`run_head_sha" != "$release_commit`,
+		`run_repository" != "$GH_REPO`,
+		`default_branch=$(gh api "repos/${GH_REPO}" --jq '.default_branch')`,
+		`case "$run_event" in`,
+		`push) [ "$run_head_sha" = "$release_commit" ] || continue ;;`,
+		`workflow_dispatch) [ "$run_head_branch" = "$default_branch" ] || continue ;;`,
 		`test "$(cat "$provenance")" = "$release_commit"`,
 		`gh release download "${VERSION}" --dir "$draft_dir"`,
 		`cmp -s "$draft_asset" "$candidate_dir/release/$name"`,
@@ -369,6 +378,15 @@ func TestReleaseWorkflowRepairsPackageManagersWithoutRebuildingPublishedRelease(
 		if !strings.Contains(workflow, want) {
 			t.Errorf("release workflow missing published-release repair contract %q", want)
 		}
+	}
+
+	packStart := strings.Index(workflow, "- name: Pack immutable published artifact")
+	packEnd := strings.Index(workflow, "- name: Upload immutable published artifact")
+	if packStart == -1 || packEnd == -1 || packStart >= packEnd {
+		t.Fatal("release workflow missing published artifact packing step")
+	}
+	if !strings.Contains(workflow[packStart:packEnd], "mkdir -p workflow-artifact") {
+		t.Fatal("published-release repair must create the artifact directory before packing")
 	}
 }
 

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -302,8 +302,8 @@ func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
 		}
 	}
 
-	if got := strings.Count(workflow, "name: candidate-release-${{ steps.version.outputs.version }}"); got != 1 {
-		t.Fatalf("release workflow must upload exactly one immutable release artifact, got %d", got)
+	if got := strings.Count(workflow, "name: candidate-release-${{ steps.version.outputs.version }}"); got != 2 {
+		t.Fatalf("release workflow must define mutually exclusive fresh and recovered artifact uploads, got %d", got)
 	}
 	if got := strings.Count(workflow, "actions/download-artifact@"); got != 3 {
 		t.Fatalf("publishers must consume the candidate and published artifacts in three downloads, got %d", got)
@@ -319,8 +319,20 @@ func TestReleaseWorkflowReusesArtifactsAcrossRerunAttempts(t *testing.T) {
 	workflow := string(data)
 	for _, want := range []string{
 		`actions/runs/${GITHUB_RUN_ID}/artifacts`,
+		`repos/${GH_REPO}/actions/artifacts`,
+		`repos/${GH_REPO}/actions/artifacts/${artifact_id}/zip`,
+		`repos/${GH_REPO}/actions/runs/${artifact_run_id}`,
 		`artifact_name="candidate-release-${VERSION}"`,
 		`artifact_name="published-release-${VERSION}"`,
+		`candidate-release-${VERSION}.commit`,
+		`run_path" != ".github/workflows/release.yml`,
+		`run_head_sha" != "$release_commit`,
+		`test "$(cat "$provenance")" = "$release_commit"`,
+		`gh release download "${VERSION}" --dir "$draft_dir"`,
+		`cmp -s "$draft_asset" "$candidate_dir/release/$name"`,
+		`No retained candidate artifact matches the existing draft assets`,
+		`cross_run=true`,
+		`if: steps.candidate_artifact.outputs.cross_run == 'true'`,
 		`if: steps.candidate_artifact.outputs.reused != 'true'`,
 		`if: steps.published_artifact.outputs.reused != 'true'`,
 	} {
@@ -450,6 +462,7 @@ func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
 		"--force-with-lease",
 		"git push --force",
 		`git merge-base --is-ancestor origin/master "origin/${BRANCH}"`,
+		`git checkout -b "${BRANCH}" origin/master`,
 		`grep -Ev "^manifests/r/Rorkai/ASC/${VERSION}/"`,
 	} {
 		if strings.Contains(workflow, unwanted) {
@@ -458,7 +471,7 @@ func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
 	}
 	for _, want := range []string{
 		`git merge-base --is-ancestor origin/master upstream/master`,
-		`git checkout -b "${BRANCH}" origin/master`,
+		`git checkout -b "${BRANCH}" upstream/master`,
 		`git push --set-upstream origin "${BRANCH}"`,
 		`git diff --name-only -z upstream/master...HEAD`,
 		`case "$changed_path" in`,

--- a/scripts/verify_release_assets.py
+++ b/scripts/verify_release_assets.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Verify that an ASC release checksum manifest covers every asset exactly once."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+
+CHECKSUM_LINE = re.compile(r"^([0-9a-fA-F]{64}) ([ *])(.+)$")
+
+
+def fail(message: str) -> None:
+    print(f"release asset verification failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-dir", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    release_dir = args.release_dir
+    checksum_name = f"asc_{args.version}_checksums.txt"
+    checksum_path = release_dir / checksum_name
+
+    if not release_dir.is_dir():
+        fail(f"release directory does not exist: {release_dir}")
+    if not checksum_path.is_file() or checksum_path.is_symlink():
+        fail(f"missing regular checksum manifest: {checksum_name}")
+
+    actual_names: list[str] = []
+    for entry in release_dir.iterdir():
+        if entry.name == checksum_name:
+            continue
+        if not entry.is_file() or entry.is_symlink():
+            fail(f"unexpected non-file release entry: {entry.name}")
+        actual_names.append(entry.name)
+
+    expected_hashes: dict[str, str] = {}
+    for line_number, line in enumerate(
+        checksum_path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        match = CHECKSUM_LINE.fullmatch(line)
+        if match is None:
+            fail(f"malformed checksum line {line_number}")
+        digest, _, name = match.groups()
+        if (
+            Path(name).name != name
+            or "/" in name
+            or "\\" in name
+            or name in {".", "..", checksum_name}
+        ):
+            fail(f"unsafe checksum filename on line {line_number}: {name}")
+        if name in expected_hashes:
+            fail(f"duplicate checksum entry: {name}")
+        expected_hashes[name] = digest.lower()
+
+    actual_set = set(actual_names)
+    expected_set = set(expected_hashes)
+    if actual_set != expected_set:
+        missing = sorted(actual_set - expected_set)
+        unexpected = sorted(expected_set - actual_set)
+        fail(
+            "checksum coverage mismatch; "
+            f"missing entries={missing}, unknown entries={unexpected}"
+        )
+
+    for name in sorted(actual_names):
+        digest = hashlib.sha256()
+        with (release_dir / name).open("rb") as asset:
+            for chunk in iter(lambda: asset.read(1024 * 1024), b""):
+                digest.update(chunk)
+        if digest.hexdigest() != expected_hashes[name]:
+            fail(f"checksum mismatch: {name}")
+
+    print(f"Verified {len(actual_names)} release asset checksum(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_release_assets.py
+++ b/scripts/verify_release_assets.py
@@ -8,6 +8,7 @@ import hashlib
 import re
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 from release_rehearsal import expected_artifact_names
 
@@ -15,7 +16,7 @@ from release_rehearsal import expected_artifact_names
 CHECKSUM_LINE = re.compile(r"^([0-9a-fA-F]{64}) ([ *])(.+)$")
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     print(f"release asset verification failed: {message}", file=sys.stderr)
     raise SystemExit(1)
 
@@ -79,8 +80,8 @@ def main() -> None:
 
     expected_set = set(expected_hashes)
     if actual_set != expected_set:
-        missing = sorted(actual_set - expected_set)
-        unexpected = sorted(expected_set - actual_set)
+        unexpected = sorted(actual_set - expected_set)
+        missing = sorted(expected_set - actual_set)
         fail(
             "checksum coverage mismatch; "
             f"missing entries={missing}, unknown entries={unexpected}"

--- a/scripts/verify_release_assets.py
+++ b/scripts/verify_release_assets.py
@@ -9,6 +9,8 @@ import re
 import sys
 from pathlib import Path
 
+from release_rehearsal import expected_artifact_names
+
 
 CHECKSUM_LINE = re.compile(r"^([0-9a-fA-F]{64}) ([ *])(.+)$")
 
@@ -42,7 +44,19 @@ def main() -> None:
             continue
         if not entry.is_file() or entry.is_symlink():
             fail(f"unexpected non-file release entry: {entry.name}")
+        if entry.stat().st_size == 0:
+            fail(f"release asset is empty: {entry.name}")
         actual_names.append(entry.name)
+
+    canonical_names = set(expected_artifact_names(args.version))
+    actual_set = set(actual_names)
+    if actual_set != canonical_names:
+        missing = sorted(canonical_names - actual_set)
+        unexpected = sorted(actual_set - canonical_names)
+        fail(
+            "canonical release asset mismatch; "
+            f"missing assets={missing}, unexpected assets={unexpected}"
+        )
 
     expected_hashes: dict[str, str] = {}
     for line_number, line in enumerate(
@@ -63,7 +77,6 @@ def main() -> None:
             fail(f"duplicate checksum entry: {name}")
         expected_hashes[name] = digest.lower()
 
-    actual_set = set(actual_names)
     expected_set = set(expected_hashes)
     if actual_set != expected_set:
         missing = sorted(actual_set - expected_set)


### PR DESCRIPTION
## What changed

- Split build/sign/notarize, GitHub publication, Homebrew, and WinGet into dependent jobs that pass exact artifacts forward.
- A fresh dispatch can recover a partial draft only from a retained candidate whose workflow path, run SHA, embedded commit, and existing asset bytes all match. Otherwise it stops.
- When the GitHub release is already public, repair skips the Apple build entirely. It downloads the published bytes, verifies them, uploads a current-run artifact, then runs Homebrew and WinGet.
- Every release consumer now checks that the checksum manifest covers each asset exactly once, rejects unsafe names, and recomputes every SHA-256 digest.
- Homebrew tests `asc --version` through stdout; the generated formula passed a real local `brew test` with CLT 27.
- New WinGet branches start at `upstream/master`. Existing retry branches keep their history and use normal pushes only.

## Validation

- RED/GREEN workflow-contract tests for cross-run draft recovery, published-release repair, checksum coverage, Homebrew, and WinGet branch handling
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- normal pre-commit hooks
- live 3.6.0 asset download passed the exact-coverage verifier; a locally patched tap formula passed `brew test rorkai/tap/asc`

## Stack

Depends on #1898 because both PRs edit the release workflow. Merge #1898 first, then retarget this PR to `main`; no history rewrite is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Release builds can resume safely and reuse verified artifacts, reducing unnecessary rebuilds.
  - Existing releases can be repaired without replacing valid published assets.
  - Release assets and checksums are validated for completeness, integrity, and unexpected files before publication.
  - Homebrew updates are safely repeatable, and WinGet submissions preserve branch history.
  - Releases for the same version are serialized to prevent conflicting updates.
  - Draft releases can resume without overwriting already-published assets.
  - Release packaging and publishing now include stronger verification and recovery safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->