### PR TITLE
ci: avoid workflow scope for WinGet releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -872,7 +872,8 @@ jobs:
             BRANCH_EXISTS=1
             git checkout -B "${BRANCH}" "origin/${BRANCH}"
           else
-            git checkout -b "${BRANCH}" upstream/master
+            # Avoid requiring workflow scope when the upstream repository has newer workflow files.
+            git checkout -b "${BRANCH}" origin/master
           fi
           git sparse-checkout set "manifests/r/Rorkai/ASC"
 

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -605,7 +605,7 @@ func TestReleaseWorkflowUsesCommitTimestampForBuildMetadata(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
+func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewriteOrWorkflowScope(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
@@ -616,7 +616,7 @@ func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
 		"--force-with-lease",
 		"git push --force",
 		`git merge-base --is-ancestor origin/master "origin/${BRANCH}"`,
-		`git checkout -b "${BRANCH}" origin/master`,
+		`git checkout -b "${BRANCH}" upstream/master`,
 		`grep -Ev "^manifests/r/Rorkai/ASC/${VERSION}/"`,
 	} {
 		if strings.Contains(workflow, unwanted) {
@@ -625,7 +625,7 @@ func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewrite(t *testing.T) {
 	}
 	for _, want := range []string{
 		`git merge-base --is-ancestor origin/master upstream/master`,
-		`git checkout -b "${BRANCH}" upstream/master`,
+		`git checkout -b "${BRANCH}" origin/master`,
 		`git push --set-upstream origin "${BRANCH}"`,
 		`git diff --name-only -z upstream/master...HEAD`,
 		`case "$changed_path" in`,


### PR DESCRIPTION
## Summary

- create new WinGet version branches from the fork's existing `master`
- avoid requiring `workflow` scope when upstream has newer workflow files
- preserve the fast-forward-only and manifest-only safety checks

## Verification

- `go test . -run '^TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewriteOrWorkflowScope$' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./...`
- `make format`
- `make check-docs`
- `make check-wall-of-apps`
- `make lint`
- `make build`

## Release evidence

The 3.7.0 release completed artifact publication, signing, notarization, and Homebrew. Its WinGet job failed because the token correctly lacks `workflow` scope and the branch based on upstream `master` attempted to introduce newer upstream workflow files into the fork.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788883952&installation_model_id=10418&pr_number=1902&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1902&signature=44452ea49f72f140fd625d11182daabe149fc6ce4203392bf12e0bd646c3ecc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WinGet submission workflow branch creation to work without requiring workflow permissions from the upstream repository.
  * Preserved fast-forward ancestry validation against the upstream branch to prevent unintended history rewrites.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->