### PR TITLE
feat(xcode): expose signing options for export and publish

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -42,6 +42,39 @@ cross-platform and only reads archive metadata. Manual signing resolution is
 Darwin-only because it inspects local Xcode signing identities and provisioning
 profiles.
 
+For a PCC-capable app, or another multi-target app that needs manual signing,
+pass the signing policy directly to export. ASC reads the archive and matches
+installed profiles for the app and its embedded targets, so the command does
+not need profile UUID flags or a checked-in plist:
+
+```bash
+asc xcode export \
+  --archive-path .asc/artifacts/App.xcarchive \
+  --ipa-path .asc/artifacts/App.ipa \
+  --signing-style manual \
+  --team-id TEAM_ID
+```
+
+The same flags work when the archive and export are owned by a local publish
+flow:
+
+```bash
+asc publish testflight \
+  --app APP_ID \
+  --workspace App.xcworkspace \
+  --scheme App \
+  --version 1.2.3 \
+  --group GROUP_ID \
+  --signing-style manual \
+  --team-id TEAM_ID
+```
+
+An explicit `--export-options` plist cannot be combined with
+`--signing-style` or `--team-id`; the plist remains authoritative when supplied.
+Generated plists contain the signing selectors required by Xcode, but command
+output replaces certificate selectors and provisioning profile values with
+`[redacted]`.
+
 Create `.asc/deployment.json`:
 
 ```json

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -71,9 +71,6 @@ asc publish testflight \
 
 An explicit `--export-options` plist cannot be combined with
 `--signing-style` or `--team-id`; the plist remains authoritative when supplied.
-Generated plists contain the signing selectors required by Xcode, but command
-output replaces certificate selectors and provisioning profile values with
-`[redacted]`.
 
 Create `.asc/deployment.json`:
 

--- a/docs/design/xcode-export-options-generation.md
+++ b/docs/design/xcode-export-options-generation.md
@@ -66,12 +66,11 @@ The generator result contains:
 - `path` and `archive_path`;
 - `method`, `destination`, and `signing_style`;
 - inferred or explicit `team_id` when available;
-- `signing_certificate` and a stable bundle-ID-to-profile map for manual
-  signing;
 - `overwritten`.
 
-JSON uses those field names. Table and Markdown render the same values with one
-stable row per provisioning-profile mapping. Existing xcode export and publish
+JSON uses those field names. Table and Markdown render the same values.
+Certificate selectors and provisioning-profile values stay in the generated
+plist and are rendered as `[redacted]`. Existing xcode export and publish
 results remain compatible; their export-options path records the actual
 generated or explicit artifact.
 

--- a/docs/design/xcode-export-options-generation.md
+++ b/docs/design/xcode-export-options-generation.md
@@ -66,11 +66,12 @@ The generator result contains:
 - `path` and `archive_path`;
 - `method`, `destination`, and `signing_style`;
 - inferred or explicit `team_id` when available;
+- `signing_certificate` and a stable bundle-ID-to-profile map for manual
+  signing;
 - `overwritten`.
 
-JSON uses those field names. Table and Markdown render the same values.
-Certificate selectors and provisioning-profile values stay in the generated
-plist and are rendered as `[redacted]`. Existing xcode export and publish
+JSON uses those field names. Table and Markdown render the same values with one
+stable row per provisioning-profile mapping. Existing xcode export and publish
 results remain compatible; their export-options path records the actual
 generated or explicit artifact.
 

--- a/docs/design/xcode-export-signing-passthrough.md
+++ b/docs/design/xcode-export-signing-passthrough.md
@@ -52,14 +52,13 @@ overwriting that file. All implicit generation continues to use a unique,
 archive-adjacent output path. Publish always uses `destination=export`; `xcode
 export --wait` continues to use `destination=upload`.
 
-## Output and sensitive values
+## Output compatibility
 
-Generated plists necessarily contain the certificate selector and profile
-mappings required by Xcode. Command output reports only the plist path and
-non-sensitive generation metadata. Existing certificate/profile output fields
-are preserved but their values are replaced with `[redacted]` in JSON,
-table, and Markdown output. The implementation does not log plist contents or
-the upstream matcher's captured stdout.
+This change adds no signing-material fields to xcode export or publish output.
+Those commands continue to report the export-options path they used. The
+existing standalone export-options generator keeps its structured output
+contract unchanged, including its certificate selector and profile mappings.
+No command logs plist contents or adds output beyond its existing result shape.
 
 ## RED-GREEN and verification
 
@@ -72,7 +71,6 @@ Focused coverage establishes:
 - explicit-plist conflicts, invalid styles, and non-local publish use fail as
   usage errors before side effects;
 - generation flags bypass, but never overwrite, a conventional publish plist;
-- manual generator results never print certificate selectors or profile values;
 - generated plist payloads retain automatic/manual behavior.
 
 Verification uses focused package tests, a built CLI for help and early-error

--- a/docs/design/xcode-export-signing-passthrough.md
+++ b/docs/design/xcode-export-signing-passthrough.md
@@ -1,0 +1,88 @@
+# Xcode export signing passthrough
+
+## Placement and current behavior
+
+`asc xcode export` and local-build `asc publish testflight` / `asc publish
+appstore` already generate App Store Connect export options from an archive when
+no plist is supplied. Those implicit paths currently hard-code automatic
+signing even though `asc xcode export-options generate` supports the shared
+`automatic|manual` signing-style contract and an optional team override.
+
+This change extends the existing commands; it does not add a registry entry or
+an App Store Connect API operation. The offline OpenAPI snapshot has no bearing
+on local `xcodebuild -exportArchive` option construction.
+
+## Public command shape
+
+The three archive-derived generation paths accept:
+
+```text
+asc xcode export ... [--signing-style automatic|manual] [--team-id TEAM_ID]
+asc publish testflight ... [--signing-style automatic|manual] [--team-id TEAM_ID]
+asc publish appstore ... [--signing-style automatic|manual] [--team-id TEAM_ID]
+```
+
+Both flags configure generated export options only. `automatic` remains the
+default. `--team-id` is optional for either style and overrides team metadata
+read from the archive. Manual generation may infer the team from the archive
+and uses the existing local certificate/profile matcher; no profile UUID flag
+is added.
+
+The signing-style enum is normalized and validated by the same
+`internal/xcode` helper used by `export-options generate`. Invalid values are
+usage errors before Xcode, filesystem generation, authentication, or network
+work.
+
+## Precedence and compatibility
+
+An explicit `--export-options` plist remains authoritative, but combining it
+with an explicitly set `--signing-style` or `--team-id` is rejected as a usage
+error instead of silently ignoring generation flags.
+
+Local publish keeps its existing conventional-plist fallback:
+
+1. explicit `--export-options`, with no generation flags;
+2. generated options when either generation flag is explicitly set;
+3. existing `.asc/export-options-app-store.plist`;
+4. generated automatic options.
+
+This preserves every existing invocation. It also makes a manual-signing
+request override the implicit conventional-plist fallback without altering or
+overwriting that file. All implicit generation continues to use a unique,
+archive-adjacent output path. Publish always uses `destination=export`; `xcode
+export --wait` continues to use `destination=upload`.
+
+## Output and sensitive values
+
+Generated plists necessarily contain the certificate selector and profile
+mappings required by Xcode. Command output reports only the plist path and
+non-sensitive generation metadata. Existing certificate/profile output fields
+are preserved but their values are replaced with `[redacted]` in JSON,
+table, and Markdown output. The implementation does not log plist contents or
+the upstream matcher's captured stdout.
+
+## RED-GREEN and verification
+
+Focused coverage establishes:
+
+- help advertises both flags on xcode export and both publish commands;
+- automatic remains the default and an explicit team reaches generation;
+- manual style and team reach archive-derived generation unchanged;
+- both local publish commands use the shared post-archive generation path;
+- explicit-plist conflicts, invalid styles, and non-local publish use fail as
+  usage errors before side effects;
+- generation flags bypass, but never overwrite, a conventional publish plist;
+- manual generator results never print certificate selectors or profile values;
+- generated plist payloads retain automatic/manual behavior.
+
+Verification uses focused package tests, a built CLI for help and early-error
+stdout/stderr/exit behavior, and the repository format/docs/lint/full-test gate.
+An actual archive export is attempted only when a disposable signed fixture is
+available; this change neither uploads nor mutates App Store Connect state.
+
+## Alternatives
+
+Silently letting an explicit plist win would preserve precedence but would
+accept ignored flags, violating the CLI contract. Adding provisioning-profile
+flags would expose unstable per-target UUIDs and duplicate the existing local
+matcher. Making manual signing the default would break automatic-signing users.

--- a/internal/cli/publish/export_options_generate_test.go
+++ b/internal/cli/publish/export_options_generate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -362,25 +363,29 @@ func TestPublishRejectsInvalidSigningStyleBeforeSideEffects(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(command.name, func(t *testing.T) {
-			restore := overridePublishCommandTestHooks(t)
-			defer restore()
+		for _, signingStyle := range []string{"heuristic", ""} {
+			t.Run(command.name+fmt.Sprintf(" value=%q", signingStyle), func(t *testing.T) {
+				restore := overridePublishCommandTestHooks(t)
+				defer restore()
 
-			getPublishASCClientFn = func(time.Duration) (*asc.Client, error) {
-				t.Fatal("ASC client must not be created for an invalid signing style")
-				return nil, nil
-			}
-			cmd := command.cmd()
-			cmd.FlagSet.SetOutput(io.Discard)
-			if err := cmd.FlagSet.Parse(command.args); err != nil {
-				t.Fatalf("parse flags: %v", err)
-			}
+				getPublishASCClientFn = func(time.Duration) (*asc.Client, error) {
+					t.Fatal("ASC client must not be created for an invalid signing style")
+					return nil, nil
+				}
+				cmd := command.cmd()
+				cmd.FlagSet.SetOutput(io.Discard)
+				args := append([]string(nil), command.args...)
+				args[len(args)-1] = signingStyle
+				if err := cmd.FlagSet.Parse(args); err != nil {
+					t.Fatalf("parse flags: %v", err)
+				}
 
-			runErr := cmd.Exec(context.Background(), nil)
-			if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--signing-style must be one of: automatic, manual") {
-				t.Fatalf("expected invalid signing-style usage error, got %v", runErr)
-			}
-		})
+				runErr := cmd.Exec(context.Background(), nil)
+				if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--signing-style must be one of: automatic, manual") {
+					t.Fatalf("expected invalid signing-style usage error, got %v", runErr)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/cli/publish/export_options_generate_test.go
+++ b/internal/cli/publish/export_options_generate_test.go
@@ -389,6 +389,59 @@ func TestPublishRejectsInvalidSigningStyleBeforeSideEffects(t *testing.T) {
 	}
 }
 
+func TestPublishRejectsExplicitlyEmptyTeamIDBeforeSideEffects(t *testing.T) {
+	for _, command := range []struct {
+		name string
+		cmd  func() *ffcli.Command
+		args []string
+	}{
+		{
+			name: "testflight",
+			cmd:  PublishTestFlightCommand,
+			args: []string{
+				"--app", "app-123", "--workspace", "Demo.xcworkspace", "--scheme", "Demo",
+				"--version", "1.2.3", "--group", "group-1", "--team-id", "",
+			},
+		},
+		{
+			name: "appstore",
+			cmd:  PublishAppStoreCommand,
+			args: []string{
+				"--app", "app-123", "--workspace", "Demo.xcworkspace", "--scheme", "Demo",
+				"--version", "1.2.3", "--team-id", "",
+			},
+		},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			restore := overridePublishCommandTestHooks(t)
+			defer restore()
+			workDir := t.TempDir()
+			t.Chdir(workDir)
+			if err := os.MkdirAll(filepath.Dir(defaultPublishExportOptionsPath), 0o755); err != nil {
+				t.Fatalf("create conventional export-options directory: %v", err)
+			}
+			if err := os.WriteFile(defaultPublishExportOptionsPath, []byte("conventional"), 0o600); err != nil {
+				t.Fatalf("write conventional export-options plist: %v", err)
+			}
+
+			getPublishASCClientFn = func(time.Duration) (*asc.Client, error) {
+				t.Fatal("ASC client must not be created for an empty team ID")
+				return nil, nil
+			}
+			cmd := command.cmd()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(command.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+
+			runErr := cmd.Exec(context.Background(), nil)
+			if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--team-id must not be empty") {
+				t.Fatalf("expected empty team-id usage error, got %v", runErr)
+			}
+		})
+	}
+}
+
 func TestPublishLocalBuildPreflightsIPADestinationBeforeSideEffects(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/internal/cli/publish/export_options_generate_test.go
+++ b/internal/cli/publish/export_options_generate_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
@@ -72,6 +75,41 @@ func TestPublishLocalBuildExportOptionsPrecedence(t *testing.T) {
 				t.Fatalf("expected export options path %q, got %q", tc.wantPath, config.ExportOptionsPath)
 			}
 		})
+	}
+}
+
+func TestPublishLocalBuildGenerationFlagsBypassConventionalOptions(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(defaultPublishExportOptionsPath), 0o755); err != nil {
+		t.Fatalf("create default export-options directory: %v", err)
+	}
+	if err := os.WriteFile(defaultPublishExportOptionsPath, []byte("checked-in plist"), 0o600); err != nil {
+		t.Fatalf("write default export options: %v", err)
+	}
+
+	fs := flag.NewFlagSet("publish signing precedence", flag.ContinueOnError)
+	values := bindPublishLocalBuildFlags(fs)
+	if err := fs.Parse([]string{
+		"--workspace", "Demo.xcworkspace",
+		"--scheme", "Demo",
+		"--signing-style", "manual",
+		"--team-id", "TEAM123456",
+	}); err != nil {
+		t.Fatalf("parse local-build flags: %v", err)
+	}
+	setFlags := collectSetFlags(fs)
+	if err := validatePublishExportOptionsFlags(values, setFlags); err != nil {
+		t.Fatalf("validatePublishExportOptionsFlags() error: %v", err)
+	}
+	config, err := resolveLocalBuildConfig(values, "IOS", "1.2.3", "42")
+	if err != nil {
+		t.Fatalf("resolveLocalBuildConfig() error: %v", err)
+	}
+	if config.ExportOptionsPath != "" {
+		t.Fatalf("generation flags must bypass conventional options, got %q", config.ExportOptionsPath)
+	}
+	if config.SigningStyle != "manual" || config.TeamID != "TEAM123456" {
+		t.Fatalf("unexpected generated signing config: style=%q team=%q", config.SigningStyle, config.TeamID)
 	}
 }
 
@@ -187,6 +225,162 @@ func TestPublishLocalBuildGeneratesExportOptionsAfterArchive(t *testing.T) {
 	}
 	if string(preserved) != string(deterministicContents) {
 		t.Fatalf("implicit generation overwrote deterministic export options: %q", preserved)
+	}
+}
+
+func TestPublishLocalBuildThreadsManualSigningOptionsAfterArchive(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+
+	wantErr := errors.New("stop after generation")
+	archivePath := filepath.Join(t.TempDir(), "Demo.xcarchive")
+	var generatedOptions localxcode.ExportOptionsGenerateOptions
+	runPublishArchiveFn = func(_ context.Context, _ localxcode.ArchiveOptions) (*localxcode.ArchiveResult, error) {
+		return &localxcode.ArchiveResult{ArchivePath: archivePath}, nil
+	}
+	generatePublishExportOptionsFn = func(_ context.Context, opts localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		generatedOptions = opts
+		return nil, wantErr
+	}
+	runPublishExportFn = func(context.Context, localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		t.Fatal("export must not run after the generation sentinel")
+		return nil, nil
+	}
+
+	_, err := runPublishLocalBuild(
+		context.Background(), nil, "app-123", "IOS", "1.2.3", "42",
+		5*time.Second, time.Minute, false,
+		publishLocalBuildConfig{
+			WorkspacePath: "Demo.xcworkspace",
+			Scheme:        "Demo",
+			ArchivePath:   archivePath,
+			IPAPath:       filepath.Join(t.TempDir(), "Demo.ipa"),
+			SigningStyle:  "manual",
+			TeamID:        "TEAM123456",
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected generation sentinel, got %v", err)
+	}
+	if generatedOptions.SigningStyle != "manual" {
+		t.Fatalf("expected manual signing style, got %q", generatedOptions.SigningStyle)
+	}
+	if generatedOptions.TeamID != "TEAM123456" {
+		t.Fatalf("expected team ID passthrough, got %q", generatedOptions.TeamID)
+	}
+}
+
+func TestPublishSigningFlagsAreDiscoverable(t *testing.T) {
+	for _, command := range []struct {
+		name string
+		cmd  func() *ffcli.Command
+	}{
+		{name: "testflight", cmd: PublishTestFlightCommand},
+		{name: "appstore", cmd: PublishAppStoreCommand},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			cmd := command.cmd()
+			for _, name := range []string{"signing-style", "team-id"} {
+				if cmd.FlagSet.Lookup(name) == nil {
+					t.Fatalf("expected --%s in publish %s help", name, command.name)
+				}
+			}
+		})
+	}
+}
+
+func TestPublishRejectsExplicitOptionsWithGenerationFlagsBeforeSideEffects(t *testing.T) {
+	for _, command := range []struct {
+		name     string
+		cmd      func() *ffcli.Command
+		baseArgs []string
+	}{
+		{
+			name: "testflight",
+			cmd:  PublishTestFlightCommand,
+			baseArgs: []string{
+				"--app", "app-123", "--workspace", "Demo.xcworkspace", "--scheme", "Demo",
+				"--version", "1.2.3", "--group", "group-1", "--export-options", "ExportOptions.plist",
+			},
+		},
+		{
+			name: "appstore",
+			cmd:  PublishAppStoreCommand,
+			baseArgs: []string{
+				"--app", "app-123", "--workspace", "Demo.xcworkspace", "--scheme", "Demo",
+				"--version", "1.2.3", "--export-options", "ExportOptions.plist",
+			},
+		},
+	} {
+		for _, generationFlag := range [][]string{
+			{"--signing-style", "automatic"},
+			{"--team-id", "TEAM123456"},
+		} {
+			t.Run(command.name+" "+generationFlag[0], func(t *testing.T) {
+				restore := overridePublishCommandTestHooks(t)
+				defer restore()
+
+				getPublishASCClientFn = func(time.Duration) (*asc.Client, error) {
+					t.Fatal("ASC client must not be created for conflicting export-options flags")
+					return nil, nil
+				}
+				cmd := command.cmd()
+				cmd.FlagSet.SetOutput(io.Discard)
+				if err := cmd.FlagSet.Parse(append(append([]string(nil), command.baseArgs...), generationFlag...)); err != nil {
+					t.Fatalf("parse flags: %v", err)
+				}
+
+				runErr := cmd.Exec(context.Background(), nil)
+				if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--export-options cannot be combined with --signing-style or --team-id") {
+					t.Fatalf("expected explicit-options conflict usage error, got %v", runErr)
+				}
+			})
+		}
+	}
+}
+
+func TestPublishRejectsInvalidSigningStyleBeforeSideEffects(t *testing.T) {
+	for _, command := range []struct {
+		name string
+		cmd  func() *ffcli.Command
+		args []string
+	}{
+		{
+			name: "testflight",
+			cmd:  PublishTestFlightCommand,
+			args: []string{
+				"--app", "app-123", "--workspace", "Demo.xcworkspace", "--scheme", "Demo",
+				"--version", "1.2.3", "--group", "group-1", "--signing-style", "heuristic",
+			},
+		},
+		{
+			name: "appstore",
+			cmd:  PublishAppStoreCommand,
+			args: []string{
+				"--app", "app-123", "--workspace", "Demo.xcworkspace", "--scheme", "Demo",
+				"--version", "1.2.3", "--signing-style", "heuristic",
+			},
+		},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			restore := overridePublishCommandTestHooks(t)
+			defer restore()
+
+			getPublishASCClientFn = func(time.Duration) (*asc.Client, error) {
+				t.Fatal("ASC client must not be created for an invalid signing style")
+				return nil, nil
+			}
+			cmd := command.cmd()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(command.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+
+			runErr := cmd.Exec(context.Background(), nil)
+			if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--signing-style must be one of: automatic, manual") {
+				t.Fatalf("expected invalid signing-style usage error, got %v", runErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/publish/local_build.go
+++ b/internal/cli/publish/local_build.go
@@ -251,6 +251,9 @@ func resolvePublishBuildNumber(ctx context.Context, client *asc.Client, appID, v
 }
 
 func runPublishLocalBuild(ctx context.Context, client *asc.Client, appID, platform, version, buildNumber string, pollInterval, timeout time.Duration, timeoutOverride bool, config publishLocalBuildConfig) (*publishLocalBuildExecutionResult, error) {
+	if strings.TrimSpace(config.SigningStyle) == "" {
+		config.SigningStyle = "automatic"
+	}
 	signingStyle, err := localxcode.NormalizeExportOptionsSigningStyle(config.SigningStyle)
 	if err != nil {
 		return nil, shared.UsageError(err.Error())

--- a/internal/cli/publish/local_build.go
+++ b/internal/cli/publish/local_build.go
@@ -50,12 +50,15 @@ type publishLocalBuildFlagValues struct {
 	scheme               *string
 	configuration        *string
 	exportOptionsPath    *string
+	signingStyle         *string
+	teamID               *string
 	archivePath          *string
 	ipaPath              *string
 	clean                *bool
 	initialBuildNumber   *int
 	archiveXcodebuildArg shared.MultiStringFlag
 	exportXcodebuildArg  shared.MultiStringFlag
+	generationFlagsSet   bool
 }
 
 type publishLocalBuildConfig struct {
@@ -64,6 +67,8 @@ type publishLocalBuildConfig struct {
 	Scheme                string
 	Configuration         string
 	ExportOptionsPath     string
+	SigningStyle          string
+	TeamID                string
 	ArchivePath           string
 	IPAPath               string
 	Clean                 bool
@@ -87,6 +92,8 @@ func bindPublishLocalBuildFlags(fs *flag.FlagSet) *publishLocalBuildFlagValues {
 	values.scheme = fs.String("scheme", "", "Xcode scheme name for local-build mode")
 	values.configuration = fs.String("configuration", "", "Build configuration for local-build mode (defaults to Release)")
 	values.exportOptionsPath = fs.String("export-options", "", "Path to ExportOptions.plist for local-build mode")
+	values.signingStyle = fs.String("signing-style", "automatic", "Signing style for generated local-build options: automatic or manual")
+	values.teamID = fs.String("team-id", "", "Apple Developer team ID for generated local-build options (overrides archive metadata)")
 	values.archivePath = fs.String("archive-path", "", "Destination path for the .xcarchive output in local-build mode")
 	values.ipaPath = fs.String("ipa-path", "", "Destination path for the .ipa output in local-build mode")
 	values.clean = fs.Bool("clean", false, "Run clean before local-build archive")
@@ -129,6 +136,8 @@ func validateLocalBuildFlagUsage(localBuildMode bool, setFlags map[string]bool) 
 		"archive-path",
 		"ipa-path",
 		"export-options",
+		"signing-style",
+		"team-id",
 		"configuration",
 		"clean",
 		"initial-build-number",
@@ -140,6 +149,20 @@ func validateLocalBuildFlagUsage(localBuildMode bool, setFlags map[string]bool) 
 			return shared.UsageErrorf("--%s requires --workspace or --project", flagName)
 		}
 	}
+	return nil
+}
+
+func validatePublishExportOptionsFlags(values *publishLocalBuildFlagValues, setFlags map[string]bool) error {
+	values.generationFlagsSet = setFlags["signing-style"] || setFlags["team-id"]
+	if strings.TrimSpace(*values.exportOptionsPath) != "" && values.generationFlagsSet {
+		return shared.UsageError("--export-options cannot be combined with --signing-style or --team-id")
+	}
+	style, err := localxcode.NormalizeExportOptionsSigningStyle(*values.signingStyle)
+	if err != nil {
+		return shared.UsageError(err.Error())
+	}
+	*values.signingStyle = style
+	*values.teamID = strings.TrimSpace(*values.teamID)
 	return nil
 }
 
@@ -170,12 +193,21 @@ func resolveLocalBuildConfig(values *publishLocalBuildFlagValues, platform, vers
 		Clean:                 values.clean != nil && *values.clean,
 		ArchiveXcodebuildArgs: append([]string(nil), values.archiveXcodebuildArg...),
 		ExportXcodebuildArgs:  append([]string(nil), values.exportXcodebuildArg...),
+		SigningStyle:          strings.TrimSpace(*values.signingStyle),
+		TeamID:                strings.TrimSpace(*values.teamID),
 	}
 	if trimmedConfiguration := strings.TrimSpace(*values.configuration); trimmedConfiguration != "" {
 		config.Configuration = trimmedConfiguration
 	}
 
-	exportOptionsPath, err := resolvePublishExportOptionsPath(strings.TrimSpace(*values.exportOptionsPath))
+	explicitExportOptionsPath := strings.TrimSpace(*values.exportOptionsPath)
+	exportOptionsPath := ""
+	var err error
+	if !values.generationFlagsSet {
+		exportOptionsPath, err = resolvePublishExportOptionsPath(explicitExportOptionsPath)
+	} else {
+		exportOptionsPath = explicitExportOptionsPath
+	}
 	if err != nil {
 		return publishLocalBuildConfig{}, err
 	}
@@ -219,6 +251,11 @@ func resolvePublishBuildNumber(ctx context.Context, client *asc.Client, appID, v
 }
 
 func runPublishLocalBuild(ctx context.Context, client *asc.Client, appID, platform, version, buildNumber string, pollInterval, timeout time.Duration, timeoutOverride bool, config publishLocalBuildConfig) (*publishLocalBuildExecutionResult, error) {
+	signingStyle, err := localxcode.NormalizeExportOptionsSigningStyle(config.SigningStyle)
+	if err != nil {
+		return nil, shared.UsageError(err.Error())
+	}
+	config.SigningStyle = signingStyle
 	if err := localxcode.ValidateExportDestination(config.IPAPath, true, false); err != nil {
 		if localxcode.IsExportDestinationUsageError(err) {
 			return nil, shared.UsageError(err.Error())
@@ -259,7 +296,8 @@ func runPublishLocalBuild(ctx context.Context, client *asc.Client, appID, platfo
 			ArchivePath:  archiveResult.ArchivePath,
 			OutputPath:   generatedPath,
 			Destination:  "export",
-			SigningStyle: "automatic",
+			SigningStyle: config.SigningStyle,
+			TeamID:       config.TeamID,
 			Overwrite:    false,
 		})
 		if err != nil {

--- a/internal/cli/publish/local_build.go
+++ b/internal/cli/publish/local_build.go
@@ -153,7 +153,15 @@ func validateLocalBuildFlagUsage(localBuildMode bool, setFlags map[string]bool) 
 }
 
 func validatePublishExportOptionsFlags(values *publishLocalBuildFlagValues, setFlags map[string]bool) error {
-	values.generationFlagsSet = setFlags["signing-style"] || setFlags["team-id"]
+	signingStyleSet := setFlags["signing-style"]
+	teamIDSet := setFlags["team-id"]
+	values.generationFlagsSet = signingStyleSet || teamIDSet
+	if signingStyleSet && strings.TrimSpace(*values.signingStyle) == "" {
+		return shared.UsageError("--signing-style must be one of: automatic, manual")
+	}
+	if teamIDSet && strings.TrimSpace(*values.teamID) == "" {
+		return shared.UsageError("--team-id must not be empty")
+	}
 	if strings.TrimSpace(*values.exportOptionsPath) != "" && values.generationFlagsSet {
 		return shared.UsageError("--export-options cannot be combined with --signing-style or --team-id")
 	}

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -95,6 +95,7 @@ Steps:
 Examples:
   asc publish testflight --app "123" --ipa app.ipa --group "GROUP_ID"
   asc publish testflight --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --group "GROUP_ID"
+  asc publish testflight --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --group "GROUP_ID" --signing-style manual --team-id TEAM_ID
   asc publish testflight --app "123" --ipa app.ipa --group "External Testers"
   asc publish testflight --app "123" --ipa app.ipa --group "G1,G2" --wait --notify
   asc publish testflight --app "123" --ipa app.ipa --group "External Testers" --submit --confirm
@@ -118,6 +119,11 @@ Examples:
 			localBuildMode := localBuild.localBuildMode()
 			if err := validateLocalBuildFlagUsage(localBuildMode, setFlags); err != nil {
 				return err
+			}
+			if localBuildMode {
+				if err := validatePublishExportOptionsFlags(localBuild, setFlags); err != nil {
+					return err
+				}
 			}
 
 			uploadMode := ipaValue != ""
@@ -435,6 +441,7 @@ Examples:
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --metadata-dir ./metadata --submit --confirm
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --submit --dry-run
   asc publish appstore --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3
+  asc publish appstore --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --signing-style manual --team-id TEAM_ID
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --submit --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -458,6 +465,11 @@ Examples:
 			localBuildMode := localBuild.localBuildMode()
 			if err := validateLocalBuildFlagUsage(localBuildMode, setFlags); err != nil {
 				return err
+			}
+			if localBuildMode {
+				if err := validatePublishExportOptionsFlags(localBuild, setFlags); err != nil {
+					return err
+				}
 			}
 			if setFlags["metadata-dir"] && metadataDirValue == "" {
 				return shared.UsageError("--metadata-dir cannot be empty")

--- a/internal/cli/xcode/export_options.go
+++ b/internal/cli/xcode/export_options.go
@@ -113,40 +113,22 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("xcode export-options generate: %w", err)
 			}
-			outputResult := redactExportOptionsResult(result)
 
 			return shared.PrintOutputWithRenderers(
-				outputResult,
+				result,
 				*output.Output,
 				*output.Pretty,
 				func() error {
-					asc.RenderTable([]string{"field", "value"}, exportOptionsResultRows(outputResult))
+					asc.RenderTable([]string{"field", "value"}, exportOptionsResultRows(result))
 					return nil
 				},
 				func() error {
-					asc.RenderMarkdown([]string{"field", "value"}, exportOptionsResultRows(outputResult))
+					asc.RenderMarkdown([]string{"field", "value"}, exportOptionsResultRows(result))
 					return nil
 				},
 			)
 		},
 	}
-}
-
-func redactExportOptionsResult(result *localxcode.ExportOptionsGenerateResult) *localxcode.ExportOptionsGenerateResult {
-	if result == nil {
-		return nil
-	}
-	redacted := *result
-	if strings.TrimSpace(redacted.SigningCertificate) != "" {
-		redacted.SigningCertificate = "[redacted]"
-	}
-	if len(redacted.ProvisioningProfiles) > 0 {
-		redacted.ProvisioningProfiles = make(map[string]string, len(redacted.ProvisioningProfiles))
-		for bundleID := range result.ProvisioningProfiles {
-			redacted.ProvisioningProfiles[bundleID] = "[redacted]"
-		}
-	}
-	return &redacted
 }
 
 func exportOptionsResultRows(result *localxcode.ExportOptionsGenerateResult) [][]string {

--- a/internal/cli/xcode/export_options.go
+++ b/internal/cli/xcode/export_options.go
@@ -86,9 +86,9 @@ Examples:
 			if trimmedDestination != "export" && trimmedDestination != "upload" {
 				return shared.UsageError("--destination must be one of: export, upload")
 			}
-			trimmedSigningStyle := strings.TrimSpace(*signingStyle)
-			if trimmedSigningStyle != "automatic" && trimmedSigningStyle != "manual" {
-				return shared.UsageError("--signing-style must be one of: automatic, manual")
+			trimmedSigningStyle, err := localxcode.NormalizeExportOptionsSigningStyle(*signingStyle)
+			if err != nil {
+				return shared.UsageError(err.Error())
 			}
 
 			trimmedArchivePath := strings.TrimSpace(*archivePath)
@@ -113,22 +113,40 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("xcode export-options generate: %w", err)
 			}
+			outputResult := redactExportOptionsResult(result)
 
 			return shared.PrintOutputWithRenderers(
-				result,
+				outputResult,
 				*output.Output,
 				*output.Pretty,
 				func() error {
-					asc.RenderTable([]string{"field", "value"}, exportOptionsResultRows(result))
+					asc.RenderTable([]string{"field", "value"}, exportOptionsResultRows(outputResult))
 					return nil
 				},
 				func() error {
-					asc.RenderMarkdown([]string{"field", "value"}, exportOptionsResultRows(result))
+					asc.RenderMarkdown([]string{"field", "value"}, exportOptionsResultRows(outputResult))
 					return nil
 				},
 			)
 		},
 	}
+}
+
+func redactExportOptionsResult(result *localxcode.ExportOptionsGenerateResult) *localxcode.ExportOptionsGenerateResult {
+	if result == nil {
+		return nil
+	}
+	redacted := *result
+	if strings.TrimSpace(redacted.SigningCertificate) != "" {
+		redacted.SigningCertificate = "[redacted]"
+	}
+	if len(redacted.ProvisioningProfiles) > 0 {
+		redacted.ProvisioningProfiles = make(map[string]string, len(redacted.ProvisioningProfiles))
+		for bundleID := range result.ProvisioningProfiles {
+			redacted.ProvisioningProfiles[bundleID] = "[redacted]"
+		}
+	}
+	return &redacted
 }
 
 func exportOptionsResultRows(result *localxcode.ExportOptionsGenerateResult) [][]string {
@@ -145,7 +163,6 @@ func exportOptionsResultRows(result *localxcode.ExportOptionsGenerateResult) [][
 	if signingCertificate := strings.TrimSpace(result.SigningCertificate); signingCertificate != "" {
 		rows = append(rows, []string{"signing_certificate", signingCertificate})
 	}
-
 	bundleIDs := make([]string, 0, len(result.ProvisioningProfiles))
 	for bundleID := range result.ProvisioningProfiles {
 		bundleIDs = append(bundleIDs, bundleID)

--- a/internal/cli/xcode/export_options_test.go
+++ b/internal/cli/xcode/export_options_test.go
@@ -323,56 +323,6 @@ func TestXcodeExportSigningFlagsAreDiscoverable(t *testing.T) {
 	}
 }
 
-func TestXcodeExportOptionsGenerateDoesNotPrintSigningMaterial(t *testing.T) {
-	restore := overrideXcodeCommandTestHooks(t)
-	defer restore()
-
-	const (
-		certificate = "Apple Distribution: Private Example (TEAM123456)"
-		profileUUID = "11111111-2222-3333-4444-555555555555"
-	)
-	runGenerateExportOptions = func(_ context.Context, opts localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
-		return &localxcode.ExportOptionsGenerateResult{
-			Path:                 opts.OutputPath,
-			ArchivePath:          opts.ArchivePath,
-			Method:               "app-store-connect",
-			Destination:          "export",
-			SigningStyle:         "manual",
-			TeamID:               "TEAM123456",
-			SigningCertificate:   certificate,
-			ProvisioningProfiles: map[string]string{"com.example.demo": profileUUID},
-		}, nil
-	}
-
-	for _, output := range []string{"json", "table", "markdown"} {
-		t.Run(output, func(t *testing.T) {
-			cmd := XcodeExportOptionsCommand()
-			cmd.FlagSet.SetOutput(io.Discard)
-			if err := cmd.FlagSet.Parse([]string{
-				"--archive-path", "Demo.xcarchive",
-				"--output-path", filepath.Join(t.TempDir(), "ExportOptions.plist"),
-				"--signing-style", "manual",
-				"--output", output,
-			}); err != nil {
-				t.Fatalf("failed to parse flags: %v", err)
-			}
-
-			stdout, stderr := captureCommandOutput(t, func() error {
-				return cmd.Exec(context.Background(), nil)
-			})
-			if stderr != "" {
-				t.Fatalf("expected empty stderr, got %q", stderr)
-			}
-			if strings.Contains(stdout, certificate) || strings.Contains(stdout, profileUUID) {
-				t.Fatalf("signing material leaked in %s output: %q", output, stdout)
-			}
-			if !strings.Contains(stdout, "[redacted]") {
-				t.Fatalf("expected redacted signing fields in %s output: %q", output, stdout)
-			}
-		})
-	}
-}
-
 func TestXcodeExportPreflightsBeforeImplicitOptionGeneration(t *testing.T) {
 	restore := overrideXcodeCommandTestHooks(t)
 	defer restore()

--- a/internal/cli/xcode/export_options_test.go
+++ b/internal/cli/xcode/export_options_test.go
@@ -202,6 +202,177 @@ func TestXcodeExportGeneratesOptionsWhenPathIsOmitted(t *testing.T) {
 	}
 }
 
+func TestXcodeExportThreadsManualSigningOptionsToImplicitGeneration(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	archivePath := writeXcodeExportOptionsTestArchive(t)
+	wantErr := errors.New("stop after generation")
+	var generatedOptions localxcode.ExportOptionsGenerateOptions
+	runGenerateExportOptions = func(_ context.Context, opts localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		generatedOptions = opts
+		return &localxcode.ExportOptionsGenerateResult{Path: opts.OutputPath}, nil
+	}
+	runExport = func(_ context.Context, _ localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		return nil, wantErr
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", archivePath,
+		"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+		"--signing-style", "manual",
+		"--team-id", "TEAM123456",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	runErr := cmd.Exec(context.Background(), nil)
+	if !errors.Is(runErr, wantErr) {
+		t.Fatalf("expected export sentinel, got %v", runErr)
+	}
+	if generatedOptions.SigningStyle != "manual" {
+		t.Fatalf("expected manual signing style, got %q", generatedOptions.SigningStyle)
+	}
+	if generatedOptions.TeamID != "TEAM123456" {
+		t.Fatalf("expected team ID passthrough, got %q", generatedOptions.TeamID)
+	}
+}
+
+func TestXcodeExportRejectsGenerationFlagsWithExplicitOptions(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "signing style", args: []string{"--signing-style", "automatic"}},
+		{name: "team ID", args: []string{"--team-id", "TEAM123456"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			restore := overrideXcodeCommandTestHooks(t)
+			defer restore()
+
+			runXcodeExportPreflight = func(context.Context) error {
+				t.Fatal("preflight must not run for conflicting generation flags")
+				return nil
+			}
+			runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+				t.Fatal("generator must not run for conflicting generation flags")
+				return nil, nil
+			}
+			runExport = func(context.Context, localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+				t.Fatal("export must not run for conflicting generation flags")
+				return nil, nil
+			}
+
+			args := []string{
+				"--archive-path", "Demo.xcarchive",
+				"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+				"--export-options", "ExportOptions.plist",
+			}
+			args = append(args, tc.args...)
+			cmd := XcodeExportCommand()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			runErr := cmd.Exec(context.Background(), nil)
+			if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--export-options cannot be combined with --signing-style or --team-id") {
+				t.Fatalf("expected explicit-options conflict usage error, got %v", runErr)
+			}
+		})
+	}
+}
+
+func TestXcodeExportRejectsInvalidSigningStyleBeforeSideEffects(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	runXcodeExportPreflight = func(context.Context) error {
+		t.Fatal("preflight must not run for an invalid signing style")
+		return nil
+	}
+	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		t.Fatal("generator must not run for an invalid signing style")
+		return nil, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+		"--signing-style", "heuristic",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	runErr := cmd.Exec(context.Background(), nil)
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--signing-style must be one of: automatic, manual") {
+		t.Fatalf("expected invalid signing-style usage error, got %v", runErr)
+	}
+}
+
+func TestXcodeExportSigningFlagsAreDiscoverable(t *testing.T) {
+	cmd := XcodeExportCommand()
+	for _, name := range []string{"signing-style", "team-id"} {
+		if cmd.FlagSet.Lookup(name) == nil {
+			t.Fatalf("expected --%s in xcode export help", name)
+		}
+	}
+}
+
+func TestXcodeExportOptionsGenerateDoesNotPrintSigningMaterial(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	const (
+		certificate = "Apple Distribution: Private Example (TEAM123456)"
+		profileUUID = "11111111-2222-3333-4444-555555555555"
+	)
+	runGenerateExportOptions = func(_ context.Context, opts localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		return &localxcode.ExportOptionsGenerateResult{
+			Path:                 opts.OutputPath,
+			ArchivePath:          opts.ArchivePath,
+			Method:               "app-store-connect",
+			Destination:          "export",
+			SigningStyle:         "manual",
+			TeamID:               "TEAM123456",
+			SigningCertificate:   certificate,
+			ProvisioningProfiles: map[string]string{"com.example.demo": profileUUID},
+		}, nil
+	}
+
+	for _, output := range []string{"json", "table", "markdown"} {
+		t.Run(output, func(t *testing.T) {
+			cmd := XcodeExportOptionsCommand()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse([]string{
+				"--archive-path", "Demo.xcarchive",
+				"--output-path", filepath.Join(t.TempDir(), "ExportOptions.plist"),
+				"--signing-style", "manual",
+				"--output", output,
+			}); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			stdout, stderr := captureCommandOutput(t, func() error {
+				return cmd.Exec(context.Background(), nil)
+			})
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if strings.Contains(stdout, certificate) || strings.Contains(stdout, profileUUID) {
+				t.Fatalf("signing material leaked in %s output: %q", output, stdout)
+			}
+			if !strings.Contains(stdout, "[redacted]") {
+				t.Fatalf("expected redacted signing fields in %s output: %q", output, stdout)
+			}
+		})
+	}
+}
+
 func TestXcodeExportPreflightsBeforeImplicitOptionGeneration(t *testing.T) {
 	restore := overrideXcodeCommandTestHooks(t)
 	defer restore()

--- a/internal/cli/xcode/export_options_test.go
+++ b/internal/cli/xcode/export_options_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -92,6 +93,11 @@ func TestXcodeExportOptionsGenerateRejectsInvalidValues(t *testing.T) {
 		{
 			name:    "signing style",
 			args:    []string{"--archive-path", "Demo.xcarchive", "--signing-style", "heuristic"},
+			message: "Error: --signing-style must be one of: automatic, manual",
+		},
+		{
+			name:    "empty signing style",
+			args:    []string{"--archive-path", "Demo.xcarchive", "--signing-style", ""},
 			message: "Error: --signing-style must be one of: automatic, manual",
 		},
 	}
@@ -286,31 +292,35 @@ func TestXcodeExportRejectsGenerationFlagsWithExplicitOptions(t *testing.T) {
 }
 
 func TestXcodeExportRejectsInvalidSigningStyleBeforeSideEffects(t *testing.T) {
-	restore := overrideXcodeCommandTestHooks(t)
-	defer restore()
+	for _, signingStyle := range []string{"heuristic", ""} {
+		t.Run(fmt.Sprintf("value=%q", signingStyle), func(t *testing.T) {
+			restore := overrideXcodeCommandTestHooks(t)
+			defer restore()
 
-	runXcodeExportPreflight = func(context.Context) error {
-		t.Fatal("preflight must not run for an invalid signing style")
-		return nil
-	}
-	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
-		t.Fatal("generator must not run for an invalid signing style")
-		return nil, nil
-	}
+			runXcodeExportPreflight = func(context.Context) error {
+				t.Fatal("preflight must not run for an invalid signing style")
+				return nil
+			}
+			runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+				t.Fatal("generator must not run for an invalid signing style")
+				return nil, nil
+			}
 
-	cmd := XcodeExportCommand()
-	cmd.FlagSet.SetOutput(io.Discard)
-	if err := cmd.FlagSet.Parse([]string{
-		"--archive-path", "Demo.xcarchive",
-		"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
-		"--signing-style", "heuristic",
-	}); err != nil {
-		t.Fatalf("failed to parse flags: %v", err)
-	}
+			cmd := XcodeExportCommand()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse([]string{
+				"--archive-path", "Demo.xcarchive",
+				"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+				"--signing-style", signingStyle,
+			}); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
 
-	runErr := cmd.Exec(context.Background(), nil)
-	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--signing-style must be one of: automatic, manual") {
-		t.Fatalf("expected invalid signing-style usage error, got %v", runErr)
+			runErr := cmd.Exec(context.Background(), nil)
+			if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--signing-style must be one of: automatic, manual") {
+				t.Fatalf("expected invalid signing-style usage error, got %v", runErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/xcode/export_options_test.go
+++ b/internal/cli/xcode/export_options_test.go
@@ -324,6 +324,35 @@ func TestXcodeExportRejectsInvalidSigningStyleBeforeSideEffects(t *testing.T) {
 	}
 }
 
+func TestXcodeExportRejectsExplicitlyEmptyTeamIDBeforeSideEffects(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	runXcodeExportPreflight = func(context.Context) error {
+		t.Fatal("preflight must not run for an empty team ID")
+		return nil
+	}
+	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		t.Fatal("generator must not run for an empty team ID")
+		return nil, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+		"--team-id", "",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	runErr := cmd.Exec(context.Background(), nil)
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--team-id must not be empty") {
+		t.Fatalf("expected empty team-id usage error, got %v", runErr)
+	}
+}
+
 func TestXcodeExportSigningFlagsAreDiscoverable(t *testing.T) {
 	cmd := XcodeExportCommand()
 	for _, name := range []string{"signing-style", "team-id"} {

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -231,16 +231,29 @@ Examples:
 				return shared.UsageError("--timeout must be zero or greater")
 			}
 			generationFlagsSet := false
+			signingStyleSet := false
+			teamIDSet := false
 			fs.Visit(func(f *flag.Flag) {
-				if f.Name == "signing-style" || f.Name == "team-id" {
+				switch f.Name {
+				case "signing-style":
 					generationFlagsSet = true
+					signingStyleSet = true
+				case "team-id":
+					generationFlagsSet = true
+					teamIDSet = true
 				}
 			})
+			if signingStyleSet && strings.TrimSpace(*signingStyle) == "" {
+				return shared.UsageError("--signing-style must be one of: automatic, manual")
+			}
 			signingStyleValue, err := localxcode.NormalizeExportOptionsSigningStyle(*signingStyle)
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
 			teamIDValue := strings.TrimSpace(*teamID)
+			if teamIDSet && teamIDValue == "" {
+				return shared.UsageError("--team-id must not be empty")
+			}
 			trimmedArchivePath := strings.TrimSpace(*archivePath)
 			exportOptionsPath := strings.TrimSpace(*exportOptions)
 			if exportOptionsPath != "" && generationFlagsSet {

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -175,6 +175,8 @@ func XcodeExportCommand() *ffcli.Command {
 
 	archivePath := fs.String("archive-path", "", "Path to the .xcarchive input (required)")
 	exportOptions := fs.String("export-options", "", "Path to ExportOptions.plist (generated automatically when omitted)")
+	signingStyle := fs.String("signing-style", "automatic", "Signing style for generated options: automatic or manual")
+	teamID := fs.String("team-id", "", "Apple Developer team ID for generated options (overrides archive metadata)")
 	ipaPath := fs.String("ipa-path", "", "Destination path for a local .ipa when one is produced (required)")
 	overwrite := fs.Bool("overwrite", false, "Replace an existing IPA at --ipa-path")
 	wait := fs.Bool("wait", false, "Wait for App Store Connect build discovery and processing when export uploads directly")
@@ -191,8 +193,10 @@ func XcodeExportCommand() *ffcli.Command {
 		LongHelp: `Export an archive to a deterministic IPA path or direct upload.
 
 This command runs xcodebuild -exportArchive into a temporary directory.
-When --export-options is omitted, asc generates archive-adjacent options with
-automatic signing. It uses destination=upload with --wait, otherwise export.
+When --export-options is omitted, asc generates archive-adjacent options. It
+uses automatic signing by default and destination=upload with --wait, otherwise
+destination=export. Use --signing-style manual to match locally installed
+certificates and profiles; --team-id optionally overrides archive metadata.
 When ExportOptions.plist produces a local IPA, asc moves it to --ipa-path.
 When ExportOptions.plist uses destination=upload, xcodebuild uploads directly
 to App Store Connect and asc returns archive metadata without writing a local
@@ -201,6 +205,7 @@ finishes processing.
 
 Examples:
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa
+  asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --signing-style manual --team-id TEAM_ID
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --timeout 10m
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options UploadExportOptions.plist --ipa-path .asc/artifacts/App.ipa --wait
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options ExportOptions.plist --ipa-path .asc/artifacts/App.ipa --xcodebuild-flag=-allowProvisioningUpdates --output json`,
@@ -225,8 +230,22 @@ Examples:
 			if *timeout < 0 {
 				return shared.UsageError("--timeout must be zero or greater")
 			}
+			generationFlagsSet := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "signing-style" || f.Name == "team-id" {
+					generationFlagsSet = true
+				}
+			})
+			signingStyleValue, err := localxcode.NormalizeExportOptionsSigningStyle(*signingStyle)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			teamIDValue := strings.TrimSpace(*teamID)
 			trimmedArchivePath := strings.TrimSpace(*archivePath)
 			exportOptionsPath := strings.TrimSpace(*exportOptions)
+			if exportOptionsPath != "" && generationFlagsSet {
+				return shared.UsageError("--export-options cannot be combined with --signing-style or --team-id")
+			}
 			if exportOptionsPath == "" {
 				destination := "export"
 				if *wait {
@@ -255,7 +274,8 @@ Examples:
 					ArchivePath:  trimmedArchivePath,
 					OutputPath:   generatedPath,
 					Destination:  destination,
-					SigningStyle: "automatic",
+					SigningStyle: signingStyleValue,
+					TeamID:       teamIDValue,
 					Overwrite:    false,
 				})
 				if err != nil {

--- a/internal/xcode/export_options.go
+++ b/internal/xcode/export_options.go
@@ -187,6 +187,21 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	return result, nil
 }
 
+// NormalizeExportOptionsSigningStyle applies the public signing-style default
+// and validates the enum shared by export-options generation callers.
+func NormalizeExportOptionsSigningStyle(value string) (string, error) {
+	style := strings.TrimSpace(value)
+	if style == "" {
+		style = exportOptionsSigningStyleAutomatic
+	}
+	switch style {
+	case exportOptionsSigningStyleAutomatic, exportOptionsSigningStyleManual:
+		return style, nil
+	default:
+		return style, fmt.Errorf("--signing-style must be one of: automatic, manual")
+	}
+}
+
 func normalizeExportOptionsGenerateOptions(opts ExportOptionsGenerateOptions) ExportOptionsGenerateOptions {
 	opts.ArchivePath = normalizeDirectoryPath(opts.ArchivePath)
 	opts.OutputPath = strings.TrimSpace(opts.OutputPath)
@@ -198,9 +213,7 @@ func normalizeExportOptionsGenerateOptions(opts ExportOptionsGenerateOptions) Ex
 		opts.Destination = exportOptionsDestinationExport
 	}
 	opts.SigningStyle = strings.ToLower(strings.TrimSpace(opts.SigningStyle))
-	if opts.SigningStyle == "" {
-		opts.SigningStyle = exportOptionsSigningStyleAutomatic
-	}
+	opts.SigningStyle, _ = NormalizeExportOptionsSigningStyle(opts.SigningStyle)
 	opts.TeamID = strings.TrimSpace(opts.TeamID)
 	return opts
 }
@@ -220,10 +233,8 @@ func validateExportOptionsGenerateOptions(opts ExportOptionsGenerateOptions) err
 	default:
 		return fmt.Errorf("--destination must be one of: export, upload")
 	}
-	switch opts.SigningStyle {
-	case exportOptionsSigningStyleAutomatic, exportOptionsSigningStyleManual:
-	default:
-		return fmt.Errorf("--signing-style must be one of: automatic, manual")
+	if _, err := NormalizeExportOptionsSigningStyle(opts.SigningStyle); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/xcode/export_options.go
+++ b/internal/xcode/export_options.go
@@ -187,13 +187,10 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	return result, nil
 }
 
-// NormalizeExportOptionsSigningStyle applies the public signing-style default
-// and validates the enum shared by export-options generation callers.
+// NormalizeExportOptionsSigningStyle validates the public signing-style enum
+// shared by export-options generation callers.
 func NormalizeExportOptionsSigningStyle(value string) (string, error) {
 	style := strings.TrimSpace(value)
-	if style == "" {
-		style = exportOptionsSigningStyleAutomatic
-	}
 	switch style {
 	case exportOptionsSigningStyleAutomatic, exportOptionsSigningStyleManual:
 		return style, nil
@@ -213,7 +210,9 @@ func normalizeExportOptionsGenerateOptions(opts ExportOptionsGenerateOptions) Ex
 		opts.Destination = exportOptionsDestinationExport
 	}
 	opts.SigningStyle = strings.ToLower(strings.TrimSpace(opts.SigningStyle))
-	opts.SigningStyle, _ = NormalizeExportOptionsSigningStyle(opts.SigningStyle)
+	if opts.SigningStyle == "" {
+		opts.SigningStyle = exportOptionsSigningStyleAutomatic
+	}
 	opts.TeamID = strings.TrimSpace(opts.TeamID)
 	return opts
 }

--- a/internal/xcode/export_options_test.go
+++ b/internal/xcode/export_options_test.go
@@ -63,7 +63,7 @@ func TestNormalizeExportOptionsSigningStyle(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{input: "", want: "automatic"},
+		{input: "", want: "", wantErr: true},
 		{input: " automatic ", want: "automatic"},
 		{input: "manual", want: "manual"},
 		{input: "heuristic", want: "heuristic", wantErr: true},

--- a/internal/xcode/export_options_test.go
+++ b/internal/xcode/export_options_test.go
@@ -57,6 +57,24 @@ func TestGenerateExportOptions_AutomaticInfersArchiveTeamAndWritesPlist(t *testi
 	}
 }
 
+func TestNormalizeExportOptionsSigningStyle(t *testing.T) {
+	for _, tc := range []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{input: "", want: "automatic"},
+		{input: " automatic ", want: "automatic"},
+		{input: "manual", want: "manual"},
+		{input: "heuristic", want: "heuristic", wantErr: true},
+	} {
+		got, err := NormalizeExportOptionsSigningStyle(tc.input)
+		if got != tc.want || (err != nil) != tc.wantErr {
+			t.Fatalf("NormalizeExportOptionsSigningStyle(%q) = %q, %v; want %q, error=%v", tc.input, got, err, tc.want, tc.wantErr)
+		}
+	}
+}
+
 func TestGenerateExportOptions_ExplicitTeamOverridesArchiveTeam(t *testing.T) {
 	archivePath := writeExportOptionsTestArchive(t, "ARCHIVE123")
 	outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")


### PR DESCRIPTION
## Summary

- expose `--signing-style` and `--team-id` on `asc xcode export` and local `asc publish testflight`/`appstore` generation paths
- keep automatic signing as the default, pass manual/team choices to archive-derived generation, and reject conflicts with an explicit `--export-options` plist
- preserve the conventional publish plist fallback unless generation flags are requested
- preserve the existing standalone export-options structured-output contract
- document a PCC/manual-signing workflow that does not require checked-in profile UUIDs

## Verification

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused `internal/xcode`, `internal/cli/xcode`, and `internal/cli/publish` tests
- built CLI help and exit-code checks for new flags, invalid styles, and explicit-plist conflicts
- built CLI automatic export-options generation against a disposable archive-shaped fixture with an explicit team override

No App Store Connect mutation or upload was performed. A real manual `xcodebuild` export was not attempted because the repository has no disposable signed multi-target archive fixture with matching local signing assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual code-signing options to `xcode export` and local TestFlight/App Store publishing.
  * Added support for specifying a development team ID.
  * Added validation and clearer command help for signing options.

* **Bug Fixes**
  * Prevented conflicting signing flags and explicit export-options files.
  * Added validation for unsupported signing styles before processing begins.

* **Documentation**
  * Documented signing workflows, precedence rules, defaults, and multi-target app support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->