### PR TITLE
feat: enable Developer Portal bundle capabilities

### DIFF
--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -428,6 +428,15 @@ func capabilityRows() []Capability {
 			},
 		},
 		{
+			Area:         "signing",
+			Capability:   "Developer Portal-only Bundle ID capabilities",
+			Status:       statusWebSession,
+			Commands:     []string{"asc web bundle-ids capabilities enable"},
+			APIResources: []string{"PRIVATE_CLOUD_COMPUTE"},
+			Notes:        []string{"Supports explicitly modeled Developer Portal capabilities that are absent from Apple's public App Store Connect capability enum; currently PRIVATE_CLOUD_COMPUTE."},
+			NextAction:   "Use asc web bundle-ids capabilities enable with a Developer Portal Bundle ID resource ID and --confirm.",
+		},
+		{
 			Area:       "automation",
 			Capability: "Xcode Cloud workflows and artifacts",
 			Status:     statusCLISupported,

--- a/internal/cli/capabilities/developer_bundle_capabilities_test.go
+++ b/internal/cli/capabilities/developer_bundle_capabilities_test.go
@@ -1,0 +1,25 @@
+package capabilities
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestDeveloperPortalBundleIDCapabilitiesAreDiscoverable(t *testing.T) {
+	for _, capability := range capabilityRows() {
+		if capability.Capability != "Developer Portal-only Bundle ID capabilities" {
+			continue
+		}
+		if capability.Status != statusWebSession {
+			t.Fatalf("status = %q, want %q", capability.Status, statusWebSession)
+		}
+		if !slices.Contains(capability.Commands, "asc web bundle-ids capabilities enable") {
+			t.Fatalf("missing enable command: %+v", capability.Commands)
+		}
+		if !slices.Contains(capability.APIResources, "PRIVATE_CLOUD_COMPUTE") {
+			t.Fatalf("missing PCC resource: %+v", capability.APIResources)
+		}
+		return
+	}
+	t.Fatal("Developer Portal-only Bundle ID capability catalog entry not found")
+}

--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -77,6 +77,19 @@ func TestWebBundleIDCapabilitiesSyncAppClipSubcommandIsRegistered(t *testing.T) 
 	}
 }
 
+func TestWebBundleIDCapabilitiesEnableSubcommandIsRegistered(t *testing.T) {
+	root := RootCommand("1.2.3")
+	sub := findSubcommand(root, "web", "bundle-ids", "capabilities", "enable")
+	if sub == nil {
+		t.Fatalf("expected web bundle-ids capabilities enable to be registered")
+	}
+	for _, flagName := range []string{"bundle-id", "capability", "confirm", "apple-id", "output"} {
+		if sub.FlagSet.Lookup(flagName) == nil {
+			t.Fatalf("expected --%s flag", flagName)
+		}
+	}
+}
+
 func TestWebSandboxCreateSubcommandIsRegistered(t *testing.T) {
 	root := RootCommand("1.2.3")
 	if sub := findSubcommand(root, "web", "sandbox", "create"); sub == nil {

--- a/internal/cli/web/test_hooks.go
+++ b/internal/cli/web/test_hooks.go
@@ -59,6 +59,14 @@ func SetSyncAppClipBundleIDCapability(fn func(context.Context, *webcore.Client, 
 	}
 }
 
+func SetEnableDeveloperBundleIDCapability(fn func(context.Context, *webcore.Client, webcore.DeveloperBundleIDCapabilityEnableRequest) (*webcore.DeveloperBundleIDCapabilityEnableResult, error)) func() {
+	prev := enableDeveloperBundleIDCapabilityFn
+	enableDeveloperBundleIDCapabilityFn = fn
+	return func() {
+		enableDeveloperBundleIDCapabilityFn = prev
+	}
+}
+
 // DisableControllingTTYForTesting prevents tests from opening the process's
 // controlling terminal. The returned function restores the previous behavior.
 func DisableControllingTTYForTesting() func() {

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -22,7 +22,7 @@ func WebCommand() *ffcli.Command {
 		ShortHelp:  "Apple web-session workflows.",
 		LongHelp: `WEB SESSION WORKFLOWS
 
-Use Apple web-session /iris flows for App Store Connect workflows.
+Use Apple web sessions for App Store Connect and Developer Portal workflows.
 Use ` + "`asc web apps create`" + ` as the canonical app-creation command in this family.
 
 Examples:

--- a/internal/cli/web/web_bundle_ids.go
+++ b/internal/cli/web/web_bundle_ids.go
@@ -19,6 +19,10 @@ var syncAppClipBundleIDCapabilityFn = func(ctx context.Context, client *webcore.
 	return client.SyncAppClipBundleIDCapability(ctx, req)
 }
 
+var enableDeveloperBundleIDCapabilityFn = func(ctx context.Context, client *webcore.Client, req webcore.DeveloperBundleIDCapabilityEnableRequest) (*webcore.DeveloperBundleIDCapabilityEnableResult, error) {
+	return client.EnableDeveloperBundleIDCapability(ctx, req)
+}
+
 // WebBundleIDsCommand returns the Bundle ID command group.
 func WebBundleIDsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web bundle-ids", flag.ExitOnError)
@@ -50,19 +54,118 @@ func WebBundleIDCapabilitiesCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "capabilities",
 		ShortUsage: "asc web bundle-ids capabilities <subcommand> [flags]",
-		ShortHelp:  "Sync Bundle ID capabilities via web sessions.",
+		ShortHelp:  "Manage Bundle ID capabilities via web sessions.",
 		LongHelp: `WEB SESSION WORKFLOWS
 
-Sync Bundle ID capabilities through Apple's Bundle ID patch endpoint.
+Manage Bundle ID capabilities through Apple's App Store Connect and Developer
+Portal web-session endpoints.
 
 `,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			WebBundleIDCapabilitiesEnableCommand(),
 			WebBundleIDCapabilitiesSyncAppClipCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
+		},
+	}
+}
+
+// WebBundleIDCapabilitiesEnableCommand enables a Developer Portal-only Bundle
+// ID capability while preserving all existing capability relationships.
+func WebBundleIDCapabilitiesEnableCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web bundle-ids capabilities enable", flag.ExitOnError)
+
+	bundleID := fs.String("bundle-id", "", "Opaque Developer Portal Bundle ID resource ID")
+	capability := fs.String("capability", "", "Developer Portal capability ID (supported: PRIVATE_CLOUD_COMPUTE)")
+	confirm := fs.Bool("confirm", false, "Confirm enabling this Bundle ID capability")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "enable",
+		ShortUsage: "asc web bundle-ids capabilities enable --bundle-id BUNDLE_RESOURCE_ID --capability PRIVATE_CLOUD_COMPUTE --confirm [flags]",
+		ShortHelp:  "Enable a Developer Portal-only Bundle ID capability.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+Enable a Bundle ID capability that is exposed by Apple Developer Portal but is
+absent from the public App Store Connect capability enum.
+
+The command loads Developer Portal capability metadata and the complete current
+Bundle ID capability graph before saving. Existing settings and relationships
+are preserved. If the requested capability is already enabled, the command
+returns an already-enabled result without sending a PATCH.
+
+Currently supported capability IDs:
+  PRIVATE_CLOUD_COMPUTE
+
+Example:
+  asc web bundle-ids capabilities enable --bundle-id "BUNDLE_RESOURCE_ID" --capability "PRIVATE_CLOUD_COMPUTE" --confirm
+
+Authentication:
+  This command needs Developer Portal cookies and CSRF headers derived from the
+  user-owned Apple web session. If a cached App Store Connect-only session cannot
+  be promoted, refresh it with:
+  asc web auth login --apple-id "user@example.com" --reauthenticate
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web bundle-ids capabilities enable does not accept positional arguments")
+			}
+
+			resolvedBundleID := strings.TrimSpace(*bundleID)
+			resolvedCapability := strings.ToUpper(strings.TrimSpace(*capability))
+			switch {
+			case resolvedBundleID == "":
+				return shared.UsageError("--bundle-id is required")
+			case resolvedCapability == "":
+				return shared.UsageError("--capability is required")
+			case !*confirm:
+				return shared.UsageError("--confirm is required")
+			case resolvedCapability != "PRIVATE_CLOUD_COMPUTE":
+				return shared.UsageErrorf("unsupported Developer Portal capability %q (supported: PRIVATE_CLOUD_COMPUTE)", resolvedCapability)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebClientFn(session)
+
+			var result *webcore.DeveloperBundleIDCapabilityEnableResult
+			err = withWebSpinner("Enabling Developer Portal Bundle ID capability", func() error {
+				var enableErr error
+				result, enableErr = enableDeveloperBundleIDCapabilityFn(requestCtx, client, webcore.DeveloperBundleIDCapabilityEnableRequest{
+					BundleID:   resolvedBundleID,
+					Capability: resolvedCapability,
+				})
+				return enableErr
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web bundle-ids capabilities enable")
+			}
+			if result == nil {
+				return fmt.Errorf("web bundle-ids capabilities enable failed: missing enable result")
+			}
+			// Developer Portal bootstrap can add origin-specific cookies to the
+			// shared jar. Cache them best-effort after the operation succeeds.
+			_ = persistWebSessionFn(session)
+
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderDeveloperBundleIDCapabilityEnableTable(result) },
+				func() error { return renderDeveloperBundleIDCapabilityEnableMarkdown(result) },
+			)
 		},
 	}
 }
@@ -199,6 +302,34 @@ func renderWebBundleIDCapabilitySyncMarkdown(result *webcore.AppClipBundleIDCapa
 			result.ParentBundleID,
 			result.Capability,
 			fmt.Sprintf("%t", result.Enabled),
+		}},
+	)
+	return nil
+}
+
+func renderDeveloperBundleIDCapabilityEnableTable(result *webcore.DeveloperBundleIDCapabilityEnableResult) error {
+	asc.RenderTable(
+		[]string{"Bundle ID", "Capability", "Enabled", "Changed", "Status"},
+		[][]string{{
+			result.BundleID,
+			result.Capability,
+			fmt.Sprintf("%t", result.Enabled),
+			fmt.Sprintf("%t", result.Changed),
+			result.Status,
+		}},
+	)
+	return nil
+}
+
+func renderDeveloperBundleIDCapabilityEnableMarkdown(result *webcore.DeveloperBundleIDCapabilityEnableResult) error {
+	asc.RenderMarkdown(
+		[]string{"Bundle ID", "Capability", "Enabled", "Changed", "Status"},
+		[][]string{{
+			result.BundleID,
+			result.Capability,
+			fmt.Sprintf("%t", result.Enabled),
+			fmt.Sprintf("%t", result.Changed),
+			result.Status,
 		}},
 	)
 	return nil

--- a/internal/cli/web/web_bundle_ids.go
+++ b/internal/cli/web/web_bundle_ids.go
@@ -107,8 +107,9 @@ Example:
 Authentication:
   This command needs Developer Portal cookies and CSRF headers derived from the
   user-owned Apple web session. If a cached App Store Connect-only session cannot
-  be promoted, refresh it with:
-  asc web auth login --apple-id "user@example.com" --reauthenticate
+  be promoted, clear only its cached session and log in again with the same binary:
+  asc web auth logout --apple-id "user@example.com"
+  asc web auth login --apple-id "user@example.com"
 
 `,
 		FlagSet:   fs,

--- a/internal/cli/web/web_bundle_ids_test.go
+++ b/internal/cli/web/web_bundle_ids_test.go
@@ -141,6 +141,19 @@ func TestWebBundleIDCapabilitiesEnableValidationErrors(t *testing.T) {
 	}
 }
 
+func TestWebBundleIDCapabilitiesEnableHelpUsesSupportedLoginFlags(t *testing.T) {
+	cmd := WebBundleIDCapabilitiesEnableCommand()
+	if strings.Contains(cmd.LongHelp, "--reauthenticate") {
+		t.Fatalf("enable help recommends unsupported web auth login flag: %q", cmd.LongHelp)
+	}
+	if !strings.Contains(cmd.LongHelp, `asc web auth logout --apple-id "user@example.com"`) {
+		t.Fatalf("enable help is missing the supported cache-clear command: %q", cmd.LongHelp)
+	}
+	if !strings.Contains(cmd.LongHelp, `asc web auth login --apple-id "user@example.com"`) {
+		t.Fatalf("enable help is missing the supported login command: %q", cmd.LongHelp)
+	}
+}
+
 func TestWebBundleIDCapabilitiesEnableCallsDeveloperPortalClient(t *testing.T) {
 	origResolveSession := resolveSessionFn
 	origNewWebClient := newWebClientFn

--- a/internal/cli/web/web_bundle_ids_test.go
+++ b/internal/cli/web/web_bundle_ids_test.go
@@ -158,10 +158,12 @@ func TestWebBundleIDCapabilitiesEnableCallsDeveloperPortalClient(t *testing.T) {
 	origResolveSession := resolveSessionFn
 	origNewWebClient := newWebClientFn
 	origEnable := enableDeveloperBundleIDCapabilityFn
+	origPersist := persistWebSessionFn
 	t.Cleanup(func() {
 		resolveSessionFn = origResolveSession
 		newWebClientFn = origNewWebClient
 		enableDeveloperBundleIDCapabilityFn = origEnable
+		persistWebSessionFn = origPersist
 	})
 
 	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
@@ -169,6 +171,9 @@ func TestWebBundleIDCapabilitiesEnableCallsDeveloperPortalClient(t *testing.T) {
 	}
 	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
 		return &webcore.Client{}
+	}
+	persistWebSessionFn = func(session *webcore.AuthSession) error {
+		return nil
 	}
 
 	var gotReq webcore.DeveloperBundleIDCapabilityEnableRequest

--- a/internal/cli/web/web_bundle_ids_test.go
+++ b/internal/cli/web/web_bundle_ids_test.go
@@ -106,3 +106,92 @@ func TestWebBundleIDCapabilitiesSyncAppClipCallsPrivateSync(t *testing.T) {
 		t.Fatalf("expected parsed settings, got %+v", gotReq.Settings)
 	}
 }
+
+func TestWebBundleIDCapabilitiesEnableValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing bundle id", args: []string{"--capability", "PRIVATE_CLOUD_COMPUTE", "--confirm"}, wantErr: "--bundle-id is required"},
+		{name: "missing capability", args: []string{"--bundle-id", "bundle-1", "--confirm"}, wantErr: "--capability is required"},
+		{name: "missing confirm", args: []string{"--bundle-id", "bundle-1", "--capability", "PRIVATE_CLOUD_COMPUTE"}, wantErr: "--confirm is required"},
+		{name: "unsupported capability", args: []string{"--bundle-id", "bundle-1", "--capability", "ICLOUD", "--confirm"}, wantErr: "unsupported Developer Portal capability"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := WebBundleIDCapabilitiesEnableCommand()
+			if err := cmd.FlagSet.Parse(tc.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			stdout, stderr := captureWebCommandOutput(t, func() {
+				err := cmd.Exec(context.Background(), nil)
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected flag.ErrHelp, got %v", err)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, tc.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", tc.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestWebBundleIDCapabilitiesEnableCallsDeveloperPortalClient(t *testing.T) {
+	origResolveSession := resolveSessionFn
+	origNewWebClient := newWebClientFn
+	origEnable := enableDeveloperBundleIDCapabilityFn
+	t.Cleanup(func() {
+		resolveSessionFn = origResolveSession
+		newWebClientFn = origNewWebClient
+		enableDeveloperBundleIDCapabilityFn = origEnable
+	})
+
+	resolveSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	}
+	newWebClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+
+	var gotReq webcore.DeveloperBundleIDCapabilityEnableRequest
+	enableDeveloperBundleIDCapabilityFn = func(ctx context.Context, client *webcore.Client, req webcore.DeveloperBundleIDCapabilityEnableRequest) (*webcore.DeveloperBundleIDCapabilityEnableResult, error) {
+		gotReq = req
+		return &webcore.DeveloperBundleIDCapabilityEnableResult{
+			BundleID:   req.BundleID,
+			Capability: req.Capability,
+			Enabled:    true,
+			Changed:    true,
+			Status:     "enabled",
+		}, nil
+	}
+
+	cmd := WebBundleIDCapabilitiesEnableCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--bundle-id", "bundle-1",
+		"--capability", "private_cloud_compute",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"capability":"PRIVATE_CLOUD_COMPUTE"`) || !strings.Contains(stdout, `"status":"enabled"`) {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+	if gotReq.BundleID != "bundle-1" || gotReq.Capability != "PRIVATE_CLOUD_COMPUTE" {
+		t.Fatalf("unexpected enable request: %+v", gotReq)
+	}
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -159,6 +159,7 @@ type Client struct {
 	developerCSRF      string
 	developerCSRFTS    string
 	developerTeamID    string
+	publicProviderID   string
 	providerName       string
 
 	// Requests are intentionally throttled to reduce pressure on fragile, unofficial
@@ -430,6 +431,7 @@ func NewClient(session *AuthSession) *Client {
 	return &Client{
 		httpClient:         session.Client,
 		baseURL:            irisV1BaseURL,
+		publicProviderID:   strings.TrimSpace(session.PublicProviderID),
 		providerName:       strings.TrimSpace(session.ProviderName),
 		minRequestInterval: resolveWebMinRequestInterval(),
 	}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -257,11 +257,7 @@ func extractAppleRequestID(headers http.Header) string {
 	if len(headers) == 0 {
 		return ""
 	}
-	requestID := headerValueCaseInsensitive(headers, "X-Apple-Request-Uuid")
-	if requestID == "" {
-		requestID = headerValueCaseInsensitive(headers, "X-Apple-Request-UUID")
-	}
-	return requestID
+	return headerValueCaseInsensitive(headers, "X-Apple-Request-UUID")
 }
 
 func sanitizeWebAuthURLForLog(rawURL string) string {

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -98,6 +98,7 @@ type AuthSession struct {
 	Client           *http.Client
 	ProviderID       int64
 	PublicProviderID string
+	ProviderName     string
 	TeamID           string
 	UserEmail        string
 
@@ -157,6 +158,8 @@ type Client struct {
 	developerSessionMu sync.Mutex
 	developerCSRF      string
 	developerCSRFTS    string
+	developerTeamID    string
+	providerName       string
 
 	// Requests are intentionally throttled to reduce pressure on fragile, unofficial
 	// web-session endpoints and avoid bursty behavior against user accounts.
@@ -431,6 +434,7 @@ func NewClient(session *AuthSession) *Client {
 	return &Client{
 		httpClient:         session.Client,
 		baseURL:            irisV1BaseURL,
+		providerName:       strings.TrimSpace(session.ProviderName),
 		minRequestInterval: resolveWebMinRequestInterval(),
 	}
 }
@@ -473,6 +477,7 @@ func applySessionInfo(session *AuthSession, info *sessionInfo) {
 	}
 	session.ProviderID = info.Provider.ProviderID
 	session.PublicProviderID = strings.TrimSpace(info.Provider.PublicProviderID)
+	session.ProviderName = strings.TrimSpace(info.Provider.Name)
 	session.TeamID = fmt.Sprintf("%d", info.Provider.ProviderID)
 	session.UserEmail = strings.TrimSpace(info.User.EmailAddress)
 }

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -154,6 +154,10 @@ type Client struct {
 	httpClient *http.Client
 	baseURL    string
 
+	developerSessionMu sync.Mutex
+	developerCSRF      string
+	developerCSRFTS    string
+
 	// Requests are intentionally throttled to reduce pressure on fragile, unofficial
 	// web-session endpoints and avoid bursty behavior against user accounts.
 	minRequestInterval time.Duration
@@ -250,9 +254,9 @@ func extractAppleRequestID(headers http.Header) string {
 	if len(headers) == 0 {
 		return ""
 	}
-	requestID := strings.TrimSpace(headers.Get("X-Apple-Request-Uuid"))
+	requestID := headerValueCaseInsensitive(headers, "X-Apple-Request-Uuid")
 	if requestID == "" {
-		requestID = strings.TrimSpace(headers.Get("X-Apple-Request-UUID"))
+		requestID = headerValueCaseInsensitive(headers, "X-Apple-Request-UUID")
 	}
 	return requestID
 }
@@ -1443,7 +1447,24 @@ func SubmitTwoFactorCode(ctx context.Context, session *AuthSession, code string)
 }
 
 func extractServiceErrorCodes(respBody []byte) []string {
-	return appleauth.ExtractServiceErrorCodes(respBody)
+	if codes := appleauth.ExtractServiceErrorCodes(respBody); len(codes) > 0 {
+		return codes
+	}
+	var payload struct {
+		Errors []struct {
+			Code string `json:"code"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(respBody, &payload); err != nil {
+		return nil
+	}
+	codes := make([]string, 0, len(payload.Errors))
+	for _, responseError := range payload.Errors {
+		if code := strings.TrimSpace(responseError.Code); code != "" {
+			codes = append(codes, code)
+		}
+	}
+	return codes
 }
 
 // Apple currently returns -20101 when signin/complete rejects SRP credentials.

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -48,6 +48,21 @@ func TestAuthStatusErrorsExposeHTTPStatus(t *testing.T) {
 	}
 }
 
+func TestNewClientPreservesProviderIdentity(t *testing.T) {
+	client := NewClient(&AuthSession{
+		Client:           &http.Client{},
+		PublicProviderID: " TEAM123 ",
+		ProviderName:     " Example Team ",
+	})
+
+	if client.publicProviderID != "TEAM123" {
+		t.Fatalf("publicProviderID = %q", client.publicProviderID)
+	}
+	if client.providerName != "Example Team" {
+		t.Fatalf("providerName = %q", client.providerName)
+	}
+}
+
 func TestLogWebAuthHTTPRedactsSensitiveQueryValues(t *testing.T) {
 	origLogger := webDebugLogger
 	origDebugEnabled := webDebugEnabledFn

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	developerPortalBaseURL    = "https://developer.apple.com"
-	developerPortalAccountURL = developerPortalBaseURL + "/account"
-	developerServicesBaseURL  = developerPortalBaseURL + "/services-account/v1"
-	privateCloudCompute       = "PRIVATE_CLOUD_COMPUTE"
-	developerPortalAuthHint   = "run 'asc web auth logout --apple-id EMAIL', then 'asc web auth login --apple-id EMAIL', and try again"
+	developerPortalBaseURL   = "https://developer.apple.com"
+	developerPortalTeamsURL  = developerPortalBaseURL + "/services-account/QH65B2/account/listTeams.action"
+	developerServicesBaseURL = developerPortalBaseURL + "/services-account/v1"
+	privateCloudCompute      = "PRIVATE_CLOUD_COMPUTE"
+	developerPortalAuthHint  = "run 'asc web auth logout --apple-id EMAIL', then 'asc web auth login --apple-id EMAIL', and try again"
 )
 
 var supportedDeveloperBundleIDCapabilities = map[string]struct{}{
@@ -71,6 +71,24 @@ type developerCapabilityMetadataAttributes struct {
 	Editable     bool   `json:"editable"`
 	CanRequest   bool   `json:"canRequestFromPortal"`
 	EnabledByDef bool   `json:"enabledByDefault"`
+}
+
+type developerPortalTeam struct {
+	TeamID string `json:"teamId"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+type developerPortalTeamsResponse struct {
+	Teams []developerPortalTeam `json:"teams"`
+	Data  struct {
+		Teams []developerPortalTeam `json:"teams"`
+	} `json:"data"`
+}
+
+type developerPortalProxyReadRequest struct {
+	URLEncodedQueryParams string `json:"urlEncodedQueryParams"`
+	TeamID                string `json:"teamId"`
 }
 
 type developerResource struct {
@@ -159,6 +177,14 @@ func (c *Client) EnableDeveloperBundleIDCapability(ctx context.Context, req Deve
 			Status:     "already-enabled",
 		}, nil
 	}
+	teamID := c.developerPortalTeamID()
+	if teamID == "" {
+		return nil, fmt.Errorf("developer portal team is not selected; %s", developerPortalAuthHint)
+	}
+	payload, err = addDeveloperPortalTeamID(payload, teamID)
+	if err != nil {
+		return nil, err
+	}
 
 	csrf, csrfTS := c.developerCSRFTokens()
 	if csrf == "" || csrfTS == "" {
@@ -179,30 +205,84 @@ func (c *Client) EnableDeveloperBundleIDCapability(ctx context.Context, req Deve
 }
 
 func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
+	// The App Store Connect SRP session becomes usable by Developer Portal only
+	// after its legacy team endpoint establishes Portal team and CSRF context.
 	headers := developerPortalHeaders("")
-	headers.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodGet, developerPortalAccountURL, nil, headers)
+	headers.Set("Accept", "application/json, text/javascript, */*; q=0.01")
+	headers.Set("Content-Type", "application/x-www-form-urlencoded")
+	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodPost, developerPortalTeamsURL, nil, headers)
 	if err != nil {
 		return err
 	}
-	_ = body
+	c.captureDeveloperCSRFTokens(response.Header)
 	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
 		return developerPortalSessionError(response.StatusCode)
 	}
-	if response.StatusCode < 200 || response.StatusCode >= 400 {
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return &APIError{Status: response.StatusCode, AppleRequestID: extractAppleRequestID(response.Header), rawBody: body}
 	}
 	if response.Request != nil && response.Request.URL != nil && !strings.EqualFold(response.Request.URL.Hostname(), "developer.apple.com") {
 		return fmt.Errorf("authentication redirected to %s instead of Developer Portal; %s", response.Request.URL.Hostname(), developerPortalAuthHint)
 	}
+
+	var payload developerPortalTeamsResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return fmt.Errorf("failed to parse Developer Portal teams response: %w", err)
+	}
+	teams := payload.Teams
+	if len(teams) == 0 {
+		teams = payload.Data.Teams
+	}
+	team, err := selectDeveloperPortalTeam(teams, c.providerName)
+	if err != nil {
+		return err
+	}
+	c.developerSessionMu.Lock()
+	c.developerTeamID = team.TeamID
+	c.developerSessionMu.Unlock()
 	return nil
+}
+
+func selectDeveloperPortalTeam(teams []developerPortalTeam, providerName string) (developerPortalTeam, error) {
+	valid := make([]developerPortalTeam, 0, len(teams))
+	for _, team := range teams {
+		team.TeamID = strings.TrimSpace(team.TeamID)
+		team.Name = strings.TrimSpace(team.Name)
+		if team.TeamID != "" {
+			valid = append(valid, team)
+		}
+	}
+	if len(valid) == 0 {
+		return developerPortalTeam{}, fmt.Errorf("apple account has no Developer Portal team; a paid Apple Developer Program membership may be required")
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName != "" {
+		for _, team := range valid {
+			if strings.EqualFold(providerName, team.Name) {
+				return team, nil
+			}
+		}
+		var prefixMatch developerPortalTeam
+		for _, team := range valid {
+			if team.Name != "" && strings.HasPrefix(strings.ToLower(providerName), strings.ToLower(team.Name)) && len(team.Name) > len(prefixMatch.Name) {
+				prefixMatch = team
+			}
+		}
+		if prefixMatch.TeamID != "" {
+			return prefixMatch, nil
+		}
+	}
+	if len(valid) == 1 {
+		return valid[0], nil
+	}
+	return developerPortalTeam{}, fmt.Errorf("could not match App Store Connect provider %q to one of %d Developer Portal teams", providerName, len(valid))
 }
 
 func (c *Client) loadDeveloperCapabilityMetadata(ctx context.Context, bundleID string) (developerCapabilityMetadataResponse, error) {
 	query := make(url.Values)
 	query.Set("filter[capabilityType]", "capability,service")
 	query.Set("filter[includeRequestable]", "true")
-	body, err := c.doDeveloperPortalRequest(ctx, http.MethodPost, "/capabilities?"+query.Encode(), nil, developerPortalHeaders(bundleID), false)
+	body, err := c.doDeveloperPortalProxyRead(ctx, "/capabilities", query, developerPortalHeaders(bundleID))
 	if err != nil {
 		return developerCapabilityMetadataResponse{}, err
 	}
@@ -226,8 +306,8 @@ func (c *Client) loadDeveloperBundleID(ctx context.Context, bundleID string) (de
 	query := make(url.Values)
 	query.Set("fields[bundleIds]", "name,identifier,platform,seedId,wildcard,~permissions.delete,~permissions.edit")
 	query.Set("include", strings.Join(developerBundleIDIncludes, ","))
-	path := "/bundleIds/" + url.PathEscape(bundleID) + "?" + query.Encode()
-	body, err := c.doDeveloperPortalRequest(ctx, http.MethodPost, path, nil, developerPortalHeaders(bundleID), false)
+	path := "/bundleIds/" + url.PathEscape(bundleID)
+	body, err := c.doDeveloperPortalProxyRead(ctx, path, query, developerPortalHeaders(bundleID))
 	if err != nil {
 		return developerBundleIDResponse{}, err
 	}
@@ -303,14 +383,36 @@ func buildDeveloperBundleIDCapabilityPatchRequest(current developerBundleIDRespo
 	return payload, false, nil
 }
 
+func addDeveloperPortalTeamID(payload developerBundleIDPatchRequest, teamID string) (developerBundleIDPatchRequest, error) {
+	var attributes map[string]json.RawMessage
+	if len(payload.Data.Attributes) > 0 {
+		if err := json.Unmarshal(payload.Data.Attributes, &attributes); err != nil {
+			return payload, fmt.Errorf("failed to parse Bundle ID attributes for Developer Portal team: %w", err)
+		}
+	}
+	if attributes == nil {
+		attributes = make(map[string]json.RawMessage)
+	}
+	encodedTeamID, err := json.Marshal(strings.TrimSpace(teamID))
+	if err != nil {
+		return payload, fmt.Errorf("failed to encode Developer Portal team: %w", err)
+	}
+	attributes["teamId"] = encodedTeamID
+	encodedAttributes, err := json.Marshal(attributes)
+	if err != nil {
+		return payload, fmt.Errorf("failed to encode Bundle ID attributes for Developer Portal team: %w", err)
+	}
+	payload.Data.Attributes = encodedAttributes
+	return payload, nil
+}
+
 func developerBundleIDCapabilities(current developerBundleIDResponse) ([]developerResource, error) {
 	var relationship developerResourceRelationship
 	rawRelationship, ok := current.Data.Relationships["bundleIdCapabilities"]
-	if !ok {
-		return []developerResource{}, nil
-	}
-	if err := json.Unmarshal(rawRelationship, &relationship); err != nil {
-		return nil, fmt.Errorf("failed to parse current Bundle ID capability relationships: %w", err)
+	if ok {
+		if err := json.Unmarshal(rawRelationship, &relationship); err != nil {
+			return nil, fmt.Errorf("failed to parse current Bundle ID capability relationships: %w", err)
+		}
 	}
 
 	includedByID := make(map[string]developerResource)
@@ -454,11 +556,32 @@ func developerPortalHeaders(bundleID string) http.Header {
 	return headers
 }
 
+func (c *Client) doDeveloperPortalProxyRead(ctx context.Context, path string, query url.Values, headers http.Header) ([]byte, error) {
+	// Developer Portal's cookie-authenticated v1 API proxies logical GETs as
+	// POSTs carrying the team and encoded query in the request body.
+	teamID := c.developerPortalTeamID()
+	if teamID == "" {
+		return nil, fmt.Errorf("developer portal team is not selected; %s", developerPortalAuthHint)
+	}
+	headers.Set("X-HTTP-Method-Override", http.MethodGet)
+	return c.doDeveloperPortalRequest(ctx, http.MethodPost, path, developerPortalProxyReadRequest{
+		URLEncodedQueryParams: query.Encode(),
+		TeamID:                teamID,
+	}, headers, false)
+}
+
 func (c *Client) doDeveloperPortalRequest(ctx context.Context, method, path string, body any, headers http.Header, requireCSRF bool) ([]byte, error) {
-	if requireCSRF {
-		csrf, csrfTS := c.developerCSRFTokens()
+	csrf, csrfTS := c.developerCSRFTokens()
+	if csrf != "" {
 		headers.Set("csrf", csrf)
+	}
+	if csrfTS != "" {
 		headers.Set("csrf_ts", csrfTS)
+	}
+	if requireCSRF {
+		if csrf == "" || csrfTS == "" {
+			return nil, fmt.Errorf("missing Developer Portal CSRF headers; %s", developerPortalAuthHint)
+		}
 	}
 	responseBody, response, err := c.doDeveloperPortalHTTP(ctx, method, developerServicesBaseURL+path, body, headers)
 	if err != nil {
@@ -550,6 +673,12 @@ func (c *Client) developerCSRFTokens() (string, string) {
 	c.developerSessionMu.Lock()
 	defer c.developerSessionMu.Unlock()
 	return c.developerCSRF, c.developerCSRFTS
+}
+
+func (c *Client) developerPortalTeamID() string {
+	c.developerSessionMu.Lock()
+	defer c.developerSessionMu.Unlock()
+	return c.developerTeamID
 }
 
 func developerPortalSessionError(status int) error {

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -327,41 +327,48 @@ func buildDeveloperBundleIDCapabilityPatchRequest(current developerBundleIDRespo
 		return developerBundleIDPatchRequest{}, false, err
 	}
 
-	updated := make([]developerResource, 0, len(capabilities)+1)
-	foundTarget := false
-	alreadyEnabled := false
-	for _, capability := range capabilities {
+	capabilityIDs := make([]string, len(capabilities))
+	targetIndex := -1
+	targetEnabled := false
+	for index, capability := range capabilities {
 		capabilityID, err := developerBundleIDCapabilityID(capability)
 		if err != nil {
 			return developerBundleIDPatchRequest{}, false, err
 		}
+		capabilityIDs[index] = capabilityID
 		if capabilityID != req.Capability {
-			updated = append(updated, capability)
 			continue
 		}
-		if foundTarget {
-			continue
-		}
-		foundTarget = true
 		enabled, err := developerBundleIDCapabilityEnabled(capability)
 		if err != nil {
 			return developerBundleIDPatchRequest{}, false, err
 		}
-		if enabled {
-			alreadyEnabled = true
+		if targetIndex == -1 || (enabled && !targetEnabled) {
+			targetIndex = index
+			targetEnabled = enabled
+		}
+	}
+	if targetEnabled {
+		return developerBundleIDPatchRequest{}, true, nil
+	}
+
+	updated := make([]developerResource, 0, len(capabilities)+1)
+	for index, capability := range capabilities {
+		if capabilityIDs[index] != req.Capability {
 			updated = append(updated, capability)
 			continue
 		}
+		if index != targetIndex {
+			continue
+		}
+		var err error
 		capability.Attributes, err = setDeveloperCapabilityEnabled(capability.Attributes)
 		if err != nil {
 			return developerBundleIDPatchRequest{}, false, err
 		}
 		updated = append(updated, capability)
 	}
-	if alreadyEnabled {
-		return developerBundleIDPatchRequest{}, true, nil
-	}
-	if !foundTarget {
+	if targetIndex == -1 {
 		updated = append(updated, newDeveloperBundleIDCapability(req.Capability))
 	}
 

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -1,0 +1,556 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	developerPortalBaseURL    = "https://developer.apple.com"
+	developerPortalAccountURL = developerPortalBaseURL + "/account"
+	developerServicesBaseURL  = developerPortalBaseURL + "/services-account/v1"
+	privateCloudCompute       = "PRIVATE_CLOUD_COMPUTE"
+)
+
+var supportedDeveloperBundleIDCapabilities = map[string]struct{}{
+	privateCloudCompute: {},
+}
+
+var developerBundleIDIncludes = []string{
+	"bundleIdCapabilities",
+	"bundleIdCapabilities.capability",
+	"bundleIdCapabilities.associatedBundleIds",
+	"bundleIdCapabilities.appGroups",
+	"bundleIdCapabilities.merchantIds",
+	"bundleIdCapabilities.cloudContainers",
+	"bundleIdCapabilities.certificates",
+	"bundleIdCapabilities.appConsentBundleId",
+	"bundleIdCapabilities.macBundleId",
+	"bundleIdCapabilities.relatedAppConsentBundleIds",
+	"bundleIdCapabilities.parentBundleId",
+	"bundleIdCapabilities.mediaSharingProtocolIds",
+}
+
+// DeveloperBundleIDCapabilityEnableRequest enables one supported Developer
+// Portal-only capability on an existing Bundle ID resource.
+type DeveloperBundleIDCapabilityEnableRequest struct {
+	BundleID   string
+	Capability string
+}
+
+// DeveloperBundleIDCapabilityEnableResult summarizes a Developer Portal
+// capability enable operation. Changed is false when the capability was already
+// enabled and no PATCH was sent.
+type DeveloperBundleIDCapabilityEnableResult struct {
+	BundleID   string `json:"bundleId"`
+	Capability string `json:"capability"`
+	Enabled    bool   `json:"enabled"`
+	Changed    bool   `json:"changed"`
+	Status     string `json:"status"`
+}
+
+type developerCapabilityMetadataResponse struct {
+	Data []struct {
+		ID         string                                `json:"id"`
+		Type       string                                `json:"type"`
+		Attributes developerCapabilityMetadataAttributes `json:"attributes"`
+	} `json:"data"`
+}
+
+type developerCapabilityMetadataAttributes struct {
+	Name         string `json:"name"`
+	Entitlement  string `json:"entitlement"`
+	IsPublic     bool   `json:"isPublic"`
+	Editable     bool   `json:"editable"`
+	CanRequest   bool   `json:"canRequestFromPortal"`
+	EnabledByDef bool   `json:"enabledByDefault"`
+}
+
+type developerResource struct {
+	ID            string                     `json:"id,omitempty"`
+	Type          string                     `json:"type"`
+	Attributes    json.RawMessage            `json:"attributes,omitempty"`
+	Relationships map[string]json.RawMessage `json:"relationships,omitempty"`
+}
+
+type developerResourceRelationship struct {
+	Data []developerResource `json:"data"`
+}
+
+type developerBundleIDResponse struct {
+	Data struct {
+		ID            string                     `json:"id"`
+		Type          string                     `json:"type"`
+		Attributes    json.RawMessage            `json:"attributes"`
+		Relationships map[string]json.RawMessage `json:"relationships"`
+	} `json:"data"`
+	Included []developerResource `json:"included"`
+}
+
+type developerBundleIDPatchRequest struct {
+	Data struct {
+		ID            string                     `json:"id"`
+		Type          string                     `json:"type"`
+		Attributes    json.RawMessage            `json:"attributes"`
+		Relationships map[string]json.RawMessage `json:"relationships"`
+	} `json:"data"`
+}
+
+func normalizeDeveloperBundleIDCapabilityEnableRequest(req DeveloperBundleIDCapabilityEnableRequest) (DeveloperBundleIDCapabilityEnableRequest, error) {
+	req.BundleID = strings.TrimSpace(req.BundleID)
+	req.Capability = strings.ToUpper(strings.TrimSpace(req.Capability))
+	if req.BundleID == "" {
+		return req, fmt.Errorf("bundle id is required")
+	}
+	if req.Capability == "" {
+		return req, fmt.Errorf("capability is required")
+	}
+	if _, ok := supportedDeveloperBundleIDCapabilities[req.Capability]; !ok {
+		return req, fmt.Errorf("unsupported Developer Portal capability %q (supported: %s)", req.Capability, privateCloudCompute)
+	}
+	return req, nil
+}
+
+// EnableDeveloperBundleIDCapability enables a supported Developer Portal-only
+// Bundle ID capability while preserving Apple's complete current capability
+// relationship payload.
+func (c *Client) EnableDeveloperBundleIDCapability(ctx context.Context, req DeveloperBundleIDCapabilityEnableRequest) (*DeveloperBundleIDCapabilityEnableResult, error) {
+	req, err := normalizeDeveloperBundleIDCapabilityEnableRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
+		return nil, err
+	}
+
+	metadata, err := c.loadDeveloperCapabilityMetadata(ctx, req.BundleID)
+	if err != nil {
+		return nil, err
+	}
+	capabilityMetadata, ok := findDeveloperCapability(metadata, req.Capability)
+	if !ok {
+		return nil, fmt.Errorf("capability %q is not available in Developer Portal for this account", req.Capability)
+	}
+	if !capabilityMetadata.Editable {
+		return nil, fmt.Errorf("capability %q is not editable in Developer Portal for this account", req.Capability)
+	}
+
+	current, err := c.loadDeveloperBundleID(ctx, req.BundleID)
+	if err != nil {
+		return nil, err
+	}
+	payload, alreadyEnabled, err := buildDeveloperBundleIDCapabilityPatchRequest(current, req)
+	if err != nil {
+		return nil, err
+	}
+	if alreadyEnabled {
+		return &DeveloperBundleIDCapabilityEnableResult{
+			BundleID:   req.BundleID,
+			Capability: req.Capability,
+			Enabled:    true,
+			Changed:    false,
+			Status:     "already-enabled",
+		}, nil
+	}
+
+	csrf, csrfTS := c.developerCSRFTokens()
+	if csrf == "" || csrfTS == "" {
+		return nil, fmt.Errorf("missing Developer Portal CSRF headers; run 'asc web auth login --apple-id EMAIL --reauthenticate' and try again")
+	}
+	path := "/bundleIds/" + url.PathEscape(req.BundleID)
+	if _, err := c.doDeveloperPortalRequest(ctx, http.MethodPatch, path, payload, developerPortalHeaders(req.BundleID), true); err != nil {
+		return nil, err
+	}
+
+	return &DeveloperBundleIDCapabilityEnableResult{
+		BundleID:   req.BundleID,
+		Capability: req.Capability,
+		Enabled:    true,
+		Changed:    true,
+		Status:     "enabled",
+	}, nil
+}
+
+func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
+	headers := developerPortalHeaders("")
+	headers.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodGet, developerPortalAccountURL, nil, headers)
+	if err != nil {
+		return err
+	}
+	_ = body
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+		return developerPortalSessionError(response.StatusCode)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 400 {
+		return &APIError{Status: response.StatusCode, AppleRequestID: extractAppleRequestID(response.Header), rawBody: body}
+	}
+	if response.Request != nil && response.Request.URL != nil && !strings.EqualFold(response.Request.URL.Hostname(), "developer.apple.com") {
+		return fmt.Errorf("authentication redirected to %s instead of Developer Portal; run 'asc web auth login --apple-id EMAIL --reauthenticate' and try again", response.Request.URL.Hostname())
+	}
+	return nil
+}
+
+func (c *Client) loadDeveloperCapabilityMetadata(ctx context.Context, bundleID string) (developerCapabilityMetadataResponse, error) {
+	query := make(url.Values)
+	query.Set("filter[capabilityType]", "capability,service")
+	query.Set("filter[includeRequestable]", "true")
+	body, err := c.doDeveloperPortalRequest(ctx, http.MethodPost, "/capabilities?"+query.Encode(), nil, developerPortalHeaders(bundleID), false)
+	if err != nil {
+		return developerCapabilityMetadataResponse{}, err
+	}
+	var response developerCapabilityMetadataResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return response, fmt.Errorf("failed to parse Developer Portal capabilities response: %w", err)
+	}
+	return response, nil
+}
+
+func findDeveloperCapability(response developerCapabilityMetadataResponse, capabilityID string) (developerCapabilityMetadataAttributes, bool) {
+	for _, capability := range response.Data {
+		if capability.Type == "capabilities" && strings.EqualFold(strings.TrimSpace(capability.ID), capabilityID) {
+			return capability.Attributes, true
+		}
+	}
+	return developerCapabilityMetadataAttributes{}, false
+}
+
+func (c *Client) loadDeveloperBundleID(ctx context.Context, bundleID string) (developerBundleIDResponse, error) {
+	query := make(url.Values)
+	query.Set("fields[bundleIds]", "name,identifier,platform,seedId,wildcard,~permissions.delete,~permissions.edit")
+	query.Set("include", strings.Join(developerBundleIDIncludes, ","))
+	path := "/bundleIds/" + url.PathEscape(bundleID) + "?" + query.Encode()
+	body, err := c.doDeveloperPortalRequest(ctx, http.MethodPost, path, nil, developerPortalHeaders(bundleID), false)
+	if err != nil {
+		return developerBundleIDResponse{}, err
+	}
+	var response developerBundleIDResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return response, fmt.Errorf("failed to parse Developer Portal Bundle ID response: %w", err)
+	}
+	if strings.TrimSpace(response.Data.ID) == "" || response.Data.Type != "bundleIds" || len(response.Data.Attributes) == 0 {
+		return response, fmt.Errorf("incomplete Bundle ID resource returned by Developer Portal")
+	}
+	return response, nil
+}
+
+func buildDeveloperBundleIDCapabilityPatchRequest(current developerBundleIDResponse, req DeveloperBundleIDCapabilityEnableRequest) (developerBundleIDPatchRequest, bool, error) {
+	capabilities, err := developerBundleIDCapabilities(current)
+	if err != nil {
+		return developerBundleIDPatchRequest{}, false, err
+	}
+
+	updated := make([]developerResource, 0, len(capabilities)+1)
+	foundTarget := false
+	alreadyEnabled := false
+	for _, capability := range capabilities {
+		capabilityID, err := developerBundleIDCapabilityID(capability)
+		if err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		if capabilityID != req.Capability {
+			updated = append(updated, capability)
+			continue
+		}
+		if foundTarget {
+			continue
+		}
+		foundTarget = true
+		enabled, err := developerBundleIDCapabilityEnabled(capability)
+		if err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		if enabled {
+			alreadyEnabled = true
+			updated = append(updated, capability)
+			continue
+		}
+		capability.Attributes, err = setDeveloperCapabilityEnabled(capability.Attributes)
+		if err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		updated = append(updated, capability)
+	}
+	if alreadyEnabled {
+		return developerBundleIDPatchRequest{}, true, nil
+	}
+	if !foundTarget {
+		updated = append(updated, newDeveloperBundleIDCapability(req.Capability))
+	}
+
+	relationshipBody, err := json.Marshal(developerResourceRelationship{Data: updated})
+	if err != nil {
+		return developerBundleIDPatchRequest{}, false, fmt.Errorf("failed to build Bundle ID capability relationships: %w", err)
+	}
+	relationships := cloneRawMessageMap(current.Data.Relationships)
+	if relationships == nil {
+		relationships = make(map[string]json.RawMessage)
+	}
+	relationships["bundleIdCapabilities"] = relationshipBody
+
+	var payload developerBundleIDPatchRequest
+	payload.Data.ID = current.Data.ID
+	payload.Data.Type = current.Data.Type
+	payload.Data.Attributes = append(json.RawMessage(nil), current.Data.Attributes...)
+	payload.Data.Relationships = relationships
+	return payload, false, nil
+}
+
+func developerBundleIDCapabilities(current developerBundleIDResponse) ([]developerResource, error) {
+	var relationship developerResourceRelationship
+	rawRelationship, ok := current.Data.Relationships["bundleIdCapabilities"]
+	if !ok {
+		return []developerResource{}, nil
+	}
+	if err := json.Unmarshal(rawRelationship, &relationship); err != nil {
+		return nil, fmt.Errorf("failed to parse current Bundle ID capability relationships: %w", err)
+	}
+
+	includedByID := make(map[string]developerResource)
+	includedOrder := make([]string, 0)
+	for _, resource := range current.Included {
+		if resource.Type != "bundleIdCapabilities" || strings.TrimSpace(resource.ID) == "" {
+			continue
+		}
+		if _, exists := includedByID[resource.ID]; !exists {
+			includedOrder = append(includedOrder, resource.ID)
+		}
+		includedByID[resource.ID] = resource
+	}
+
+	capabilities := make([]developerResource, 0, len(relationship.Data))
+	seen := make(map[string]struct{})
+	for _, resource := range relationship.Data {
+		if resource.Type != "bundleIdCapabilities" {
+			continue
+		}
+		if resource.ID != "" {
+			if _, duplicate := seen[resource.ID]; duplicate {
+				continue
+			}
+			seen[resource.ID] = struct{}{}
+			if included, ok := includedByID[resource.ID]; ok {
+				resource = included
+			}
+		}
+		if _, err := developerBundleIDCapabilityID(resource); err != nil {
+			return nil, fmt.Errorf("cannot safely preserve Bundle ID capability %q: %w", resource.ID, err)
+		}
+		capabilities = append(capabilities, resource)
+	}
+	for _, id := range includedOrder {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		resource := includedByID[id]
+		if _, err := developerBundleIDCapabilityID(resource); err != nil {
+			return nil, fmt.Errorf("cannot safely preserve Bundle ID capability %q: %w", resource.ID, err)
+		}
+		seen[id] = struct{}{}
+		capabilities = append(capabilities, resource)
+	}
+	return capabilities, nil
+}
+
+func developerBundleIDCapabilityID(resource developerResource) (string, error) {
+	raw, ok := resource.Relationships["capability"]
+	if !ok {
+		return "", fmt.Errorf("missing capability relationship")
+	}
+	var relationship struct {
+		Data relationshipData `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &relationship); err != nil {
+		return "", fmt.Errorf("invalid capability relationship: %w", err)
+	}
+	id := strings.ToUpper(strings.TrimSpace(relationship.Data.ID))
+	if relationship.Data.Type != "capabilities" || id == "" {
+		return "", fmt.Errorf("invalid capability relationship data")
+	}
+	return id, nil
+}
+
+func developerBundleIDCapabilityEnabled(resource developerResource) (bool, error) {
+	if len(resource.Attributes) == 0 {
+		return false, fmt.Errorf("bundle ID capability %q is missing attributes", resource.ID)
+	}
+	var attributes map[string]json.RawMessage
+	if err := json.Unmarshal(resource.Attributes, &attributes); err != nil {
+		return false, fmt.Errorf("failed to parse Bundle ID capability %q attributes: %w", resource.ID, err)
+	}
+	var enabled bool
+	raw, ok := attributes["enabled"]
+	if !ok {
+		return false, nil
+	}
+	if err := json.Unmarshal(raw, &enabled); err != nil {
+		return false, fmt.Errorf("failed to parse Bundle ID capability %q enabled state: %w", resource.ID, err)
+	}
+	return enabled, nil
+}
+
+func setDeveloperCapabilityEnabled(raw json.RawMessage) (json.RawMessage, error) {
+	var attributes map[string]json.RawMessage
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &attributes); err != nil {
+			return nil, fmt.Errorf("failed to parse existing capability attributes: %w", err)
+		}
+	}
+	if attributes == nil {
+		attributes = make(map[string]json.RawMessage)
+	}
+	attributes["enabled"] = json.RawMessage("true")
+	if _, ok := attributes["settings"]; !ok {
+		attributes["settings"] = json.RawMessage("[]")
+	}
+	updated, err := json.Marshal(attributes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode capability attributes: %w", err)
+	}
+	return updated, nil
+}
+
+func newDeveloperBundleIDCapability(capability string) developerResource {
+	capabilityRelationship, _ := json.Marshal(struct {
+		Data relationshipData `json:"data"`
+	}{Data: relationshipData{Type: "capabilities", ID: capability}})
+	return developerResource{
+		Type:       "bundleIdCapabilities",
+		Attributes: json.RawMessage(`{"enabled":true,"settings":[]}`),
+		Relationships: map[string]json.RawMessage{
+			"capability": capabilityRelationship,
+		},
+	}
+}
+
+func cloneRawMessageMap(source map[string]json.RawMessage) map[string]json.RawMessage {
+	if source == nil {
+		return nil
+	}
+	cloned := make(map[string]json.RawMessage, len(source))
+	for key, value := range source {
+		cloned[key] = append(json.RawMessage(nil), value...)
+	}
+	return cloned
+}
+
+func developerPortalHeaders(bundleID string) http.Header {
+	headers := make(http.Header)
+	headers.Set("Accept", "application/vnd.api+json, application/json")
+	headers.Set("Content-Type", "application/vnd.api+json")
+	headers.Set("Referer", developerPortalBaseURL+"/account/resources/identifiers/list")
+	if strings.TrimSpace(bundleID) != "" {
+		headers.Set("Referer", developerPortalBaseURL+"/account/resources/identifiers/bundleId/edit/"+url.PathEscape(bundleID))
+	}
+	headers.Set("User-Agent", "App-Store-Connect-CLI")
+	headers.Set("X-Requested-With", "XMLHttpRequest")
+	return headers
+}
+
+func (c *Client) doDeveloperPortalRequest(ctx context.Context, method, path string, body any, headers http.Header, requireCSRF bool) ([]byte, error) {
+	if requireCSRF {
+		csrf, csrfTS := c.developerCSRFTokens()
+		headers.Set("csrf", csrf)
+		headers.Set("csrf_ts", csrfTS)
+	}
+	responseBody, response, err := c.doDeveloperPortalHTTP(ctx, method, developerServicesBaseURL+path, body, headers)
+	if err != nil {
+		return nil, err
+	}
+	c.captureDeveloperCSRFTokens(response.Header)
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+		return nil, developerPortalSessionError(response.StatusCode)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, &APIError{
+			Status:         response.StatusCode,
+			AppleRequestID: extractAppleRequestID(response.Header),
+			CorrelationKey: strings.TrimSpace(response.Header.Get("X-Apple-Jingle-Correlation-Key")),
+			rawBody:        responseBody,
+		}
+	}
+	return responseBody, nil
+}
+
+func (c *Client) doDeveloperPortalHTTP(ctx context.Context, method, requestURL string, body any, headers http.Header) ([]byte, *http.Response, error) {
+	if c == nil || c.httpClient == nil {
+		return nil, nil, fmt.Errorf("web client is not configured for Developer Portal")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := c.waitForRateLimit(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	var requestBody io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal Developer Portal request: %w", err)
+		}
+		requestBody = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, requestURL, requestBody)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create Developer Portal request: %w", err)
+	}
+	request.Header = cloneHeaders(headers)
+	setModifiedCookieHeader(c.httpClient, request)
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		logWebAuthHTTP("developer_portal_request", request, nil, nil, err)
+		return nil, nil, fmt.Errorf("request to Developer Portal failed: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		logWebAuthHTTP("developer_portal_request", request, response, nil, err)
+		return nil, response, fmt.Errorf("failed to read Developer Portal response: %w", err)
+	}
+	logWebAuthHTTP("developer_portal_request", request, response, responseBody, nil)
+	return responseBody, response, nil
+}
+
+func (c *Client) captureDeveloperCSRFTokens(headers http.Header) {
+	csrf := headerValueCaseInsensitive(headers, "csrf")
+	csrfTS := headerValueCaseInsensitive(headers, "csrf_ts")
+	if csrf == "" && csrfTS == "" {
+		return
+	}
+	c.developerSessionMu.Lock()
+	defer c.developerSessionMu.Unlock()
+	if csrf != "" {
+		c.developerCSRF = csrf
+	}
+	if csrfTS != "" {
+		c.developerCSRFTS = csrfTS
+	}
+}
+
+func headerValueCaseInsensitive(headers http.Header, name string) string {
+	for key, values := range headers {
+		if !strings.EqualFold(key, name) || len(values) == 0 {
+			continue
+		}
+		return strings.TrimSpace(values[0])
+	}
+	return ""
+}
+
+func (c *Client) developerCSRFTokens() (string, string) {
+	c.developerSessionMu.Lock()
+	defer c.developerSessionMu.Unlock()
+	return c.developerCSRF, c.developerCSRFTS
+}
+
+func developerPortalSessionError(status int) error {
+	return fmt.Errorf("web session is unauthorized or expired for Developer Portal (status %d); run 'asc web auth login --apple-id EMAIL --reauthenticate' and try again", status)
+}

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -16,6 +16,7 @@ const (
 	developerPortalAccountURL = developerPortalBaseURL + "/account"
 	developerServicesBaseURL  = developerPortalBaseURL + "/services-account/v1"
 	privateCloudCompute       = "PRIVATE_CLOUD_COMPUTE"
+	developerPortalAuthHint   = "run 'asc web auth logout --apple-id EMAIL', then 'asc web auth login --apple-id EMAIL', and try again"
 )
 
 var supportedDeveloperBundleIDCapabilities = map[string]struct{}{
@@ -161,7 +162,7 @@ func (c *Client) EnableDeveloperBundleIDCapability(ctx context.Context, req Deve
 
 	csrf, csrfTS := c.developerCSRFTokens()
 	if csrf == "" || csrfTS == "" {
-		return nil, fmt.Errorf("missing Developer Portal CSRF headers; run 'asc web auth login --apple-id EMAIL --reauthenticate' and try again")
+		return nil, fmt.Errorf("missing Developer Portal CSRF headers; %s", developerPortalAuthHint)
 	}
 	path := "/bundleIds/" + url.PathEscape(req.BundleID)
 	if _, err := c.doDeveloperPortalRequest(ctx, http.MethodPatch, path, payload, developerPortalHeaders(req.BundleID), true); err != nil {
@@ -192,7 +193,7 @@ func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
 		return &APIError{Status: response.StatusCode, AppleRequestID: extractAppleRequestID(response.Header), rawBody: body}
 	}
 	if response.Request != nil && response.Request.URL != nil && !strings.EqualFold(response.Request.URL.Hostname(), "developer.apple.com") {
-		return fmt.Errorf("authentication redirected to %s instead of Developer Portal; run 'asc web auth login --apple-id EMAIL --reauthenticate' and try again", response.Request.URL.Hostname())
+		return fmt.Errorf("authentication redirected to %s instead of Developer Portal; %s", response.Request.URL.Hostname(), developerPortalAuthHint)
 	}
 	return nil
 }
@@ -552,5 +553,5 @@ func (c *Client) developerCSRFTokens() (string, string) {
 }
 
 func developerPortalSessionError(status int) error {
-	return fmt.Errorf("web session is unauthorized or expired for Developer Portal (status %d); run 'asc web auth login --apple-id EMAIL --reauthenticate' and try again", status)
+	return fmt.Errorf("web session is unauthorized or expired for Developer Portal (status %d); %s", status, developerPortalAuthHint)
 }

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -233,7 +233,7 @@ func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
 	if len(teams) == 0 {
 		teams = payload.Data.Teams
 	}
-	team, err := selectDeveloperPortalTeam(teams, c.providerName)
+	team, err := selectDeveloperPortalTeam(teams, c.publicProviderID, c.providerName)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
 	return nil
 }
 
-func selectDeveloperPortalTeam(teams []developerPortalTeam, providerName string) (developerPortalTeam, error) {
+func selectDeveloperPortalTeam(teams []developerPortalTeam, publicProviderID, providerName string) (developerPortalTeam, error) {
 	valid := make([]developerPortalTeam, 0, len(teams))
 	for _, team := range teams {
 		team.TeamID = strings.TrimSpace(team.TeamID)
@@ -254,6 +254,14 @@ func selectDeveloperPortalTeam(teams []developerPortalTeam, providerName string)
 	}
 	if len(valid) == 0 {
 		return developerPortalTeam{}, fmt.Errorf("apple account has no Developer Portal team; a paid Apple Developer Program membership may be required")
+	}
+	publicProviderID = strings.TrimSpace(publicProviderID)
+	if publicProviderID != "" {
+		for _, team := range valid {
+			if strings.EqualFold(publicProviderID, team.TeamID) {
+				return team, nil
+			}
+		}
 	}
 	providerName = strings.TrimSpace(providerName)
 	if providerName != "" {

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -233,8 +233,18 @@ func TestSelectDeveloperPortalTeam(t *testing.T) {
 		{TeamID: "TEAMTWO456", Name: "Example Company"},
 	}
 
+	t.Run("exact public provider id wins", func(t *testing.T) {
+		team, err := selectDeveloperPortalTeam(teams, "TEAMONE123", "Example Company")
+		if err != nil {
+			t.Fatalf("selectDeveloperPortalTeam() error: %v", err)
+		}
+		if team.TeamID != "TEAMONE123" {
+			t.Fatalf("team = %+v", team)
+		}
+	})
+
 	t.Run("exact provider name", func(t *testing.T) {
-		team, err := selectDeveloperPortalTeam(teams, "Example Company")
+		team, err := selectDeveloperPortalTeam(teams, "", "Example Company")
 		if err != nil {
 			t.Fatalf("selectDeveloperPortalTeam() error: %v", err)
 		}
@@ -244,7 +254,7 @@ func TestSelectDeveloperPortalTeam(t *testing.T) {
 	})
 
 	t.Run("provider name suffix", func(t *testing.T) {
-		team, err := selectDeveloperPortalTeam(teams, "Example Company (App Store Connect)")
+		team, err := selectDeveloperPortalTeam(teams, "", "Example Company (App Store Connect)")
 		if err != nil {
 			t.Fatalf("selectDeveloperPortalTeam() error: %v", err)
 		}
@@ -254,7 +264,7 @@ func TestSelectDeveloperPortalTeam(t *testing.T) {
 	})
 
 	t.Run("single team fallback", func(t *testing.T) {
-		team, err := selectDeveloperPortalTeam(teams[:1], "Different Provider")
+		team, err := selectDeveloperPortalTeam(teams[:1], "", "Different Provider")
 		if err != nil {
 			t.Fatalf("selectDeveloperPortalTeam() error: %v", err)
 		}
@@ -264,7 +274,7 @@ func TestSelectDeveloperPortalTeam(t *testing.T) {
 	})
 
 	t.Run("ambiguous teams", func(t *testing.T) {
-		if _, err := selectDeveloperPortalTeam(teams, "Different Provider"); err == nil {
+		if _, err := selectDeveloperPortalTeam(teams, "", "Different Provider"); err == nil {
 			t.Fatal("expected provider matching error")
 		}
 	})

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -382,7 +382,7 @@ func TestEnableDeveloperBundleIDCapabilityRequiresDeveloperPortalSession(t *test
 		BundleID:   "bundle-1",
 		Capability: "PRIVATE_CLOUD_COMPUTE",
 	})
-	if err == nil || !strings.Contains(err.Error(), "Developer Portal") || !strings.Contains(err.Error(), "asc web auth login") {
+	if err == nil || !strings.Contains(err.Error(), "Developer Portal") || !strings.Contains(err.Error(), "asc web auth login") || strings.Contains(err.Error(), "--reauthenticate") {
 		t.Fatalf("error = %v", err)
 	}
 }
@@ -408,7 +408,7 @@ func TestEnableDeveloperBundleIDCapabilityRequiresCSRFTokensBeforePatch(t *testi
 		BundleID:   "bundle-1",
 		Capability: "PRIVATE_CLOUD_COMPUTE",
 	})
-	if err == nil || !strings.Contains(err.Error(), "CSRF") || !strings.Contains(err.Error(), "asc web auth login") {
+	if err == nil || !strings.Contains(err.Error(), "CSRF") || !strings.Contains(err.Error(), "asc web auth login") || strings.Contains(err.Error(), "--reauthenticate") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -32,19 +33,33 @@ func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 
 				switch requestCount {
 				case 1:
-					if r.Method != http.MethodGet || r.URL.Path != "/account" {
+					if r.Method != http.MethodPost || r.URL.Path != "/services-account/QH65B2/account/listTeams.action" {
 						t.Fatalf("unexpected bootstrap request %s %s", r.Method, r.URL.String())
 					}
-					return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+					return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": []string{"bootstrap-csrf"}, "csrf_ts": []string{"bootstrap-ts"}}), nil
 				case 2:
 					if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/capabilities" {
 						t.Fatalf("unexpected metadata request %s %s", r.Method, r.URL.String())
 					}
-					if got := r.URL.Query().Get("filter[capabilityType]"); got != "capability,service" {
+					if got := r.Header.Get("X-HTTP-Method-Override"); got != http.MethodGet {
+						t.Fatalf("metadata method override = %q", got)
+					}
+					proxy := decodeDeveloperPortalProxyReadRequest(t, r)
+					if proxy.TeamID != "TEAM123456" {
+						t.Fatalf("metadata teamId = %q", proxy.TeamID)
+					}
+					query, err := url.ParseQuery(proxy.URLEncodedQueryParams)
+					if err != nil {
+						t.Fatalf("metadata query: %v", err)
+					}
+					if got := query.Get("filter[capabilityType]"); got != "capability,service" {
 						t.Fatalf("filter[capabilityType] = %q", got)
 					}
-					if got := r.URL.Query().Get("filter[includeRequestable]"); got != "true" {
+					if got := query.Get("filter[includeRequestable]"); got != "true" {
 						t.Fatalf("filter[includeRequestable] = %q", got)
+					}
+					if r.Header.Get("csrf") != "bootstrap-csrf" || r.Header.Get("csrf_ts") != "bootstrap-ts" {
+						t.Fatalf("metadata request missing bootstrap CSRF headers")
 					}
 					return developerPortalTestResponse(http.StatusOK, `{
 						"data":[{
@@ -63,10 +78,18 @@ func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 					if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
 						t.Fatalf("unexpected bundle request %s %s", r.Method, r.URL.String())
 					}
-					if got := r.URL.Query().Get("fields[bundleIds]"); got != "name,identifier,platform,seedId,wildcard,~permissions.delete,~permissions.edit" {
+					if got := r.Header.Get("X-HTTP-Method-Override"); got != http.MethodGet {
+						t.Fatalf("bundle method override = %q", got)
+					}
+					proxy := decodeDeveloperPortalProxyReadRequest(t, r)
+					query, err := url.ParseQuery(proxy.URLEncodedQueryParams)
+					if err != nil {
+						t.Fatalf("bundle query: %v", err)
+					}
+					if got := query.Get("fields[bundleIds]"); got != "name,identifier,platform,seedId,wildcard,~permissions.delete,~permissions.edit" {
 						t.Fatalf("fields[bundleIds] = %q", got)
 					}
-					include := r.URL.Query().Get("include")
+					include := query.Get("include")
 					for _, relationship := range []string{
 						"bundleIdCapabilities",
 						"bundleIdCapabilities.capability",
@@ -161,6 +184,9 @@ func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 	if payload.Data.Attributes["platform"] != "IOS" || payload.Data.Attributes["seedId"] != "TEAMID" || payload.Data.Attributes["~permissions.edit"] != true {
 		t.Fatalf("bundle attributes were not preserved: %+v", payload.Data.Attributes)
 	}
+	if payload.Data.Attributes["teamId"] != "TEAM123456" {
+		t.Fatalf("Developer Portal teamId = %v", payload.Data.Attributes["teamId"])
+	}
 
 	var capabilityRelationship struct {
 		Data []struct {
@@ -201,13 +227,56 @@ func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 	}
 }
 
+func TestSelectDeveloperPortalTeam(t *testing.T) {
+	teams := []developerPortalTeam{
+		{TeamID: "TEAMONE123", Name: "Example"},
+		{TeamID: "TEAMTWO456", Name: "Example Company"},
+	}
+
+	t.Run("exact provider name", func(t *testing.T) {
+		team, err := selectDeveloperPortalTeam(teams, "Example Company")
+		if err != nil {
+			t.Fatalf("selectDeveloperPortalTeam() error: %v", err)
+		}
+		if team.TeamID != "TEAMTWO456" {
+			t.Fatalf("team = %+v", team)
+		}
+	})
+
+	t.Run("provider name suffix", func(t *testing.T) {
+		team, err := selectDeveloperPortalTeam(teams, "Example Company (App Store Connect)")
+		if err != nil {
+			t.Fatalf("selectDeveloperPortalTeam() error: %v", err)
+		}
+		if team.TeamID != "TEAMTWO456" {
+			t.Fatalf("team = %+v", team)
+		}
+	})
+
+	t.Run("single team fallback", func(t *testing.T) {
+		team, err := selectDeveloperPortalTeam(teams[:1], "Different Provider")
+		if err != nil {
+			t.Fatalf("selectDeveloperPortalTeam() error: %v", err)
+		}
+		if team.TeamID != "TEAMONE123" {
+			t.Fatalf("team = %+v", team)
+		}
+	})
+
+	t.Run("ambiguous teams", func(t *testing.T) {
+		if _, err := selectDeveloperPortalTeam(teams, "Different Provider"); err == nil {
+			t.Fatal("expected provider matching error")
+		}
+	})
+}
+
 func TestEnableDeveloperBundleIDCapabilityAlreadyEnabledSkipsPatch(t *testing.T) {
 	requestCount := 0
 	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
 		requestCount++
 		switch requestCount {
 		case 1:
-			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil), nil
 		case 2:
 			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), http.Header{"csrf": []string{"token"}, "csrf_ts": []string{"time"}}), nil
 		case 3:
@@ -230,6 +299,44 @@ func TestEnableDeveloperBundleIDCapabilityAlreadyEnabledSkipsPatch(t *testing.T)
 	}
 }
 
+func TestEnableDeveloperBundleIDCapabilityUsesIncludedCapabilitiesWhenTopLevelRelationshipsAreOmitted(t *testing.T) {
+	requestCount := 0
+	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil), nil
+		case 2:
+			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), http.Header{"csrf": []string{"token"}, "csrf_ts": []string{"time"}}), nil
+		case 3:
+			return developerPortalTestResponse(http.StatusOK, `{
+				"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app"}},
+				"included":[
+					{"type":"bundleIdCapabilities","id":"iap-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"IN_APP_PURCHASE"}}}},
+					{"type":"bundleIdCapabilities","id":"pcc-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE"}}}}
+				]
+			}`, nil), nil
+		default:
+			t.Fatalf("unexpected PATCH or extra request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	})
+
+	result, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "PRIVATE_CLOUD_COMPUTE",
+	})
+	if err != nil {
+		t.Fatalf("EnableDeveloperBundleIDCapability() error: %v", err)
+	}
+	if !result.Enabled || result.Changed || result.Status != "already-enabled" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if requestCount != 3 {
+		t.Fatalf("request count = %d, want 3", requestCount)
+	}
+}
+
 func TestEnableDeveloperBundleIDCapabilityUpdatesDisabledTargetOnce(t *testing.T) {
 	requestCount := 0
 	var patchBody []byte
@@ -237,7 +344,7 @@ func TestEnableDeveloperBundleIDCapabilityUpdatesDisabledTargetOnce(t *testing.T
 		requestCount++
 		switch requestCount {
 		case 1:
-			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil), nil
 		case 2:
 			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), http.Header{"csrf": []string{"token"}, "csrf_ts": []string{"time"}}), nil
 		case 3:
@@ -342,7 +449,7 @@ func TestEnableDeveloperBundleIDCapabilityRejectsUnavailableAndNonEditable(t *te
 			client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
 				requestCount++
 				if requestCount == 1 {
-					return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+					return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil), nil
 				}
 				return developerPortalTestResponse(http.StatusOK, tc.metadataBody, nil), nil
 			})
@@ -393,7 +500,7 @@ func TestEnableDeveloperBundleIDCapabilityRequiresCSRFTokensBeforePatch(t *testi
 		requestCount++
 		switch requestCount {
 		case 1:
-			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil), nil
 		case 2:
 			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), nil), nil
 		case 3:
@@ -419,7 +526,7 @@ func TestEnableDeveloperBundleIDCapabilitySurfacesAppleError(t *testing.T) {
 		requestCount++
 		switch requestCount {
 		case 1:
-			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil), nil
 		case 2:
 			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), http.Header{"csrf": []string{"token"}, "csrf_ts": []string{"time"}}), nil
 		case 3:
@@ -459,6 +566,19 @@ func developerPortalTestResponse(status int, body string, headers http.Header) *
 		Header:     headers,
 		Body:       io.NopCloser(bytes.NewBufferString(body)),
 	}
+}
+
+func developerPortalTeamsFixture() string {
+	return `{"teams":[{"teamId":"TEAM123456","name":"Example Team","status":"active"}]}`
+}
+
+func decodeDeveloperPortalProxyReadRequest(t *testing.T, r *http.Request) developerPortalProxyReadRequest {
+	t.Helper()
+	var request developerPortalProxyReadRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		t.Fatalf("decode Developer Portal proxy request: %v", err)
+	}
+	return request
 }
 
 func developerCapabilityMetadata(editable bool) string {

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -1,0 +1,476 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"testing"
+)
+
+func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New() error: %v", err)
+	}
+
+	var patchBody []byte
+	requestCount := 0
+	client := &Client{
+		httpClient: &http.Client{
+			Jar: jar,
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				requestCount++
+				for _, header := range []string{"Accept", "Content-Type", "Referer", "User-Agent", "X-Requested-With"} {
+					if strings.TrimSpace(r.Header.Get(header)) == "" {
+						t.Fatalf("request %d missing %s header", requestCount, header)
+					}
+				}
+
+				switch requestCount {
+				case 1:
+					if r.Method != http.MethodGet || r.URL.Path != "/account" {
+						t.Fatalf("unexpected bootstrap request %s %s", r.Method, r.URL.String())
+					}
+					return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+				case 2:
+					if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/capabilities" {
+						t.Fatalf("unexpected metadata request %s %s", r.Method, r.URL.String())
+					}
+					if got := r.URL.Query().Get("filter[capabilityType]"); got != "capability,service" {
+						t.Fatalf("filter[capabilityType] = %q", got)
+					}
+					if got := r.URL.Query().Get("filter[includeRequestable]"); got != "true" {
+						t.Fatalf("filter[includeRequestable] = %q", got)
+					}
+					return developerPortalTestResponse(http.StatusOK, `{
+						"data":[{
+							"type":"capabilities",
+							"id":"PRIVATE_CLOUD_COMPUTE",
+							"attributes":{
+								"name":"Access to models on Private Cloud Compute",
+								"entitlement":"com.apple.developer.private-cloud-compute",
+								"isPublic":false,
+								"editable":true,
+								"canRequestFromPortal":false
+							}
+						}]
+					}`, http.Header{"csrf": []string{"secret-csrf"}, "csrf_ts": []string{"secret-ts"}}), nil
+				case 3:
+					if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
+						t.Fatalf("unexpected bundle request %s %s", r.Method, r.URL.String())
+					}
+					if got := r.URL.Query().Get("fields[bundleIds]"); got != "name,identifier,platform,seedId,wildcard,~permissions.delete,~permissions.edit" {
+						t.Fatalf("fields[bundleIds] = %q", got)
+					}
+					include := r.URL.Query().Get("include")
+					for _, relationship := range []string{
+						"bundleIdCapabilities",
+						"bundleIdCapabilities.capability",
+						"bundleIdCapabilities.appGroups",
+						"bundleIdCapabilities.cloudContainers",
+					} {
+						if !strings.Contains(include, relationship) {
+							t.Fatalf("include missing %q: %q", relationship, include)
+						}
+					}
+					return developerPortalTestResponse(http.StatusOK, `{
+						"data":{
+							"id":"bundle-1",
+							"type":"bundleIds",
+							"attributes":{
+								"name":"Example",
+								"identifier":"com.example.app",
+								"platform":"IOS",
+								"seedId":"TEAMID",
+								"wildcard":false,
+								"~permissions.delete":true,
+								"~permissions.edit":true
+							},
+							"relationships":{
+								"bundleIdCapabilities":{
+									"data":[
+										{"type":"bundleIdCapabilities","id":"icloud-1"},
+										{"type":"bundleIdCapabilities","id":"icloud-1"}
+									]
+								}
+							}
+						},
+						"included":[{
+							"type":"bundleIdCapabilities",
+							"id":"icloud-1",
+							"attributes":{"enabled":true,"settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]},
+							"relationships":{
+								"capability":{"data":{"type":"capabilities","id":"ICLOUD"}},
+								"appGroups":{"data":[{"type":"appGroups","id":"group-1"}]},
+								"cloudContainers":{"data":[{"type":"cloudContainers","id":"cloud-1"}]}
+							}
+						}]
+					}`, nil), nil
+				case 4:
+					if r.Method != http.MethodPatch || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
+						t.Fatalf("unexpected patch request %s %s", r.Method, r.URL.String())
+					}
+					if r.Header.Get("csrf") != "secret-csrf" || r.Header.Get("csrf_ts") != "secret-ts" {
+						t.Fatalf("missing CSRF headers")
+					}
+					patchBody, err = io.ReadAll(r.Body)
+					if err != nil {
+						t.Fatalf("ReadAll() error: %v", err)
+					}
+					return developerPortalTestResponse(http.StatusOK, `{"data":{"type":"bundleIds","id":"bundle-1"}}`, nil), nil
+				default:
+					t.Fatalf("unexpected request %d: %s %s", requestCount, r.Method, r.URL.String())
+					return nil, nil
+				}
+			}),
+		},
+	}
+
+	result, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "private_cloud_compute",
+	})
+	if err != nil {
+		t.Fatalf("EnableDeveloperBundleIDCapability() error: %v", err)
+	}
+	if !result.Enabled || !result.Changed || result.Status != "enabled" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if requestCount != 4 {
+		t.Fatalf("request count = %d, want 4", requestCount)
+	}
+
+	var payload struct {
+		Data struct {
+			ID            string                     `json:"id"`
+			Type          string                     `json:"type"`
+			Attributes    map[string]any             `json:"attributes"`
+			Relationships map[string]json.RawMessage `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(patchBody, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; body=%s", err, patchBody)
+	}
+	if payload.Data.ID != "bundle-1" || payload.Data.Type != "bundleIds" {
+		t.Fatalf("unexpected resource identity: %+v", payload.Data)
+	}
+	if payload.Data.Attributes["platform"] != "IOS" || payload.Data.Attributes["seedId"] != "TEAMID" || payload.Data.Attributes["~permissions.edit"] != true {
+		t.Fatalf("bundle attributes were not preserved: %+v", payload.Data.Attributes)
+	}
+
+	var capabilityRelationship struct {
+		Data []struct {
+			ID            string                     `json:"id"`
+			Type          string                     `json:"type"`
+			Attributes    map[string]any             `json:"attributes"`
+			Relationships map[string]json.RawMessage `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(payload.Data.Relationships["bundleIdCapabilities"], &capabilityRelationship); err != nil {
+		t.Fatalf("decode bundleIdCapabilities: %v", err)
+	}
+	if len(capabilityRelationship.Data) != 2 {
+		t.Fatalf("capability count = %d, want preserved ICLOUD plus PCC: %+v", len(capabilityRelationship.Data), capabilityRelationship.Data)
+	}
+	existing := capabilityRelationship.Data[0]
+	if existing.ID != "icloud-1" || existing.Attributes["enabled"] != true {
+		t.Fatalf("existing capability changed: %+v", existing)
+	}
+	if _, ok := existing.Relationships["appGroups"]; !ok {
+		t.Fatalf("existing appGroups relationship was not preserved: %+v", existing.Relationships)
+	}
+	if _, ok := existing.Relationships["cloudContainers"]; !ok {
+		t.Fatalf("existing cloudContainers relationship was not preserved: %+v", existing.Relationships)
+	}
+	added := capabilityRelationship.Data[1]
+	if added.Type != "bundleIdCapabilities" || added.Attributes["enabled"] != true {
+		t.Fatalf("unexpected PCC relationship: %+v", added)
+	}
+	var capability struct {
+		Data relationshipData `json:"data"`
+	}
+	if err := json.Unmarshal(added.Relationships["capability"], &capability); err != nil {
+		t.Fatalf("decode capability relationship: %v", err)
+	}
+	if capability.Data != (relationshipData{Type: "capabilities", ID: "PRIVATE_CLOUD_COMPUTE"}) {
+		t.Fatalf("unexpected capability data: %+v", capability.Data)
+	}
+}
+
+func TestEnableDeveloperBundleIDCapabilityAlreadyEnabledSkipsPatch(t *testing.T) {
+	requestCount := 0
+	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+		case 2:
+			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), http.Header{"csrf": []string{"token"}, "csrf_ts": []string{"time"}}), nil
+		case 3:
+			return developerPortalTestResponse(http.StatusOK, developerBundleResponse(true), nil), nil
+		default:
+			t.Fatalf("unexpected PATCH or extra request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	})
+
+	result, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "PRIVATE_CLOUD_COMPUTE",
+	})
+	if err != nil {
+		t.Fatalf("EnableDeveloperBundleIDCapability() error: %v", err)
+	}
+	if !result.Enabled || result.Changed || result.Status != "already-enabled" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestEnableDeveloperBundleIDCapabilityUpdatesDisabledTargetOnce(t *testing.T) {
+	requestCount := 0
+	var patchBody []byte
+	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+		case 2:
+			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), http.Header{"csrf": []string{"token"}, "csrf_ts": []string{"time"}}), nil
+		case 3:
+			return developerPortalTestResponse(http.StatusOK, `{
+				"data":{
+					"id":"bundle-1",
+					"type":"bundleIds",
+					"attributes":{"name":"Example","identifier":"com.example.app"},
+					"relationships":{"bundleIdCapabilities":{"data":[
+						{"type":"bundleIdCapabilities","id":"pcc-disabled-1"},
+						{"type":"bundleIdCapabilities","id":"pcc-disabled-2"}
+					]}}
+				},
+				"included":[
+					{
+						"type":"bundleIdCapabilities",
+						"id":"pcc-disabled-1",
+						"attributes":{"enabled":false,"settings":[{"key":"EXISTING_SETTING"}],"portalOwned":"keep"},
+						"relationships":{
+							"capability":{"data":{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE"}},
+							"associatedBundleIds":{"data":[{"type":"bundleIds","id":"related-1"}]}
+						}
+					},
+					{
+						"type":"bundleIdCapabilities",
+						"id":"pcc-disabled-2",
+						"attributes":{"enabled":false,"settings":[]},
+						"relationships":{"capability":{"data":{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE"}}}
+					}
+				]
+			}`, nil), nil
+		case 4:
+			var err error
+			patchBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			return developerPortalTestResponse(http.StatusOK, `{"data":{"type":"bundleIds","id":"bundle-1"}}`, nil), nil
+		default:
+			t.Fatalf("unexpected request")
+			return nil, nil
+		}
+	})
+
+	result, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "PRIVATE_CLOUD_COMPUTE",
+	})
+	if err != nil {
+		t.Fatalf("EnableDeveloperBundleIDCapability() error: %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("expected changed result: %+v", result)
+	}
+
+	var payload struct {
+		Data struct {
+			Relationships struct {
+				BundleIDCapabilities developerResourceRelationship `json:"bundleIdCapabilities"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(patchBody, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+	caps := payload.Data.Relationships.BundleIDCapabilities.Data
+	if len(caps) != 1 {
+		t.Fatalf("target capability count = %d, want 1: %+v", len(caps), caps)
+	}
+	if caps[0].ID != "pcc-disabled-1" {
+		t.Fatalf("first target identity not preserved: %+v", caps[0])
+	}
+	var attributes map[string]any
+	if err := json.Unmarshal(caps[0].Attributes, &attributes); err != nil {
+		t.Fatalf("decode attributes: %v", err)
+	}
+	if attributes["enabled"] != true || attributes["portalOwned"] != "keep" {
+		t.Fatalf("target attributes not preserved: %+v", attributes)
+	}
+	settings, ok := attributes["settings"].([]any)
+	if !ok || len(settings) != 1 {
+		t.Fatalf("target settings not preserved: %+v", attributes["settings"])
+	}
+	if _, ok := caps[0].Relationships["associatedBundleIds"]; !ok {
+		t.Fatalf("target relationships not preserved: %+v", caps[0].Relationships)
+	}
+}
+
+func TestEnableDeveloperBundleIDCapabilityRejectsUnavailableAndNonEditable(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadataBody string
+		wantErr      string
+	}{
+		{name: "unavailable", metadataBody: `{"data":[]}`, wantErr: "not available"},
+		{name: "non-editable", metadataBody: developerCapabilityMetadata(false), wantErr: "not editable"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requestCount := 0
+			client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+				requestCount++
+				if requestCount == 1 {
+					return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+				}
+				return developerPortalTestResponse(http.StatusOK, tc.metadataBody, nil), nil
+			})
+
+			_, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+				BundleID:   "bundle-1",
+				Capability: "PRIVATE_CLOUD_COMPUTE",
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnableDeveloperBundleIDCapabilityRejectsUnsupportedCapabilityBeforeHTTP(t *testing.T) {
+	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected HTTP request: %s %s", r.Method, r.URL.String())
+		return nil, nil
+	})
+
+	_, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "ICLOUD",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported Developer Portal capability") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEnableDeveloperBundleIDCapabilityRequiresDeveloperPortalSession(t *testing.T) {
+	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+		return developerPortalTestResponse(http.StatusForbidden, `forbidden`, nil), nil
+	})
+
+	_, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "PRIVATE_CLOUD_COMPUTE",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Developer Portal") || !strings.Contains(err.Error(), "asc web auth login") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEnableDeveloperBundleIDCapabilityRequiresCSRFTokensBeforePatch(t *testing.T) {
+	requestCount := 0
+	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+		case 2:
+			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), nil), nil
+		case 3:
+			return developerPortalTestResponse(http.StatusOK, developerBundleResponse(false), nil), nil
+		default:
+			t.Fatalf("unexpected PATCH without CSRF headers")
+			return nil, nil
+		}
+	})
+
+	_, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "PRIVATE_CLOUD_COMPUTE",
+	})
+	if err == nil || !strings.Contains(err.Error(), "CSRF") || !strings.Contains(err.Error(), "asc web auth login") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEnableDeveloperBundleIDCapabilitySurfacesAppleError(t *testing.T) {
+	requestCount := 0
+	client := developerPortalTestClient(t, func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return developerPortalTestResponse(http.StatusOK, `<html></html>`, nil), nil
+		case 2:
+			return developerPortalTestResponse(http.StatusOK, developerCapabilityMetadata(true), http.Header{"csrf": []string{"token"}, "csrf_ts": []string{"time"}}), nil
+		case 3:
+			return developerPortalTestResponse(http.StatusOK, developerBundleResponse(false), nil), nil
+		case 4:
+			return developerPortalTestResponse(http.StatusUnprocessableEntity, `{"errors":[{"code":"CAPABILITY_NOT_ALLOWED"}]}`, http.Header{"X-Apple-Request-UUID": []string{"request-1"}}), nil
+		default:
+			t.Fatalf("unexpected request")
+			return nil, nil
+		}
+	})
+
+	_, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "PRIVATE_CLOUD_COMPUTE",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status 422") || !strings.Contains(err.Error(), "CAPABILITY_NOT_ALLOWED") || !strings.Contains(err.Error(), "request-1") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func developerPortalTestClient(t *testing.T, fn roundTripFunc) *Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New() error: %v", err)
+	}
+	return &Client{httpClient: &http.Client{Jar: jar, Transport: fn}}
+}
+
+func developerPortalTestResponse(status int, body string, headers http.Header) *http.Response {
+	if headers == nil {
+		headers = make(http.Header)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     headers,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func developerCapabilityMetadata(editable bool) string {
+	if editable {
+		return `{"data":[{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE","attributes":{"name":"Access to models on Private Cloud Compute","editable":true}}]}`
+	}
+	return `{"data":[{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE","attributes":{"name":"Access to models on Private Cloud Compute","editable":false}}]}`
+}
+
+func developerBundleResponse(enabled bool) string {
+	if enabled {
+		return `{"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app"},"relationships":{"bundleIdCapabilities":{"data":[{"type":"bundleIdCapabilities","id":"pcc-1"}]}}},"included":[{"type":"bundleIdCapabilities","id":"pcc-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE"}}}}]}`
+	}
+	return `{"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app"},"relationships":{"bundleIdCapabilities":{"data":[]}}},"included":[]}`
+}

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -433,6 +433,30 @@ func TestEnableDeveloperBundleIDCapabilityUpdatesDisabledTargetOnce(t *testing.T
 	}
 }
 
+func TestBuildDeveloperBundleIDCapabilityPatchPrefersEnabledDuplicate(t *testing.T) {
+	current := developerBundleIDResponse{}
+	current.Data.ID = "bundle-1"
+	current.Data.Type = "bundleIds"
+	current.Data.Attributes = json.RawMessage(`{"name":"Example","identifier":"com.example.app"}`)
+	current.Data.Relationships = map[string]json.RawMessage{
+		"bundleIdCapabilities": json.RawMessage(`{"data":[
+			{"type":"bundleIdCapabilities","id":"pcc-disabled","attributes":{"enabled":false,"settings":[{"key":"DISABLED"}]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE"}}}},
+			{"type":"bundleIdCapabilities","id":"pcc-enabled","attributes":{"enabled":true,"settings":[{"key":"ENABLED"}]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PRIVATE_CLOUD_COMPUTE"}},"associatedBundleIds":{"data":[{"type":"bundleIds","id":"related-1"}]}}}
+		]}`),
+	}
+
+	_, alreadyEnabled, err := buildDeveloperBundleIDCapabilityPatchRequest(current, DeveloperBundleIDCapabilityEnableRequest{
+		BundleID:   "bundle-1",
+		Capability: "PRIVATE_CLOUD_COMPUTE",
+	})
+	if err != nil {
+		t.Fatalf("buildDeveloperBundleIDCapabilityPatchRequest() error: %v", err)
+	}
+	if !alreadyEnabled {
+		t.Fatal("enabled duplicate was not recognized")
+	}
+}
+
 func TestEnableDeveloperBundleIDCapabilityRejectsUnavailableAndNonEditable(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -215,6 +215,7 @@ func legacyIrisLastFilePath() (string, error) {
 func sessionCookieURLs() []*url.URL {
 	return []*url.URL{
 		{Scheme: "https", Host: "appstoreconnect.apple.com", Path: "/"},
+		{Scheme: "https", Host: "developer.apple.com", Path: "/"},
 		{Scheme: "https", Host: "idmsa.apple.com", Path: "/"},
 		{Scheme: "https", Host: "gsa.apple.com", Path: "/"},
 	}

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -809,6 +809,25 @@ func TestHydrateCookieJarSkipsExpiredCookies(t *testing.T) {
 	}
 }
 
+func TestSerializeCookieJarIncludesDeveloperPortalOrigin(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New() error: %v", err)
+	}
+	developerURL, err := url.Parse("https://developer.apple.com/")
+	if err != nil {
+		t.Fatalf("url.Parse() error: %v", err)
+	}
+	jar.SetCookies(developerURL, []*http.Cookie{
+		{Name: "myacinfo", Value: "developer-session", Secure: true},
+	})
+
+	serialized := serializeCookieJar(jar, "user@example.com")
+	if got := persistedMyacinfoCookieValue(serialized, "https://developer.apple.com/"); got != "developer-session" {
+		t.Fatalf("developer portal cookie = %q, want persisted session", got)
+	}
+}
+
 func TestPersistSessionUsesSingleSharedKeychainStore(t *testing.T) {
 	kr := withArraySessionKeyring(t)
 	t.Setenv(webSessionBackendEnv, "keychain")
@@ -994,7 +1013,7 @@ func TestTryResumeSessionPersistsRefreshedCookies(t *testing.T) {
 		t.Fatal("expected refreshed session in cache")
 	}
 
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "refreshed-token" {
+	if got := persistedMyacinfoCookieValue(stored, "https://appstoreconnect.apple.com/"); got != "refreshed-token" {
 		t.Fatalf("expected refreshed cookie value, got %q", got)
 	}
 }
@@ -1052,7 +1071,7 @@ func TestTryResumeLastSessionPersistsRefreshedCookies(t *testing.T) {
 	if !ok {
 		t.Fatal("expected refreshed session in cache")
 	}
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "new-token" {
+	if got := persistedMyacinfoCookieValue(stored, "https://appstoreconnect.apple.com/"); got != "new-token" {
 		t.Fatalf("expected refreshed cookie value, got %q", got)
 	}
 }
@@ -1336,7 +1355,7 @@ func TestTryResumeSessionMigratesLegacyIrisFileCache(t *testing.T) {
 	if !ok {
 		t.Fatal("expected migrated session in web cache")
 	}
-	if got := persistedCookieValue(stored, "https://appstoreconnect.apple.com/", "myacinfo"); got != "legacy-iris-token" {
+	if got := persistedMyacinfoCookieValue(stored, "https://appstoreconnect.apple.com/"); got != "legacy-iris-token" {
 		t.Fatalf("expected migrated legacy cookie value, got %q", got)
 	}
 	if _, err := os.Stat(filepath.Join(legacyDir, "session-"+key+".json")); !os.IsNotExist(err) {
@@ -2012,10 +2031,10 @@ func TestClearLastSessionMarkerDefaultBackendIgnoresUnavailableKeychainFallback(
 	}
 }
 
-func persistedCookieValue(sess persistedSession, baseURL, cookieName string) string {
+func persistedMyacinfoCookieValue(sess persistedSession, baseURL string) string {
 	list := sess.Cookies[baseURL]
 	for _, cookie := range list {
-		if cookie.Name == cookieName {
+		if cookie.Name == "myacinfo" {
 			return cookie.Value
 		}
 	}


### PR DESCRIPTION
## Summary

- add `asc web bundle-ids capabilities enable --bundle-id BUNDLE_RESOURCE_ID --capability PRIVATE_CLOUD_COMPUTE --confirm`
- bootstrap the App Store Connect SRP session through Developer Portal's `QH65B2/account/listTeams.action` endpoint
- use Developer Portal's cookie-authenticated `services-account/v1` proxy contract: logical reads are `POST` requests with `X-HTTP-Method-Override: GET`, `teamId`, and encoded query parameters
- load capability metadata and the complete Bundle ID capability graph before PATCHing
- preserve existing attributes, settings, and relationships; collapse duplicates and skip PATCH when PCC is already enabled
- retain Developer Portal cookies and CSRF response headers without logging secret values
- surface auth/CSRF failures and Apple JSON:API error codes with actionable diagnostics
- add the command to capability discovery as a web-session workflow

## Why `asc web`

Apple's public `BundleIdCapabilityCreateRequest` uses the published `CapabilityType` enum, which does not include `PRIVATE_CLOUD_COMPUTE`. The public list endpoint can decode and display PCC after it has been enabled, but the public create endpoint rejects it. The working write contract is Developer Portal's full Bundle ID PATCH, so this path stays isolated from `asc bundle-ids capabilities add`.

## Safety

- requires `--confirm`
- supports only `PRIVATE_CLOUD_COMPUTE`
- validates that the capability is available and editable
- sends the complete current capability relationship array and preserves server-owned fields
- handles capability resources returned only through top-level `included`
- returns `already-enabled` without PATCHing when no change is needed
- fails closed when an existing capability cannot be reconstructed safely

## Testing

- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused `internal/web`, `internal/cli/web`, and `internal/cli/cmdtest` tests
- built `/tmp/asc-pcc-live` and verified help, validation, live enable, public read-back, and live idempotency

HTTP fixtures cover the Portal team bootstrap, team matching, CSRF propagation, proxy method/path/body/header shape, metadata and Bundle ID reads, full PATCH preservation, duplicate handling, omitted top-level relationships with `included` capability resources, idempotency, missing CSRF, expired auth, and Apple error responses.

## Live verification

Disposable App Store app only:

- app: `6759231657` (`ASC Test 20260216074703`)
- Bundle ID resource: `JJ9F7BJ3FY`
- identifier: `com.rudrank.asc.throwaway20260216074703`

Public API baseline contained only `IN_APP_PURCHASE`. The public command:

```console
asc bundle-ids capabilities add --bundle JJ9F7BJ3FY --capability PRIVATE_CLOUD_COMPUTE
```

exited `5` because Apple rejected `PRIVATE_CLOUD_COMPUTE` as outside the public `capabilityType` enum. The capability list remained unchanged.

With the Developer Portal bootstrap/proxy flow, read-only metadata returned 216 records and PCC was present and editable. The new command then returned:

```json
{"bundleId":"JJ9F7BJ3FY","capability":"PRIVATE_CLOUD_COMPUTE","enabled":true,"changed":true,"status":"enabled"}
```

Independent public API read-back returned exactly one `JJ9F7BJ3FY_PRIVATE_CLOUD_COMPUTE` resource alongside `IN_APP_PURCHASE`.

The first idempotency check exposed a response-shape bug: Apple omitted `data.relationships` while returning current capabilities in top-level `included`, causing one redundant idempotent PATCH. The parser now consumes `included` even when the relationship object is absent, with a regression test. The rebuilt command returned:

```json
{"bundleId":"JJ9F7BJ3FY","capability":"PRIVATE_CLOUD_COMPUTE","enabled":true,"changed":false,"status":"already-enabled"}
```

Final public read-back still contains exactly one PCC resource. Presset and all other non-disposable apps were untouched. No cookies, passwords, CSRF values, 2FA codes, or tokens were logged or committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support for enabling Developer Portal Bundle ID capabilities.
  * Added support for the `PRIVATE_CLOUD_COMPUTE` capability.
  * Added table, Markdown, and JSON output showing capability status and changes.
* **Improvements**
  * Improved Developer Portal session handling, cookie persistence, authentication, and API error reporting.
  * Updated web-session help text to cover App Store Connect and Developer Portal workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
