### PR TITLE
fix(screenshots): reconcile interrupted upload reservations

### DIFF
--- a/internal/cli/assets/assets_screenshot_order.go
+++ b/internal/cli/assets/assets_screenshot_order.go
@@ -20,6 +20,11 @@ type screenshotUploadProgress struct {
 // UploadScreenshotsToSet uploads screenshots in the provided file order and then
 // applies that order to the remote screenshot set.
 func UploadScreenshotsToSet(ctx context.Context, client *asc.Client, setID string, files []string, preserveExistingOrder bool) ([]asc.AssetUploadResultItem, error) {
+	sourceRootPath, err := resolveScreenshotUploadRoot("", files)
+	if err != nil {
+		return nil, err
+	}
+
 	orderedIDs := make([]string, 0, len(files))
 	if preserveExistingOrder {
 		existingIDs, err := GetOrderedAppScreenshotIDs(ctx, client, setID)
@@ -29,21 +34,21 @@ func UploadScreenshotsToSet(ctx context.Context, client *asc.Client, setID strin
 		orderedIDs = append(orderedIDs, existingIDs...)
 	}
 
-	progress, err := uploadScreenshotsWithOrderState(ctx, client, setID, orderedIDs, files, false, true)
+	progress, err := uploadScreenshotsWithOrderState(ctx, client, setID, orderedIDs, files, sourceRootPath, false, true)
 	if err != nil {
 		return nil, err
 	}
 	return progress.Results, nil
 }
 
-func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, setID string, orderedIDs, files []string, syncIfNoNew, syncAfterUpload bool) (screenshotUploadProgress, error) {
+func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, setID string, orderedIDs, files []string, sourceRootPath string, syncIfNoNew, syncAfterUpload bool) (screenshotUploadProgress, error) {
 	progress := screenshotUploadProgress{
 		Results:    make([]asc.AssetUploadResultItem, 0, len(files)),
 		OrderedIDs: append([]string(nil), orderedIDs...),
 	}
 
 	for idx, filePath := range files {
-		item, pending, err := uploadScreenshotAsset(ctx, client, setID, filePath)
+		item, pending, err := uploadScreenshotAsset(ctx, client, setID, sourceRootPath, filePath)
 		if err != nil {
 			progress.PendingFiles = append([]string{filePath}, files[idx+1:]...)
 			if strings.TrimSpace(pending.AssetID) != "" {
@@ -111,7 +116,7 @@ func resumeScreenshotsWithOrderState(ctx context.Context, client *asc.Client, se
 		}
 	}
 
-	remaining, err := uploadScreenshotsWithOrderState(ctx, client, setID, progress.OrderedIDs, remainingFiles, syncIfNoNew, syncAfterUpload)
+	remaining, err := uploadScreenshotsWithOrderState(ctx, client, setID, progress.OrderedIDs, remainingFiles, sourceRootPath, syncIfNoNew, syncAfterUpload)
 	progress.Results = append(progress.Results, remaining.Results...)
 	progress.OrderedIDs = remaining.OrderedIDs
 	progress.PendingFiles = remaining.PendingFiles

--- a/internal/cli/assets/assets_screenshot_order.go
+++ b/internal/cli/assets/assets_screenshot_order.go
@@ -71,7 +71,7 @@ func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, se
 	return progress, nil
 }
 
-func resumeScreenshotsWithOrderState(ctx context.Context, client *asc.Client, setID string, orderedIDs, files []string, pendingAssets []screenshotPendingAsset, syncIfNoNew, syncAfterUpload bool) (screenshotUploadProgress, error) {
+func resumeScreenshotsWithOrderState(ctx context.Context, client *asc.Client, setID string, orderedIDs, files []string, pendingAssets []screenshotPendingAsset, sourceRootPath string, syncIfNoNew, syncAfterUpload bool) (screenshotUploadProgress, error) {
 	progress := screenshotUploadProgress{
 		Results:    make([]asc.AssetUploadResultItem, 0, len(files)),
 		OrderedIDs: append([]string(nil), orderedIDs...),
@@ -97,7 +97,7 @@ func resumeScreenshotsWithOrderState(ctx context.Context, client *asc.Client, se
 			return progress, fmt.Errorf("pending screenshot asset does not match the first pending file")
 		}
 
-		result, updatedPending, retryUpload, err := reconcilePendingScreenshotAsset(ctx, client, pending)
+		result, updatedPending, retryUpload, err := reconcilePendingScreenshotAsset(ctx, client, pending, sourceRootPath)
 		if err != nil {
 			progress.PendingFiles = remainingFiles
 			progress.PendingAssets = []screenshotPendingAsset{updatedPending}
@@ -120,7 +120,7 @@ func resumeScreenshotsWithOrderState(ctx context.Context, client *asc.Client, se
 	return progress, err
 }
 
-func reconcilePendingScreenshotAsset(ctx context.Context, client *asc.Client, pending screenshotPendingAsset) (asc.AssetUploadResultItem, screenshotPendingAsset, bool, error) {
+func reconcilePendingScreenshotAsset(ctx context.Context, client *asc.Client, pending screenshotPendingAsset, sourceRootPath string) (asc.AssetUploadResultItem, screenshotPendingAsset, bool, error) {
 	remote, err := client.GetAppScreenshot(ctx, pending.AssetID)
 	if err != nil {
 		if asc.IsNotFound(err) {
@@ -135,6 +135,9 @@ func reconcilePendingScreenshotAsset(ctx context.Context, client *asc.Client, pe
 	}
 	switch remoteState {
 	case "COMPLETE":
+		if err := validatePendingScreenshotChecksum(sourceRootPath, pending); err != nil {
+			return asc.AssetUploadResultItem{}, pending, false, err
+		}
 		return completedPendingScreenshotResult(pending), screenshotPendingAsset{}, false, nil
 	case "FAILED":
 		if err := client.DeleteAppScreenshot(ctx, pending.AssetID); err != nil {
@@ -142,16 +145,15 @@ func reconcilePendingScreenshotAsset(ctx context.Context, client *asc.Client, pe
 		}
 		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, true, nil
 	case "UPLOAD_COMPLETE":
+		if err := validatePendingScreenshotChecksum(sourceRootPath, pending); err != nil {
+			return asc.AssetUploadResultItem{}, pending, false, err
+		}
 		return waitForPendingScreenshotDelivery(ctx, client, pending)
 	case "AWAITING_UPLOAD", "":
 		pendingState := strings.ToUpper(strings.TrimSpace(pending.State))
 		if pendingState == "UPLOADED" || pendingState == "UPLOAD_COMPLETE" || pendingState == "COMPLETE" {
-			checksum, err := computeFileChecksum(pending.FilePath)
-			if err != nil {
+			if err := validatePendingScreenshotChecksum(sourceRootPath, pending); err != nil {
 				return asc.AssetUploadResultItem{}, pending, false, err
-			}
-			if !strings.EqualFold(strings.TrimSpace(checksum), strings.TrimSpace(pending.Checksum)) {
-				return asc.AssetUploadResultItem{}, pending, false, fmt.Errorf("pending screenshot file changed after upload: %q", pending.FilePath)
 			}
 			updated, err := client.UpdateAppScreenshot(ctx, pending.AssetID, true, pending.Checksum)
 			if err != nil {
@@ -172,6 +174,17 @@ func reconcilePendingScreenshotAsset(ctx context.Context, client *asc.Client, pe
 		pending.State = remoteState
 		return asc.AssetUploadResultItem{}, pending, false, fmt.Errorf("screenshot %s has unrecognized delivery state %q", pending.AssetID, remoteState)
 	}
+}
+
+func validatePendingScreenshotChecksum(sourceRootPath string, pending screenshotPendingAsset) error {
+	checksum, err := computeFileChecksumInRoot(sourceRootPath, pending.FilePath)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(strings.TrimSpace(checksum), strings.TrimSpace(pending.Checksum)) {
+		return fmt.Errorf("pending screenshot file changed after upload: %q", pending.FilePath)
+	}
+	return nil
 }
 
 func waitForPendingScreenshotDelivery(ctx context.Context, client *asc.Client, pending screenshotPendingAsset) (asc.AssetUploadResultItem, screenshotPendingAsset, bool, error) {

--- a/internal/cli/assets/assets_screenshot_order.go
+++ b/internal/cli/assets/assets_screenshot_order.go
@@ -24,7 +24,10 @@ func UploadScreenshotsToSet(ctx context.Context, client *asc.Client, setID strin
 	if err != nil {
 		return nil, err
 	}
+	return uploadScreenshotsToSetFromRoot(ctx, client, setID, files, sourceRootPath, preserveExistingOrder)
+}
 
+func uploadScreenshotsToSetFromRoot(ctx context.Context, client *asc.Client, setID string, files []string, sourceRootPath string, preserveExistingOrder bool) ([]asc.AssetUploadResultItem, error) {
 	orderedIDs := make([]string, 0, len(files))
 	if preserveExistingOrder {
 		existingIDs, err := GetOrderedAppScreenshotIDs(ctx, client, setID)

--- a/internal/cli/assets/assets_screenshot_order.go
+++ b/internal/cli/assets/assets_screenshot_order.go
@@ -3,16 +3,18 @@ package assets
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 type screenshotUploadProgress struct {
-	Results      []asc.AssetUploadResultItem
-	OrderedIDs   []string
-	PendingFiles []string
-	FailedFile   string
+	Results       []asc.AssetUploadResultItem
+	OrderedIDs    []string
+	PendingFiles  []string
+	PendingAssets []screenshotPendingAsset
+	FailedFile    string
 }
 
 // UploadScreenshotsToSet uploads screenshots in the provided file order and then
@@ -41,9 +43,12 @@ func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, se
 	}
 
 	for idx, filePath := range files {
-		item, err := uploadScreenshotAsset(ctx, client, setID, filePath)
+		item, pending, err := uploadScreenshotAsset(ctx, client, setID, filePath)
 		if err != nil {
 			progress.PendingFiles = append([]string{filePath}, files[idx+1:]...)
+			if strings.TrimSpace(pending.AssetID) != "" {
+				progress.PendingAssets = []screenshotPendingAsset{pending}
+			}
 			progress.FailedFile = filePath
 			return progress, err
 		}
@@ -64,6 +69,129 @@ func uploadScreenshotsWithOrderState(ctx context.Context, client *asc.Client, se
 		return progress, err
 	}
 	return progress, nil
+}
+
+func resumeScreenshotsWithOrderState(ctx context.Context, client *asc.Client, setID string, orderedIDs, files []string, pendingAssets []screenshotPendingAsset, syncIfNoNew, syncAfterUpload bool) (screenshotUploadProgress, error) {
+	progress := screenshotUploadProgress{
+		Results:    make([]asc.AssetUploadResultItem, 0, len(files)),
+		OrderedIDs: append([]string(nil), orderedIDs...),
+	}
+	remainingFiles := append([]string(nil), files...)
+
+	if len(pendingAssets) > 1 {
+		progress.PendingFiles = remainingFiles
+		progress.PendingAssets = append([]screenshotPendingAsset(nil), pendingAssets...)
+		if len(remainingFiles) > 0 {
+			progress.FailedFile = remainingFiles[0]
+		}
+		return progress, fmt.Errorf("resume artifact contains multiple in-flight screenshot assets")
+	}
+	if len(pendingAssets) == 1 {
+		pending := pendingAssets[0]
+		if len(remainingFiles) == 0 || filepath.Clean(pending.FilePath) != filepath.Clean(remainingFiles[0]) {
+			progress.PendingFiles = remainingFiles
+			progress.PendingAssets = []screenshotPendingAsset{pending}
+			if len(remainingFiles) > 0 {
+				progress.FailedFile = remainingFiles[0]
+			}
+			return progress, fmt.Errorf("pending screenshot asset does not match the first pending file")
+		}
+
+		result, updatedPending, retryUpload, err := reconcilePendingScreenshotAsset(ctx, client, pending)
+		if err != nil {
+			progress.PendingFiles = remainingFiles
+			progress.PendingAssets = []screenshotPendingAsset{updatedPending}
+			progress.FailedFile = remainingFiles[0]
+			return progress, err
+		}
+		if !retryUpload {
+			progress.Results = append(progress.Results, result)
+			progress.OrderedIDs = appendUniqueScreenshotID(progress.OrderedIDs, result.AssetID)
+			remainingFiles = remainingFiles[1:]
+		}
+	}
+
+	remaining, err := uploadScreenshotsWithOrderState(ctx, client, setID, progress.OrderedIDs, remainingFiles, syncIfNoNew, syncAfterUpload)
+	progress.Results = append(progress.Results, remaining.Results...)
+	progress.OrderedIDs = remaining.OrderedIDs
+	progress.PendingFiles = remaining.PendingFiles
+	progress.PendingAssets = remaining.PendingAssets
+	progress.FailedFile = remaining.FailedFile
+	return progress, err
+}
+
+func reconcilePendingScreenshotAsset(ctx context.Context, client *asc.Client, pending screenshotPendingAsset) (asc.AssetUploadResultItem, screenshotPendingAsset, bool, error) {
+	remote, err := client.GetAppScreenshot(ctx, pending.AssetID)
+	if err != nil {
+		if asc.IsNotFound(err) {
+			return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, true, nil
+		}
+		return asc.AssetUploadResultItem{}, pending, false, err
+	}
+
+	remoteState := ""
+	if remote.Data.Attributes.AssetDeliveryState != nil {
+		remoteState = strings.ToUpper(strings.TrimSpace(remote.Data.Attributes.AssetDeliveryState.State))
+	}
+	switch remoteState {
+	case "COMPLETE":
+		return completedPendingScreenshotResult(pending), screenshotPendingAsset{}, false, nil
+	case "FAILED":
+		if err := client.DeleteAppScreenshot(ctx, pending.AssetID); err != nil {
+			return asc.AssetUploadResultItem{}, pending, false, fmt.Errorf("delete failed screenshot reservation %s: %w", pending.AssetID, err)
+		}
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, true, nil
+	case "UPLOAD_COMPLETE":
+		return waitForPendingScreenshotDelivery(ctx, client, pending)
+	case "AWAITING_UPLOAD", "":
+		pendingState := strings.ToUpper(strings.TrimSpace(pending.State))
+		if pendingState == "UPLOADED" || pendingState == "UPLOAD_COMPLETE" || pendingState == "COMPLETE" {
+			checksum, err := computeFileChecksum(pending.FilePath)
+			if err != nil {
+				return asc.AssetUploadResultItem{}, pending, false, err
+			}
+			if !strings.EqualFold(strings.TrimSpace(checksum), strings.TrimSpace(pending.Checksum)) {
+				return asc.AssetUploadResultItem{}, pending, false, fmt.Errorf("pending screenshot file changed after upload: %q", pending.FilePath)
+			}
+			updated, err := client.UpdateAppScreenshot(ctx, pending.AssetID, true, pending.Checksum)
+			if err != nil {
+				return asc.AssetUploadResultItem{}, pending, false, err
+			}
+			pending.State = "UPLOAD_COMPLETE"
+			if updated.Data.Attributes.AssetDeliveryState != nil && strings.TrimSpace(updated.Data.Attributes.AssetDeliveryState.State) != "" {
+				pending.State = strings.ToUpper(strings.TrimSpace(updated.Data.Attributes.AssetDeliveryState.State))
+			}
+			return waitForPendingScreenshotDelivery(ctx, client, pending)
+		}
+
+		if err := client.DeleteAppScreenshot(ctx, pending.AssetID); err != nil {
+			return asc.AssetUploadResultItem{}, pending, false, fmt.Errorf("delete incomplete screenshot reservation %s: %w", pending.AssetID, err)
+		}
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, true, nil
+	default:
+		pending.State = remoteState
+		return asc.AssetUploadResultItem{}, pending, false, fmt.Errorf("screenshot %s has unrecognized delivery state %q", pending.AssetID, remoteState)
+	}
+}
+
+func waitForPendingScreenshotDelivery(ctx context.Context, client *asc.Client, pending screenshotPendingAsset) (asc.AssetUploadResultItem, screenshotPendingAsset, bool, error) {
+	state, err := waitForScreenshotDelivery(ctx, client, pending.AssetID)
+	if strings.TrimSpace(state) != "" {
+		pending.State = strings.ToUpper(strings.TrimSpace(state))
+	}
+	if err != nil {
+		return asc.AssetUploadResultItem{}, pending, false, err
+	}
+	return completedPendingScreenshotResult(pending), screenshotPendingAsset{}, false, nil
+}
+
+func completedPendingScreenshotResult(pending screenshotPendingAsset) asc.AssetUploadResultItem {
+	return asc.AssetUploadResultItem{
+		FileName: pending.FileName,
+		FilePath: pending.FilePath,
+		AssetID:  pending.AssetID,
+		State:    "COMPLETE",
+	}
 }
 
 // GetOrderedAppScreenshotIDs returns screenshot IDs in the current remote order.

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -72,6 +72,7 @@ type screenshotUploadConfig[T any] struct {
 	Client         *asc.Client
 	LocalizationID string
 	DisplayType    string
+	RootPath       string
 	Files          []string
 	SkipExisting   bool
 	Replace        bool
@@ -608,6 +609,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 			Client:         client,
 			LocalizationID: locID,
 			DisplayType:    apiDisplayType,
+			RootPath:       pathValue,
 			Files:          files,
 			SkipExisting:   opts.SkipExisting,
 			Replace:        opts.Replace,

--- a/internal/cli/assets/assets_screenshots_discovery.go
+++ b/internal/cli/assets/assets_screenshots_discovery.go
@@ -187,6 +187,7 @@ func uploadScreenshotsFanout(ctx context.Context, cfg screenshotUploadFanoutConf
 			Client:         cfg.Client,
 			LocalizationID: localizationID,
 			DisplayType:    cfg.DisplayType,
+			RootPath:       cfg.RootPath,
 			Files:          item.Files,
 			SkipExisting:   cfg.SkipExisting,
 			Replace:        cfg.Replace,

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -24,10 +24,19 @@ type screenshotUploadFailureArtifact struct {
 	Files                 []string                     `json:"files,omitempty"`
 	OrderedIDs            []string                     `json:"orderedIds,omitempty"`
 	PendingFiles          []string                     `json:"pendingFiles,omitempty"`
+	PendingAssets         []screenshotPendingAsset     `json:"pendingAssets,omitempty"`
 	Results               []asc.AssetUploadResultItem  `json:"results,omitempty"`
 	Failures              []asc.AssetUploadFailureItem `json:"failures,omitempty"`
 	Error                 string                       `json:"error,omitempty"`
 	GeneratedAt           string                       `json:"generatedAt"`
+}
+
+type screenshotPendingAsset struct {
+	FileName string `json:"fileName"`
+	FilePath string `json:"filePath"`
+	AssetID  string `json:"assetId"`
+	Checksum string `json:"checksum"`
+	State    string `json:"state"`
 }
 
 type screenshotUploadPreparedState struct {
@@ -273,6 +282,7 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 		Files:                 append([]string(nil), cfg.Files...),
 		OrderedIDs:            orderedIDs,
 		PendingFiles:          append([]string(nil), progress.PendingFiles...),
+		PendingAssets:         append([]screenshotPendingAsset(nil), progress.PendingAssets...),
 		Results:               append([]asc.AssetUploadResultItem(nil), result.Results...),
 		Failures:              append([]asc.AssetUploadFailureItem(nil), result.Failures...),
 		Error:                 uploadErr.Error(),
@@ -307,7 +317,7 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 	defer cancel()
 
 	syncAfterUpload := !artifact.SkipExisting || len(artifact.Files) == 0
-	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, client, artifact.SetID, artifact.OrderedIDs, artifact.PendingFiles, true, syncAfterUpload)
+	progress, uploadErr := resumeScreenshotsWithOrderState(uploadCtx, client, artifact.SetID, artifact.OrderedIDs, artifact.PendingFiles, artifact.PendingAssets, true, syncAfterUpload)
 
 	result := asc.AppScreenshotUploadResult{
 		VersionLocalizationID: artifact.VersionLocalizationID,
@@ -353,6 +363,7 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 		Files:                 append([]string(nil), artifact.Files...),
 		OrderedIDs:            append([]string(nil), progress.OrderedIDs...),
 		PendingFiles:          append([]string(nil), progress.PendingFiles...),
+		PendingAssets:         append([]screenshotPendingAsset(nil), progress.PendingAssets...),
 		Results:               append([]asc.AssetUploadResultItem(nil), result.Results...),
 		Failures:              append([]asc.AssetUploadFailureItem(nil), result.Failures...),
 		Error:                 uploadErr.Error(),
@@ -419,6 +430,14 @@ func normalizeScreenshotUploadFailureArtifactPaths(artifact screenshotUploadFail
 			return screenshotUploadFailureArtifact{}, err
 		}
 		artifact.PendingFiles[i] = normalized
+	}
+
+	for i := range artifact.PendingAssets {
+		normalized, err := normalizeScreenshotUploadArtifactFilePath(artifact.PendingAssets[i].FilePath)
+		if err != nil {
+			return screenshotUploadFailureArtifact{}, err
+		}
+		artifact.PendingAssets[i].FilePath = normalized
 	}
 
 	for i := range artifact.Results {

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -628,7 +629,7 @@ func screenshotSourceValidationRoot(absolutePath string) string {
 		best = volume + string(filepath.Separator)
 	}
 
-	candidates := make([]string, 0, 3)
+	candidates := make([]string, 0, 4)
 	if cwd, err := os.Getwd(); err == nil {
 		candidates = append(candidates, cwd)
 	}
@@ -637,6 +638,9 @@ func screenshotSourceValidationRoot(absolutePath string) string {
 	}
 	if temporary := strings.TrimSpace(os.TempDir()); temporary != "" {
 		candidates = append(candidates, temporary)
+	}
+	if runtime.GOOS != "windows" {
+		candidates = append(candidates, "/tmp")
 	}
 	for _, candidate := range candidates {
 		candidate, err := filepath.Abs(candidate)

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -506,6 +507,10 @@ func screenshotArtifactSourcePaths(artifact screenshotUploadFailureArtifact) []s
 }
 
 func resolveScreenshotUploadRoot(rootPath string, filePaths []string) (string, error) {
+	if err := validateScreenshotSourceAncestry(filePaths); err != nil {
+		return "", err
+	}
+
 	rootPath = strings.TrimSpace(rootPath)
 	if rootPath != "" {
 		absolute, err := filepath.Abs(rootPath)
@@ -591,6 +596,63 @@ func resolveScreenshotUploadRoot(rootPath string, filePaths []string) (string, e
 		}
 	}
 	return trustedRoot.Path(), nil
+}
+
+func validateScreenshotSourceAncestry(filePaths []string) error {
+	for _, filePath := range filePaths {
+		filePath = strings.TrimSpace(filePath)
+		if filePath == "" {
+			continue
+		}
+		absolute, err := filepath.Abs(filePath)
+		if err != nil {
+			return err
+		}
+		validationRoot := screenshotSourceValidationRoot(absolute)
+		root, err := rootfs.New(validationRoot)
+		if err != nil {
+			return err
+		}
+		if err := root.CheckContained(absolute); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func screenshotSourceValidationRoot(absolutePath string) string {
+	absolutePath = filepath.Clean(absolutePath)
+	volume := filepath.VolumeName(absolutePath)
+	best := string(filepath.Separator)
+	if volume != "" {
+		best = volume + string(filepath.Separator)
+	}
+
+	candidates := make([]string, 0, 3)
+	if cwd, err := os.Getwd(); err == nil {
+		candidates = append(candidates, cwd)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, home)
+	}
+	if temporary := strings.TrimSpace(os.TempDir()); temporary != "" {
+		candidates = append(candidates, temporary)
+	}
+	for _, candidate := range candidates {
+		candidate, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		candidate = filepath.Clean(candidate)
+		relative, err := filepath.Rel(candidate, absolutePath)
+		if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if len(candidate) > len(best) {
+			best = candidate
+		}
+	}
+	return best
 }
 
 func persistScreenshotUploadFailureArtifact(path string, artifact screenshotUploadFailureArtifact) (string, error) {

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 type screenshotUploadFailureArtifact struct {
@@ -212,6 +212,13 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	if cfg.UploadContext == nil {
 		cfg.UploadContext = contextWithAssetUploadTimeout
 	}
+	if !cfg.DryRun && len(cfg.Files) > 0 {
+		sourceRootPath, err := resolveScreenshotUploadRoot(cfg.RootPath, cfg.Files)
+		if err != nil {
+			return asc.AppScreenshotUploadResult{}, fmt.Errorf("resolve screenshot source root: %w", err)
+		}
+		cfg.RootPath = sourceRootPath
+	}
 	prepared, err := prepareAppScreenshotUpload(ctx, cfg)
 	if err != nil {
 		return asc.AppScreenshotUploadResult{}, err
@@ -242,7 +249,7 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	uploadCtx, cancel := cfg.UploadContext(ctx)
 	defer cancel()
 
-	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, cfg.Client, prepared.Set.ID, prepared.OrderedIDs, prepared.Files, false, true)
+	progress, uploadErr := uploadScreenshotsWithOrderState(uploadCtx, cfg.Client, prepared.Set.ID, prepared.OrderedIDs, prepared.Files, cfg.RootPath, false, true)
 	if uploadErr == nil && cfg.SkipExisting && len(prepared.SkippedResults) > 0 {
 		desiredIDs, err := syncSkippedScreenshotOrder(uploadCtx, cfg.Client, prepared.Set.ID, cfg.Files, prepared.SkippedResults, progress.Results)
 		if err != nil {
@@ -320,9 +327,12 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 	defer cancel()
 
 	syncAfterUpload := !artifact.SkipExisting || len(artifact.Files) == 0
-	sourceRootPath, err := resolveScreenshotUploadRoot(artifact.RootPath, screenshotArtifactSourcePaths(artifact))
-	if err != nil {
-		return asc.AppScreenshotUploadResult{}, fmt.Errorf("resolve resume source root: %w", err)
+	sourceRootPath := strings.TrimSpace(artifact.RootPath)
+	if screenshotArtifactNeedsSourceFiles(artifact) {
+		sourceRootPath, err = resolveScreenshotUploadRoot(artifact.RootPath, screenshotArtifactSourcePaths(artifact))
+		if err != nil {
+			return asc.AppScreenshotUploadResult{}, fmt.Errorf("resolve resume source root: %w", err)
+		}
 	}
 	progress, uploadErr := resumeScreenshotsWithOrderState(uploadCtx, client, artifact.SetID, artifact.OrderedIDs, artifact.PendingFiles, artifact.PendingAssets, sourceRootPath, true, syncAfterUpload)
 
@@ -464,13 +474,25 @@ func normalizeScreenshotUploadFailureArtifactPaths(artifact screenshotUploadFail
 		artifact.Failures[i].FilePath = normalized
 	}
 
-	rootPath, err := resolveScreenshotUploadRoot(artifact.RootPath, screenshotArtifactSourcePaths(artifact))
-	if err != nil {
-		return screenshotUploadFailureArtifact{}, err
+	if screenshotArtifactNeedsSourceFiles(artifact) {
+		rootPath, err := resolveScreenshotUploadRoot(artifact.RootPath, screenshotArtifactSourcePaths(artifact))
+		if err != nil {
+			return screenshotUploadFailureArtifact{}, err
+		}
+		artifact.RootPath = rootPath
+	} else if strings.TrimSpace(artifact.RootPath) != "" {
+		rootPath, err := filepath.Abs(artifact.RootPath)
+		if err != nil {
+			return screenshotUploadFailureArtifact{}, err
+		}
+		artifact.RootPath = filepath.Clean(rootPath)
 	}
-	artifact.RootPath = rootPath
 
 	return artifact, nil
+}
+
+func screenshotArtifactNeedsSourceFiles(artifact screenshotUploadFailureArtifact) bool {
+	return len(artifact.PendingFiles) > 0 || len(artifact.PendingAssets) > 0
 }
 
 func screenshotArtifactSourcePaths(artifact screenshotUploadFailureArtifact) []string {
@@ -490,14 +512,37 @@ func resolveScreenshotUploadRoot(rootPath string, filePaths []string) (string, e
 		if err != nil {
 			return "", err
 		}
-		info, err := os.Lstat(absolute)
+		absolute = filepath.Clean(absolute)
+		for _, filePath := range filePaths {
+			fileAbsolute, err := filepath.Abs(strings.TrimSpace(filePath))
+			if err != nil {
+				return "", err
+			}
+			if filepath.Clean(fileAbsolute) == absolute {
+				absolute = filepath.Dir(absolute)
+				break
+			}
+		}
+		root, err := rootfs.New(absolute)
 		if err != nil {
 			return "", err
 		}
-		if info.IsDir() {
-			return filepath.Clean(absolute), nil
+		if err := root.CheckContained("."); err != nil {
+			return "", err
 		}
-		return filepath.Dir(absolute), nil
+		for _, filePath := range filePaths {
+			if strings.TrimSpace(filePath) == "" {
+				continue
+			}
+			fileAbsolute, err := filepath.Abs(filePath)
+			if err != nil {
+				return "", err
+			}
+			if _, err := root.Resolve(fileAbsolute); err != nil {
+				return "", err
+			}
+		}
+		return root.Path(), nil
 	}
 
 	cleaned := make([]string, 0, len(filePaths))
@@ -533,7 +578,19 @@ func resolveScreenshotUploadRoot(rootPath string, filePaths []string) (string, e
 			root = parent
 		}
 	}
-	return root, nil
+	trustedRoot, err := rootfs.New(root)
+	if err != nil {
+		return "", err
+	}
+	if err := trustedRoot.CheckContained("."); err != nil {
+		return "", err
+	}
+	for _, filePath := range cleaned {
+		if _, err := trustedRoot.Resolve(filePath); err != nil {
+			return "", err
+		}
+	}
+	return trustedRoot.Path(), nil
 }
 
 func persistScreenshotUploadFailureArtifact(path string, artifact screenshotUploadFailureArtifact) (string, error) {

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 type screenshotUploadFailureArtifact struct {
 	VersionLocalizationID string                       `json:"versionLocalizationId"`
 	Path                  string                       `json:"path,omitempty"`
+	RootPath              string                       `json:"rootPath,omitempty"`
 	DeviceType            string                       `json:"deviceType,omitempty"`
 	DisplayType           string                       `json:"displayType,omitempty"`
 	SkipExisting          bool                         `json:"skipExisting,omitempty"`
@@ -274,6 +276,7 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	artifact := screenshotUploadFailureArtifact{
 		VersionLocalizationID: cfg.LocalizationID,
 		Path:                  artifactPath,
+		RootPath:              cfg.RootPath,
 		DeviceType:            strings.TrimPrefix(cfg.DisplayType, "APP_"),
 		DisplayType:           cfg.DisplayType,
 		SkipExisting:          cfg.SkipExisting,
@@ -317,7 +320,11 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 	defer cancel()
 
 	syncAfterUpload := !artifact.SkipExisting || len(artifact.Files) == 0
-	progress, uploadErr := resumeScreenshotsWithOrderState(uploadCtx, client, artifact.SetID, artifact.OrderedIDs, artifact.PendingFiles, artifact.PendingAssets, true, syncAfterUpload)
+	sourceRootPath, err := resolveScreenshotUploadRoot(artifact.RootPath, screenshotArtifactSourcePaths(artifact))
+	if err != nil {
+		return asc.AppScreenshotUploadResult{}, fmt.Errorf("resolve resume source root: %w", err)
+	}
+	progress, uploadErr := resumeScreenshotsWithOrderState(uploadCtx, client, artifact.SetID, artifact.OrderedIDs, artifact.PendingFiles, artifact.PendingAssets, sourceRootPath, true, syncAfterUpload)
 
 	result := asc.AppScreenshotUploadResult{
 		VersionLocalizationID: artifact.VersionLocalizationID,
@@ -355,6 +362,7 @@ func resumeAppScreenshotUpload(ctx context.Context, client *asc.Client, artifact
 	nextArtifact := screenshotUploadFailureArtifact{
 		VersionLocalizationID: artifact.VersionLocalizationID,
 		Path:                  artifactPath,
+		RootPath:              sourceRootPath,
 		DeviceType:            artifact.DeviceType,
 		DisplayType:           artifact.DisplayType,
 		SkipExisting:          artifact.SkipExisting,
@@ -456,7 +464,76 @@ func normalizeScreenshotUploadFailureArtifactPaths(artifact screenshotUploadFail
 		artifact.Failures[i].FilePath = normalized
 	}
 
+	rootPath, err := resolveScreenshotUploadRoot(artifact.RootPath, screenshotArtifactSourcePaths(artifact))
+	if err != nil {
+		return screenshotUploadFailureArtifact{}, err
+	}
+	artifact.RootPath = rootPath
+
 	return artifact, nil
+}
+
+func screenshotArtifactSourcePaths(artifact screenshotUploadFailureArtifact) []string {
+	paths := make([]string, 0, len(artifact.Files)+len(artifact.PendingFiles)+len(artifact.PendingAssets))
+	paths = append(paths, artifact.Files...)
+	paths = append(paths, artifact.PendingFiles...)
+	for _, pending := range artifact.PendingAssets {
+		paths = append(paths, pending.FilePath)
+	}
+	return paths
+}
+
+func resolveScreenshotUploadRoot(rootPath string, filePaths []string) (string, error) {
+	rootPath = strings.TrimSpace(rootPath)
+	if rootPath != "" {
+		absolute, err := filepath.Abs(rootPath)
+		if err != nil {
+			return "", err
+		}
+		info, err := os.Lstat(absolute)
+		if err != nil {
+			return "", err
+		}
+		if info.IsDir() {
+			return filepath.Clean(absolute), nil
+		}
+		return filepath.Dir(absolute), nil
+	}
+
+	cleaned := make([]string, 0, len(filePaths))
+	for _, filePath := range filePaths {
+		filePath = strings.TrimSpace(filePath)
+		if filePath == "" {
+			continue
+		}
+		absolute, err := filepath.Abs(filePath)
+		if err != nil {
+			return "", err
+		}
+		cleaned = append(cleaned, filepath.Clean(absolute))
+	}
+	if len(cleaned) == 0 {
+		return "", nil
+	}
+
+	root := filepath.Dir(cleaned[0])
+	for _, filePath := range cleaned[1:] {
+		for {
+			relative, err := filepath.Rel(root, filePath)
+			if err != nil {
+				return "", err
+			}
+			if relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+				break
+			}
+			parent := filepath.Dir(root)
+			if parent == root {
+				return "", fmt.Errorf("screenshot files do not share a common source root")
+			}
+			root = parent
+		}
+	}
+	return root, nil
 }
 
 func persistScreenshotUploadFailureArtifact(path string, artifact screenshotUploadFailureArtifact) (string, error) {

--- a/internal/cli/assets/assets_screenshots_resume.go
+++ b/internal/cli/assets/assets_screenshots_resume.go
@@ -212,7 +212,7 @@ func executeAppScreenshotUpload(ctx context.Context, cfg screenshotUploadConfig[
 	if cfg.UploadContext == nil {
 		cfg.UploadContext = contextWithAssetUploadTimeout
 	}
-	if !cfg.DryRun && len(cfg.Files) > 0 {
+	if len(cfg.Files) > 0 {
 		sourceRootPath, err := resolveScreenshotUploadRoot(cfg.RootPath, cfg.Files)
 		if err != nil {
 			return asc.AppScreenshotUploadResult{}, fmt.Errorf("resolve screenshot source root: %w", err)
@@ -538,7 +538,7 @@ func resolveScreenshotUploadRoot(rootPath string, filePaths []string) (string, e
 			if err != nil {
 				return "", err
 			}
-			if _, err := root.Resolve(fileAbsolute); err != nil {
+			if err := root.CheckContained(fileAbsolute); err != nil {
 				return "", err
 			}
 		}
@@ -586,7 +586,7 @@ func resolveScreenshotUploadRoot(rootPath string, filePaths []string) (string, e
 		return "", err
 	}
 	for _, filePath := range cleaned {
-		if _, err := trustedRoot.Resolve(filePath); err != nil {
+		if err := trustedRoot.CheckContained(filePath); err != nil {
 			return "", err
 		}
 	}

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -54,6 +54,44 @@ func TestExecuteAppScreenshotUploadDryRunValidatesSourceRootBeforePreview(t *tes
 	}
 }
 
+func TestExecuteAppScreenshotUploadDryRunRejectsSymlinkAboveSelectedFileRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	outsideDir := filepath.Join(t.TempDir(), "nested")
+	if err := os.Mkdir(outsideDir, 0o700); err != nil {
+		t.Fatalf("create outside directory: %v", err)
+	}
+	writeAssetsTestPNG(t, outsideDir, "01-home.png")
+	linkDir := filepath.Join(rootDir, "linked")
+	if err := os.Symlink(filepath.Dir(outsideDir), linkDir); err != nil {
+		t.Fatalf("create source symlink: %v", err)
+	}
+	filePath := filepath.Join(linkDir, filepath.Base(outsideDir), "01-home.png")
+
+	requests := 0
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		writeAssetsTestJSON(w, http.StatusOK, `{"data":[],"links":{}}`)
+	}))
+
+	_, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		RootPath:       filePath,
+		Files:          []string{filePath},
+		DryRun:         true,
+		RequestContext: contextWithAssetUploadTimeout,
+		UploadContext:  contextWithAssetUploadTimeout,
+		Access:         appStoreVersionScreenshotSetAccess,
+	}, "")
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("executeAppScreenshotUpload() error = %v, want rootfs.ErrSymlink", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected source validation before API lookup, got %d requests", requests)
+	}
+}
+
 func TestExecuteAppScreenshotUploadSkipExistingDoesNotPatchOrderingWhenAlreadyMatched(t *testing.T) {
 	filePath := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
 	checksum, err := computeFileChecksum(filePath)

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -167,6 +167,201 @@ func TestResumeAppScreenshotUploadReplacesResolvedFailures(t *testing.T) {
 	}
 }
 
+func TestResumeAppScreenshotUploadReusesCreatedAssetAfterCommitFailure(t *testing.T) {
+	workDir := t.TempDir()
+	filePath := writeAssetsTestPNG(t, workDir, "01-home.png")
+	fileSizeBytes := fileSize(t, filePath)
+	artifactPath := filepath.Join(workDir, "resume-artifact.json")
+
+	createCount := 0
+	commitCount := 0
+	committed := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			createCount++
+			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/pending-1","length":%d,"offset":0}]}}}`, fileSizeBytes))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return assetsJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/pending-1":
+			commitCount++
+			if commitCount == 1 {
+				return assetsJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"ENTITY_ERROR","detail":"commit interrupted"}]}`)
+			}
+			committed = true
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
+			state := "AWAITING_UPLOAD"
+			if committed {
+				state = "COMPLETE"
+			}
+			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":%q}}}}`, state))
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	client := newAssetsUploadTestClient(t)
+	result, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		Files:          []string{filePath},
+		RequestContext: contextWithAssetUploadTimeout,
+		UploadContext:  contextWithAssetUploadTimeout,
+		Access:         appStoreVersionScreenshotSetAccess,
+	}, artifactPath)
+	if err == nil {
+		t.Fatal("expected initial upload error")
+	}
+	if result.Pending != 1 || result.FailureArtifactPath == "" {
+		t.Fatalf("expected resumable failure result, got %#v", result)
+	}
+
+	artifact, err := loadScreenshotUploadFailureArtifact(artifactPath)
+	if err != nil {
+		t.Fatalf("loadScreenshotUploadFailureArtifact() error: %v", err)
+	}
+	if len(artifact.PendingAssets) != 1 {
+		t.Fatalf("expected one pending remote asset, got %#v", artifact.PendingAssets)
+	}
+	pending := artifact.PendingAssets[0]
+	if pending.AssetID != "pending-1" || pending.FilePath != filePath || pending.State != "UPLOADED" || pending.Checksum == "" {
+		t.Fatalf("unexpected pending asset: %#v", pending)
+	}
+
+	result, err = resumeAppScreenshotUpload(context.Background(), client, artifactPath)
+	if err != nil {
+		t.Fatalf("resumeAppScreenshotUpload() error: %v", err)
+	}
+	if len(result.Results) != 1 || result.Results[0].AssetID != "pending-1" || result.Results[0].State != "COMPLETE" {
+		t.Fatalf("expected resumed result to reuse pending-1, got %#v", result.Results)
+	}
+	if createCount != 1 {
+		t.Fatalf("expected exactly one screenshot reservation, got %d", createCount)
+	}
+	if commitCount != 2 {
+		t.Fatalf("expected resume to retry the commit once, got %d attempts", commitCount)
+	}
+}
+
+func TestResumeScreenshotsDeletesIncompleteReservationBeforeRecreating(t *testing.T) {
+	filePath := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
+	fileSizeBytes := fileSize(t, filePath)
+	checksum, err := computeFileChecksum(filePath)
+	if err != nil {
+		t.Fatalf("computeFileChecksum() error: %v", err)
+	}
+
+	deletedIncomplete := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/incomplete-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"incomplete-1","attributes":{"assetDeliveryState":{"state":"AWAITING_UPLOAD"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/appScreenshots/incomplete-1":
+			deletedIncomplete = true
+			return assetsJSONResponse(http.StatusNoContent, "")
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			if !deletedIncomplete {
+				t.Fatal("replacement reservation was created before the incomplete one was deleted")
+			}
+			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/replacement-1","length":%d,"offset":0}]}}}`, fileSizeBytes))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return assetsJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/replacement-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/replacement-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	progress, err := resumeScreenshotsWithOrderState(
+		context.Background(),
+		newAssetsUploadTestClient(t),
+		"set-1",
+		nil,
+		[]string{filePath},
+		[]screenshotPendingAsset{{
+			FileName: filepath.Base(filePath),
+			FilePath: filePath,
+			AssetID:  "incomplete-1",
+			Checksum: checksum,
+			State:    "AWAITING_UPLOAD",
+		}},
+		true,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("resumeScreenshotsWithOrderState() error: %v", err)
+	}
+	if len(progress.Results) != 1 || progress.Results[0].AssetID != "replacement-1" {
+		t.Fatalf("expected replacement upload result, got %#v", progress.Results)
+	}
+}
+
+func TestResumeScreenshotsDoesNotCreateWhenPendingLookupFails(t *testing.T) {
+	filePath := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
+	createCalled := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
+			return assetsJSONResponse(http.StatusForbidden, `{"errors":[{"status":"403","code":"FORBIDDEN","detail":"lookup unavailable"}]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			createCalled = true
+			return assetsJSONResponse(http.StatusInternalServerError, `{}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = origTransport
+	})
+
+	progress, err := resumeScreenshotsWithOrderState(
+		context.Background(),
+		newAssetsUploadTestClient(t),
+		"set-1",
+		nil,
+		[]string{filePath},
+		[]screenshotPendingAsset{{FileName: filepath.Base(filePath), FilePath: filePath, AssetID: "pending-1", State: "UPLOAD_COMPLETE"}},
+		true,
+		true,
+	)
+	if err == nil {
+		t.Fatal("expected pending lookup error")
+	}
+	if createCalled {
+		t.Fatal("did not expect a new reservation after an inconclusive lookup")
+	}
+	if len(progress.PendingAssets) != 1 || progress.PendingAssets[0].AssetID != "pending-1" {
+		t.Fatalf("expected pending asset to remain resumable, got %#v", progress.PendingAssets)
+	}
+}
+
 func TestExecuteAppScreenshotUploadOrderSyncFailureSurfacesOrderingError(t *testing.T) {
 	workDir := t.TempDir()
 	filePath := writeAssetsTestPNG(t, workDir, "01-home.png")

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -16,7 +16,43 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
+
+func TestExecuteAppScreenshotUploadDryRunValidatesSourceRootBeforePreview(t *testing.T) {
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+	writeAssetsTestPNG(t, outsideDir, "01-home.png")
+	linkDir := filepath.Join(rootDir, "linked")
+	if err := os.Symlink(outsideDir, linkDir); err != nil {
+		t.Fatalf("create source symlink: %v", err)
+	}
+	filePath := filepath.Join(linkDir, "01-home.png")
+
+	requests := 0
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		writeAssetsTestJSON(w, http.StatusOK, `{"data":[],"links":{}}`)
+	}))
+
+	_, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		RootPath:       rootDir,
+		Files:          []string{filePath},
+		DryRun:         true,
+		RequestContext: contextWithAssetUploadTimeout,
+		UploadContext:  contextWithAssetUploadTimeout,
+		Access:         appStoreVersionScreenshotSetAccess,
+	}, "")
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("executeAppScreenshotUpload() error = %v, want rootfs.ErrSymlink", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected source validation before API lookup, got %d requests", requests)
+	}
+}
 
 func TestExecuteAppScreenshotUploadSkipExistingDoesNotPatchOrderingWhenAlreadyMatched(t *testing.T) {
 	filePath := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
@@ -318,7 +354,7 @@ func TestResumeAppScreenshotUploadRejectsSymlinkedParentBelowRecordedRoot(t *tes
 		t.Fatalf("computeFileChecksum() error: %v", err)
 	}
 	artifactPath := filepath.Join(rootDir, "resume-artifact.json")
-	_, err = persistScreenshotUploadFailureArtifact(artifactPath, screenshotUploadFailureArtifact{
+	artifactData, err := json.MarshalIndent(screenshotUploadFailureArtifact{
 		RootPath:     rootDir,
 		SetID:        "set-1",
 		PendingFiles: []string{linkedPath},
@@ -330,24 +366,30 @@ func TestResumeAppScreenshotUploadRejectsSymlinkedParentBelowRecordedRoot(t *tes
 			State:    "UPLOAD_COMPLETE",
 		}},
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-	})
+	}, "", "  ")
 	if err != nil {
-		t.Fatalf("persistScreenshotUploadFailureArtifact() error: %v", err)
+		t.Fatalf("marshal screenshot artifact: %v", err)
+	}
+	root, err := rootfs.New(rootDir)
+	if err != nil {
+		t.Fatalf("rootfs.New() error: %v", err)
+	}
+	if err := root.WriteFile(filepath.Base(artifactPath), append(artifactData, '\n'), 0o600); err != nil {
+		t.Fatalf("write screenshot artifact: %v", err)
 	}
 
+	requests := 0
 	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodGet || req.URL.Path != "/v1/appScreenshots/pending-1" {
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-		}
+		requests++
 		writeAssetsTestJSON(w, http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
 	}))
 
-	result, err := resumeAppScreenshotUpload(context.Background(), client, artifactPath)
-	if err == nil {
-		t.Fatal("expected rooted parent-symlink rejection")
+	_, err = resumeAppScreenshotUpload(context.Background(), client, artifactPath)
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("resumeAppScreenshotUpload() error = %v, want rootfs.ErrSymlink", err)
 	}
-	if len(result.Failures) != 1 || !strings.Contains(strings.ToLower(result.Failures[0].Error), "symlink") {
-		t.Fatalf("expected rooted parent-symlink failure detail, got %#v", result.Failures)
+	if requests != 0 {
+		t.Fatalf("expected source validation before API lookup, got %d requests", requests)
 	}
 }
 

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -89,6 +90,45 @@ func TestExecuteAppScreenshotUploadDryRunRejectsSymlinkAboveSelectedFileRoot(t *
 	}
 	if requests != 0 {
 		t.Fatalf("expected source validation before API lookup, got %d requests", requests)
+	}
+}
+
+func TestExecuteAppScreenshotUploadDryRunAllowsSystemTemporaryAlias(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("system /tmp alias is Unix-only")
+	}
+	workDir, err := os.MkdirTemp("/tmp", "asc-screenshot-source-*")
+	if err != nil {
+		t.Fatalf("create temporary screenshot directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(workDir); err != nil {
+			t.Errorf("remove temporary screenshot directory: %v", err)
+		}
+	})
+	filePath := writeAssetsTestPNG(t, workDir, "01-home.png")
+
+	requests := 0
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		writeAssetsTestJSON(w, http.StatusOK, `{"data":[],"links":{}}`)
+	}))
+
+	_, err = executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
+		Client:         client,
+		LocalizationID: "LOC_123",
+		DisplayType:    "APP_IPHONE_65",
+		Files:          []string{filePath},
+		DryRun:         true,
+		RequestContext: contextWithAssetUploadTimeout,
+		UploadContext:  contextWithAssetUploadTimeout,
+		Access:         appStoreVersionScreenshotSetAccess,
+	}, "")
+	if err != nil {
+		t.Fatalf("executeAppScreenshotUpload() error: %v", err)
+	}
+	if requests == 0 {
+		t.Fatal("expected dry-run API lookup after source validation")
 	}
 }
 

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -258,6 +258,109 @@ func TestResumeAppScreenshotUploadReusesCreatedAssetAfterCommitFailure(t *testin
 	}
 }
 
+func TestResumeAppScreenshotUploadRejectsChangedFileForCompletedReservation(t *testing.T) {
+	workDir := t.TempDir()
+	filePath := writeAssetsTestPNG(t, workDir, "01-home.png")
+	checksum, err := computeFileChecksum(filePath)
+	if err != nil {
+		t.Fatalf("computeFileChecksum() error: %v", err)
+	}
+	artifactPath := filepath.Join(workDir, "resume-artifact.json")
+	_, err = persistScreenshotUploadFailureArtifact(artifactPath, screenshotUploadFailureArtifact{
+		RootPath:     workDir,
+		SetID:        "set-1",
+		PendingFiles: []string{filePath},
+		PendingAssets: []screenshotPendingAsset{{
+			FileName: filepath.Base(filePath),
+			FilePath: filePath,
+			AssetID:  "pending-1",
+			Checksum: checksum,
+			State:    "UPLOAD_COMPLETE",
+		}},
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("persistScreenshotUploadFailureArtifact() error: %v", err)
+	}
+	writeAssetsTestPNGWithSize(t, workDir, filepath.Base(filePath), 9, 8)
+
+	orderPatched := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
+			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			orderPatched = true
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = origTransport })
+
+	result, err := resumeAppScreenshotUpload(context.Background(), newAssetsUploadTestClient(t), artifactPath)
+	if err == nil {
+		t.Fatal("expected changed-file error")
+	}
+	if len(result.Failures) != 1 || !strings.Contains(result.Failures[0].Error, "pending screenshot file changed after upload") {
+		t.Fatalf("expected changed-file failure detail, got %#v", result.Failures)
+	}
+	if orderPatched {
+		t.Fatal("did not expect ordering to be updated for a stale completed reservation")
+	}
+}
+
+func TestResumeAppScreenshotUploadRejectsSymlinkedParentBelowRecordedRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := writeAssetsTestPNG(t, outsideDir, "01-home.png")
+	linkDir := filepath.Join(rootDir, "linked")
+	if err := os.Symlink(outsideDir, linkDir); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+	linkedPath := filepath.Join(linkDir, filepath.Base(outsidePath))
+	checksum, err := computeFileChecksum(linkedPath)
+	if err != nil {
+		t.Fatalf("computeFileChecksum() error: %v", err)
+	}
+	artifactPath := filepath.Join(rootDir, "resume-artifact.json")
+	_, err = persistScreenshotUploadFailureArtifact(artifactPath, screenshotUploadFailureArtifact{
+		RootPath:     rootDir,
+		SetID:        "set-1",
+		PendingFiles: []string{linkedPath},
+		PendingAssets: []screenshotPendingAsset{{
+			FileName: filepath.Base(linkedPath),
+			FilePath: linkedPath,
+			AssetID:  "pending-1",
+			Checksum: checksum,
+			State:    "UPLOAD_COMPLETE",
+		}},
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("persistScreenshotUploadFailureArtifact() error: %v", err)
+	}
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appScreenshots/pending-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+	})
+	t.Cleanup(func() { http.DefaultTransport = origTransport })
+
+	result, err := resumeAppScreenshotUpload(context.Background(), newAssetsUploadTestClient(t), artifactPath)
+	if err == nil {
+		t.Fatal("expected rooted parent-symlink rejection")
+	}
+	if len(result.Failures) != 1 || !strings.Contains(strings.ToLower(result.Failures[0].Error), "symlink") {
+		t.Fatalf("expected rooted parent-symlink failure detail, got %#v", result.Failures)
+	}
+}
+
 func TestResumeScreenshotsDeletesIncompleteReservationBeforeRecreating(t *testing.T) {
 	filePath := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
 	fileSizeBytes := fileSize(t, filePath)
@@ -310,6 +413,7 @@ func TestResumeScreenshotsDeletesIncompleteReservationBeforeRecreating(t *testin
 			Checksum: checksum,
 			State:    "AWAITING_UPLOAD",
 		}},
+		filepath.Dir(filePath),
 		true,
 		true,
 	)
@@ -348,6 +452,7 @@ func TestResumeScreenshotsDoesNotCreateWhenPendingLookupFails(t *testing.T) {
 		nil,
 		[]string{filePath},
 		[]screenshotPendingAsset{{FileName: filepath.Base(filePath), FilePath: filePath, AssetID: "pending-1", State: "UPLOAD_COMPLETE"}},
+		filepath.Dir(filePath),
 		true,
 		true,
 	)

--- a/internal/cli/assets/assets_screenshots_resume_test.go
+++ b/internal/cli/assets/assets_screenshots_resume_test.go
@@ -176,45 +176,40 @@ func TestResumeAppScreenshotUploadReusesCreatedAssetAfterCommitFailure(t *testin
 	createCount := 0
 	commitCount := 0
 	committed := false
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
-			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
-			return assetsJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":[],"links":{}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
-			return assetsJSONResponse(http.StatusOK, `{"data":[],"links":{}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":[],"links":{}}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
 			createCount++
-			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/pending-1","length":%d,"offset":0}]}}}`, fileSizeBytes))
-		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
-			return assetsJSONResponse(http.StatusOK, `{}`)
+			writeAssetsTestJSON(w, http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"uploadOperations":[{"method":"PUT","url":"http://%s/uploads/pending-1","length":%d,"offset":0}]}}}`, req.Host, fileSizeBytes))
+		case req.Method == http.MethodPut && req.URL.Path == "/uploads/pending-1":
+			writeAssetsTestJSON(w, http.StatusOK, `{}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/pending-1":
 			commitCount++
 			if commitCount == 1 {
-				return assetsJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"ENTITY_ERROR","detail":"commit interrupted"}]}`)
+				writeAssetsTestJSON(w, http.StatusBadRequest, `{"errors":[{"status":"400","code":"ENTITY_ERROR","detail":"commit interrupted"}]}`)
+				return
 			}
 			committed = true
-			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
 			state := "AWAITING_UPLOAD"
 			if committed {
 				state = "COMPLETE"
 			}
-			return assetsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":%q}}}}`, state))
+			writeAssetsTestJSON(w, http.StatusOK, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":%q}}}}`, state))
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
-			return assetsJSONResponse(http.StatusNoContent, "")
+			writeAssetsTestJSON(w, http.StatusNoContent, "")
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
 		}
-	})
-	t.Cleanup(func() {
-		http.DefaultTransport = origTransport
-	})
+	}))
 
-	client := newAssetsUploadTestClient(t)
 	result, err := executeAppScreenshotUpload(context.Background(), screenshotUploadConfig[asc.AppScreenshotUploadResult]{
 		Client:         client,
 		LocalizationID: "LOC_123",
@@ -285,22 +280,19 @@ func TestResumeAppScreenshotUploadRejectsChangedFileForCompletedReservation(t *t
 	writeAssetsTestPNGWithSize(t, workDir, filepath.Base(filePath), 9, 8)
 
 	orderPatched := false
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
-			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
 			orderPatched = true
-			return assetsJSONResponse(http.StatusNoContent, "")
+			writeAssetsTestJSON(w, http.StatusNoContent, "")
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
 		}
-	})
-	t.Cleanup(func() { http.DefaultTransport = origTransport })
+	}))
 
-	result, err := resumeAppScreenshotUpload(context.Background(), newAssetsUploadTestClient(t), artifactPath)
+	result, err := resumeAppScreenshotUpload(context.Background(), client, artifactPath)
 	if err == nil {
 		t.Fatal("expected changed-file error")
 	}
@@ -343,21 +335,34 @@ func TestResumeAppScreenshotUploadRejectsSymlinkedParentBelowRecordedRoot(t *tes
 		t.Fatalf("persistScreenshotUploadFailureArtifact() error: %v", err)
 	}
 
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/appScreenshots/pending-1" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
-		return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
-	})
-	t.Cleanup(func() { http.DefaultTransport = origTransport })
+		writeAssetsTestJSON(w, http.StatusOK, `{"data":{"type":"appScreenshots","id":"pending-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+	}))
 
-	result, err := resumeAppScreenshotUpload(context.Background(), newAssetsUploadTestClient(t), artifactPath)
+	result, err := resumeAppScreenshotUpload(context.Background(), client, artifactPath)
 	if err == nil {
 		t.Fatal("expected rooted parent-symlink rejection")
 	}
 	if len(result.Failures) != 1 || !strings.Contains(strings.ToLower(result.Failures[0].Error), "symlink") {
 		t.Fatalf("expected rooted parent-symlink failure detail, got %#v", result.Failures)
+	}
+}
+
+func TestUploadScreenshotAssetRejectsSymlinkedParentBelowSourceRoot(t *testing.T) {
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := writeAssetsTestPNG(t, outsideDir, "01-home.png")
+	linkDir := filepath.Join(rootDir, "linked")
+	if err := os.Symlink(outsideDir, linkDir); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+
+	_, _, err := uploadScreenshotAsset(context.Background(), nil, "set-1", rootDir, filepath.Join(linkDir, filepath.Base(outsidePath)))
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "symlink") {
+		t.Fatalf("expected rooted parent-symlink rejection, got %v", err)
 	}
 }
 
@@ -370,39 +375,34 @@ func TestResumeScreenshotsDeletesIncompleteReservationBeforeRecreating(t *testin
 	}
 
 	deletedIncomplete := false
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/incomplete-1":
-			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"incomplete-1","attributes":{"assetDeliveryState":{"state":"AWAITING_UPLOAD"}}}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":{"type":"appScreenshots","id":"incomplete-1","attributes":{"assetDeliveryState":{"state":"AWAITING_UPLOAD"}}}}`)
 		case req.Method == http.MethodDelete && req.URL.Path == "/v1/appScreenshots/incomplete-1":
 			deletedIncomplete = true
-			return assetsJSONResponse(http.StatusNoContent, "")
+			writeAssetsTestJSON(w, http.StatusNoContent, "")
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
 			if !deletedIncomplete {
 				t.Fatal("replacement reservation was created before the incomplete one was deleted")
 			}
-			return assetsJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/replacement-1","length":%d,"offset":0}]}}}`, fileSizeBytes))
-		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
-			return assetsJSONResponse(http.StatusOK, `{}`)
+			writeAssetsTestJSON(w, http.StatusCreated, fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"uploadOperations":[{"method":"PUT","url":"http://%s/uploads/replacement-1","length":%d,"offset":0}]}}}`, req.Host, fileSizeBytes))
+		case req.Method == http.MethodPut && req.URL.Path == "/uploads/replacement-1":
+			writeAssetsTestJSON(w, http.StatusOK, `{}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/replacement-1":
-			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/replacement-1":
-			return assetsJSONResponse(http.StatusOK, `{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":{"type":"appScreenshots","id":"replacement-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
-			return assetsJSONResponse(http.StatusNoContent, "")
+			writeAssetsTestJSON(w, http.StatusNoContent, "")
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
 		}
-	})
-	t.Cleanup(func() {
-		http.DefaultTransport = origTransport
-	})
+	}))
 
 	progress, err := resumeScreenshotsWithOrderState(
 		context.Background(),
-		newAssetsUploadTestClient(t),
+		client,
 		"set-1",
 		nil,
 		[]string{filePath},
@@ -428,26 +428,21 @@ func TestResumeScreenshotsDeletesIncompleteReservationBeforeRecreating(t *testin
 func TestResumeScreenshotsDoesNotCreateWhenPendingLookupFails(t *testing.T) {
 	filePath := writeAssetsTestPNG(t, t.TempDir(), "01-home.png")
 	createCalled := false
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/pending-1":
-			return assetsJSONResponse(http.StatusForbidden, `{"errors":[{"status":"403","code":"FORBIDDEN","detail":"lookup unavailable"}]}`)
+			writeAssetsTestJSON(w, http.StatusForbidden, `{"errors":[{"status":"403","code":"FORBIDDEN","detail":"lookup unavailable"}]}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
 			createCalled = true
-			return assetsJSONResponse(http.StatusInternalServerError, `{}`)
+			writeAssetsTestJSON(w, http.StatusInternalServerError, `{}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
 		}
-	})
-	t.Cleanup(func() {
-		http.DefaultTransport = origTransport
-	})
+	}))
 
 	progress, err := resumeScreenshotsWithOrderState(
 		context.Background(),
-		newAssetsUploadTestClient(t),
+		client,
 		"set-1",
 		nil,
 		[]string{filePath},
@@ -553,6 +548,49 @@ func TestExecuteAppScreenshotUploadOrderSyncFailureSurfacesOrderingError(t *test
 	}
 	if len(artifactData.Failures) != 1 || artifactData.Failures[0].FileName != "screenshot ordering" {
 		t.Fatalf("expected ordering failure in artifact, got %#v", artifactData.Failures)
+	}
+}
+
+func TestResumeAppScreenshotUploadOrderingOnlyDoesNotRequireSourceRoot(t *testing.T) {
+	workDir := t.TempDir()
+	missingRoot := filepath.Join(workDir, "removed-screenshots")
+	artifactPath := filepath.Join(workDir, "failure-artifact.json")
+	_, err := persistScreenshotUploadFailureArtifact(artifactPath, screenshotUploadFailureArtifact{
+		RootPath:   missingRoot,
+		SetID:      "set-1",
+		Files:      []string{filepath.Join(missingRoot, "01-home.png")},
+		OrderedIDs: []string{"new-1"},
+		Results: []asc.AssetUploadResultItem{{
+			FileName: "01-home.png",
+			FilePath: filepath.Join(missingRoot, "01-home.png"),
+			AssetID:  "new-1",
+			State:    "COMPLETE",
+		}},
+		Error:       "reorder failed",
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("persistScreenshotUploadFailureArtifact() error: %v", err)
+	}
+
+	patched := false
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appScreenshotSets/set-1/relationships/appScreenshots" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		patched = true
+		writeAssetsTestJSON(w, http.StatusNoContent, "")
+	}))
+
+	result, err := resumeAppScreenshotUpload(context.Background(), client, artifactPath)
+	if err != nil {
+		t.Fatalf("resumeAppScreenshotUpload() error: %v", err)
+	}
+	if !patched {
+		t.Fatal("expected ordering retry")
+	}
+	if len(result.Results) != 1 || result.Results[0].AssetID != "new-1" {
+		t.Fatalf("expected preserved completed result, got %#v", result.Results)
 	}
 }
 

--- a/internal/cli/assets/assets_screenshots_upload.go
+++ b/internal/cli/assets/assets_screenshots_upload.go
@@ -361,12 +361,16 @@ func computeFileChecksumInRoot(rootPath, filePath string) (string, error) {
 	return checksum.Hash, nil
 }
 
-func uploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, screenshotPendingAsset, error) {
-	if err := asc.ValidateImageFile(filePath); err != nil {
+func uploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, sourceRootPath, filePath string) (asc.AssetUploadResultItem, screenshotPendingAsset, error) {
+	root, err := rootfs.New(sourceRootPath)
+	if err != nil {
 		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
 	}
-
-	file, err := shared.OpenExistingNoFollow(filePath)
+	sourcePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
+	}
+	file, err := root.OpenFile(sourcePath)
 	if err != nil {
 		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
 	}
@@ -448,7 +452,11 @@ func uploadScreenshotAssetFromFile(ctx context.Context, client *asc.Client, setI
 
 // UploadScreenshotAsset uploads a screenshot file to a set.
 func UploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, error) {
-	result, _, err := uploadScreenshotAsset(ctx, client, setID, filePath)
+	sourceRootPath, err := resolveScreenshotUploadRoot("", []string{filePath})
+	if err != nil {
+		return asc.AssetUploadResultItem{}, err
+	}
+	result, _, err := uploadScreenshotAsset(ctx, client, setID, sourceRootPath, filePath)
 	return result, err
 }
 

--- a/internal/cli/assets/assets_screenshots_upload.go
+++ b/internal/cli/assets/assets_screenshots_upload.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 func normalizeScreenshotDisplayType(input string) (string, error) {
@@ -330,6 +331,24 @@ func sameScreenshotIDOrder(a, b []string) bool {
 
 func computeFileChecksum(filePath string) (string, error) {
 	file, err := shared.OpenExistingNoFollow(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	checksum, err := asc.ComputeChecksumFromReader(file, asc.ChecksumAlgorithmMD5)
+	if err != nil {
+		return "", err
+	}
+	return checksum.Hash, nil
+}
+
+func computeFileChecksumInRoot(rootPath, filePath string) (string, error) {
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return "", err
+	}
+	file, err := root.OpenFile(filePath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/assets/assets_screenshots_upload.go
+++ b/internal/cli/assets/assets_screenshots_upload.go
@@ -342,65 +342,81 @@ func computeFileChecksum(filePath string) (string, error) {
 	return checksum.Hash, nil
 }
 
-func uploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, error) {
+func uploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, screenshotPendingAsset, error) {
 	if err := asc.ValidateImageFile(filePath); err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
 	}
 
 	file, err := shared.OpenExistingNoFollow(filePath)
 	if err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
 	}
 	defer file.Close()
 	return uploadScreenshotAssetFromFile(ctx, client, setID, filePath, file)
 }
 
-func uploadScreenshotAssetFromFile(ctx context.Context, client *asc.Client, setID, filePath string, file *os.File) (asc.AssetUploadResultItem, error) {
+func uploadScreenshotAssetFromFile(ctx context.Context, client *asc.Client, setID, filePath string, file *os.File) (asc.AssetUploadResultItem, screenshotPendingAsset, error) {
 	if file == nil {
-		return asc.AssetUploadResultItem{}, fmt.Errorf("screenshot file is required")
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, fmt.Errorf("screenshot file is required")
 	}
 	info, err := file.Stat()
 	if err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
 	}
 	if !info.Mode().IsRegular() {
-		return asc.AssetUploadResultItem{}, fmt.Errorf("expected regular file: %q", filePath)
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, fmt.Errorf("expected regular file: %q", filePath)
 	}
 	if info.Size() <= 0 {
-		return asc.AssetUploadResultItem{}, fmt.Errorf("file is empty: %q", filePath)
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, fmt.Errorf("file is empty: %q", filePath)
 	}
 	const maxScreenshotUploadFileSize = int64(1024 * 1024 * 1024)
 	if info.Size() > maxScreenshotUploadFileSize {
-		return asc.AssetUploadResultItem{}, fmt.Errorf("file size exceeds %d bytes: %q", maxScreenshotUploadFileSize, filePath)
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, fmt.Errorf("file size exceeds %d bytes: %q", maxScreenshotUploadFileSize, filePath)
 	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
 	}
 
 	checksum, err := asc.ComputeChecksumFromReader(file, asc.ChecksumAlgorithmMD5)
 	if err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
 	}
 
 	created, err := client.CreateAppScreenshot(ctx, setID, info.Name(), info.Size())
 	if err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, screenshotPendingAsset{}, err
+	}
+	pending := screenshotPendingAsset{
+		FileName: info.Name(),
+		FilePath: filePath,
+		AssetID:  created.Data.ID,
+		Checksum: checksum.Hash,
+		State:    "AWAITING_UPLOAD",
 	}
 	if len(created.Data.Attributes.UploadOperations) == 0 {
-		return asc.AssetUploadResultItem{}, fmt.Errorf("no upload operations returned for %q", info.Name())
+		return asc.AssetUploadResultItem{}, pending, fmt.Errorf("no upload operations returned for %q", info.Name())
 	}
 
 	if err := asc.UploadAssetFromFile(ctx, file, info.Size(), created.Data.Attributes.UploadOperations); err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, pending, err
 	}
+	pending.State = "UPLOADED"
 
-	if _, err := client.UpdateAppScreenshot(ctx, created.Data.ID, true, checksum.Hash); err != nil {
-		return asc.AssetUploadResultItem{}, err
+	updated, err := client.UpdateAppScreenshot(ctx, created.Data.ID, true, checksum.Hash)
+	if err != nil {
+		return asc.AssetUploadResultItem{}, pending, err
+	}
+	pending.State = "UPLOAD_COMPLETE"
+	if updated.Data.Attributes.AssetDeliveryState != nil && strings.TrimSpace(updated.Data.Attributes.AssetDeliveryState.State) != "" {
+		pending.State = strings.ToUpper(strings.TrimSpace(updated.Data.Attributes.AssetDeliveryState.State))
 	}
 
 	state, err := waitForScreenshotDelivery(ctx, client, created.Data.ID)
+	if strings.TrimSpace(state) != "" {
+		pending.State = strings.ToUpper(strings.TrimSpace(state))
+	}
 	if err != nil {
-		return asc.AssetUploadResultItem{}, err
+		return asc.AssetUploadResultItem{}, pending, err
 	}
 
 	return asc.AssetUploadResultItem{
@@ -408,19 +424,21 @@ func uploadScreenshotAssetFromFile(ctx context.Context, client *asc.Client, setI
 		FilePath: filePath,
 		AssetID:  created.Data.ID,
 		State:    state,
-	}, nil
+	}, screenshotPendingAsset{}, nil
 }
 
 // UploadScreenshotAsset uploads a screenshot file to a set.
 func UploadScreenshotAsset(ctx context.Context, client *asc.Client, setID, filePath string) (asc.AssetUploadResultItem, error) {
-	return uploadScreenshotAsset(ctx, client, setID, filePath)
+	result, _, err := uploadScreenshotAsset(ctx, client, setID, filePath)
+	return result, err
 }
 
 // UploadScreenshotAssetFromFile uploads from an already-open, validated source
 // handle. Callers that discover files under a rooted filesystem can retain the
 // handle so a later pathname replacement cannot redirect the upload.
 func UploadScreenshotAssetFromFile(ctx context.Context, client *asc.Client, setID, filePath string, file *os.File) (asc.AssetUploadResultItem, error) {
-	return uploadScreenshotAssetFromFile(ctx, client, setID, filePath, file)
+	result, _, err := uploadScreenshotAssetFromFile(ctx, client, setID, filePath, file)
+	return result, err
 }
 
 func waitForScreenshotDelivery(ctx context.Context, client *asc.Client, screenshotID string) (string, error) {

--- a/internal/cli/assets/assets_screenshots_upload.go
+++ b/internal/cli/assets/assets_screenshots_upload.go
@@ -121,7 +121,7 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 	}
 
 	sourceRootPath := ""
-	if !cfg.DryRun && len(cfg.Files) > 0 {
+	if len(cfg.Files) > 0 {
 		var err error
 		sourceRootPath, err = resolveScreenshotUploadRoot(cfg.RootPath, cfg.Files)
 		if err != nil {

--- a/internal/cli/assets/assets_screenshots_upload.go
+++ b/internal/cli/assets/assets_screenshots_upload.go
@@ -120,6 +120,15 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 		cfg.UploadContext = contextWithAssetUploadTimeout
 	}
 
+	sourceRootPath := ""
+	if !cfg.DryRun && len(cfg.Files) > 0 {
+		var err error
+		sourceRootPath, err = resolveScreenshotUploadRoot(cfg.RootPath, cfg.Files)
+		if err != nil {
+			return zero, fmt.Errorf("resolve screenshot source root: %w", err)
+		}
+	}
+
 	requestCtx, reqCancel := cfg.RequestContext(ctx)
 	var (
 		set asc.Resource[asc.AppScreenshotSetAttributes]
@@ -193,7 +202,7 @@ func uploadScreenshotsWithConfig[T any](ctx context.Context, cfg screenshotUploa
 
 	results := make([]asc.AssetUploadResultItem, 0, len(skippedResults)+len(files))
 	if len(files) > 0 {
-		uploadedResults, err := UploadScreenshotsToSet(uploadCtx, cfg.Client, set.ID, files, !cfg.Replace)
+		uploadedResults, err := uploadScreenshotsToSetFromRoot(uploadCtx, cfg.Client, set.ID, files, sourceRootPath, !cfg.Replace)
 		if err != nil {
 			return zero, err
 		}

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -53,13 +53,16 @@ func TestUploadScreenshotsReplaceValidatesRootBeforeDeletingExistingScreenshots(
 
 func TestUploadScreenshotsDryRunValidatesSourceRootBeforePreview(t *testing.T) {
 	rootDir := t.TempDir()
-	outsideDir := t.TempDir()
+	outsideDir := filepath.Join(t.TempDir(), "nested")
+	if err := os.Mkdir(outsideDir, 0o700); err != nil {
+		t.Fatalf("create outside directory: %v", err)
+	}
 	writeAssetsTestPNG(t, outsideDir, "01-home.png")
 	linkDir := filepath.Join(rootDir, "linked")
-	if err := os.Symlink(outsideDir, linkDir); err != nil {
+	if err := os.Symlink(filepath.Dir(outsideDir), linkDir); err != nil {
 		t.Fatalf("create source symlink: %v", err)
 	}
-	filePath := filepath.Join(linkDir, "01-home.png")
+	filePath := filepath.Join(linkDir, filepath.Base(outsideDir), "01-home.png")
 
 	requests := 0
 	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -51,6 +51,31 @@ func TestUploadScreenshotsReplaceValidatesRootBeforeDeletingExistingScreenshots(
 	}
 }
 
+func TestUploadScreenshotsDryRunValidatesSourceRootBeforePreview(t *testing.T) {
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+	writeAssetsTestPNG(t, outsideDir, "01-home.png")
+	linkDir := filepath.Join(rootDir, "linked")
+	if err := os.Symlink(outsideDir, linkDir); err != nil {
+		t.Fatalf("create source symlink: %v", err)
+	}
+	filePath := filepath.Join(linkDir, "01-home.png")
+
+	requests := 0
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		writeAssetsTestJSON(w, http.StatusOK, `{"data":[],"links":{}}`)
+	}))
+
+	_, err := uploadScreenshots(context.Background(), client, "LOC_123", "APP_IPHONE_65", []string{filePath}, false, false, true)
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("uploadScreenshots() error = %v, want rootfs.ErrSymlink", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected source validation before API lookup, got %d requests", requests)
+	}
+}
+
 func TestUploadScreenshotsSkipExistingStartsUploadTimeoutAfterChecksumFiltering(t *testing.T) {
 	t.Setenv("ASC_TIMEOUT", "200ms")
 	t.Setenv("ASC_UPLOAD_TIMEOUT", "30s")

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -28,24 +28,21 @@ func TestUploadScreenshotsReplaceValidatesRootBeforeDeletingExistingScreenshots(
 	filePath := filepath.Join(root, "linked", "01-home.png")
 
 	deleted := false
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
-			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
-			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"old.png"}}],"links":{}}`)
+			writeAssetsTestJSON(w, http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"old.png"}}],"links":{}}`)
 		case req.Method == http.MethodDelete && req.URL.Path == "/v1/appScreenshots/existing-1":
 			deleted = true
-			return assetsJSONResponse(http.StatusNoContent, "")
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
 		}
-	})
-	t.Cleanup(func() { http.DefaultTransport = origTransport })
+	}))
 
-	_, err := uploadScreenshots(context.Background(), newAssetsUploadTestClient(t), "LOC_123", "APP_IPHONE_65", []string{filePath}, false, true, false)
+	_, err := uploadScreenshots(context.Background(), client, "LOC_123", "APP_IPHONE_65", []string{filePath}, false, true, false)
 	if !errors.Is(err, rootfs.ErrSymlink) {
 		t.Fatalf("uploadScreenshots() error = %v, want rootfs.ErrSymlink", err)
 	}

--- a/internal/cli/assets/assets_screenshots_upload_test.go
+++ b/internal/cli/assets/assets_screenshots_upload_test.go
@@ -3,9 +3,11 @@ package assets
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -13,7 +15,44 @@ import (
 	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
+
+func TestUploadScreenshotsReplaceValidatesRootBeforeDeletingExistingScreenshots(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeAssetsTestPNG(t, outside, "01-home.png")
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Fatalf("create source symlink: %v", err)
+	}
+	filePath := filepath.Join(root, "linked", "01-home.png")
+
+	deleted := false
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = assetsUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}],"links":{}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return assetsJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"existing-1","attributes":{"fileName":"old.png"}}],"links":{}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/appScreenshots/existing-1":
+			deleted = true
+			return assetsJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = origTransport })
+
+	_, err := uploadScreenshots(context.Background(), newAssetsUploadTestClient(t), "LOC_123", "APP_IPHONE_65", []string{filePath}, false, true, false)
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("uploadScreenshots() error = %v, want rootfs.ErrSymlink", err)
+	}
+	if deleted {
+		t.Fatal("existing screenshot was deleted before the upload source root was validated")
+	}
+}
 
 func TestUploadScreenshotsSkipExistingStartsUploadTimeoutAfterChecksumFiltering(t *testing.T) {
 	t.Setenv("ASC_TIMEOUT", "200ms")


### PR DESCRIPTION
## Summary

- preserve the remote screenshot ID, checksum, and upload stage in failure artifacts
- reconcile recorded reservations before creating replacement assets
- resume completed and committed uploads without duplicate create requests
- fail closed when the recorded remote state cannot be inspected
- keep older failure artifacts compatible

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- live disposable-app check: uploaded one temporary screenshot, resumed from its recorded completed reservation, and confirmed the set still contained exactly the same single asset ID
- deleted the temporary screenshot and confirmed the target set returned to zero assets

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788898885&installation_model_id=10418&pr_number=1904&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1904&signature=ed00ada107a6836b2928b2996efbd855639e7ecbf1e37ff4976c6f3d7325eee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot upload recovery after interrupted or failed uploads.
  * Resuming uploads now reuses successfully uploaded assets when possible.
  * Incomplete or invalid reservations are automatically retried or cleaned up.
  * Added validation to prevent mismatched, changed, symlinked, or inaccessible files from being resumed incorrectly.
  * Upload progress now accurately reflects pending assets and delivery status.
* **Reliability**
  * Preserved upload metadata and source paths across failures.
  * Improved checksum verification, delivery tracking, retry handling, and ordering-only resume scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->