### PR TITLE
fix(status): correlate TestFlight reviews with their builds

### DIFF
--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -251,9 +251,10 @@ func (c *Client) GetBuilds(ctx context.Context, appID string, opts ...BuildsOpti
 	} else {
 		values := url.Values{}
 		// Use /v1/builds endpoint when sorting, limiting, or filtering by
-		// version/preReleaseVersion.version/processingState/preReleaseVersion/platform/expired,
+		// version/preReleaseVersion.version/processingState/preReleaseVersion/platform/
+		// betaAppReviewSubmission.betaReviewState/expired,
 		// since /v1/apps/{id}/builds doesn't support these
-		if query.sort != "" || query.limit > 0 || query.version != "" || query.preReleaseVersion != "" || len(query.processingStates) > 0 || len(query.preReleasePlatforms) > 0 || len(query.preReleaseVersionIDs) > 0 || query.expired != nil || len(query.include) > 0 {
+		if query.sort != "" || query.limit > 0 || query.version != "" || query.preReleaseVersion != "" || len(query.processingStates) > 0 || len(query.preReleasePlatforms) > 0 || len(query.preReleaseVersionIDs) > 0 || len(query.betaReviewStates) > 0 || query.expired != nil || len(query.include) > 0 {
 			path = "/v1/builds"
 			values.Set("filter[app]", appID)
 			if query.sort != "" {
@@ -276,6 +277,9 @@ func (c *Client) GetBuilds(ctx context.Context, appID string, opts ...BuildsOpti
 			}
 			if len(query.preReleaseVersionIDs) > 0 {
 				values.Set("filter[preReleaseVersion]", strings.Join(query.preReleaseVersionIDs, ","))
+			}
+			if len(query.betaReviewStates) > 0 {
+				values.Set("filter[betaAppReviewSubmission.betaReviewState]", strings.Join(query.betaReviewStates, ","))
 			}
 			if query.expired != nil {
 				values.Set("filter[expired]", strconv.FormatBool(*query.expired))

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -9748,7 +9748,15 @@ func TestUpdateBetaAppReviewDetail_SendsRequest(t *testing.T) {
 }
 
 func TestGetBetaAppReviewSubmissions_WithBuildFilter(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":[{"type":"betaAppReviewSubmissions","id":"submission-1","attributes":{"betaReviewState":"IN_REVIEW"}}]}`)
+	response := jsonResponse(http.StatusOK, `{
+		"data":[{
+			"type":"betaAppReviewSubmissions",
+			"id":"submission-1",
+			"attributes":{"betaReviewState":"IN_REVIEW"},
+			"relationships":{"build":{"data":{"type":"builds","id":"build-1"}}}
+		}],
+		"included":[{"type":"builds","id":"build-1","attributes":{"version":"42"}}]
+	}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -9766,12 +9774,32 @@ func TestGetBetaAppReviewSubmissions_WithBuildFilter(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetBetaAppReviewSubmissions(
+	submissions, err := client.GetBetaAppReviewSubmissions(
 		context.Background(),
 		WithBetaAppReviewSubmissionsBuildIDs([]string{"build-1"}),
 		WithBetaAppReviewSubmissionsIncludeBuild(),
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("GetBetaAppReviewSubmissions() error: %v", err)
+	}
+	if len(submissions.Data) != 1 {
+		t.Fatalf("expected one submission, got %d", len(submissions.Data))
+	}
+	var relationships struct {
+		Build Relationship `json:"build"`
+	}
+	if err := json.Unmarshal(submissions.Data[0].Relationships, &relationships); err != nil {
+		t.Fatalf("decode build relationship: %v", err)
+	}
+	if relationships.Build.Data.Type != ResourceTypeBuilds || relationships.Build.Data.ID != "build-1" {
+		t.Fatalf("expected build-1 relationship, got %+v", relationships.Build.Data)
+	}
+	var included []Resource[BuildAttributes]
+	if err := json.Unmarshal(submissions.Included, &included); err != nil {
+		t.Fatalf("decode included build: %v", err)
+	}
+	if len(included) != 1 || included[0].ID != "build-1" || included[0].Attributes.Version != "42" {
+		t.Fatalf("expected included build-1 version 42, got %+v", included)
 	}
 }
 

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -1410,6 +1410,34 @@ func TestGetBuilds_WithProcessingStateFilter(t *testing.T) {
 	}
 }
 
+func TestGetBuilds_WithBetaReviewStateFilter(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-review","attributes":{"version":"42"}}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/builds" {
+			t.Fatalf("expected path /v1/builds, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("filter[app]") != "123" {
+			t.Fatalf("expected filter[app]=123, got %q", values.Get("filter[app]"))
+		}
+		if got := values.Get("filter[betaAppReviewSubmission.betaReviewState]"); got != "WAITING_FOR_REVIEW,IN_REVIEW" {
+			t.Fatalf("expected active beta review states, got %q", got)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	builds, err := client.GetBuilds(context.Background(), "123", WithBuildsBetaReviewStates([]string{"waiting_for_review", "IN_REVIEW"}))
+	if err != nil {
+		t.Fatalf("GetBuilds() error: %v", err)
+	}
+	if len(builds.Data) != 1 || builds.Data[0].ID != "build-review" {
+		t.Fatalf("expected active review build, got %+v", builds.Data)
+	}
+}
+
 func TestGetBuilds_WithPreReleaseVersion(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1","attributes":{"version":"1.0","uploadedDate":"2026-01-20T00:00:00Z"}}]}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -9732,10 +9732,17 @@ func TestGetBetaAppReviewSubmissions_WithBuildFilter(t *testing.T) {
 		if values.Get("filter[build]") != "build-1" {
 			t.Fatalf("expected filter[build]=build-1, got %q", values.Get("filter[build]"))
 		}
+		if values.Get("include") != "build" {
+			t.Fatalf("expected include=build, got %q", values.Get("include"))
+		}
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetBetaAppReviewSubmissions(context.Background(), WithBetaAppReviewSubmissionsBuildIDs([]string{"build-1"})); err != nil {
+	if _, err := client.GetBetaAppReviewSubmissions(
+		context.Background(),
+		WithBetaAppReviewSubmissionsBuildIDs([]string{"build-1"}),
+		WithBetaAppReviewSubmissionsIncludeBuild(),
+	); err != nil {
 		t.Fatalf("GetBetaAppReviewSubmissions() error: %v", err)
 	}
 }

--- a/internal/asc/client_query_builds.go
+++ b/internal/asc/client_query_builds.go
@@ -14,6 +14,7 @@ type buildsQuery struct {
 	processingStates     []string
 	preReleasePlatforms  []string
 	preReleaseVersionIDs []string
+	betaReviewStates     []string
 	expired              *bool
 	include              []string
 }
@@ -203,6 +204,16 @@ func WithBuildsPreReleaseVersionPlatforms(platforms []string) BuildsOption {
 		normalized := normalizeUpperList(platforms)
 		if len(normalized) > 0 {
 			q.preReleasePlatforms = normalized
+		}
+	}
+}
+
+// WithBuildsBetaReviewStates filters builds by their beta app review submission state.
+func WithBuildsBetaReviewStates(states []string) BuildsOption {
+	return func(q *buildsQuery) {
+		normalized := normalizeUpperList(states)
+		if len(normalized) > 0 {
+			q.betaReviewStates = normalized
 		}
 	}
 }

--- a/internal/asc/client_query_testflight.go
+++ b/internal/asc/client_query_testflight.go
@@ -85,7 +85,8 @@ type betaAppReviewDetailsQuery struct {
 
 type betaAppReviewSubmissionsQuery struct {
 	listQuery
-	buildIDs []string
+	buildIDs     []string
+	includeBuild bool
 }
 
 type buildBetaDetailsQuery struct {
@@ -226,6 +227,9 @@ func buildBetaAppReviewDetailsQuery(appID string, query *betaAppReviewDetailsQue
 func buildBetaAppReviewSubmissionsQuery(query *betaAppReviewSubmissionsQuery) string {
 	values := url.Values{}
 	addCSV(values, "filter[build]", query.buildIDs)
+	if query.includeBuild {
+		values.Set("include", "build")
+	}
 	addLimit(values, query.limit)
 	return values.Encode()
 }
@@ -716,6 +720,13 @@ func WithBetaAppReviewSubmissionsNextURL(next string) BetaAppReviewSubmissionsOp
 func WithBetaAppReviewSubmissionsBuildIDs(ids []string) BetaAppReviewSubmissionsOption {
 	return func(q *betaAppReviewSubmissionsQuery) {
 		q.buildIDs = normalizeList(ids)
+	}
+}
+
+// WithBetaAppReviewSubmissionsIncludeBuild includes each submission's related build.
+func WithBetaAppReviewSubmissionsIncludeBuild() BetaAppReviewSubmissionsOption {
+	return func(q *betaAppReviewSubmissionsQuery) {
+		q.includeBuild = true
 	}
 }
 

--- a/internal/cli/cmdtest/status_test.go
+++ b/internal/cli/cmdtest/status_test.go
@@ -65,6 +65,21 @@ func TestStatusDefaultJSONIncludesAllSections(t *testing.T) {
 			if query.Get("filter[app]") != "app-1" {
 				t.Fatalf("expected filter[app]=app-1, got %q", query.Get("filter[app]"))
 			}
+			if stateFilter := query.Get("filter[betaAppReviewSubmission.betaReviewState]"); stateFilter != "" {
+				if stateFilter != "WAITING_FOR_REVIEW,IN_REVIEW" || query.Get("limit") != "50" || query.Get("include") != "preReleaseVersion" {
+					t.Fatalf("expected bounded active beta review build query, got %s", req.URL.RawQuery)
+				}
+				return statusJSONResponse(`{
+					"data":[{
+						"type":"builds",
+						"id":"build-2",
+						"attributes":{"version":"45","uploadedDate":"2026-02-20T00:00:00Z","processingState":"VALID"},
+						"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"prv-2"}}}
+					}],
+					"included":[{"type":"preReleaseVersions","id":"prv-2","attributes":{"version":"1.2.3","platform":"IOS"}}],
+					"links":{"next":""}
+				}`), nil
+			}
 			if query.Get("sort") != "-uploadedDate" {
 				t.Fatalf("expected sort=-uploadedDate, got %q", query.Get("sort"))
 			}
@@ -679,6 +694,153 @@ func TestStatusEnrichesLinkedActiveReviewBuildOutsideSnapshot(t *testing.T) {
 	}
 	if payload.Summary.Health != "red" || len(payload.Summary.Blockers) != 1 {
 		t.Fatalf("expected enriched older active review to block latest build, got %+v", payload.Summary)
+	}
+}
+
+func TestStatusFindsActiveBetaReviewBeyondFiftyBuildSnapshot(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	buildPageCalls := 0
+	reviewSubmissionCalls := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/builds":
+			buildPageCalls++
+			if got := req.URL.Query().Get("filter[betaAppReviewSubmission.betaReviewState]"); got != "" {
+				if got != "WAITING_FOR_REVIEW,IN_REVIEW" {
+					t.Fatalf("expected active beta review build filter, got %q", got)
+				}
+				if req.URL.Query().Get("filter[app]") != "6748252780" || req.URL.Query().Get("filter[preReleaseVersion.platform]") != "IOS" {
+					t.Fatalf("expected active review builds scoped to the explicit app and platform, got %s", req.URL.RawQuery)
+				}
+				if req.URL.Query().Get("include") != "preReleaseVersion" || req.URL.Query().Get("limit") != "50" {
+					t.Fatalf("expected bounded active review build context query, got %s", req.URL.RawQuery)
+				}
+				if req.URL.Query().Get("cursor") == "active-older" {
+					return statusJSONResponse(`{
+						"data":[{
+							"type":"builds",
+							"id":"build-325",
+							"attributes":{"version":"325","uploadedDate":"2026-08-08T02:00:00Z","processingState":"VALID"},
+							"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+						}],
+						"included":[{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}],
+						"links":{"next":""}
+					}`), nil
+				}
+				return statusJSONResponse(`{
+					"data":[{
+						"type":"builds",
+						"id":"build-376",
+						"attributes":{"version":"376","uploadedDate":"2026-08-10T02:00:00Z","processingState":"VALID"},
+						"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+					}],
+					"included":[{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}],
+					"links":{"next":"https://api.appstoreconnect.apple.com/v1/builds?cursor=active-older&filter%5Bapp%5D=6748252780&filter%5BbetaAppReviewSubmission.betaReviewState%5D=WAITING_FOR_REVIEW%2CIN_REVIEW&filter%5BpreReleaseVersion.platform%5D=IOS&include=preReleaseVersion&limit=50"}
+				}`), nil
+			}
+
+			builds := make([]map[string]any, 0, 50)
+			for buildNumber := 376; buildNumber >= 327; buildNumber-- {
+				builds = append(builds, map[string]any{
+					"type": "builds",
+					"id":   fmt.Sprintf("build-%d", buildNumber),
+					"attributes": map[string]any{
+						"version":         fmt.Sprintf("%d", buildNumber),
+						"uploadedDate":    "2026-08-10T02:00:00Z",
+						"processingState": "VALID",
+					},
+					"relationships": map[string]any{
+						"preReleaseVersion": map[string]any{
+							"data": map[string]any{"type": "preReleaseVersions", "id": "train-1.2.3-ios"},
+						},
+					},
+				})
+			}
+			body, err := json.Marshal(map[string]any{
+				"data": builds,
+				"included": []map[string]any{{
+					"type": "preReleaseVersions", "id": "train-1.2.3-ios",
+					"attributes": map[string]any{"version": "1.2.3", "platform": "IOS"},
+				}},
+				"links": map[string]any{"next": "https://api.appstoreconnect.apple.com/v1/builds?cursor=older"},
+			})
+			if err != nil {
+				t.Fatalf("marshal builds response: %v", err)
+			}
+			return statusJSONResponse(string(body)), nil
+		case "/v1/buildBetaDetails":
+			return statusJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+		case "/v1/betaAppReviewSubmissions":
+			reviewSubmissionCalls++
+			buildFilter := req.URL.Query().Get("filter[build]")
+			if strings.Contains(buildFilter, "build-325") {
+				return statusJSONResponse(`{
+					"data":[{
+						"type":"betaAppReviewSubmissions",
+						"id":"waiting-325",
+						"attributes":{"betaReviewState":"WAITING_FOR_REVIEW","submittedDate":"2026-08-09T03:00:00Z"},
+						"relationships":{"build":{"data":{"type":"builds","id":"build-325"}}}
+					}],
+					"links":{"next":""}
+				}`), nil
+			}
+			return statusJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"status", "--app", "6748252780", "--platform", "IOS", "--include", "builds,testflight", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Summary struct {
+			Health     string   `json:"health"`
+			Blockers   []string `json:"blockers"`
+			NextAction string   `json:"nextAction"`
+		} `json:"summary"`
+		TestFlight struct {
+			BetaReviewSubmission struct {
+				ID                    string                 `json:"id"`
+				RelationToLatestBuild string                 `json:"relationToLatestBuild"`
+				Build                 betaReviewBuildPayload `json:"build"`
+			} `json:"betaReviewSubmission"`
+		} `json:"testflight"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+
+	review := payload.TestFlight.BetaReviewSubmission
+	if buildPageCalls != 3 || reviewSubmissionCalls != 2 {
+		t.Fatalf("expected one snapshot plus two active-review build pages and two batched review queries, got builds=%d reviews=%d", buildPageCalls, reviewSubmissionCalls)
+	}
+	if review.ID != "waiting-325" || review.RelationToLatestBuild != "sameVersionTrain" {
+		t.Fatalf("expected active review beyond snapshot to match the latest train, got %+v", review)
+	}
+	if review.Build.ID != "build-325" || review.Build.BuildNumber != "325" || review.Build.Version != "1.2.3" || review.Build.Platform != "IOS" {
+		t.Fatalf("expected full older review build identity, got %+v", review.Build)
+	}
+	if payload.Summary.Health != "red" || len(payload.Summary.Blockers) != 1 {
+		t.Fatalf("expected older active review to block instead of reporting green, got %+v", payload.Summary)
+	}
+	if !strings.Contains(payload.Summary.NextAction, "build 325") || !strings.Contains(payload.Summary.NextAction, "build 376") {
+		t.Fatalf("expected action naming review build 325 and latest build 376, got %q", payload.Summary.NextAction)
 	}
 }
 

--- a/internal/cli/cmdtest/status_test.go
+++ b/internal/cli/cmdtest/status_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -474,6 +475,124 @@ func TestStatusResolvesMissingActiveBetaReviewBuildBeforeSelection(t *testing.T)
 	}
 	if payload.Summary.Health != "red" || len(payload.Summary.Blockers) != 1 {
 		t.Fatalf("expected older active review to block latest build, got %+v", payload.Summary)
+	}
+}
+
+func TestStatusResolvesSelectedActiveBetaReviewBeyondPrefetchCap(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	reviewSubmissions := make([]map[string]any, 0, 6)
+	for index := 1; index <= 6; index++ {
+		reviewSubmissions = append(reviewSubmissions, map[string]any{
+			"type": "betaAppReviewSubmissions",
+			"id":   fmt.Sprintf("waiting-%d", index),
+			"attributes": map[string]any{
+				"betaReviewState": "WAITING_FOR_REVIEW",
+				"submittedDate":   fmt.Sprintf("2026-08-09T%02d:00:00Z", 7-index),
+			},
+		})
+	}
+	reviewResponse, err := json.Marshal(map[string]any{
+		"data":  reviewSubmissions,
+		"links": map[string]any{"next": ""},
+	})
+	if err != nil {
+		t.Fatalf("marshal review response: %v", err)
+	}
+
+	relatedBuildCalls := 0
+	preReleaseCalls := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/v1/builds":
+			return statusJSONResponse(`{
+				"data":[{
+					"type":"builds",
+					"id":"build-326",
+					"attributes":{"version":"326","uploadedDate":"2026-08-10T02:00:00Z","processingState":"VALID"},
+					"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+				}],
+				"included":[{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}],
+				"links":{"next":""}
+			}`), nil
+		case req.URL.Path == "/v1/buildBetaDetails":
+			return statusJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+		case req.URL.Path == "/v1/betaAppReviewSubmissions":
+			return statusJSONResponse(string(reviewResponse)), nil
+		case strings.HasPrefix(req.URL.Path, "/v1/betaAppReviewSubmissions/waiting-") && strings.HasSuffix(req.URL.Path, "/build"):
+			relatedBuildCalls++
+			submissionID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/betaAppReviewSubmissions/"), "/build")
+			buildNumber := "400"
+			if submissionID == "waiting-6" {
+				buildNumber = "325"
+			}
+			return statusJSONResponse(fmt.Sprintf(`{
+				"data":{"type":"builds","id":"review-build-%s","attributes":{"version":"%s","uploadedDate":"2026-08-09T02:00:00Z","processingState":"VALID"}}
+			}`, submissionID, buildNumber)), nil
+		case strings.HasPrefix(req.URL.Path, "/v1/builds/review-build-waiting-") && strings.HasSuffix(req.URL.Path, "/preReleaseVersion"):
+			preReleaseCalls++
+			version := "2.0.0"
+			if strings.Contains(req.URL.Path, "waiting-6") {
+				version = "1.2.3"
+			}
+			return statusJSONResponse(fmt.Sprintf(`{
+				"data":{"type":"preReleaseVersions","id":"train-%s-ios","attributes":{"version":"%s","platform":"IOS"}}
+			}`, version, version)), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"status", "--app", "6748252780", "--platform", "IOS", "--include", "builds,testflight", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Summary struct {
+			Health     string   `json:"health"`
+			Blockers   []string `json:"blockers"`
+			NextAction string   `json:"nextAction"`
+		} `json:"summary"`
+		TestFlight struct {
+			BetaReviewSubmission struct {
+				ID                    string                 `json:"id"`
+				RelationToLatestBuild string                 `json:"relationToLatestBuild"`
+				Build                 betaReviewBuildPayload `json:"build"`
+			} `json:"betaReviewSubmission"`
+		} `json:"testflight"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+
+	review := payload.TestFlight.BetaReviewSubmission
+	if relatedBuildCalls != 6 || preReleaseCalls != 6 {
+		t.Fatalf("expected exactly six bounded fallback contexts (12 requests), got related=%d preRelease=%d", relatedBuildCalls, preReleaseCalls)
+	}
+	if review.ID != "waiting-6" || review.RelationToLatestBuild != "sameVersionTrain" {
+		t.Fatalf("expected selected sixth active review to resolve as same train, got %+v", review)
+	}
+	if review.Build.ID != "review-build-waiting-6" || review.Build.BuildNumber != "325" || review.Build.Version != "1.2.3" || review.Build.Platform != "IOS" {
+		t.Fatalf("expected resolved selected review build, got %+v", review.Build)
+	}
+	if payload.Summary.Health != "red" || len(payload.Summary.Blockers) != 1 {
+		t.Fatalf("expected selected older active review to block latest build, got %+v", payload.Summary)
+	}
+	if !strings.Contains(payload.Summary.NextAction, "build 325") || !strings.Contains(payload.Summary.NextAction, "build 326") {
+		t.Fatalf("expected actionable next step naming review and latest builds, got %q", payload.Summary.NextAction)
 	}
 }
 

--- a/internal/cli/cmdtest/status_test.go
+++ b/internal/cli/cmdtest/status_test.go
@@ -477,6 +477,99 @@ func TestStatusResolvesMissingActiveBetaReviewBuildBeforeSelection(t *testing.T)
 	}
 }
 
+func TestStatusEnrichesLinkedActiveReviewBuildOutsideSnapshot(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/builds":
+			return statusJSONResponse(`{
+				"data":[{
+					"type":"builds",
+					"id":"build-326",
+					"attributes":{"version":"326","uploadedDate":"2026-08-10T02:00:00Z","processingState":"VALID"},
+					"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+				}],
+				"included":[{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/buildBetaDetails":
+			return statusJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+		case "/v1/betaAppReviewSubmissions":
+			return statusJSONResponse(`{
+				"data":[{
+					"type":"betaAppReviewSubmissions",
+					"id":"waiting-325",
+					"attributes":{"betaReviewState":"WAITING_FOR_REVIEW","submittedDate":"2026-08-09T03:00:00Z"},
+					"relationships":{"build":{"data":{"type":"builds","id":"build-325"}}}
+				}],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/betaAppReviewSubmissions/waiting-325/build":
+			return statusJSONResponse(`{
+				"data":{"type":"builds","id":"build-325","attributes":{"version":"325","uploadedDate":"2026-08-09T02:00:00Z","processingState":"VALID"}}
+			}`), nil
+		case "/v1/builds/build-325/preReleaseVersion":
+			return statusJSONResponse(`{
+				"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}
+			}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"status", "--app", "6748252780", "--platform", "IOS", "--include", "builds,testflight", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Summary struct {
+			Health   string   `json:"health"`
+			Blockers []string `json:"blockers"`
+		} `json:"summary"`
+		TestFlight struct {
+			BetaReviewSubmission struct {
+				RelationToLatestBuild string                 `json:"relationToLatestBuild"`
+				Build                 betaReviewBuildPayload `json:"build"`
+			} `json:"betaReviewSubmission"`
+		} `json:"testflight"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+
+	review := payload.TestFlight.BetaReviewSubmission
+	if review.RelationToLatestBuild != "sameVersionTrain" {
+		t.Fatalf("expected enriched sameVersionTrain relation, got %+v", review)
+	}
+	if review.Build.ID != "build-325" || review.Build.BuildNumber != "325" || review.Build.Version != "1.2.3" || review.Build.Platform != "IOS" {
+		t.Fatalf("expected full review build identity outside snapshot, got %+v", review.Build)
+	}
+	if payload.Summary.Health != "red" || len(payload.Summary.Blockers) != 1 {
+		t.Fatalf("expected enriched older active review to block latest build, got %+v", payload.Summary)
+	}
+}
+
+type betaReviewBuildPayload struct {
+	ID          string `json:"id"`
+	Version     string `json:"version"`
+	BuildNumber string `json:"buildNumber"`
+	Platform    string `json:"platform"`
+}
+
 func TestStatusPlatformFiltersPlatformScopedSections(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/status_test.go
+++ b/internal/cli/cmdtest/status_test.go
@@ -241,6 +241,242 @@ func TestStatusDefaultJSONIncludesAllSections(t *testing.T) {
 	}
 }
 
+func TestStatusCorrelatesOlderBetaReviewSubmissionWithItsActualBuild(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/builds":
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"builds",
+						"id":"build-326",
+						"attributes":{"version":"326","uploadedDate":"2026-08-10T02:00:00Z","processingState":"VALID"},
+						"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+					},
+					{
+						"type":"builds",
+						"id":"build-325",
+						"attributes":{"version":"325","uploadedDate":"2026-08-09T02:00:00Z","processingState":"VALID"},
+						"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+					}
+				],
+				"included":[
+					{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}
+				],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/builds/build-326/preReleaseVersion":
+			return statusJSONResponse(`{
+				"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}
+			}`), nil
+		case "/v1/buildBetaDetails":
+			return statusJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+		case "/v1/betaAppReviewSubmissions":
+			return statusJSONResponse(`{
+				"data":[{
+					"type":"betaAppReviewSubmissions",
+					"id":"review-325",
+					"attributes":{"betaReviewState":"WAITING_FOR_REVIEW","submittedDate":"2026-08-09T03:00:00Z"},
+					"relationships":{"build":{"data":{"type":"builds","id":"build-325"}}}
+				}],
+				"links":{"next":""}
+			}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"status", "--app", "6748252780", "--platform", "IOS", "--include", "builds,testflight", "--output", "json", "--pretty"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Summary struct {
+			Health     string   `json:"health"`
+			NextAction string   `json:"nextAction"`
+			Blockers   []string `json:"blockers"`
+		} `json:"summary"`
+		Builds struct {
+			Latest struct {
+				ID          string `json:"id"`
+				BuildNumber string `json:"buildNumber"`
+			} `json:"latest"`
+		} `json:"builds"`
+		TestFlight struct {
+			BetaReviewState      string `json:"betaReviewState"`
+			SubmittedDate        string `json:"submittedDate"`
+			BetaReviewSubmission struct {
+				ID                    string `json:"id"`
+				State                 string `json:"state"`
+				RelationToLatestBuild string `json:"relationToLatestBuild"`
+				Build                 struct {
+					ID          string `json:"id"`
+					Version     string `json:"version"`
+					BuildNumber string `json:"buildNumber"`
+					Platform    string `json:"platform"`
+				} `json:"build"`
+			} `json:"betaReviewSubmission"`
+		} `json:"testflight"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+
+	if payload.Builds.Latest.ID != "build-326" || payload.Builds.Latest.BuildNumber != "326" {
+		t.Fatalf("expected latest uploaded build 326, got %+v", payload.Builds.Latest)
+	}
+	review := payload.TestFlight.BetaReviewSubmission
+	if payload.TestFlight.BetaReviewState != "WAITING_FOR_REVIEW" || payload.TestFlight.SubmittedDate != "2026-08-09T03:00:00Z" {
+		t.Fatalf("expected additive compatibility fields to remain populated, got %+v", payload.TestFlight)
+	}
+	if review.ID != "review-325" || review.State != "WAITING_FOR_REVIEW" {
+		t.Fatalf("expected review submission 325 identity, got %+v", review)
+	}
+	if review.Build.ID != "build-325" || review.Build.BuildNumber != "325" || review.Build.Version != "1.2.3" || review.Build.Platform != "IOS" {
+		t.Fatalf("expected actual review build context for 325, got %+v", review.Build)
+	}
+	if review.RelationToLatestBuild != "sameVersionTrain" {
+		t.Fatalf("expected sameVersionTrain relation, got %q", review.RelationToLatestBuild)
+	}
+	if payload.Summary.Health != "red" {
+		t.Fatalf("expected blocked health=red, got %q", payload.Summary.Health)
+	}
+	if len(payload.Summary.Blockers) != 1 || !strings.Contains(payload.Summary.Blockers[0], "build 325") || !strings.Contains(payload.Summary.Blockers[0], "build 326") {
+		t.Fatalf("expected blocker naming review build 325 and latest build 326, got %v", payload.Summary.Blockers)
+	}
+	if !strings.Contains(payload.Summary.NextAction, "build 325") || !strings.Contains(payload.Summary.NextAction, "build 326") {
+		t.Fatalf("expected actionable next step naming both builds, got %q", payload.Summary.NextAction)
+	}
+}
+
+func TestStatusResolvesMissingActiveBetaReviewBuildBeforeSelection(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	relatedBuildCalls := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/builds":
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"builds",
+						"id":"build-326",
+						"attributes":{"version":"326","uploadedDate":"2026-08-10T02:00:00Z","processingState":"VALID"},
+						"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+					},
+					{
+						"type":"builds",
+						"id":"build-325",
+						"attributes":{"version":"325","uploadedDate":"2026-08-09T02:00:00Z","processingState":"VALID"},
+						"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+					}
+				],
+				"included":[{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/buildBetaDetails":
+			return statusJSONResponse(`{"data":[],"links":{"next":""}}`), nil
+		case "/v1/betaAppReviewSubmissions":
+			if req.URL.Query().Get("include") != "build" {
+				t.Fatalf("expected include=build, got %q", req.URL.Query().Get("include"))
+			}
+			return statusJSONResponse(`{
+				"data":[
+					{
+						"type":"betaAppReviewSubmissions",
+						"id":"approved-326",
+						"attributes":{"betaReviewState":"APPROVED","submittedDate":"2026-08-10T05:00:00Z"},
+						"relationships":{"build":{"data":{"type":"builds","id":"build-326"}}}
+					},
+					{
+						"type":"betaAppReviewSubmissions",
+						"id":"waiting-325",
+						"attributes":{"betaReviewState":"WAITING_FOR_REVIEW","submittedDate":"2026-08-09T03:00:00Z"}
+					}
+				],
+				"links":{"next":""}
+			}`), nil
+		case "/v1/betaAppReviewSubmissions/waiting-325/build":
+			relatedBuildCalls++
+			return statusJSONResponse(`{
+				"data":{"type":"builds","id":"build-325","attributes":{"version":"325","uploadedDate":"2026-08-09T02:00:00Z","processingState":"VALID"}}
+			}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"status", "--app", "6748252780", "--platform", "IOS", "--include", "builds,testflight", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Summary struct {
+			Health   string   `json:"health"`
+			Blockers []string `json:"blockers"`
+		} `json:"summary"`
+		TestFlight struct {
+			BetaReviewSubmission struct {
+				ID                    string `json:"id"`
+				RelationToLatestBuild string `json:"relationToLatestBuild"`
+				Build                 struct {
+					ID          string `json:"id"`
+					Version     string `json:"version"`
+					BuildNumber string `json:"buildNumber"`
+					Platform    string `json:"platform"`
+				} `json:"build"`
+			} `json:"betaReviewSubmission"`
+		} `json:"testflight"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+
+	review := payload.TestFlight.BetaReviewSubmission
+	if relatedBuildCalls != 1 {
+		t.Fatalf("expected one bounded related-build fallback, got %d", relatedBuildCalls)
+	}
+	if review.ID != "waiting-325" || review.RelationToLatestBuild != "sameVersionTrain" {
+		t.Fatalf("expected active same-train review to win selection, got %+v", review)
+	}
+	if review.Build.ID != "build-325" || review.Build.BuildNumber != "325" || review.Build.Version != "1.2.3" || review.Build.Platform != "IOS" {
+		t.Fatalf("expected resolved review build context, got %+v", review.Build)
+	}
+	if payload.Summary.Health != "red" || len(payload.Summary.Blockers) != 1 {
+		t.Fatalf("expected older active review to block latest build, got %+v", payload.Summary)
+	}
+}
+
 func TestStatusPlatformFiltersPlatformScopedSections(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -1073,7 +1309,13 @@ func TestStatusTestFlightHandlesMissingBuildRelationship(t *testing.T) {
 			}`), nil
 		case "/v1/builds":
 			return statusJSONResponse(`{
-				"data":[{"type":"builds","id":"build-2","attributes":{"version":"45","uploadedDate":"2026-02-20T00:00:00Z","processingState":"VALID"}}],
+				"data":[{
+					"type":"builds",
+					"id":"build-2",
+					"attributes":{"version":"45","uploadedDate":"2026-02-20T00:00:00Z","processingState":"VALID"},
+					"relationships":{"preReleaseVersion":{"data":{"type":"preReleaseVersions","id":"train-1.2.3-ios"}}}
+				}],
+				"included":[{"type":"preReleaseVersions","id":"train-1.2.3-ios","attributes":{"version":"1.2.3","platform":"IOS"}}],
 				"links":{"next":""}
 			}`), nil
 		case "/v1/buildBetaDetails":

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -1173,10 +1173,10 @@ func resolveHealth(resp *dashboardResponse, blockers []string) string {
 }
 
 func resolveNextAction(resp *dashboardResponse, blockers []string) string {
-	if action := betaReviewBlockerNextAction(resp); action != "" {
-		return action
-	}
 	if len(blockers) > 0 {
+		if action := betaReviewBlockerNextAction(resp); action != "" && len(blockers) == 1 {
+			return action
+		}
 		return fmt.Sprintf("Resolve blocker: %s", blockers[0])
 	}
 	if resp == nil {

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -608,12 +608,7 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 		}
 	}
 
-	reviewSubmissions, err := client.GetBetaAppReviewSubmissions(
-		ctx,
-		asc.WithBetaAppReviewSubmissionsBuildIDs(buildIDs),
-		asc.WithBetaAppReviewSubmissionsIncludeBuild(),
-		asc.WithBetaAppReviewSubmissionsLimit(200),
-	)
+	reviewSubmissions, err := fetchBetaReviewSubmissionsForStatus(ctx, client, appID, platform, buildsResp, buildsByID)
 	if err != nil {
 		return err
 	}
@@ -668,6 +663,114 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 
 	resp.TestFlight = section
 	return nil
+}
+
+func fetchBetaReviewSubmissionsForStatus(
+	ctx context.Context,
+	client *asc.Client,
+	appID string,
+	platform string,
+	latestBuilds *asc.BuildsResponse,
+	buildsByID map[string]*betaReviewBuildStatus,
+) (*asc.BetaAppReviewSubmissionsResponse, error) {
+	result := &asc.BetaAppReviewSubmissionsResponse{}
+	seenSubmissions := make(map[string]struct{})
+	appendSubmissions := func(firstPage *asc.BetaAppReviewSubmissionsResponse) error {
+		paginated, err := asc.PaginateAll(ctx, firstPage, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+			return client.GetBetaAppReviewSubmissions(pageCtx, asc.WithBetaAppReviewSubmissionsNextURL(nextURL))
+		})
+		if err != nil {
+			return err
+		}
+		all, ok := paginated.(*asc.BetaAppReviewSubmissionsResponse)
+		if !ok {
+			return fmt.Errorf("unexpected beta review submissions response type %T", paginated)
+		}
+		for _, submission := range all.Data {
+			if submission.ID != "" {
+				if _, exists := seenSubmissions[submission.ID]; exists {
+					continue
+				}
+				seenSubmissions[submission.ID] = struct{}{}
+			}
+			result.Data = append(result.Data, submission)
+		}
+		return nil
+	}
+
+	latestBuildIDs := make(map[string]struct{}, len(latestBuilds.Data))
+	buildIDs := make([]string, 0, len(latestBuilds.Data))
+	for _, build := range latestBuilds.Data {
+		latestBuildIDs[build.ID] = struct{}{}
+		buildIDs = append(buildIDs, build.ID)
+	}
+	if len(buildIDs) > 0 {
+		firstPage, err := client.GetBetaAppReviewSubmissions(
+			ctx,
+			asc.WithBetaAppReviewSubmissionsBuildIDs(buildIDs),
+			asc.WithBetaAppReviewSubmissionsIncludeBuild(),
+			asc.WithBetaAppReviewSubmissionsLimit(200),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := appendSubmissions(firstPage); err != nil {
+			return nil, err
+		}
+	}
+
+	activeBuildOpts := []asc.BuildsOption{
+		asc.WithBuildsBetaReviewStates([]string{"WAITING_FOR_REVIEW", "IN_REVIEW"}),
+		asc.WithBuildsLimit(50),
+		asc.WithBuildsInclude([]string{"preReleaseVersion"}),
+	}
+	if platform != "" {
+		activeBuildOpts = append(activeBuildOpts, asc.WithBuildsPreReleaseVersionPlatforms([]string{platform}))
+	}
+	activeBuilds, err := client.GetBuilds(ctx, appID, activeBuildOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	err = asc.PaginateEach(ctx, activeBuilds, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetBuilds(pageCtx, appID, asc.WithBuildsNextURL(nextURL))
+	}, func(page asc.PaginatedResponse) error {
+		buildPage, ok := page.(*asc.BuildsResponse)
+		if !ok {
+			return fmt.Errorf("unexpected active beta review builds response type %T", page)
+		}
+		for buildID, buildContext := range buildReviewContexts(buildPage) {
+			if existing := buildsByID[buildID]; existing == nil || betaReviewBuildContextIncomplete(existing) {
+				buildsByID[buildID] = buildContext
+			}
+		}
+
+		olderActiveBuildIDs := make([]string, 0, len(buildPage.Data))
+		for _, build := range buildPage.Data {
+			if _, alreadyQueried := latestBuildIDs[build.ID]; !alreadyQueried {
+				olderActiveBuildIDs = append(olderActiveBuildIDs, build.ID)
+			}
+		}
+		if len(olderActiveBuildIDs) == 0 {
+			return nil
+		}
+
+		firstPage, err := client.GetBetaAppReviewSubmissions(
+			ctx,
+			asc.WithBetaAppReviewSubmissionsBuildIDs(olderActiveBuildIDs),
+			asc.WithBetaAppReviewSubmissionsIncludeBuild(),
+			asc.WithBetaAppReviewSubmissionsLimit(200),
+		)
+		if err != nil {
+			return err
+		}
+		return appendSubmissions(firstPage)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func buildExternalStatesByBuildID(buildIDs []string, betaDetails *asc.BuildBetaDetailsResponse) map[string]string {

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -146,7 +146,7 @@ var allowedIncludes = []string{
 	"links",
 }
 
-const maxBetaReviewBuildFallbacks = 5
+const maxBetaReviewBuildPrefetches = 5
 
 // StatusCommand returns the root status dashboard command.
 func StatusCommand() *ffcli.Command {
@@ -619,6 +619,7 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 	}
 	reviewBuildsBySubmissionID := make(map[string]*betaReviewBuildStatus, len(reviewSubmissions.Data))
 	missingActiveBuilds := make([]asc.Resource[asc.BetaAppReviewSubmissionAttributes], 0)
+	attemptedBuildFallbacks := make(map[string]struct{}, maxBetaReviewBuildPrefetches)
 	for _, submission := range reviewSubmissions.Data {
 		reviewBuild := reviewBuildForSubmission(submission, buildsByID)
 		if reviewBuild != nil {
@@ -628,13 +629,15 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 			missingActiveBuilds = append(missingActiveBuilds, submission)
 		}
 	}
-	// include=build is the normal correlation path. Bound related-build fallbacks
-	// for partial responses so status never fans out across the entire history.
+	// include=build is the normal correlation path. Prefetch at most five partial
+	// active contexts, then reserve one final fallback for the selected submission.
+	// This caps resolution at six contexts and at most twelve related API requests.
 	sortBetaReviewSubmissionsLatestFirst(missingActiveBuilds)
 	for index, submission := range missingActiveBuilds {
-		if index >= maxBetaReviewBuildFallbacks {
+		if index >= maxBetaReviewBuildPrefetches {
 			break
 		}
+		attemptedBuildFallbacks[submission.ID] = struct{}{}
 		if reviewBuild := resolveBetaReviewBuildContext(ctx, client, submission, buildsByID); reviewBuild != nil {
 			reviewBuildsBySubmissionID[submission.ID] = reviewBuild
 		}
@@ -642,14 +645,18 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 
 	latestReviewSubmission := selectBetaReviewSubmissionForLatestBuild(reviewSubmissions.Data, latestContext, buildsByID, reviewBuildsBySubmissionID)
 	if latestReviewSubmission != nil {
-		section.BetaReviewState = latestReviewSubmission.Attributes.BetaReviewState
-		section.SubmittedDate = latestReviewSubmission.Attributes.SubmittedDate
-
 		reviewBuild := reviewBuildsBySubmissionID[latestReviewSubmission.ID]
-		if reviewBuild == nil && !isInProgressBetaReviewState(latestReviewSubmission.Attributes.BetaReviewState) {
-			reviewBuild = resolveBetaReviewBuildContext(ctx, client, *latestReviewSubmission, buildsByID)
+		_, fallbackAttempted := attemptedBuildFallbacks[latestReviewSubmission.ID]
+		if betaReviewBuildContextIncomplete(reviewBuild) && !fallbackAttempted {
+			if resolvedBuild := resolveBetaReviewBuildContext(ctx, client, *latestReviewSubmission, buildsByID); resolvedBuild != nil {
+				reviewBuildsBySubmissionID[latestReviewSubmission.ID] = resolvedBuild
+			}
+			latestReviewSubmission = selectBetaReviewSubmissionForLatestBuild(reviewSubmissions.Data, latestContext, buildsByID, reviewBuildsBySubmissionID)
+			reviewBuild = reviewBuildsBySubmissionID[latestReviewSubmission.ID]
 		}
 
+		section.BetaReviewState = latestReviewSubmission.Attributes.BetaReviewState
+		section.SubmittedDate = latestReviewSubmission.Attributes.SubmittedDate
 		section.BetaReviewSubmission = &betaReviewSubmissionStatus{
 			ID:                    latestReviewSubmission.ID,
 			State:                 latestReviewSubmission.Attributes.BetaReviewState,

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -68,10 +68,27 @@ type latestBuild struct {
 }
 
 type testFlightSection struct {
-	LatestDistributedBuildID string `json:"latestDistributedBuildId,omitempty"`
-	BetaReviewState          string `json:"betaReviewState,omitempty"`
-	ExternalBuildState       string `json:"externalBuildState,omitempty"`
-	SubmittedDate            string `json:"submittedDate,omitempty"`
+	LatestDistributedBuildID string                      `json:"latestDistributedBuildId,omitempty"`
+	BetaReviewState          string                      `json:"betaReviewState,omitempty"`
+	ExternalBuildState       string                      `json:"externalBuildState,omitempty"`
+	SubmittedDate            string                      `json:"submittedDate,omitempty"`
+	BetaReviewSubmission     *betaReviewSubmissionStatus `json:"betaReviewSubmission,omitempty"`
+	latestBuild              *betaReviewBuildStatus
+}
+
+type betaReviewSubmissionStatus struct {
+	ID                    string                 `json:"id"`
+	State                 string                 `json:"state,omitempty"`
+	SubmittedDate         string                 `json:"submittedDate,omitempty"`
+	RelationToLatestBuild string                 `json:"relationToLatestBuild"`
+	Build                 *betaReviewBuildStatus `json:"build,omitempty"`
+}
+
+type betaReviewBuildStatus struct {
+	ID          string `json:"id"`
+	Version     string `json:"version,omitempty"`
+	BuildNumber string `json:"buildNumber,omitempty"`
+	Platform    string `json:"platform,omitempty"`
 }
 
 type appStoreSection struct {
@@ -128,6 +145,8 @@ var allowedIncludes = []string{
 	"phased-release",
 	"links",
 }
+
+const maxBetaReviewBuildFallbacks = 5
 
 // StatusCommand returns the root status dashboard command.
 func StatusCommand() *ffcli.Command {
@@ -498,7 +517,11 @@ func runTasks(tasks []sectionTask, limit int) error {
 }
 
 func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID string, platform string, includes includeSet, resp *dashboardResponse) error {
-	buildOpts := []asc.BuildsOption{asc.WithBuildsSort("-uploadedDate"), asc.WithBuildsLimit(50)}
+	buildOpts := []asc.BuildsOption{
+		asc.WithBuildsSort("-uploadedDate"),
+		asc.WithBuildsLimit(50),
+		asc.WithBuildsInclude([]string{"preReleaseVersion"}),
+	}
 	if platform != "" {
 		buildOpts = append(buildOpts, asc.WithBuildsPreReleaseVersionPlatforms([]string{platform}))
 	}
@@ -511,25 +534,40 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 	if len(buildsResp.Data) > 0 {
 		latest = &buildsResp.Data[0]
 	}
-
-	if includes.builds {
-		section := &buildsSection{}
-		if latest != nil {
-			entry := &latestBuild{
-				ID:              latest.ID,
-				BuildNumber:     latest.Attributes.Version,
-				ProcessingState: latest.Attributes.ProcessingState,
-				UploadedDate:    latest.Attributes.UploadedDate,
+	buildsByID := buildReviewContexts(buildsResp)
+	var latestContext *betaReviewBuildStatus
+	if latest != nil {
+		latestContext = buildsByID[latest.ID]
+		if latestContext == nil {
+			latestContext = &betaReviewBuildStatus{
+				ID:          latest.ID,
+				BuildNumber: latest.Attributes.Version,
 			}
-
+			buildsByID[latest.ID] = latestContext
+		}
+		if latestContext.Version == "" || latestContext.Platform == "" {
 			preRelease, preErr := client.GetBuildPreReleaseVersion(ctx, latest.ID)
 			if preErr != nil {
 				if !asc.IsNotFound(preErr) {
 					return preErr
 				}
 			} else {
-				entry.Version = preRelease.Data.Attributes.Version
-				entry.Platform = string(preRelease.Data.Attributes.Platform)
+				latestContext.Version = preRelease.Data.Attributes.Version
+				latestContext.Platform = string(preRelease.Data.Attributes.Platform)
+			}
+		}
+	}
+
+	if includes.builds {
+		section := &buildsSection{}
+		if latest != nil {
+			entry := &latestBuild{
+				ID:              latest.ID,
+				Version:         latestContext.Version,
+				BuildNumber:     latest.Attributes.Version,
+				ProcessingState: latest.Attributes.ProcessingState,
+				UploadedDate:    latest.Attributes.UploadedDate,
+				Platform:        latestContext.Platform,
 			}
 			section.Latest = entry
 		}
@@ -540,7 +578,7 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 		return nil
 	}
 
-	section := &testFlightSection{}
+	section := &testFlightSection{latestBuild: latestContext}
 	if len(buildsResp.Data) == 0 {
 		resp.TestFlight = section
 		return nil
@@ -573,15 +611,51 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 	reviewSubmissions, err := client.GetBetaAppReviewSubmissions(
 		ctx,
 		asc.WithBetaAppReviewSubmissionsBuildIDs(buildIDs),
+		asc.WithBetaAppReviewSubmissionsIncludeBuild(),
 		asc.WithBetaAppReviewSubmissionsLimit(200),
 	)
 	if err != nil {
 		return err
 	}
-	latestReviewSubmission := selectLatestBetaReviewSubmission(reviewSubmissions.Data)
+	reviewBuildsBySubmissionID := make(map[string]*betaReviewBuildStatus, len(reviewSubmissions.Data))
+	missingActiveBuilds := make([]asc.Resource[asc.BetaAppReviewSubmissionAttributes], 0)
+	for _, submission := range reviewSubmissions.Data {
+		reviewBuild := reviewBuildForSubmission(submission, buildsByID)
+		if reviewBuild != nil {
+			reviewBuildsBySubmissionID[submission.ID] = reviewBuild
+		} else if isInProgressBetaReviewState(submission.Attributes.BetaReviewState) {
+			missingActiveBuilds = append(missingActiveBuilds, submission)
+		}
+	}
+	// include=build is the normal correlation path. Bound related-build fallbacks
+	// for partial responses so status never fans out across the entire history.
+	sortBetaReviewSubmissionsLatestFirst(missingActiveBuilds)
+	for index, submission := range missingActiveBuilds {
+		if index >= maxBetaReviewBuildFallbacks {
+			break
+		}
+		if reviewBuild := resolveBetaReviewBuildContext(ctx, client, submission, buildsByID); reviewBuild != nil {
+			reviewBuildsBySubmissionID[submission.ID] = reviewBuild
+		}
+	}
+
+	latestReviewSubmission := selectBetaReviewSubmissionForLatestBuild(reviewSubmissions.Data, latestContext, buildsByID, reviewBuildsBySubmissionID)
 	if latestReviewSubmission != nil {
 		section.BetaReviewState = latestReviewSubmission.Attributes.BetaReviewState
 		section.SubmittedDate = latestReviewSubmission.Attributes.SubmittedDate
+
+		reviewBuild := reviewBuildsBySubmissionID[latestReviewSubmission.ID]
+		if reviewBuild == nil && !isInProgressBetaReviewState(latestReviewSubmission.Attributes.BetaReviewState) {
+			reviewBuild = resolveBetaReviewBuildContext(ctx, client, *latestReviewSubmission, buildsByID)
+		}
+
+		section.BetaReviewSubmission = &betaReviewSubmissionStatus{
+			ID:                    latestReviewSubmission.ID,
+			State:                 latestReviewSubmission.Attributes.BetaReviewState,
+			SubmittedDate:         latestReviewSubmission.Attributes.SubmittedDate,
+			RelationToLatestBuild: betaReviewBuildRelation(latestContext, reviewBuild),
+			Build:                 reviewBuild,
+		}
 	}
 
 	resp.TestFlight = section
@@ -635,6 +709,109 @@ func optionalRelationshipResourceID(relationships json.RawMessage, key string) (
 	}
 
 	return id, true
+}
+
+func buildReviewContexts(builds *asc.BuildsResponse) map[string]*betaReviewBuildStatus {
+	contexts := make(map[string]*betaReviewBuildStatus)
+	if builds == nil {
+		return contexts
+	}
+
+	preReleaseVersions := make(map[string]asc.PreReleaseVersionAttributes)
+	if len(builds.Included) > 0 {
+		var included []asc.Resource[asc.PreReleaseVersionAttributes]
+		if err := json.Unmarshal(builds.Included, &included); err == nil {
+			for _, resource := range included {
+				if resource.Type == asc.ResourceTypePreReleaseVersions {
+					preReleaseVersions[resource.ID] = resource.Attributes
+				}
+			}
+		}
+	}
+
+	for _, build := range builds.Data {
+		context := &betaReviewBuildStatus{
+			ID:          build.ID,
+			BuildNumber: build.Attributes.Version,
+		}
+		if preReleaseID, ok := optionalRelationshipResourceID(build.Relationships, "preReleaseVersion"); ok {
+			if preRelease, found := preReleaseVersions[preReleaseID]; found {
+				context.Version = preRelease.Version
+				context.Platform = string(preRelease.Platform)
+			}
+		}
+		contexts[build.ID] = context
+	}
+
+	return contexts
+}
+
+func reviewBuildForSubmission(submission asc.Resource[asc.BetaAppReviewSubmissionAttributes], buildsByID map[string]*betaReviewBuildStatus) *betaReviewBuildStatus {
+	buildID, ok := optionalRelationshipResourceID(submission.Relationships, "build")
+	if !ok {
+		return nil
+	}
+	if build := buildsByID[buildID]; build != nil {
+		return build
+	}
+	return &betaReviewBuildStatus{ID: buildID}
+}
+
+func resolveBetaReviewBuildContext(
+	ctx context.Context,
+	client *asc.Client,
+	submission asc.Resource[asc.BetaAppReviewSubmissionAttributes],
+	buildsByID map[string]*betaReviewBuildStatus,
+) *betaReviewBuildStatus {
+	reviewBuild := reviewBuildForSubmission(submission, buildsByID)
+	if reviewBuild == nil {
+		relatedBuild, err := client.GetBetaAppReviewSubmissionBuild(ctx, submission.ID)
+		if err != nil || relatedBuild == nil || strings.TrimSpace(relatedBuild.Data.ID) == "" {
+			return nil
+		}
+		reviewBuild = buildsByID[relatedBuild.Data.ID]
+		if reviewBuild == nil {
+			reviewBuild = &betaReviewBuildStatus{ID: relatedBuild.Data.ID}
+			buildsByID[relatedBuild.Data.ID] = reviewBuild
+		}
+		if reviewBuild.BuildNumber == "" {
+			reviewBuild.BuildNumber = relatedBuild.Data.Attributes.Version
+		}
+	}
+
+	if reviewBuild.Version == "" || reviewBuild.Platform == "" {
+		if preRelease, err := client.GetBuildPreReleaseVersion(ctx, reviewBuild.ID); err == nil && preRelease != nil {
+			reviewBuild.Version = preRelease.Data.Attributes.Version
+			reviewBuild.Platform = string(preRelease.Data.Attributes.Platform)
+		}
+	}
+	return reviewBuild
+}
+
+func betaReviewBuildRelation(latest, review *betaReviewBuildStatus) string {
+	if latest == nil || review == nil || strings.TrimSpace(review.ID) == "" {
+		return "unknown"
+	}
+	if latest.ID == review.ID {
+		return "sameBuild"
+	}
+	if sameBetaReviewVersionTrain(latest, review) {
+		return "sameVersionTrain"
+	}
+	if latest.Version != "" && latest.Platform != "" && review.Version != "" && review.Platform != "" {
+		return "differentVersionTrain"
+	}
+	return "unknown"
+}
+
+func sameBetaReviewVersionTrain(first, second *betaReviewBuildStatus) bool {
+	if first == nil || second == nil {
+		return false
+	}
+	return strings.TrimSpace(first.Version) != "" &&
+		strings.EqualFold(first.Version, second.Version) &&
+		strings.TrimSpace(first.Platform) != "" &&
+		strings.EqualFold(first.Platform, second.Platform)
 }
 
 func fillAppStoreAndPhasedRelease(ctx context.Context, client *asc.Client, appID string, platform string, includes includeSet, resp *dashboardResponse) error {
@@ -825,6 +1002,70 @@ func selectLatestBetaReviewSubmission(submissions []asc.Resource[asc.BetaAppRevi
 	return &best
 }
 
+func selectBetaReviewSubmissionForLatestBuild(
+	submissions []asc.Resource[asc.BetaAppReviewSubmissionAttributes],
+	latestBuild *betaReviewBuildStatus,
+	buildsByID map[string]*betaReviewBuildStatus,
+	reviewBuildsBySubmissionID map[string]*betaReviewBuildStatus,
+) *asc.Resource[asc.BetaAppReviewSubmissionAttributes] {
+	if len(submissions) == 0 {
+		return nil
+	}
+
+	relevantActive := make([]asc.Resource[asc.BetaAppReviewSubmissionAttributes], 0)
+	unknownActive := make([]asc.Resource[asc.BetaAppReviewSubmissionAttributes], 0)
+	relevantTerminal := make([]asc.Resource[asc.BetaAppReviewSubmissionAttributes], 0)
+	for _, submission := range submissions {
+		reviewBuild := reviewBuildsBySubmissionID[submission.ID]
+		if reviewBuild == nil {
+			reviewBuild = reviewBuildForSubmission(submission, buildsByID)
+		}
+		relation := betaReviewBuildRelation(latestBuild, reviewBuild)
+		if relation == "unknown" && isInProgressBetaReviewState(submission.Attributes.BetaReviewState) {
+			unknownActive = append(unknownActive, submission)
+			continue
+		}
+		if relation != "sameBuild" && relation != "sameVersionTrain" {
+			continue
+		}
+		if isInProgressBetaReviewState(submission.Attributes.BetaReviewState) {
+			relevantActive = append(relevantActive, submission)
+		} else {
+			relevantTerminal = append(relevantTerminal, submission)
+		}
+	}
+
+	if selected := selectLatestBetaReviewSubmission(relevantActive); selected != nil {
+		return selected
+	}
+	if selected := selectLatestBetaReviewSubmission(unknownActive); selected != nil {
+		return selected
+	}
+	if selected := selectLatestBetaReviewSubmission(relevantTerminal); selected != nil {
+		return selected
+	}
+	return selectLatestBetaReviewSubmission(submissions)
+}
+
+func sortBetaReviewSubmissionsLatestFirst(submissions []asc.Resource[asc.BetaAppReviewSubmissionAttributes]) {
+	slices.SortFunc(submissions, func(first, second asc.Resource[asc.BetaAppReviewSubmissionAttributes]) int {
+		dateOrder := shared.CompareRFC3339DateStrings(first.Attributes.SubmittedDate, second.Attributes.SubmittedDate)
+		if dateOrder != 0 {
+			return -dateOrder
+		}
+		return -strings.Compare(first.ID, second.ID)
+	})
+}
+
+func isInProgressBetaReviewState(state string) bool {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "WAITING_FOR_REVIEW", "IN_REVIEW":
+		return true
+	default:
+		return false
+	}
+}
+
 func isDistributedState(state string) bool {
 	switch strings.ToUpper(strings.TrimSpace(state)) {
 	case "IN_BETA_TESTING", "READY_FOR_TESTING":
@@ -888,6 +1129,9 @@ func collectBlockers(resp *dashboardResponse) []string {
 	if resp.Builds != nil && resp.Builds.Latest == nil {
 		blockers = append(blockers, "No builds found for this app")
 	}
+	if blocker := betaReviewBlocker(resp); blocker != "" {
+		blockers = append(blockers, blocker)
+	}
 
 	slices.Sort(blockers)
 	return slices.Compact(blockers)
@@ -910,11 +1154,23 @@ func resolveHealth(resp *dashboardResponse, blockers []string) string {
 	if resp.AppStore != nil && isInProgressAppStoreState(resp.AppStore.State) {
 		return "yellow"
 	}
+	if resp.TestFlight != nil && resp.TestFlight.BetaReviewSubmission != nil {
+		review := resp.TestFlight.BetaReviewSubmission
+		if isInProgressBetaReviewState(review.State) && (review.RelationToLatestBuild == "sameBuild" || review.RelationToLatestBuild == "unknown") {
+			return "yellow"
+		}
+		if strings.EqualFold(strings.TrimSpace(review.State), "REJECTED") && (review.RelationToLatestBuild == "sameBuild" || review.RelationToLatestBuild == "sameVersionTrain") {
+			return "yellow"
+		}
+	}
 
 	return "green"
 }
 
 func resolveNextAction(resp *dashboardResponse, blockers []string) string {
+	if action := betaReviewBlockerNextAction(resp); action != "" {
+		return action
+	}
 	if len(blockers) > 0 {
 		return fmt.Sprintf("Resolve blocker: %s", blockers[0])
 	}
@@ -927,6 +1183,20 @@ func resolveNextAction(resp *dashboardResponse, blockers []string) string {
 	}
 	if resp.Review != nil && isInProgressReviewState(resp.Review.State) {
 		return "Monitor App Store review progress."
+	}
+	if resp.TestFlight != nil && resp.TestFlight.BetaReviewSubmission != nil {
+		review := resp.TestFlight.BetaReviewSubmission
+		if isInProgressBetaReviewState(review.State) {
+			switch review.RelationToLatestBuild {
+			case "sameBuild":
+				return fmt.Sprintf("Wait for Beta App Review of %s to finish.", betaReviewBuildLabel(review.Build))
+			case "unknown":
+				return fmt.Sprintf("Inspect Beta App Review submission %s to identify its build.", review.ID)
+			}
+		}
+		if strings.EqualFold(strings.TrimSpace(review.State), "REJECTED") && (review.RelationToLatestBuild == "sameBuild" || review.RelationToLatestBuild == "sameVersionTrain") {
+			return fmt.Sprintf("Review Beta App Review feedback for %s before the next external testing submission.", betaReviewBuildLabel(review.Build))
+		}
 	}
 	if resp.AppStore != nil {
 		state := strings.ToUpper(strings.TrimSpace(resp.AppStore.State))
@@ -945,6 +1215,53 @@ func resolveNextAction(resp *dashboardResponse, blockers []string) string {
 	}
 
 	return "Review release status."
+}
+
+func betaReviewBlocker(resp *dashboardResponse) string {
+	if resp == nil || resp.TestFlight == nil || resp.TestFlight.BetaReviewSubmission == nil {
+		return ""
+	}
+	review := resp.TestFlight.BetaReviewSubmission
+	latest := resp.TestFlight.latestBuild
+	if review.RelationToLatestBuild != "sameVersionTrain" || !isInProgressBetaReviewState(review.State) || review.Build == nil || latest == nil || review.Build.ID == latest.ID {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Beta App Review for %s is %s and blocks external testing for latest %s",
+		betaReviewBuildLabel(review.Build),
+		strings.ToUpper(strings.TrimSpace(review.State)),
+		betaReviewBuildLabel(latest),
+	)
+}
+
+func betaReviewBlockerNextAction(resp *dashboardResponse) string {
+	if betaReviewBlocker(resp) == "" {
+		return ""
+	}
+	review := resp.TestFlight.BetaReviewSubmission
+	return fmt.Sprintf(
+		"Wait for Beta App Review of %s to finish before submitting %s for external testing.",
+		betaReviewBuildLabel(review.Build),
+		betaReviewBuildLabel(resp.TestFlight.latestBuild),
+	)
+}
+
+func betaReviewBuildLabel(build *betaReviewBuildStatus) string {
+	if build == nil {
+		return "unknown build"
+	}
+	identifier := strings.TrimSpace(build.BuildNumber)
+	if identifier == "" {
+		identifier = strings.TrimSpace(build.ID)
+	}
+	if identifier == "" {
+		return "unknown build"
+	}
+	label := "build " + identifier
+	if strings.TrimSpace(build.Version) != "" {
+		label += " (version " + strings.TrimSpace(build.Version) + ")"
+	}
+	return label
 }
 
 func isInProgressReviewState(state string) bool {
@@ -1036,12 +1353,33 @@ func renderDashboard(resp *dashboardResponse, markdown bool) {
 	}
 
 	if resp.TestFlight != nil {
-		shared.RenderSection("TestFlight", []string{"field", "value"}, [][]string{
+		rows := [][]string{
 			{"latestDistributedBuildId", shared.OrNA(resp.TestFlight.LatestDistributedBuildID)},
-			{"betaReviewState", prefixedState(resp.TestFlight.BetaReviewState)},
 			{"externalBuildState", prefixedState(resp.TestFlight.ExternalBuildState)},
-			{"submittedDate", formatDateWithRelative(resp.TestFlight.SubmittedDate)},
-		}, markdown)
+		}
+		if review := resp.TestFlight.BetaReviewSubmission; review != nil {
+			rows = append(
+				rows,
+				[]string{"betaReviewSubmission.id", shared.OrNA(review.ID)},
+				[]string{"betaReviewSubmission.state", prefixedState(review.State)},
+				[]string{"betaReviewSubmission.submittedDate", formatDateWithRelative(review.SubmittedDate)},
+				[]string{"betaReviewSubmission.relationToLatestBuild", shared.OrNA(review.RelationToLatestBuild)},
+			)
+			if review.Build == nil {
+				rows = append(rows, []string{"betaReviewSubmission.build", "[-] unknown"})
+			} else {
+				rows = append(
+					rows,
+					[]string{"betaReviewSubmission.build.id", shared.OrNA(review.Build.ID)},
+					[]string{"betaReviewSubmission.build.version", shared.OrNA(review.Build.Version)},
+					[]string{"betaReviewSubmission.build.buildNumber", shared.OrNA(review.Build.BuildNumber)},
+					[]string{"betaReviewSubmission.build.platform", shared.OrNA(review.Build.Platform)},
+				)
+			}
+		} else {
+			rows = append(rows, []string{"betaReviewSubmission", "[-] none"})
+		}
+		shared.RenderSection("TestFlight", []string{"field", "value"}, rows, markdown)
 	}
 
 	if resp.AppStore != nil {

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -1341,6 +1341,9 @@ func betaReviewBlocker(resp *dashboardResponse) string {
 	if review.RelationToLatestBuild != "sameVersionTrain" || !isInProgressBetaReviewState(review.State) || review.Build == nil || latest == nil || review.Build.ID == latest.ID {
 		return ""
 	}
+	if resp.TestFlight.LatestDistributedBuildID == latest.ID {
+		return ""
+	}
 	return fmt.Sprintf(
 		"Beta App Review for %s is %s and blocks external testing for latest %s",
 		betaReviewBuildLabel(review.Build),

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -1384,6 +1384,11 @@ func renderDashboard(resp *dashboardResponse, markdown bool) {
 		} else {
 			rows = append(rows, []string{"betaReviewSubmission", "[-] none"})
 		}
+		rows = append(
+			rows,
+			[]string{"betaReviewState", prefixedState(resp.TestFlight.BetaReviewState)},
+			[]string{"submittedDate", formatDateWithRelative(resp.TestFlight.SubmittedDate)},
+		)
 		shared.RenderSection("TestFlight", []string{"field", "value"}, rows, markdown)
 	}
 

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -623,7 +623,8 @@ func fillBuildsAndTestFlight(ctx context.Context, client *asc.Client, appID stri
 		reviewBuild := reviewBuildForSubmission(submission, buildsByID)
 		if reviewBuild != nil {
 			reviewBuildsBySubmissionID[submission.ID] = reviewBuild
-		} else if isInProgressBetaReviewState(submission.Attributes.BetaReviewState) {
+		}
+		if isInProgressBetaReviewState(submission.Attributes.BetaReviewState) && betaReviewBuildContextIncomplete(reviewBuild) {
 			missingActiveBuilds = append(missingActiveBuilds, submission)
 		}
 	}
@@ -764,10 +765,10 @@ func resolveBetaReviewBuildContext(
 	buildsByID map[string]*betaReviewBuildStatus,
 ) *betaReviewBuildStatus {
 	reviewBuild := reviewBuildForSubmission(submission, buildsByID)
-	if reviewBuild == nil {
+	if reviewBuild == nil || reviewBuild.BuildNumber == "" {
 		relatedBuild, err := client.GetBetaAppReviewSubmissionBuild(ctx, submission.ID)
 		if err != nil || relatedBuild == nil || strings.TrimSpace(relatedBuild.Data.ID) == "" {
-			return nil
+			return reviewBuild
 		}
 		reviewBuild = buildsByID[relatedBuild.Data.ID]
 		if reviewBuild == nil {
@@ -786,6 +787,10 @@ func resolveBetaReviewBuildContext(
 		}
 	}
 	return reviewBuild
+}
+
+func betaReviewBuildContextIncomplete(build *betaReviewBuildStatus) bool {
+	return build == nil || build.BuildNumber == "" || build.Version == "" || build.Platform == ""
 }
 
 func betaReviewBuildRelation(latest, review *betaReviewBuildStatus) string {

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -336,6 +337,100 @@ func TestSelectLatestBetaReviewSubmission_ParsesRFC3339Offsets(t *testing.T) {
 	}
 }
 
+func TestSelectBetaReviewSubmissionForLatestBuild_PrefersActiveSameTrainSubmission(t *testing.T) {
+	latest := &betaReviewBuildStatus{ID: "build-326", Version: "1.2.3", BuildNumber: "326", Platform: "IOS"}
+	buildsByID := map[string]*betaReviewBuildStatus{
+		"build-326": latest,
+		"build-325": {ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+		"build-mac": {ID: "build-mac", Version: "1.2.3", BuildNumber: "900", Platform: "MAC_OS"},
+	}
+	submissions := []asc.Resource[asc.BetaAppReviewSubmissionAttributes]{
+		betaReviewSubmissionFixture("approved-latest", "build-326", "APPROVED", "2026-08-10T04:00:00Z"),
+		betaReviewSubmissionFixture("waiting-older", "build-325", "WAITING_FOR_REVIEW", "2026-08-09T04:00:00Z"),
+		betaReviewSubmissionFixture("waiting-other-platform", "build-mac", "WAITING_FOR_REVIEW", "2026-08-10T05:00:00Z"),
+	}
+
+	selected := selectBetaReviewSubmissionForLatestBuild(submissions, latest, buildsByID, nil)
+	if selected == nil || selected.ID != "waiting-older" {
+		t.Fatalf("expected active same-train submission waiting-older, got %+v", selected)
+	}
+}
+
+func TestSelectBetaReviewSubmissionForLatestBuild_PrefersRelevantTrainOverNewerOtherPlatform(t *testing.T) {
+	latest := &betaReviewBuildStatus{ID: "build-ios", Version: "2.0", BuildNumber: "20", Platform: "IOS"}
+	buildsByID := map[string]*betaReviewBuildStatus{
+		"build-ios": latest,
+		"build-mac": {ID: "build-mac", Version: "2.0", BuildNumber: "50", Platform: "MAC_OS"},
+	}
+	submissions := []asc.Resource[asc.BetaAppReviewSubmissionAttributes]{
+		betaReviewSubmissionFixture("approved-ios", "build-ios", "APPROVED", "2026-08-09T04:00:00Z"),
+		betaReviewSubmissionFixture("waiting-mac", "build-mac", "WAITING_FOR_REVIEW", "2026-08-10T05:00:00Z"),
+	}
+
+	selected := selectBetaReviewSubmissionForLatestBuild(submissions, latest, buildsByID, nil)
+	if selected == nil || selected.ID != "approved-ios" {
+		t.Fatalf("expected relevant iOS submission approved-ios, got %+v", selected)
+	}
+}
+
+func TestSelectBetaReviewSubmissionForLatestBuild_PreservesUnknownActiveCorrelation(t *testing.T) {
+	latest := &betaReviewBuildStatus{ID: "build-326", Version: "1.2.3", BuildNumber: "326", Platform: "IOS"}
+	buildsByID := map[string]*betaReviewBuildStatus{"build-326": latest}
+	submissions := []asc.Resource[asc.BetaAppReviewSubmissionAttributes]{
+		betaReviewSubmissionFixture("approved-326", "build-326", "APPROVED", "2026-08-10T05:00:00Z"),
+		{
+			ID: "waiting-unknown",
+			Attributes: asc.BetaAppReviewSubmissionAttributes{
+				BetaReviewState: "WAITING_FOR_REVIEW",
+				SubmittedDate:   "2026-08-09T03:00:00Z",
+			},
+		},
+	}
+	reviewBuildsBySubmissionID := map[string]*betaReviewBuildStatus{
+		// A related-build lookup succeeded but pre-release context did not.
+		"waiting-unknown": {ID: "build-325", BuildNumber: "325"},
+	}
+
+	selected := selectBetaReviewSubmissionForLatestBuild(submissions, latest, buildsByID, reviewBuildsBySubmissionID)
+	if selected == nil || selected.ID != "waiting-unknown" {
+		t.Fatalf("expected unresolved active review to remain visible, got %+v", selected)
+	}
+	relation := betaReviewBuildRelation(latest, reviewBuildsBySubmissionID[selected.ID])
+	if relation != "unknown" {
+		t.Fatalf("expected unknown relation without pre-release context, got %q", relation)
+	}
+	summary := buildStatusSummary(&dashboardResponse{TestFlight: &testFlightSection{
+		BetaReviewState: selected.Attributes.BetaReviewState,
+		latestBuild:     latest,
+		BetaReviewSubmission: &betaReviewSubmissionStatus{
+			ID: selected.ID, State: selected.Attributes.BetaReviewState, RelationToLatestBuild: relation,
+			Build: reviewBuildsBySubmissionID[selected.ID],
+		},
+	}})
+	if summary.Health != "yellow" || len(summary.Blockers) != 0 {
+		t.Fatalf("expected transiently incomplete correlation to be yellow, not green/red: %+v", summary)
+	}
+}
+
+func betaReviewSubmissionFixture(id, buildID, state, submittedDate string) asc.Resource[asc.BetaAppReviewSubmissionAttributes] {
+	relationships, err := json.Marshal(map[string]any{
+		"build": map[string]any{
+			"data": map[string]string{"type": "builds", "id": buildID},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return asc.Resource[asc.BetaAppReviewSubmissionAttributes]{
+		ID:            id,
+		Relationships: relationships,
+		Attributes: asc.BetaAppReviewSubmissionAttributes{
+			BetaReviewState: state,
+			SubmittedDate:   submittedDate,
+		},
+	}
+}
+
 func TestBuildStatusSummary_RedWhenBlockingIssuesExist(t *testing.T) {
 	resp := &dashboardResponse{
 		Submission: &submissionSection{
@@ -385,6 +480,139 @@ func TestBuildStatusSummary_GreenWhenReadyForSale(t *testing.T) {
 	}
 	if summary.NextAction != "No action needed." {
 		t.Fatalf("expected no action needed, got %q", summary.NextAction)
+	}
+}
+
+func TestBuildStatusSummary_BetaReviewCorrelation(t *testing.T) {
+	latest := &betaReviewBuildStatus{ID: "build-326", Version: "1.2.3", BuildNumber: "326", Platform: "IOS"}
+	tests := []struct {
+		name       string
+		review     *betaReviewSubmissionStatus
+		wantHealth string
+		wantBlock  bool
+		wantAction string
+	}{
+		{
+			name: "same build waiting is in progress, not blocked",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-326", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "sameBuild",
+				Build: latest,
+			},
+			wantHealth: "yellow",
+			wantAction: "build 326",
+		},
+		{
+			name: "older same train waiting blocks latest",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-325", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "sameVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+			},
+			wantHealth: "red",
+			wantBlock:  true,
+			wantAction: "build 325",
+		},
+		{
+			name: "older same train in review blocks latest",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-325", State: "IN_REVIEW", RelationToLatestBuild: "sameVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+			},
+			wantHealth: "red",
+			wantBlock:  true,
+			wantAction: "build 325",
+		},
+		{
+			name: "older same train approved is terminal history",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-325", State: "APPROVED", RelationToLatestBuild: "sameVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+			},
+			wantHealth: "green",
+		},
+		{
+			name: "older same train rejected is attention, not a blocker",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-325", State: "REJECTED", RelationToLatestBuild: "sameVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+			},
+			wantHealth: "yellow",
+			wantAction: "feedback",
+		},
+		{
+			name: "other platform waiting is unrelated",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-mac", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "differentVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-mac", Version: "1.2.3", BuildNumber: "900", Platform: "MAC_OS"},
+			},
+			wantHealth: "green",
+		},
+		{
+			name: "missing relationship is unknown, not guessed",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-unknown", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "unknown",
+			},
+			wantHealth: "yellow",
+			wantAction: "identify its build",
+		},
+		{
+			name:       "no review submission",
+			wantHealth: "green",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp := &dashboardResponse{
+				TestFlight: &testFlightSection{
+					BetaReviewSubmission: test.review,
+					latestBuild:          latest,
+				},
+			}
+			if test.review != nil {
+				resp.TestFlight.BetaReviewState = test.review.State
+			}
+
+			summary := buildStatusSummary(resp)
+			if summary.Health != test.wantHealth {
+				t.Fatalf("expected health=%s, got %+v", test.wantHealth, summary)
+			}
+			if got := len(summary.Blockers) > 0; got != test.wantBlock {
+				t.Fatalf("expected blocker=%t, got %v", test.wantBlock, summary.Blockers)
+			}
+			if test.wantAction != "" && !strings.Contains(summary.NextAction, test.wantAction) {
+				t.Fatalf("expected next action containing %q, got %q", test.wantAction, summary.NextAction)
+			}
+		})
+	}
+}
+
+func TestRenderDashboardLabelsBetaReviewBuildExplicitly(t *testing.T) {
+	resp := &dashboardResponse{
+		Summary: statusSummary{Health: "yellow", NextAction: "Wait.", Blockers: []string{}},
+		TestFlight: &testFlightSection{
+			BetaReviewSubmission: &betaReviewSubmissionStatus{
+				ID: "review-325", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "sameVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+			},
+		},
+	}
+
+	stdout, stderr := captureOutput(t, func() { renderTable(resp) })
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, label := range []string{
+		"betaReviewSubmission.id",
+		"betaReviewSubmission.relationToLatestBuild",
+		"betaReviewSubmission.build.id",
+		"betaReviewSubmission.build.buildNumber",
+	} {
+		if !strings.Contains(stdout, label) {
+			t.Fatalf("expected explicit label %q in output:\n%s", label, stdout)
+		}
+	}
+	if strings.Contains(stdout, "\nbetaReviewState") {
+		t.Fatalf("ambiguous legacy betaReviewState label should not be rendered:\n%s", stdout)
 	}
 }
 

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -486,11 +486,12 @@ func TestBuildStatusSummary_GreenWhenReadyForSale(t *testing.T) {
 func TestBuildStatusSummary_BetaReviewCorrelation(t *testing.T) {
 	latest := &betaReviewBuildStatus{ID: "build-326", Version: "1.2.3", BuildNumber: "326", Platform: "IOS"}
 	tests := []struct {
-		name       string
-		review     *betaReviewSubmissionStatus
-		wantHealth string
-		wantBlock  bool
-		wantAction string
+		name                     string
+		review                   *betaReviewSubmissionStatus
+		latestDistributedBuildID string
+		wantHealth               string
+		wantBlock                bool
+		wantAction               string
 	}{
 		{
 			name: "same build waiting is in progress, not blocked",
@@ -510,6 +511,15 @@ func TestBuildStatusSummary_BetaReviewCorrelation(t *testing.T) {
 			wantHealth: "red",
 			wantBlock:  true,
 			wantAction: "build 325",
+		},
+		{
+			name: "older same train waiting does not block an already distributed latest build",
+			review: &betaReviewSubmissionStatus{
+				ID: "review-325", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "sameVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+			},
+			latestDistributedBuildID: "build-326",
+			wantHealth:               "green",
 		},
 		{
 			name: "older same train in review blocks latest",
@@ -564,8 +574,9 @@ func TestBuildStatusSummary_BetaReviewCorrelation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			resp := &dashboardResponse{
 				TestFlight: &testFlightSection{
-					BetaReviewSubmission: test.review,
-					latestBuild:          latest,
+					BetaReviewSubmission:     test.review,
+					LatestDistributedBuildID: test.latestDistributedBuildID,
+					latestBuild:              latest,
 				},
 			}
 			if test.review != nil {

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -590,8 +590,10 @@ func TestRenderDashboardLabelsBetaReviewBuildExplicitly(t *testing.T) {
 	resp := &dashboardResponse{
 		Summary: statusSummary{Health: "yellow", NextAction: "Wait.", Blockers: []string{}},
 		TestFlight: &testFlightSection{
+			BetaReviewState: "WAITING_FOR_REVIEW",
+			SubmittedDate:   "2026-08-09T04:00:00Z",
 			BetaReviewSubmission: &betaReviewSubmissionStatus{
-				ID: "review-325", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "sameVersionTrain",
+				ID: "review-325", State: "WAITING_FOR_REVIEW", SubmittedDate: "2026-08-09T04:00:00Z", RelationToLatestBuild: "sameVersionTrain",
 				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
 			},
 		},
@@ -611,8 +613,13 @@ func TestRenderDashboardLabelsBetaReviewBuildExplicitly(t *testing.T) {
 			t.Fatalf("expected explicit label %q in output:\n%s", label, stdout)
 		}
 	}
-	if strings.Contains(stdout, "\nbetaReviewState") {
-		t.Fatalf("ambiguous legacy betaReviewState label should not be rendered:\n%s", stdout)
+	for _, label := range []string{"betaReviewState", "submittedDate"} {
+		if !strings.Contains(stdout, label) {
+			t.Fatalf("expected legacy compatibility label %q in output:\n%s", label, stdout)
+		}
+	}
+	if strings.Index(stdout, "betaReviewSubmission.build.id") > strings.Index(stdout, "betaReviewState") {
+		t.Fatalf("expected explicit review build identity before legacy state alias:\n%s", stdout)
 	}
 }
 

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -586,6 +586,28 @@ func TestBuildStatusSummary_BetaReviewCorrelation(t *testing.T) {
 	}
 }
 
+func TestBuildStatusSummary_AppStoreBlockerPrecedesBetaReviewAction(t *testing.T) {
+	latest := &betaReviewBuildStatus{ID: "build-326", Version: "1.2.3", BuildNumber: "326", Platform: "IOS"}
+	resp := &dashboardResponse{
+		Review: &reviewSection{State: "REJECTED"},
+		TestFlight: &testFlightSection{
+			latestBuild: latest,
+			BetaReviewSubmission: &betaReviewSubmissionStatus{
+				ID: "review-325", State: "WAITING_FOR_REVIEW", RelationToLatestBuild: "sameVersionTrain",
+				Build: &betaReviewBuildStatus{ID: "build-325", Version: "1.2.3", BuildNumber: "325", Platform: "IOS"},
+			},
+		},
+	}
+
+	summary := buildStatusSummary(resp)
+	if len(summary.Blockers) != 2 {
+		t.Fatalf("expected both App Store and beta review blockers, got %v", summary.Blockers)
+	}
+	if summary.NextAction != "Resolve blocker: App Store review is rejected" {
+		t.Fatalf("expected App Store blocker precedence, got %q", summary.NextAction)
+	}
+}
+
 func TestRenderDashboardLabelsBetaReviewBuildExplicitly(t *testing.T) {
 	resp := &dashboardResponse{
 		Summary: statusSummary{Health: "yellow", NextAction: "Wait.", Blockers: []string{}},


### PR DESCRIPTION
## Summary

- keep the latest uploaded build separate from the beta review submission build
- add additive machine-readable review submission/build identity and latest-build relation
- report older in-flight same-train reviews as blockers with an actionable next step
- prefer relevant active submissions, use include=build, and bound partial-response fallbacks
- preserve terminal review history without treating it as a blocker

## Verification

- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- built CLI live read-only status verification against direct build and beta review queries

No TestFlight state was mutated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788900101&installation_model_id=10418&pr_number=1908&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1908&signature=1572dd28833dc344388dfb83f755f6b2f9eec4f2d9e4046eae25690f4cabdd2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TestFlight status reporting for beta review submissions linked to older, missing, or previously unfetched builds.
  - More accurately correlates reviews with the correct build and version train across platforms.
  - Preserves compatibility details and provides clearer labels when relationships are unresolved.

- **Status Improvements**
  - Beta review conditions now more accurately affect health indicators, blockers, and recommended next actions.
  - Improved handling of active reviews, including clearer warnings when review status may affect release readiness.
  - Supports more reliable beta review filtering and related-build details when retrieving builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->