### PR TITLE
fix(signing): keep synchronized assets profile-scoped

### DIFF
--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -317,7 +317,7 @@ func resolveSigningCertificateTypes(profileType, raw string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		certificateTypes = []string{inferred}
+		certificateTypes = shared.SplitCSVUpper(inferred)
 	}
 
 	for _, certificateType := range certificateTypes {
@@ -427,17 +427,17 @@ func inferCertificateType(profileType string) (string, error) {
 
 	switch {
 	case strings.Contains(normalized, "IOS_APP_DEVELOPMENT"):
-		return "IOS_DEVELOPMENT", nil
+		return "IOS_DEVELOPMENT,DEVELOPMENT", nil
 	case strings.Contains(normalized, "IOS_APP_STORE"),
 		strings.Contains(normalized, "IOS_APP_ADHOC"),
 		strings.Contains(normalized, "IOS_APP_INHOUSE"):
-		return "IOS_DISTRIBUTION", nil
+		return "IOS_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "TVOS_APP_DEVELOPMENT"):
-		return "IOS_DEVELOPMENT", nil
+		return "IOS_DEVELOPMENT,DEVELOPMENT", nil
 	case strings.Contains(normalized, "TVOS_APP_STORE"),
 		strings.Contains(normalized, "TVOS_APP_ADHOC"),
 		strings.Contains(normalized, "TVOS_APP_INHOUSE"):
-		return "IOS_DISTRIBUTION", nil
+		return "IOS_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_DEVELOPMENT"):
 		return "IOS_DEVELOPMENT", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_STORE"):

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -222,14 +222,31 @@ type signingAssetsOptions struct {
 
 var errNoMatchingProfileCertificates = errors.New("profile has no matching associated certificates")
 
+var supportedSigningCertificateTypes = map[string]struct{}{
+	"APPLE_PAY":                   {},
+	"APPLE_PAY_MERCHANT_IDENTITY": {},
+	"APPLE_PAY_PSP_IDENTITY":      {},
+	"APPLE_PAY_RSA":               {},
+	"DEVELOPER_ID_KEXT":           {},
+	"DEVELOPER_ID_KEXT_G2":        {},
+	"DEVELOPER_ID_APPLICATION":    {},
+	"DEVELOPER_ID_APPLICATION_G2": {},
+	"DEVELOPMENT":                 {},
+	"DISTRIBUTION":                {},
+	"IDENTITY_ACCESS":             {},
+	"IOS_DEVELOPMENT":             {},
+	"IOS_DISTRIBUTION":            {},
+	"MAC_APP_DISTRIBUTION":        {},
+	"MAC_INSTALLER_DISTRIBUTION":  {},
+	"MAC_APP_DEVELOPMENT":         {},
+	"PASS_TYPE_ID":                {},
+	"PASS_TYPE_ID_WITH_NFC":       {},
+}
+
 func resolveSigningAssets(ctx context.Context, client *asc.Client, options signingAssetsOptions) (*asc.ProfileResponse, *asc.CertificatesResponse, bool, error) {
-	certificateType := strings.TrimSpace(options.CertificateType)
-	if certificateType == "" {
-		var err error
-		certificateType, err = inferCertificateType(options.ProfileType)
-		if err != nil {
-			return nil, nil, false, err
-		}
+	certificateType, err := resolveSigningCertificateTypes(options.ProfileType, options.CertificateType)
+	if err != nil {
+		return nil, nil, false, err
 	}
 
 	profiles, err := findActiveProfiles(ctx, client, options.BundleIDResourceID, options.ProfileType)
@@ -291,6 +308,24 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 		return nil, nil, false, err
 	}
 	return profile, certificates, true, nil
+}
+
+func resolveSigningCertificateTypes(profileType, raw string) (string, error) {
+	certificateTypes := shared.SplitCSVUpper(raw)
+	if len(certificateTypes) == 0 {
+		inferred, err := inferCertificateType(profileType)
+		if err != nil {
+			return "", err
+		}
+		certificateTypes = []string{inferred}
+	}
+
+	for _, certificateType := range certificateTypes {
+		if _, ok := supportedSigningCertificateTypes[certificateType]; !ok {
+			return "", fmt.Errorf("unsupported certificate type %s", certificateType)
+		}
+	}
+	return strings.Join(certificateTypes, ","), nil
 }
 
 func findActiveProfiles(ctx context.Context, client *asc.Client, bundleIDResourceID, profileType string) ([]asc.Resource[asc.ProfileAttributes], error) {

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -325,19 +325,24 @@ func findProfileCertificates(ctx context.Context, client *asc.Client, profileID,
 		next = response.Links.Next
 	}
 
-	requestedType := strings.TrimSpace(certificateType)
-	if requestedType != "" {
+	requestedTypes := shared.SplitCSVUpper(certificateType)
+	if len(requestedTypes) > 0 {
+		requestedTypeSet := make(map[string]struct{}, len(requestedTypes))
+		for _, requestedType := range requestedTypes {
+			requestedTypeSet[requestedType] = struct{}{}
+		}
 		filtered := make([]asc.Resource[asc.CertificateAttributes], 0, len(all))
 		for _, certificate := range all {
-			if strings.EqualFold(strings.TrimSpace(certificate.Attributes.CertificateType), requestedType) {
+			certificateType := strings.ToUpper(strings.TrimSpace(certificate.Attributes.CertificateType))
+			if _, matches := requestedTypeSet[certificateType]; matches {
 				filtered = append(filtered, certificate)
 			}
 		}
 		all = filtered
 	}
 	if len(all) == 0 {
-		if requestedType != "" {
-			return nil, fmt.Errorf("profile %s has no associated certificates of type %s", profileID, requestedType)
+		if len(requestedTypes) > 0 {
+			return nil, fmt.Errorf("profile %s has no associated certificates of type %s", profileID, strings.Join(requestedTypes, ","))
 		}
 		return nil, fmt.Errorf("profile %s has no associated certificates", profileID)
 	}

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -98,25 +98,22 @@ Examples:
 			}
 			result.BundleIDResource = bundleIDResp.Data.ID
 
-			certs, err := findCertificates(requestCtx, client, profType, *certType)
-			if err != nil {
-				return fmt.Errorf("signing fetch: %w", err)
-			}
-			result.CertificateIDs = extractIDs(certs.Data)
-
-			profile, created, err := findOrCreateProfile(
+			profile, certs, created, err := resolveSigningAssets(
 				requestCtx,
 				client,
-				bundleIDResp.Data.ID,
-				bundle,
-				profType,
-				result.CertificateIDs,
-				shared.SplitCSV(*deviceIDs),
-				*createMissing,
+				signingAssetsOptions{
+					BundleIDResourceID: bundleIDResp.Data.ID,
+					BundleIdentifier:   bundle,
+					ProfileType:        profType,
+					CertificateType:    *certType,
+					DeviceIDs:          shared.SplitCSV(*deviceIDs),
+					CreateMissing:      *createMissing,
+				},
 			)
 			if err != nil {
 				return fmt.Errorf("signing fetch: %w", err)
 			}
+			result.CertificateIDs = extractIDs(certs.Data)
 			result.ProfileID = profile.Data.ID
 			result.Created = created
 
@@ -212,7 +209,62 @@ func findCertificates(ctx context.Context, client *asc.Client, profileType, cert
 	return &asc.CertificatesResponse{Data: all, Links: links}, nil
 }
 
-func findOrCreateProfile(ctx context.Context, client *asc.Client, bundleIDResourceID, bundleIdentifier, profileType string, certIDs, deviceIDs []string, createMissing bool) (*asc.ProfileResponse, bool, error) {
+type signingAssetsOptions struct {
+	BundleIDResourceID string
+	BundleIdentifier   string
+	ProfileType        string
+	CertificateType    string
+	DeviceIDs          []string
+	CreateMissing      bool
+	BeforeCreate       func() error
+}
+
+func resolveSigningAssets(ctx context.Context, client *asc.Client, options signingAssetsOptions) (*asc.ProfileResponse, *asc.CertificatesResponse, bool, error) {
+	profile, err := findActiveProfile(ctx, client, options.BundleIDResourceID, options.ProfileType)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if profile != nil {
+		certificates, err := findProfileCertificates(ctx, client, profile.Data.ID, options.CertificateType)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		return profile, certificates, false, nil
+	}
+
+	if !options.CreateMissing {
+		return nil, nil, false, fmt.Errorf(
+			"no active %s profile found for bundle ID %s; use --create-missing to create one",
+			options.ProfileType,
+			options.BundleIdentifier,
+		)
+	}
+
+	certificates, err := findCertificates(ctx, client, options.ProfileType, options.CertificateType)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if options.BeforeCreate != nil {
+		if err := options.BeforeCreate(); err != nil {
+			return nil, nil, false, fmt.Errorf("preflight before creating profile: %w", err)
+		}
+	}
+
+	profile, err = createProfile(
+		ctx,
+		client,
+		options.BundleIDResourceID,
+		options.ProfileType,
+		extractIDs(certificates.Data),
+		options.DeviceIDs,
+	)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return profile, certificates, true, nil
+}
+
+func findActiveProfile(ctx context.Context, client *asc.Client, bundleIDResourceID, profileType string) (*asc.ProfileResponse, error) {
 	next := ""
 	for {
 		profiles, err := client.GetBundleIDProfiles(
@@ -221,7 +273,7 @@ func findOrCreateProfile(ctx context.Context, client *asc.Client, bundleIDResour
 			asc.WithBundleIDProfilesNextURL(next),
 		)
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 
 		for _, profile := range profiles.Data {
@@ -229,31 +281,68 @@ func findOrCreateProfile(ctx context.Context, client *asc.Client, bundleIDResour
 				continue
 			}
 			if strings.EqualFold(strings.TrimSpace(profile.Attributes.ProfileType), profileType) {
-				return &asc.ProfileResponse{Data: profile}, false, nil
+				return &asc.ProfileResponse{Data: profile}, nil
 			}
 		}
 
 		if strings.TrimSpace(profiles.Links.Next) == "" {
-			break
+			return nil, nil
 		}
 		next = profiles.Links.Next
 	}
+}
 
-	if !createMissing {
-		return nil, false, fmt.Errorf("no active %s profile found for bundle ID %s; use --create-missing to create one", profileType, bundleIdentifier)
+func findProfileCertificates(ctx context.Context, client *asc.Client, profileID, certificateType string) (*asc.CertificatesResponse, error) {
+	var (
+		all   []asc.Resource[asc.CertificateAttributes]
+		links asc.Links
+		next  string
+	)
+	for {
+		response, err := client.GetProfileCertificates(
+			ctx,
+			profileID,
+			asc.WithProfileCertificatesNextURL(next),
+		)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, response.Data...)
+		links = response.Links
+		if strings.TrimSpace(response.Links.Next) == "" {
+			break
+		}
+		next = response.Links.Next
 	}
+
+	requestedType := strings.TrimSpace(certificateType)
+	if requestedType != "" {
+		filtered := make([]asc.Resource[asc.CertificateAttributes], 0, len(all))
+		for _, certificate := range all {
+			if strings.EqualFold(strings.TrimSpace(certificate.Attributes.CertificateType), requestedType) {
+				filtered = append(filtered, certificate)
+			}
+		}
+		all = filtered
+	}
+	if len(all) == 0 {
+		if requestedType != "" {
+			return nil, fmt.Errorf("profile %s has no associated certificates of type %s", profileID, requestedType)
+		}
+		return nil, fmt.Errorf("profile %s has no associated certificates", profileID)
+	}
+	return &asc.CertificatesResponse{Data: all, Links: links}, nil
+}
+
+func createProfile(ctx context.Context, client *asc.Client, bundleIDResourceID, profileType string, certIDs, deviceIDs []string) (*asc.ProfileResponse, error) {
 	if len(certIDs) == 0 {
-		return nil, false, fmt.Errorf("no certificates available to create profile")
+		return nil, fmt.Errorf("no certificates available to create profile")
 	}
 	name := fmt.Sprintf("%s-%s", profileType, time.Now().Format("20060102"))
-	profile, err := client.CreateProfile(ctx, asc.ProfileCreateAttributes{
+	return client.CreateProfile(ctx, asc.ProfileCreateAttributes{
 		Name:        name,
 		ProfileType: profileType,
 	}, bundleIDResourceID, certIDs, deviceIDs)
-	if err != nil {
-		return nil, false, err
-	}
-	return profile, true, nil
 }
 
 func isDevelopmentProfile(profileType string) bool {

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -223,6 +223,15 @@ type signingAssetsOptions struct {
 var errNoMatchingProfileCertificates = errors.New("profile has no matching associated certificates")
 
 func resolveSigningAssets(ctx context.Context, client *asc.Client, options signingAssetsOptions) (*asc.ProfileResponse, *asc.CertificatesResponse, bool, error) {
+	certificateType := strings.TrimSpace(options.CertificateType)
+	if certificateType == "" {
+		var err error
+		certificateType, err = inferCertificateType(options.ProfileType)
+		if err != nil {
+			return nil, nil, false, err
+		}
+	}
+
 	profiles, err := findActiveProfiles(ctx, client, options.BundleIDResourceID, options.ProfileType)
 	if err != nil {
 		return nil, nil, false, err
@@ -230,7 +239,7 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 	var certificateMatchErr error
 	for _, profileResource := range profiles {
 		profile := &asc.ProfileResponse{Data: profileResource}
-		certificates, err := findProfileCertificates(ctx, client, profile.Data.ID, options.CertificateType)
+		certificates, err := findProfileCertificates(ctx, client, profile.Data.ID, certificateType)
 		if err == nil {
 			return profile, certificates, false, nil
 		}
@@ -251,7 +260,7 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 		)
 	}
 
-	certificates, err := findCertificates(ctx, client, options.ProfileType, options.CertificateType)
+	certificates, err := findCertificates(ctx, client, options.ProfileType, certificateType)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -220,20 +220,30 @@ type signingAssetsOptions struct {
 	CreateContext      func() (context.Context, context.CancelFunc)
 }
 
+var errNoMatchingProfileCertificates = errors.New("profile has no matching associated certificates")
+
 func resolveSigningAssets(ctx context.Context, client *asc.Client, options signingAssetsOptions) (*asc.ProfileResponse, *asc.CertificatesResponse, bool, error) {
-	profile, err := findActiveProfile(ctx, client, options.BundleIDResourceID, options.ProfileType)
+	profiles, err := findActiveProfiles(ctx, client, options.BundleIDResourceID, options.ProfileType)
 	if err != nil {
 		return nil, nil, false, err
 	}
-	if profile != nil {
+	var certificateMatchErr error
+	for _, profileResource := range profiles {
+		profile := &asc.ProfileResponse{Data: profileResource}
 		certificates, err := findProfileCertificates(ctx, client, profile.Data.ID, options.CertificateType)
-		if err != nil {
+		if err == nil {
+			return profile, certificates, false, nil
+		}
+		if !errors.Is(err, errNoMatchingProfileCertificates) {
 			return nil, nil, false, err
 		}
-		return profile, certificates, false, nil
+		certificateMatchErr = err
 	}
 
 	if !options.CreateMissing {
+		if certificateMatchErr != nil {
+			return nil, nil, false, certificateMatchErr
+		}
 		return nil, nil, false, fmt.Errorf(
 			"no active %s profile found for bundle ID %s; use --create-missing to create one",
 			options.ProfileType,
@@ -259,7 +269,7 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 			return nil, nil, false, fmt.Errorf("profile create context is nil")
 		}
 	}
-	profile, err = createProfile(
+	profile, err := createProfile(
 		createCtx,
 		client,
 		options.BundleIDResourceID,
@@ -274,7 +284,8 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 	return profile, certificates, true, nil
 }
 
-func findActiveProfile(ctx context.Context, client *asc.Client, bundleIDResourceID, profileType string) (*asc.ProfileResponse, error) {
+func findActiveProfiles(ctx context.Context, client *asc.Client, bundleIDResourceID, profileType string) ([]asc.Resource[asc.ProfileAttributes], error) {
+	var matches []asc.Resource[asc.ProfileAttributes]
 	next := ""
 	for {
 		profiles, err := client.GetBundleIDProfiles(
@@ -291,12 +302,12 @@ func findActiveProfile(ctx context.Context, client *asc.Client, bundleIDResource
 				continue
 			}
 			if strings.EqualFold(strings.TrimSpace(profile.Attributes.ProfileType), profileType) {
-				return &asc.ProfileResponse{Data: profile}, nil
+				matches = append(matches, profile)
 			}
 		}
 
 		if strings.TrimSpace(profiles.Links.Next) == "" {
-			return nil, nil
+			return matches, nil
 		}
 		next = profiles.Links.Next
 	}
@@ -342,9 +353,9 @@ func findProfileCertificates(ctx context.Context, client *asc.Client, profileID,
 	}
 	if len(all) == 0 {
 		if len(requestedTypes) > 0 {
-			return nil, fmt.Errorf("profile %s has no associated certificates of type %s", profileID, strings.Join(requestedTypes, ","))
+			return nil, fmt.Errorf("profile %s has no associated certificates of type %s: %w", profileID, strings.Join(requestedTypes, ","), errNoMatchingProfileCertificates)
 		}
-		return nil, fmt.Errorf("profile %s has no associated certificates", profileID)
+		return nil, fmt.Errorf("profile %s has no associated certificates: %w", profileID, errNoMatchingProfileCertificates)
 	}
 	return &asc.CertificatesResponse{Data: all, Links: links}, nil
 }

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -433,11 +433,11 @@ func inferCertificateType(profileType string) (string, error) {
 		strings.Contains(normalized, "IOS_APP_INHOUSE"):
 		return "IOS_DISTRIBUTION", nil
 	case strings.Contains(normalized, "TVOS_APP_DEVELOPMENT"):
-		return "TVOS_DEVELOPMENT", nil
+		return "IOS_DEVELOPMENT", nil
 	case strings.Contains(normalized, "TVOS_APP_STORE"),
 		strings.Contains(normalized, "TVOS_APP_ADHOC"),
 		strings.Contains(normalized, "TVOS_APP_INHOUSE"):
-		return "TVOS_DISTRIBUTION", nil
+		return "IOS_DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_DEVELOPMENT"):
 		return "IOS_DEVELOPMENT", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_STORE"):

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -217,6 +217,7 @@ type signingAssetsOptions struct {
 	DeviceIDs          []string
 	CreateMissing      bool
 	BeforeCreate       func() error
+	CreateContext      func() (context.Context, context.CancelFunc)
 }
 
 func resolveSigningAssets(ctx context.Context, client *asc.Client, options signingAssetsOptions) (*asc.ProfileResponse, *asc.CertificatesResponse, bool, error) {
@@ -250,14 +251,23 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 		}
 	}
 
+	createCtx := ctx
+	cancelCreate := func() {}
+	if options.CreateContext != nil {
+		createCtx, cancelCreate = options.CreateContext()
+		if createCtx == nil {
+			return nil, nil, false, fmt.Errorf("profile create context is nil")
+		}
+	}
 	profile, err = createProfile(
-		ctx,
+		createCtx,
 		client,
 		options.BundleIDResourceID,
 		options.ProfileType,
 		extractIDs(certificates.Data),
 		options.DeviceIDs,
 	)
+	cancelCreate()
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -179,7 +179,7 @@ func TestSigningFetchWriteFiles_NoOverwrite(t *testing.T) {
 	}
 }
 
-func TestFindActiveProfileUsesBundleIDRelationship(t *testing.T) {
+func TestFindActiveProfilesUseBundleIDRelationship(t *testing.T) {
 	widgetProfileContent := base64.StdEncoding.EncodeToString([]byte("application-identifier=TEAM.com.example.signing.profile.widget"))
 	mainProfileContent := base64.StdEncoding.EncodeToString([]byte("application-identifier=TEAM.com.example.signing.profile"))
 	requestPaths := []string{}
@@ -209,17 +209,17 @@ func TestFindActiveProfileUsesBundleIDRelationship(t *testing.T) {
 		}
 	})
 
-	profile, err := findActiveProfile(
+	profiles, err := findActiveProfiles(
 		context.Background(),
 		client,
 		"bundle-main",
 		"IOS_APP_STORE",
 	)
 	if err != nil {
-		t.Fatalf("findActiveProfile() error: %v", err)
+		t.Fatalf("findActiveProfiles() error: %v", err)
 	}
-	if profile.Data.ID != "profile-main" {
-		t.Fatalf("expected exact bundle profile, got %s", profile.Data.ID)
+	if len(profiles) != 1 || profiles[0].ID != "profile-main" {
+		t.Fatalf("expected exact bundle profile, got %#v", profiles)
 	}
 
 	if len(requestPaths) != 1 || requestPaths[0] != "/v1/bundleIds/bundle-main/profiles" {
@@ -359,6 +359,87 @@ func TestResolveSigningAssetsFiltersExistingProfileCertificatesByRequestedType(t
 				t.Fatalf("expected only %s, got %v", tt.wantID, got)
 			}
 		})
+	}
+}
+
+func TestResolveSigningAssetsChecksEveryActiveProfileForRequestedCertificate(t *testing.T) {
+	requestPaths := []string{}
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		requestPaths = append(requestPaths, req.URL.Path)
+		switch req.URL.Path {
+		case "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"profiles","id":"profile-first","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}},{"type":"profiles","id":"profile-second","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}]}`)
+		case "/v1/profiles/profile-first/certificates":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-mac","attributes":{"certificateType":"MAC_APP_DISTRIBUTION"}}]}`)
+		case "/v1/profiles/profile-second/certificates":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-ios","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	profile, certificates, created, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+			CertificateType:    "IOS_DISTRIBUTION",
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveSigningAssets() error: %v", err)
+	}
+	if created || profile.Data.ID != "profile-second" {
+		t.Fatalf("expected matching existing profile, got created=%v profile=%#v", created, profile)
+	}
+	if got := extractIDs(certificates.Data); len(got) != 1 || got[0] != "cert-ios" {
+		t.Fatalf("expected cert-ios, got %v", got)
+	}
+	wantPaths := "/v1/bundleIds/bundle-main/profiles,/v1/profiles/profile-first/certificates,/v1/profiles/profile-second/certificates"
+	if strings.Join(requestPaths, ",") != wantPaths {
+		t.Fatalf("unexpected lookup order: %v", requestPaths)
+	}
+}
+
+func TestResolveSigningAssetsCreatesWhenActiveProfilesLackRequestedCertificate(t *testing.T) {
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"profiles","id":"profile-first","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}},{"type":"profiles","id":"profile-second","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}]}`)
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/profiles/"):
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-mac","attributes":{"certificateType":"MAC_APP_DISTRIBUTION"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-ios","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	profile, certificates, created, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+			CertificateType:    "IOS_DISTRIBUTION",
+			CreateMissing:      true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveSigningAssets() error: %v", err)
+	}
+	if !created || profile.Data.ID != "profile-created" {
+		t.Fatalf("expected created profile, got created=%v profile=%#v", created, profile)
+	}
+	if got := extractIDs(certificates.Data); len(got) != 1 || got[0] != "cert-ios" {
+		t.Fatalf("expected creation certificate cert-ios, got %v", got)
 	}
 }
 

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -362,6 +362,32 @@ func TestResolveSigningAssetsFiltersExistingProfileCertificatesByRequestedType(t
 	}
 }
 
+func TestResolveSigningAssetsRejectsUnknownCertificateTypesBeforeLookup(t *testing.T) {
+	requests := 0
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		requests++
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+	})
+
+	_, _, _, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+			CertificateType:    "IOS_DISTRIBUTION,BOGUS",
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unsupported certificate type BOGUS") {
+		t.Fatalf("resolveSigningAssets() error = %v, want unsupported certificate type", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected validation before lookup, got %d requests", requests)
+	}
+}
+
 func TestResolveSigningAssetsChecksEveryActiveProfileForInferredCertificateType(t *testing.T) {
 	requestPaths := []string{}
 	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -388,6 +388,30 @@ func TestResolveSigningAssetsRejectsUnknownCertificateTypesBeforeLookup(t *testi
 	}
 }
 
+func TestResolveSigningCertificateTypesUsesIOSCertificatesForTVOSProfiles(t *testing.T) {
+	tests := []struct {
+		profileType string
+		want        string
+	}{
+		{profileType: "TVOS_APP_DEVELOPMENT", want: "IOS_DEVELOPMENT"},
+		{profileType: "TVOS_APP_STORE", want: "IOS_DISTRIBUTION"},
+		{profileType: "TVOS_APP_ADHOC", want: "IOS_DISTRIBUTION"},
+		{profileType: "TVOS_APP_INHOUSE", want: "IOS_DISTRIBUTION"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profileType, func(t *testing.T) {
+			got, err := resolveSigningCertificateTypes(tt.profileType, "")
+			if err != nil {
+				t.Fatalf("resolveSigningCertificateTypes() error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveSigningCertificateTypes() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveSigningAssetsChecksEveryActiveProfileForInferredCertificateType(t *testing.T) {
 	requestPaths := []string{}
 	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -362,7 +362,7 @@ func TestResolveSigningAssetsFiltersExistingProfileCertificatesByRequestedType(t
 	}
 }
 
-func TestResolveSigningAssetsChecksEveryActiveProfileForRequestedCertificate(t *testing.T) {
+func TestResolveSigningAssetsChecksEveryActiveProfileForInferredCertificateType(t *testing.T) {
 	requestPaths := []string{}
 	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
 		requestPaths = append(requestPaths, req.URL.Path)
@@ -386,7 +386,6 @@ func TestResolveSigningAssetsChecksEveryActiveProfileForRequestedCertificate(t *
 			BundleIDResourceID: "bundle-main",
 			BundleIdentifier:   "com.example.signing.profile",
 			ProfileType:        "IOS_APP_STORE",
-			CertificateType:    "IOS_DISTRIBUTION",
 		},
 	)
 	if err != nil {
@@ -405,7 +404,9 @@ func TestResolveSigningAssetsChecksEveryActiveProfileForRequestedCertificate(t *
 }
 
 func TestResolveSigningAssetsCreatesWhenActiveProfilesLackRequestedCertificate(t *testing.T) {
+	requestPaths := []string{}
 	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		requestPaths = append(requestPaths, req.Method+" "+req.URL.Path)
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
 			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"profiles","id":"profile-first","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}},{"type":"profiles","id":"profile-second","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}]}`)
@@ -440,6 +441,10 @@ func TestResolveSigningAssetsCreatesWhenActiveProfilesLackRequestedCertificate(t
 	}
 	if got := extractIDs(certificates.Data); len(got) != 1 || got[0] != "cert-ios" {
 		t.Fatalf("expected creation certificate cert-ios, got %v", got)
+	}
+	wantPaths := "GET /v1/bundleIds/bundle-main/profiles,GET /v1/profiles/profile-first/certificates,GET /v1/profiles/profile-second/certificates,GET /v1/certificates,POST /v1/profiles"
+	if strings.Join(requestPaths, ",") != wantPaths {
+		t.Fatalf("unexpected lookup and creation order: %v", requestPaths)
 	}
 }
 

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -305,6 +305,11 @@ func TestResolveSigningAssetsFiltersExistingProfileCertificatesByRequestedType(t
 			wantID:          "cert-ios",
 		},
 		{
+			name:            "comma separated types include matching certificate",
+			certificateType: "DEVELOPER_ID_APPLICATION, ios_distribution",
+			wantID:          "cert-ios",
+		},
+		{
 			name:            "no associated certificate matches",
 			certificateType: "DEVELOPER_ID_APPLICATION",
 			wantErr:         "profile profile-main has no associated certificates of type DEVELOPER_ID_APPLICATION",

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -388,15 +388,19 @@ func TestResolveSigningAssetsRejectsUnknownCertificateTypesBeforeLookup(t *testi
 	}
 }
 
-func TestResolveSigningCertificateTypesUsesIOSCertificatesForTVOSProfiles(t *testing.T) {
+func TestResolveSigningCertificateTypesIncludesCompatibleCertificatesForIOSAndTVOSProfiles(t *testing.T) {
 	tests := []struct {
 		profileType string
 		want        string
 	}{
-		{profileType: "TVOS_APP_DEVELOPMENT", want: "IOS_DEVELOPMENT"},
-		{profileType: "TVOS_APP_STORE", want: "IOS_DISTRIBUTION"},
-		{profileType: "TVOS_APP_ADHOC", want: "IOS_DISTRIBUTION"},
-		{profileType: "TVOS_APP_INHOUSE", want: "IOS_DISTRIBUTION"},
+		{profileType: "IOS_APP_DEVELOPMENT", want: "IOS_DEVELOPMENT,DEVELOPMENT"},
+		{profileType: "IOS_APP_STORE", want: "IOS_DISTRIBUTION,DISTRIBUTION"},
+		{profileType: "IOS_APP_ADHOC", want: "IOS_DISTRIBUTION,DISTRIBUTION"},
+		{profileType: "IOS_APP_INHOUSE", want: "IOS_DISTRIBUTION,DISTRIBUTION"},
+		{profileType: "TVOS_APP_DEVELOPMENT", want: "IOS_DEVELOPMENT,DEVELOPMENT"},
+		{profileType: "TVOS_APP_STORE", want: "IOS_DISTRIBUTION,DISTRIBUTION"},
+		{profileType: "TVOS_APP_ADHOC", want: "IOS_DISTRIBUTION,DISTRIBUTION"},
+		{profileType: "TVOS_APP_INHOUSE", want: "IOS_DISTRIBUTION,DISTRIBUTION"},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -292,6 +292,71 @@ func TestResolveSigningAssetsUsesOnlyExistingProfileCertificates(t *testing.T) {
 	}
 }
 
+func TestResolveSigningAssetsFiltersExistingProfileCertificatesByRequestedType(t *testing.T) {
+	tests := []struct {
+		name            string
+		certificateType string
+		wantID          string
+		wantErr         string
+	}{
+		{
+			name:            "matching associated certificate",
+			certificateType: "ios_distribution",
+			wantID:          "cert-ios",
+		},
+		{
+			name:            "no associated certificate matches",
+			certificateType: "DEVELOPER_ID_APPLICATION",
+			wantErr:         "profile profile-main has no associated certificates of type DEVELOPER_ID_APPLICATION",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+				switch req.URL.Path {
+				case "/v1/bundleIds/bundle-main/profiles":
+					return signingFetchJSONResponse(
+						http.StatusOK,
+						`{"data":[{"type":"profiles","id":"profile-main","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}]}`,
+					)
+				case "/v1/profiles/profile-main/certificates":
+					return signingFetchJSONResponse(
+						http.StatusOK,
+						`{"data":[{"type":"certificates","id":"cert-mac","attributes":{"certificateType":"MAC_APP_DISTRIBUTION"}},{"type":"certificates","id":"cert-ios","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`,
+					)
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+					return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+				}
+			})
+
+			_, certificates, _, err := resolveSigningAssets(
+				context.Background(),
+				client,
+				signingAssetsOptions{
+					BundleIDResourceID: "bundle-main",
+					BundleIdentifier:   "com.example.signing.profile",
+					ProfileType:        "IOS_APP_STORE",
+					CertificateType:    tt.certificateType,
+				},
+			)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveSigningAssets() error: %v", err)
+			}
+			if got := extractIDs(certificates.Data); len(got) != 1 || got[0] != tt.wantID {
+				t.Fatalf("expected only %s, got %v", tt.wantID, got)
+			}
+		})
+	}
+}
+
 func TestResolveSigningAssetsPreflightsBeforeCreatingProfile(t *testing.T) {
 	certificateContent := base64.StdEncoding.EncodeToString([]byte("certificate"))
 	profileContent := base64.StdEncoding.EncodeToString([]byte("profile"))
@@ -351,6 +416,61 @@ func TestResolveSigningAssetsPreflightsBeforeCreatingProfile(t *testing.T) {
 		"GET /v1/bundleIds/bundle-main/profiles",
 		"GET /v1/certificates",
 		"repository preflight",
+		"POST /v1/profiles",
+	}
+	if strings.Join(events, ",") != strings.Join(wantEvents, ",") {
+		t.Fatalf("unexpected operation order: got %v, want %v", events, wantEvents)
+	}
+}
+
+func TestResolveSigningAssetsRefreshesCreateTimeoutAfterPreflight(t *testing.T) {
+	requestCtx, expireRequest := context.WithCancel(context.Background())
+	events := []string{}
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		events = append(events, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	profile, _, created, err := resolveSigningAssets(
+		requestCtx,
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+			CreateMissing:      true,
+			BeforeCreate: func() error {
+				events = append(events, "repository preflight")
+				expireRequest()
+				return nil
+			},
+			CreateContext: func() (context.Context, context.CancelFunc) {
+				events = append(events, "refresh request timeout")
+				return context.WithCancel(context.Background())
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveSigningAssets() error: %v", err)
+	}
+	if !created || profile.Data.ID != "profile-created" {
+		t.Fatalf("expected created profile, got created=%v profile=%#v", created, profile)
+	}
+	wantEvents := []string{
+		"GET /v1/bundleIds/bundle-main/profiles",
+		"GET /v1/certificates",
+		"repository preflight",
+		"refresh request timeout",
 		"POST /v1/profiles",
 	}
 	if strings.Join(events, ",") != strings.Join(wantEvents, ",") {

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -179,7 +179,7 @@ func TestSigningFetchWriteFiles_NoOverwrite(t *testing.T) {
 	}
 }
 
-func TestFindOrCreateProfileUsesBundleIDRelationship(t *testing.T) {
+func TestFindActiveProfileUsesBundleIDRelationship(t *testing.T) {
 	widgetProfileContent := base64.StdEncoding.EncodeToString([]byte("application-identifier=TEAM.com.example.signing.profile.widget"))
 	mainProfileContent := base64.StdEncoding.EncodeToString([]byte("application-identifier=TEAM.com.example.signing.profile"))
 	requestPaths := []string{}
@@ -209,21 +209,14 @@ func TestFindOrCreateProfileUsesBundleIDRelationship(t *testing.T) {
 		}
 	})
 
-	profile, created, err := findOrCreateProfile(
+	profile, err := findActiveProfile(
 		context.Background(),
 		client,
 		"bundle-main",
-		"com.example.signing.profile",
 		"IOS_APP_STORE",
-		[]string{"cert-1"},
-		nil,
-		false,
 	)
 	if err != nil {
-		t.Fatalf("findOrCreateProfile() error: %v", err)
-	}
-	if created {
-		t.Fatal("expected existing profile, got created profile")
+		t.Fatalf("findActiveProfile() error: %v", err)
 	}
 	if profile.Data.ID != "profile-main" {
 		t.Fatalf("expected exact bundle profile, got %s", profile.Data.ID)
@@ -231,6 +224,137 @@ func TestFindOrCreateProfileUsesBundleIDRelationship(t *testing.T) {
 
 	if len(requestPaths) != 1 || requestPaths[0] != "/v1/bundleIds/bundle-main/profiles" {
 		t.Fatalf("expected Bundle ID scoped profile lookup, got %v", requestPaths)
+	}
+}
+
+func TestResolveSigningAssetsUsesOnlyExistingProfileCertificates(t *testing.T) {
+	profileContent := base64.StdEncoding.EncodeToString([]byte("profile"))
+	profileCertificateContent := base64.StdEncoding.EncodeToString([]byte("profile-certificate"))
+	requestPaths := []string{}
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		requestPaths = append(requestPaths, req.URL.Path)
+
+		switch req.URL.Path {
+		case "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(
+				http.StatusOK,
+				fmt.Sprintf(
+					`{"data":[{"type":"profiles","id":"profile-main","attributes":{"name":"Main App Store","profileType":"IOS_APP_STORE","profileState":"ACTIVE","profileContent":%q}}]}`,
+					profileContent,
+				),
+			)
+		case "/v1/profiles/profile-main/certificates":
+			if req.URL.Query().Get("cursor") == "next" {
+				return signingFetchJSONResponse(
+					http.StatusOK,
+					fmt.Sprintf(
+						`{"data":[{"type":"certificates","id":"cert-profile-2","attributes":{"certificateType":"IOS_DISTRIBUTION","serialNumber":"PROFILE2","certificateContent":%q}}]}`,
+						profileCertificateContent,
+					),
+				)
+			}
+			return signingFetchJSONResponse(
+				http.StatusOK,
+				fmt.Sprintf(
+					`{"data":[{"type":"certificates","id":"cert-profile","attributes":{"certificateType":"IOS_DISTRIBUTION","serialNumber":"PROFILE","certificateContent":%q}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/profiles/profile-main/certificates?cursor=next"}}`,
+					profileCertificateContent,
+				),
+			)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	profile, certificates, created, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveSigningAssets() error: %v", err)
+	}
+	if created {
+		t.Fatal("expected existing profile, got created profile")
+	}
+	if profile.Data.ID != "profile-main" {
+		t.Fatalf("expected profile-main, got %s", profile.Data.ID)
+	}
+	if got := strings.Join(extractIDs(certificates.Data), ","); got != "cert-profile,cert-profile-2" {
+		t.Fatalf("expected only the paginated profile certificates, got %s", got)
+	}
+	if strings.Join(requestPaths, ",") != "/v1/bundleIds/bundle-main/profiles,/v1/profiles/profile-main/certificates,/v1/profiles/profile-main/certificates" {
+		t.Fatalf("expected profile-scoped certificate lookup, got %v", requestPaths)
+	}
+}
+
+func TestResolveSigningAssetsPreflightsBeforeCreatingProfile(t *testing.T) {
+	certificateContent := base64.StdEncoding.EncodeToString([]byte("certificate"))
+	profileContent := base64.StdEncoding.EncodeToString([]byte("profile"))
+	events := []string{}
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		events = append(events, req.Method+" "+req.URL.Path)
+
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+			return signingFetchJSONResponse(
+				http.StatusOK,
+				fmt.Sprintf(
+					`{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION","serialNumber":"CERT1","certificateContent":%q}}]}`,
+					certificateContent,
+				),
+			)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+			return signingFetchJSONResponse(
+				http.StatusCreated,
+				fmt.Sprintf(
+					`{"data":{"type":"profiles","id":"profile-created","attributes":{"name":"Created Profile","profileType":"IOS_APP_STORE","profileState":"ACTIVE","profileContent":%q}}}`,
+					profileContent,
+				),
+			)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	profile, certificates, created, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+			CreateMissing:      true,
+			BeforeCreate: func() error {
+				events = append(events, "repository preflight")
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveSigningAssets() error: %v", err)
+	}
+	if !created || profile.Data.ID != "profile-created" {
+		t.Fatalf("expected newly created profile, got created=%v id=%s", created, profile.Data.ID)
+	}
+	if got := extractIDs(certificates.Data); len(got) != 1 || got[0] != "cert-1" {
+		t.Fatalf("expected creation certificate, got %v", got)
+	}
+	wantEvents := []string{
+		"GET /v1/bundleIds/bundle-main/profiles",
+		"GET /v1/certificates",
+		"repository preflight",
+		"POST /v1/profiles",
+	}
+	if strings.Join(events, ",") != strings.Join(wantEvents, ",") {
+		t.Fatalf("unexpected operation order: got %v, want %v", events, wantEvents)
 	}
 }
 

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -133,26 +133,6 @@ func syncPushCommand() *ffcli.Command {
 				return fmt.Errorf("signing sync push: %w", err)
 			}
 
-			certs, err := findCertificates(requestCtx, client, profType, *certType)
-			if err != nil {
-				return fmt.Errorf("signing sync push: %w", err)
-			}
-
-			profile, created, err := findOrCreateProfile(
-				requestCtx, client,
-				bundleIDResp.Data.ID, bundle, profType,
-				extractIDs(certs.Data),
-				shared.SplitCSV(*deviceIDs),
-				*createMissing,
-			)
-			if err != nil {
-				return fmt.Errorf("signing sync push: %w", err)
-			}
-			if created {
-				fmt.Fprintln(os.Stderr, "Created new profile")
-			}
-
-			// Clone git repo.
 			tmpDir, err := os.MkdirTemp("", "asc-signing-sync-*")
 			if err != nil {
 				return fmt.Errorf("signing sync push: create temp dir: %w", err)
@@ -165,8 +145,39 @@ func syncPushCommand() *ffcli.Command {
 			}
 			defer func() { _ = store.Cleanup() }()
 
-			fmt.Fprintln(os.Stderr, "Cloning signing repo...")
-			if err := store.Clone(ctx, true); err != nil {
+			repositoryReady := false
+			prepareRepository := func() error {
+				if repositoryReady {
+					return nil
+				}
+				fmt.Fprintln(os.Stderr, "Cloning signing repo...")
+				if err := store.Clone(ctx, true); err != nil {
+					return err
+				}
+				repositoryReady = true
+				return nil
+			}
+
+			profile, certs, created, err := resolveSigningAssets(
+				requestCtx,
+				client,
+				signingAssetsOptions{
+					BundleIDResourceID: bundleIDResp.Data.ID,
+					BundleIdentifier:   bundle,
+					ProfileType:        profType,
+					CertificateType:    *certType,
+					DeviceIDs:          shared.SplitCSV(*deviceIDs),
+					CreateMissing:      *createMissing,
+					BeforeCreate:       prepareRepository,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("signing sync push: %w", err)
+			}
+			if created {
+				fmt.Fprintln(os.Stderr, "Created new profile")
+			}
+			if err := prepareRepository(); err != nil {
 				return fmt.Errorf("signing sync push: %w", err)
 			}
 

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -72,6 +72,20 @@ func resolvePassword(flagValue string) (string, error) {
 	return "", shared.UsageError("--password is required (or set ASC_MATCH_PASSWORD)")
 }
 
+func onceAfterSuccess(operation func() error) func() error {
+	done := false
+	return func() error {
+		if done {
+			return nil
+		}
+		if err := operation(); err != nil {
+			return err
+		}
+		done = true
+		return nil
+	}
+}
+
 func syncPushCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("push", flag.ExitOnError)
 
@@ -145,18 +159,13 @@ func syncPushCommand() *ffcli.Command {
 			}
 			defer func() { _ = store.Cleanup() }()
 
-			repositoryReady := false
-			prepareRepository := func() error {
-				if repositoryReady {
-					return nil
-				}
+			prepareRepository := onceAfterSuccess(func() error {
 				fmt.Fprintln(os.Stderr, "Cloning signing repo...")
 				if err := store.Clone(ctx, true); err != nil {
 					return err
 				}
-				repositoryReady = true
 				return nil
-			}
+			})
 
 			profile, certs, created, err := resolveSigningAssets(
 				requestCtx,
@@ -169,6 +178,9 @@ func syncPushCommand() *ffcli.Command {
 					DeviceIDs:          shared.SplitCSV(*deviceIDs),
 					CreateMissing:      *createMissing,
 					BeforeCreate:       prepareRepository,
+					CreateContext: func() (context.Context, context.CancelFunc) {
+						return shared.ContextWithTimeout(ctx)
+					},
 				},
 			)
 			if err != nil {

--- a/internal/cli/signing/signing_sync_test.go
+++ b/internal/cli/signing/signing_sync_test.go
@@ -1,6 +1,8 @@
 package signing
 
 import (
+	"context"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +16,88 @@ func TestSigningSyncCommandLongHelpUsesOutputDirExample(t *testing.T) {
 	}
 	if strings.Contains(cmd.LongHelp, "--output ./signing") {
 		t.Fatalf("expected long help to avoid --output path example, got %q", cmd.LongHelp)
+	}
+}
+
+func TestSigningSyncPreparesRepositoryOnceInAssetOrder(t *testing.T) {
+	tests := []struct {
+		name       string
+		hasProfile bool
+		wantEvents []string
+	}{
+		{
+			name:       "existing profile",
+			hasProfile: true,
+			wantEvents: []string{
+				"GET /v1/bundleIds/bundle-main/profiles",
+				"GET /v1/profiles/profile-main/certificates",
+				"clone repository",
+			},
+		},
+		{
+			name: "missing profile",
+			wantEvents: []string{
+				"GET /v1/bundleIds/bundle-main/profiles",
+				"GET /v1/certificates",
+				"clone repository",
+				"POST /v1/profiles",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := []string{}
+			client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+				events = append(events, req.Method+" "+req.URL.Path)
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+					if tt.hasProfile {
+						return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"profiles","id":"profile-main","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}]}`)
+					}
+					return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/profiles/profile-main/certificates":
+					return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+					return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+				case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+					return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+					return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+				}
+			})
+
+			cloneCount := 0
+			prepareRepository := onceAfterSuccess(func() error {
+				cloneCount++
+				events = append(events, "clone repository")
+				return nil
+			})
+			_, _, _, err := resolveSigningAssets(
+				context.Background(),
+				client,
+				signingAssetsOptions{
+					BundleIDResourceID: "bundle-main",
+					BundleIdentifier:   "com.example.signing.profile",
+					ProfileType:        "IOS_APP_STORE",
+					CreateMissing:      !tt.hasProfile,
+					BeforeCreate:       prepareRepository,
+				},
+			)
+			if err != nil {
+				t.Fatalf("resolveSigningAssets() error: %v", err)
+			}
+			if err := prepareRepository(); err != nil {
+				t.Fatalf("prepareRepository() error: %v", err)
+			}
+			if cloneCount != 1 {
+				t.Fatalf("repository clone count = %d, want 1", cloneCount)
+			}
+			if strings.Join(events, ",") != strings.Join(tt.wantEvents, ",") {
+				t.Fatalf("unexpected operation order: got %v, want %v", events, tt.wantEvents)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve existing signing certificates through the selected profile relationship
- paginate profile certificate results and reject empty or mismatched selections
- preflight encrypted repository access before creating a missing profile
- share the same asset resolver between fetch and sync paths

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- live disposable-app check: created one temporary profile, confirmed an existing-profile fetch returned exactly its related certificate IDs, then deleted the profile
- live failure check: an unavailable repository prevented profile creation and left the bundle with zero profiles

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788897928&installation_model_id=10418&pr_number=1903&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1903&signature=7aef3cad3dfc63bda60db7e846f5b9d9707508723e0028a20561b972a32eb67d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signing asset retrieval now reuses active matching profiles and associated certificates.
  * Certificate searches support pagination and optional certificate-type filtering.
  * Missing signing assets can be created when explicitly enabled, after certificate validation.
* **Bug Fixes**
  * Prevented unrelated certificates from being used during signing.
  * Signing now evaluates all active matching profiles before creating a new one.
  * Avoided unnecessary or duplicate repository preparation during signing setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->