### PR TITLE
fix(workflow): accept explicit JSON validation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ asc bundle-ids list
 ### Workflow automation
 
 ```bash
-asc workflow validate
+asc workflow validate --output json
 asc workflow run --dry-run testflight_beta VERSION:1.2.3
 ```
 
@@ -357,7 +357,7 @@ See [docs/WORKFLOWS.md](docs/WORKFLOWS.md) for a copyable `.asc/deployment.json`
 distributing to an external TestFlight group that needs beta app review submission.
 
 ```bash
-asc workflow validate
+asc workflow validate --output json
 asc xcode inject --manifest .asc/deployment.json --set version=1.2.3 --set build_number=42 --dry-run --output json
 asc workflow run --dry-run testflight_beta VERSION:1.2.3
 asc workflow run testflight_beta VERSION:1.2.3

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -151,7 +151,7 @@ Create `.asc/workflow.json`:
 Run it:
 
 ```bash
-asc workflow validate
+asc workflow validate --output json
 asc workflow run --dry-run testflight_beta VERSION:1.2.3
 asc workflow run testflight_beta VERSION:1.2.3
 ```

--- a/internal/cli/cmdtest/workflow_test.go
+++ b/internal/cli/cmdtest/workflow_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func writeWorkflowJSON(t *testing.T, dir, content string) string {
@@ -483,6 +485,9 @@ func TestWorkflowRun_Valid_WithJSONCComments(t *testing.T) {
 }
 
 func TestWorkflowValidate_ValidFile(t *testing.T) {
+	// Workflow validation is JSON-only even when the global default prefers tables.
+	t.Setenv("ASC_DEFAULT_OUTPUT", "table")
+
 	dir := t.TempDir()
 	path := writeWorkflowJSON(t, dir, `{
 		"workflows": {
@@ -508,6 +513,191 @@ func TestWorkflowValidate_ValidFile(t *testing.T) {
 	}
 	if result["valid"] != true {
 		t.Fatalf("expected valid=true, got %v", result["valid"])
+	}
+}
+
+func TestWorkflowValidate_ExplicitJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflowJSON(t, dir, `{
+		"workflows": {
+			"beta": {"steps": ["echo hello"]}
+		}
+	}`)
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{
+			"workflow", "validate",
+			"--file", path,
+			"--output", "json",
+		}, "1.2.3")
+	})
+
+	if code != rootcmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, rootcmd.ExitSuccess, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if strings.Contains(stdout, "\n  ") {
+		t.Fatalf("expected minified JSON when stdout is piped, got %q", stdout)
+	}
+
+	var result struct {
+		Valid bool `json:"valid"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("expected JSON stdout, got %q: %v", stdout, err)
+	}
+	if !result.Valid {
+		t.Fatalf("expected valid=true, got %q", stdout)
+	}
+}
+
+func TestWorkflowValidate_HelpDocumentsJSONOutput(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"workflow", "validate", "--help"}, "1.2.3")
+	})
+
+	if code != rootcmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitSuccess)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	for _, want := range []string{
+		"--output",
+		"Output format: json",
+		"asc workflow validate --output json",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected help to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestWorkflowValidate_SearchDocumentsJSONOutput(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "workflow validate"}, "1.2.3")
+	})
+
+	if code != rootcmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, rootcmd.ExitSuccess, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result struct {
+		Results []struct {
+			Command  string   `json:"command"`
+			Examples []string `json:"examples"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("expected JSON search output, got %q: %v", stdout, err)
+	}
+	for _, item := range result.Results {
+		if item.Command != "asc workflow validate" {
+			continue
+		}
+		for _, example := range item.Examples {
+			if example == "asc workflow validate --output json" {
+				return
+			}
+		}
+		t.Fatalf("workflow validate search result missing explicit JSON example: %#v", item.Examples)
+	}
+	t.Fatal("search result missing asc workflow validate")
+}
+
+func TestWorkflowValidate_UnsupportedOutputExitsWithUsageCode(t *testing.T) {
+	for _, format := range []string{"table", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				code = rootcmd.Run([]string{
+					"workflow", "validate",
+					"--file", "/definitely/missing/workflow.json",
+					"--output", format,
+				}, "1.2.3")
+			})
+
+			if code != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "unsupported format: "+format) {
+				t.Fatalf("expected standard output validation error, got %q", stderr)
+			}
+			if strings.Contains(stderr, "read workflow") {
+				t.Fatalf("expected output validation before file I/O, got %q", stderr)
+			}
+		})
+	}
+}
+
+func TestWorkflowValidate_InvalidWorkflowWithExplicitJSONExitsWithErrorCode(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflowJSON(t, dir, `{
+		"workflows": {
+			"beta": {"steps": []}
+		}
+	}`)
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{
+			"workflow", "validate",
+			"--output", "json",
+			"--file", path,
+		}, "1.2.3")
+	})
+
+	if code != rootcmd.ExitError {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, rootcmd.ExitError, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected structured validation failure only on stdout, got stderr %q", stderr)
+	}
+
+	var result struct {
+		Valid  bool  `json:"valid"`
+		Errors []any `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("expected JSON stdout, got %q: %v", stdout, err)
+	}
+	if result.Valid || len(result.Errors) == 0 {
+		t.Fatalf("expected valid=false with errors, got %q", stdout)
+	}
+}
+
+func TestWorkflowValidate_MalformedWorkflowWithExplicitJSONExitsWithErrorCode(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflowJSON(t, dir, `{not valid json`)
+
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{
+			"workflow", "validate",
+			"--file", path,
+			"--output", "json",
+		}, "1.2.3")
+	})
+
+	if code != rootcmd.ExitError {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", code, rootcmd.ExitError, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout when the workflow cannot be parsed, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "parse workflow JSON") {
+		t.Fatalf("expected workflow parse error on stderr, got %q", stderr)
 	}
 }
 
@@ -1625,7 +1815,7 @@ func TestWorkflowValidate_Pretty(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, _ := captureOutput(t, func() {
-		if err := root.Parse([]string{"workflow", "validate", "--pretty", "--file", path}); err != nil {
+		if err := root.Parse([]string{"workflow", "validate", "--output", "json", "--pretty", "--file", path}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -241,7 +241,7 @@ Examples:
 func workflowValidateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("workflow validate", flag.ExitOnError)
 	filePath := fs.String("file", wf.DefaultPath, "Path to workflow.json")
-	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+	output := shared.BindOutputFlagsWithAllowed(fs, "output", "json", "Output format: json", "json")
 
 	return &ffcli.Command{
 		Name:       "validate",
@@ -252,7 +252,8 @@ This checks schema and wiring only; it does not assess shell-command safety.
 
 Examples:
   asc workflow validate
-  asc workflow validate --file ./.asc/workflow.json`,
+  asc workflow validate --output json
+  asc workflow validate --file ./.asc/workflow.json --output json --pretty`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(_ context.Context, args []string) error {
@@ -281,7 +282,7 @@ Examples:
 				Errors: errs,
 			}
 
-			if printErr := printJSON(os.Stdout, result, *pretty); printErr != nil {
+			if printErr := shared.PrintOutput(result, *output.Output, *output.Pretty); printErr != nil {
 				return printErr
 			}
 


### PR DESCRIPTION
## Summary

- accept explicit `--output json` for `asc workflow validate`
- keep validation JSON-only and reject table or Markdown through the standard output validator
- document the script-friendly invocation in help, search examples, README, and workflow docs
- cover piped/minified JSON, pretty JSON, unsupported formats, malformed and structurally invalid files, stdout/stderr separation, and exit codes 0/1/2

## Validation

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built CLI matrix for default/explicit/pretty JSON, invalid and malformed files, unsupported table output, help, and search

No live App Store Connect call was needed because `workflow validate` reads and validates only the local workflow file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788898892&installation_model_id=10418&pr_number=1905&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1905&signature=7bc77937ad966f77d840da45a0944a9c5183110b0c8e4db24258be84b9c587c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit JSON output support to `workflow validate`.
  * Added shared output options, including pretty-printed JSON.
  * Updated command help and search documentation with available output formats.
  * Unsupported output formats now provide a usage error.

* **Documentation**
  * Updated workflow validation examples in the README and workflow guide to use JSON output.

* **Bug Fixes**
  * Improved error handling and exit codes for invalid or malformed workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->