### PR TITLE
feat(workflow): add bounded step retry and timeout

### DIFF
--- a/commands/workflow.mdx
+++ b/commands/workflow.mdx
@@ -146,12 +146,15 @@ per-attempt `timeout`. Retry is explicit: the runner does not classify commands
 or automatically retry mutations. Attempt diagnostics stream to stderr, while
 the structured result and resume state retain attempt outcomes. Workflow-call
 steps and lifecycle hooks do not accept retry or timeout.
+Persisted failed-attempt diagnostics alone are not a resume checkpoint. Recovery
+requires an already successful step or hook, or a retry-enabled failed step.
 
 If a command exits successfully but declared output extraction fails, the run
 is terminal and `--resume` refuses to repeat the possibly mutating command.
 A timeout-only failure is likewise terminal because the command may have
 completed remotely. Adding `retry` is the explicit repeat-safety signal that
 makes a timed-out step eligible for retry and later resume.
+Omit `retry` or `timeout` to disable it; explicit `null` is invalid.
 
 ## Output
 

--- a/commands/workflow.mdx
+++ b/commands/workflow.mdx
@@ -42,7 +42,12 @@ Workflows are defined in `.asc/workflow.json`:
         },
         {
           "name": "add_build_to_group",
-          "run": "asc builds add-groups --build-id ${steps.resolve_build.BUILD_ID} --group $GROUP_ID"
+          "run": "asc builds add-groups --build-id ${steps.resolve_build.BUILD_ID} --group $GROUP_ID",
+          "retry": {
+            "max_attempts": 6,
+            "delay": "10s"
+          },
+          "timeout": "2m"
         }
       ]
     },
@@ -133,6 +138,14 @@ as no single workflow run can reach both producers.
 ### Repo-local run state
 
 Workflow runs persist state next to the workflow file so you can resume interrupted runs with `--resume`.
+
+### Bounded retry and timeout
+
+Long-form `run` steps can set `retry.max_attempts`, a fixed `retry.delay`, and a
+per-attempt `timeout`. Retry is explicit: the runner does not classify commands
+or automatically retry mutations. Attempt diagnostics stream to stderr, while
+the structured result and resume state retain attempt outcomes. Workflow-call
+steps and lifecycle hooks do not accept retry or timeout.
 
 ## Output
 

--- a/commands/workflow.mdx
+++ b/commands/workflow.mdx
@@ -149,6 +149,9 @@ steps and lifecycle hooks do not accept retry or timeout.
 
 If a command exits successfully but declared output extraction fails, the run
 is terminal and `--resume` refuses to repeat the possibly mutating command.
+A timeout-only failure is likewise terminal because the command may have
+completed remotely. Adding `retry` is the explicit repeat-safety signal that
+makes a timed-out step eligible for retry and later resume.
 
 ## Output
 

--- a/commands/workflow.mdx
+++ b/commands/workflow.mdx
@@ -147,6 +147,9 @@ or automatically retry mutations. Attempt diagnostics stream to stderr, while
 the structured result and resume state retain attempt outcomes. Workflow-call
 steps and lifecycle hooks do not accept retry or timeout.
 
+If a command exits successfully but declared output extraction fails, the run
+is terminal and `--resume` refuses to repeat the possibly mutating command.
+
 ## Output
 
 All workflow commands emit JSON to stdout. Step and hook output streams to stderr so stdout stays machine-parseable.

--- a/concepts/workflows.mdx
+++ b/concepts/workflows.mdx
@@ -145,6 +145,10 @@ A step with `timeout` but no `retry` becomes terminal if it times out, so
 `--resume` cannot replay a command that may have completed remotely. Combining
 `retry` and `timeout` keeps failures resumable because retry is the explicit
 repeat-safety opt-in.
+Persisted diagnostics from a failed timeout-configured step do not create a
+resume checkpoint by themselves. Recovery still requires a prior successful
+step or hook, or an explicitly retry-enabled failure. Omit either field to
+disable it; explicit `null` is invalid.
 
 ## Environment Variables
 

--- a/concepts/workflows.mdx
+++ b/concepts/workflows.mdx
@@ -107,6 +107,8 @@ Steps can be **short form** (bare string) or **long form** (object):
   "name": "list_apps",
   "run": "asc apps list --output json",
   "if": "VARIABLE_NAME",
+  "retry": {"max_attempts": 4, "delay": "5s"},
+  "timeout": "1m",
   "with": {"KEY": "value"},
   "workflow": "sub_workflow_name"
 }
@@ -119,10 +121,25 @@ Steps can be **short form** (bare string) or **long form** (object):
 | `name`     | string | No          | Step identifier (for debugging and JSON output)                  |
 | `if`       | string | No          | Only run if the environment variable exists and is non-empty     |
 | `with`     | object | No          | Additional environment variables for this step only              |
+| `retry`    | object | No          | Explicit fixed-delay retry policy for `run` steps                 |
+| `timeout`  | string | No          | Positive per-attempt timeout for `run` steps                      |
 
 <Warning>
   A step must have **either** `run` or `workflow`, but not both.
 </Warning>
+
+### Bounded retry and timeout
+
+Long-form `run` steps can opt into bounded retries with `retry.max_attempts`
+(2-100) and a fixed positive `retry.delay`, plus a positive per-attempt
+`timeout`. Durations use values such as `250ms`, `10s`, or `2m` and are capped
+at `24h`.
+
+Retry is never implicit. Choose it only for a command that is safe to repeat;
+the runner does not infer whether a command is read-only or a mutation.
+Workflow-call steps and lifecycle hooks do not accept these fields. Attempt
+diagnostics go to stderr, successful-attempt outputs are persisted, and resume
+continues to skip already successful steps.
 
 ## Environment Variables
 

--- a/concepts/workflows.mdx
+++ b/concepts/workflows.mdx
@@ -141,6 +141,11 @@ Workflow-call steps and lifecycle hooks do not accept these fields. Attempt
 diagnostics go to stderr, successful-attempt outputs are persisted, and resume
 continues to skip already successful steps.
 
+A step with `timeout` but no `retry` becomes terminal if it times out, so
+`--resume` cannot replay a command that may have completed remotely. Combining
+`retry` and `timeout` keeps failures resumable because retry is the explicit
+repeat-safety opt-in.
+
 ## Environment Variables
 
 Workflows support environment variable expansion using `$VAR` or `${VAR}` syntax:

--- a/configuration/workflows.mdx
+++ b/configuration/workflows.mdx
@@ -171,9 +171,10 @@ Steps can be defined in two formats:
 </ParamField>
 
 <ParamField path="if" type="string">
-  Condition expression (evaluated as shell command)
+  Name of an environment variable that controls whether the step runs
 
-  Step runs only if the command exits with code 0.
+  The step runs only when the variable has a truthy value such as `1`, `true`,
+  `yes`, or `on` (case-insensitive).
 </ParamField>
 
 <ParamField path="with" type="object">

--- a/configuration/workflows.mdx
+++ b/configuration/workflows.mdx
@@ -216,6 +216,8 @@ The retry delay is fixed and deterministic. `timeout` applies to each attempt.
 Attempt counts and delays stream to stderr; stdout remains structured JSON.
 Only successful-attempt output can satisfy declared `outputs`. Retry and timeout
 are rejected on sub-workflow calls and are not configurable on lifecycle hooks.
+If a command exits successfully but output extraction fails, the run is terminal;
+`--resume` reports the reason without re-executing the command.
 
 ## Environment variable precedence
 

--- a/configuration/workflows.mdx
+++ b/configuration/workflows.mdx
@@ -137,7 +137,12 @@ Steps can be defined in two formats:
   {
     "name": "Verify upload",
     "run": "asc builds list --app $APP_ID --limit 1",
-    "if": "$VERIFY == true"
+    "if": "VERIFY",
+    "retry": {
+      "max_attempts": 4,
+      "delay": "5s"
+    },
+    "timeout": "1m"
   },
   {
     "name": "Run sub-workflow",
@@ -176,6 +181,41 @@ Steps can be defined in two formats:
 
   Only applies to `workflow` steps.
 </ParamField>
+
+<ParamField path="retry" type="object">
+  Explicit fixed-delay retry policy for a `run` step
+
+  Requires `max_attempts` from 2 through 100 and a positive `delay` duration no
+  greater than `24h`. `max_attempts` includes the initial execution.
+</ParamField>
+
+<ParamField path="timeout" type="string">
+  Positive per-attempt timeout for a `run` step, up to `24h`
+
+  Uses Go duration syntax such as `250ms`, `10s`, or `2m`.
+</ParamField>
+
+## Bounded retry and timeout
+
+Use retry only for a command you have explicitly determined is safe to repeat.
+The workflow runner does not inspect the command or silently retry mutations.
+
+```jsonc  theme={null}
+{
+  "name": "add_build_to_group",
+  "run": "asc builds add-groups --build-id $BUILD_ID --group $GROUP_ID",
+  "retry": {
+    "max_attempts": 6,
+    "delay": "10s"
+  },
+  "timeout": "2m"
+}
+```
+
+The retry delay is fixed and deterministic. `timeout` applies to each attempt.
+Attempt counts and delays stream to stderr; stdout remains structured JSON.
+Only successful-attempt output can satisfy declared `outputs`. Retry and timeout
+are rejected on sub-workflow calls and are not configurable on lifecycle hooks.
 
 ## Environment variable precedence
 

--- a/configuration/workflows.mdx
+++ b/configuration/workflows.mdx
@@ -222,6 +222,9 @@ If a command exits successfully but output extraction fails, the run is terminal
 A timeout without `retry` is also terminal because the command may have completed
 remotely. A step that configures both fields remains resumable because `retry`
 explicitly opts into repeat execution.
+Persisted failed-attempt diagnostics alone do not make a run resumable. Recovery
+requires a successful checkpoint or a retry-enabled failed step. Omit `retry`
+or `timeout` to disable it; explicit `null` is rejected.
 
 ## Environment variable precedence
 

--- a/configuration/workflows.mdx
+++ b/configuration/workflows.mdx
@@ -219,6 +219,9 @@ Only successful-attempt output can satisfy declared `outputs`. Retry and timeout
 are rejected on sub-workflow calls and are not configurable on lifecycle hooks.
 If a command exits successfully but output extraction fails, the run is terminal;
 `--resume` reports the reason without re-executing the command.
+A timeout without `retry` is also terminal because the command may have completed
+remotely. A step that configures both fields remains resumable because `retry`
+explicitly opts into repeat execution.
 
 ## Environment variable precedence
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -209,6 +209,9 @@ A timeout-only failure is terminal for the same replay-safety reason: local
 termination cannot prove that a remote mutation was not accepted. A step that
 configures both `retry` and `timeout` remains resumable because `retry` is the
 explicit repeat-safety opt-in.
+Failed-attempt diagnostics from `timeout` alone do not create a resume checkpoint.
+Recovery requires a previously successful step or hook, or a retry-enabled
+failed step. Omit `retry` or `timeout` to disable it; explicit `null` is invalid.
 
 Attempt numbers and retry delays are written to stderr. stdout remains the one
 machine-readable workflow result. Each attempt gets a fresh output buffer, and

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -169,6 +169,47 @@ Notes:
   can execute together in the same run graph. Independent workflows can reuse
   names like `archive` or `publish`.
 
+## Bounded retry and timeout
+
+Long-form `run` steps can opt into a fixed-delay retry policy and a per-attempt
+timeout. This replaces shell retry loops for operations such as Apple's
+eventually consistent build-to-beta-group relationship:
+
+```jsonc
+{
+  "name": "add_build_to_group",
+  "run": "asc builds add-groups --build-id $BUILD_ID --group $GROUP_ID",
+  "retry": {
+    "max_attempts": 6,
+    "delay": "10s"
+  },
+  "timeout": "2m"
+}
+```
+
+`max_attempts` includes the initial execution and must be between 2 and 100.
+`delay` and `timeout` use positive Go duration strings up to `24h`; examples
+include `250ms`, `10s`, and `2m`. The delay is fixed and has no jitter. Timeout
+applies separately to each attempt. With the example above, the total policy is
+bounded by six two-minute attempts plus five ten-second delays.
+
+Retry and timeout are supported only on `run` steps. Workflow-call steps and the
+`before_all`, `after_all`, and `error` string hooks remain single-execution.
+Caller cancellation stops a running process tree or retry delay immediately.
+The error hook runs only after the final attempt fails; `after_all` still runs
+only after success.
+
+Use retry only when you have explicitly decided the command is safe to repeat.
+The runner does not infer whether a shell command is read-only, idempotent, or a
+mutation. A successful command with invalid declared output is not retried,
+because its side effect may already have happened.
+
+Attempt numbers and retry delays are written to stderr. stdout remains the one
+machine-readable workflow result. Each attempt gets a fresh output buffer, and
+declared outputs are extracted and persisted only from the successful attempt.
+Persisted attempt diagnostics remain available across `--resume`; already
+successful steps are never rerun.
+
 Example:
 
 ```json

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -202,7 +202,9 @@ only after success.
 Use retry only when you have explicitly decided the command is safe to repeat.
 The runner does not infer whether a shell command is read-only, idempotent, or a
 mutation. A successful command with invalid declared output is not retried,
-because its side effect may already have happened.
+because its side effect may already have happened. That failure is terminal:
+the structured result sets `terminal: true`, the run state records the terminal
+reason, and `--resume` rejects the run instead of executing the command again.
 
 Attempt numbers and retry delays are written to stderr. stdout remains the one
 machine-readable workflow result. Each attempt gets a fresh output buffer, and

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -205,6 +205,10 @@ mutation. A successful command with invalid declared output is not retried,
 because its side effect may already have happened. That failure is terminal:
 the structured result sets `terminal: true`, the run state records the terminal
 reason, and `--resume` rejects the run instead of executing the command again.
+A timeout-only failure is terminal for the same replay-safety reason: local
+termination cannot prove that a remote mutation was not accepted. A step that
+configures both `retry` and `timeout` remains resumable because `retry` is the
+explicit repeat-safety opt-in.
 
 Attempt numbers and retry delays are written to stderr. stdout remains the one
 machine-readable workflow result. Each attempt gets a fresh output buffer, and

--- a/docs/design/workflow-step-retry-timeout.md
+++ b/docs/design/workflow-step-retry-timeout.md
@@ -91,6 +91,14 @@ and the user did not authorize mutating the documented Apple relationship.
 Read-only verification is limited to current CLI help and the checked-in
 OpenAPI contract.
 
+## Residual risk
+
+A timeout proves only that the local process tree was terminated. A remote
+service may have accepted a mutating request before the deadline even though
+the command returned no success result. A configured retry can therefore replay
+that mutation. Operators must limit retry policies to commands whose duplicate
+execution is acceptable or whose remote operation is idempotent.
+
 ## Alternatives
 
 An exponential multiplier, jitter, exit-code filters, or HTTP-aware policy

--- a/docs/design/workflow-step-retry-timeout.md
+++ b/docs/design/workflow-step-retry-timeout.md
@@ -60,7 +60,9 @@ callers to parse platform-specific process errors.
 Each attempt receives a fresh output buffer. Declared outputs are extracted and
 persisted only after a command exits successfully; output from failed attempts
 cannot become step output. Output-extraction failures are not retried because a
-successful command may already have performed a mutation.
+successful command may already have performed a mutation. They are also marked
+terminal and cannot be resumed automatically; the operator must inspect any
+side effects before deciding whether to start a new run.
 
 Caller cancellation stops immediately and never waits for or starts another
 attempt. A timeout terminates the shell process tree before the runner records a
@@ -72,7 +74,8 @@ Run state records attempt diagnostics for configured steps, including failed
 attempts. Resume continues to skip every persisted successful step, restores
 its outputs, and re-executes only the failed step with a new bounded invocation.
 The previous attempt history remains available in the persisted state and the
-resumed structured result.
+resumed structured result. A terminal output-extraction failure is the exception:
+`--resume` returns a diagnostic without executing any workflow command.
 
 ## RED-GREEN and verification
 

--- a/docs/design/workflow-step-retry-timeout.md
+++ b/docs/design/workflow-step-retry-timeout.md
@@ -68,14 +68,17 @@ Caller cancellation stops immediately and never waits for or starts another
 attempt. A timeout terminates the shell process tree before the runner records a
 `timeout` attempt. On Unix, each command runs in its own process group; on
 Windows, the runner uses the platform process-tree termination path. Hooks use
-the same cancellation-aware command runner.
+the same cancellation-aware command runner. A timeout-only failure is persisted
+as terminal and cannot be resumed, because local termination does not prove a
+remote mutation was rejected. Configuring `retry` is the explicit repeat-safety
+signal that keeps retry-plus-timeout failures resumable.
 
 Run state records attempt diagnostics for configured steps, including failed
 attempts. Resume continues to skip every persisted successful step, restores
-its outputs, and re-executes only the failed step with a new bounded invocation.
-The previous attempt history remains available in the persisted state and the
-resumed structured result. A terminal output-extraction failure is the exception:
-`--resume` returns a diagnostic without executing any workflow command.
+its outputs, and re-executes only a retry-enabled failed step with a new bounded
+invocation. The previous attempt history remains available in the persisted
+state and the resumed structured result. Terminal output-extraction and
+timeout-only failures reject `--resume` without executing any workflow command.
 
 ## RED-GREEN and verification
 

--- a/docs/design/workflow-step-retry-timeout.md
+++ b/docs/design/workflow-step-retry-timeout.md
@@ -1,0 +1,98 @@
+# Workflow step retry and timeout
+
+## Placement and invocation
+
+This change extends the existing `.asc/workflow.json` long-form `run` step. It
+does not add a command or flag, and it does not change registry placement.
+`asc workflow validate`, `asc workflow run`, `--dry-run`, and `--resume` keep
+their current invocation shapes.
+
+```jsonc
+{
+  "name": "add_build_to_group",
+  "run": "asc builds add-groups --build-id $BUILD_ID --group $GROUP_ID",
+  "retry": {
+    "max_attempts": 6,
+    "delay": "10s"
+  },
+  "timeout": "2m"
+}
+```
+
+`max_attempts` counts the initial execution. The delay is fixed, deterministic,
+and occurs only between failed attempts. `timeout` applies independently to
+each attempt, so the total step bound is the sum of attempt timeouts and retry
+delays. Retry and timeout are opt-in; existing steps still execute once with no
+new timeout.
+
+## API and output contract
+
+The runner is client-side orchestration and does not add or change an App Store
+Connect request. The motivating command uses
+`POST /v1/builds/{id}/relationships/betaGroups`, whose OpenAPI operation accepts
+`BuildBetaGroupsLinkagesRequest`, returns `204` on success, and documents `404`
+among its failures. The workflow layer intentionally does not infer HTTP
+methods, status codes, idempotency, or mutation safety from a shell command.
+
+Step command output continues to use the runner's command-output writer; the
+CLI routes that writer to stderr so stdout remains one structured JSON result.
+Retry diagnostics report the step, attempt number, total attempts, and next
+delay on stderr. The structured step result records attempt status and failure
+kind. Timeout and cancellation use stable failure kinds rather than requiring
+callers to parse platform-specific process errors.
+
+## Validation and compatibility
+
+- `retry` is valid only on `run` steps and requires `max_attempts` from 2 through
+  100 plus a positive, bounded Go duration in `delay`.
+- `timeout` is valid only on `run` steps and must be a positive, bounded Go
+  duration.
+- Workflow-call steps reject both fields with an exact
+  `workflows.<name>.steps[<index>]...` path.
+- Bare string steps remain supported and keep single-attempt behavior.
+- `before_all`, `after_all`, and `error` remain string hooks without retry or
+  timeout configuration. They still honor caller cancellation, including
+  process-tree termination.
+- This is additive and requires no lifecycle migration or deprecation.
+
+## Execution, state, and failure behavior
+
+Each attempt receives a fresh output buffer. Declared outputs are extracted and
+persisted only after a command exits successfully; output from failed attempts
+cannot become step output. Output-extraction failures are not retried because a
+successful command may already have performed a mutation.
+
+Caller cancellation stops immediately and never waits for or starts another
+attempt. A timeout terminates the shell process tree before the runner records a
+`timeout` attempt. On Unix, each command runs in its own process group; on
+Windows, the runner uses the platform process-tree termination path. Hooks use
+the same cancellation-aware command runner.
+
+Run state records attempt diagnostics for configured steps, including failed
+attempts. Resume continues to skip every persisted successful step, restores
+its outputs, and re-executes only the failed step with a new bounded invocation.
+The previous attempt history remains available in the persisted state and the
+resumed structured result.
+
+## RED-GREEN and verification
+
+Focused tests cover validation paths, eventual success, exhaustion, timeout,
+caller cancellation, process-tree termination, clean output capture, hook
+ordering, and resume behavior. A built CLI fixture workflow verifies JSON-only
+stdout, retry diagnostics on stderr, persisted state, timeout failure shape, and
+successful resume. The repository gates are `make build`, `make format`,
+`make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`.
+
+No live mutation is appropriate: the behavior is local process orchestration,
+and the user did not authorize mutating the documented Apple relationship.
+Read-only verification is limited to current CLI help and the checked-in
+OpenAPI contract.
+
+## Alternatives
+
+An exponential multiplier, jitter, exit-code filters, or HTTP-aware policy
+would enlarge the schema and make timing or mutation behavior less predictable.
+A fixed required delay is enough for eventually consistent endpoints and is
+easy to audit. Applying policies to workflow-call steps or hooks would require
+new nested state and hook schemas; rejecting those placements keeps this change
+focused while still making every contained `run` step configurable.

--- a/docs/design/workflow-step-retry-timeout.md
+++ b/docs/design/workflow-step-retry-timeout.md
@@ -74,11 +74,14 @@ remote mutation was rejected. Configuring `retry` is the explicit repeat-safety
 signal that keeps retry-plus-timeout failures resumable.
 
 Run state records attempt diagnostics for configured steps, including failed
-attempts. Resume continues to skip every persisted successful step, restores
-its outputs, and re-executes only a retry-enabled failed step with a new bounded
-invocation. The previous attempt history remains available in the persisted
-state and the resumed structured result. Terminal output-extraction and
+attempts, and explicitly records whether the step enabled retry. A diagnostic-only
+failed record is not a resume checkpoint. Resume requires a persisted successful
+step or hook, or a retry-enabled failed step; it skips successes, restores their
+outputs, and re-executes the failed step. The previous attempt history remains
+available in state and the resumed result. Terminal output-extraction and
 timeout-only failures reject `--resume` without executing any workflow command.
+Omitted policies remain disabled, while explicit `retry: null` or `timeout: null`
+is rejected with the step field path.
 
 ## RED-GREEN and verification
 

--- a/internal/cli/cmdtest/workflow_retry_test.go
+++ b/internal/cli/cmdtest/workflow_retry_test.go
@@ -1,0 +1,69 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkflowRun_RetryKeepsStdoutStructured(t *testing.T) {
+	dir := t.TempDir()
+	counterPath := filepath.Join(dir, "attempts")
+	path := writeWorkflowJSON(t, dir, fmt.Sprintf(`{
+		"env": {"COUNTER_PATH": %q},
+		"workflows": {
+			"beta": {
+				"steps": [{
+					"name": "eventual_build_group",
+					"run": "count=$(cat \"$COUNTER_PATH\" 2>/dev/null || echo 0); count=$((count+1)); printf '%%s' \"$count\" > \"$COUNTER_PATH\"; if [ \"$count\" -lt 2 ]; then printf 'transient-404'; exit 44; fi; printf 'linked'",
+					"retry": {"max_attempts": 2, "delay": "1ms"},
+					"timeout": "2s"
+				}]
+			}
+		}
+	}`, counterPath))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"workflow", "run", "--file", path, "beta"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Status string `json:"status"`
+		Steps  []struct {
+			Status   string `json:"status"`
+			Attempts []struct {
+				Attempt int    `json:"attempt"`
+				Status  string `json:"status"`
+			} `json:"attempts"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout must be one JSON result, got %q: %v", stdout, err)
+	}
+	if result.Status != "ok" || len(result.Steps) != 1 || result.Steps[0].Status != "ok" {
+		t.Fatalf("unexpected workflow result: %+v", result)
+	}
+	if len(result.Steps[0].Attempts) != 2 {
+		t.Fatalf("attempts = %+v, want two attempts", result.Steps[0].Attempts)
+	}
+	if result.Steps[0].Attempts[0].Status != "error" || result.Steps[0].Attempts[1].Status != "ok" {
+		t.Fatalf("attempt statuses = %+v, want error then ok", result.Steps[0].Attempts)
+	}
+	if !strings.Contains(stderr, "attempt 1/2") || !strings.Contains(stderr, "retrying in 1ms") {
+		t.Fatalf("stderr must expose retry attempt and delay, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "transient-404") || !strings.Contains(stderr, "linked") {
+		t.Fatalf("step output must stream to stderr, got %q", stderr)
+	}
+}

--- a/internal/cli/cmdtest/workflow_retry_test.go
+++ b/internal/cli/cmdtest/workflow_retry_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestWorkflowRun_RetryKeepsStdoutStructured(t *testing.T) {
+	requireWorkflowShell(t)
 	dir := t.TempDir()
 	counterPath := filepath.Join(dir, "attempts")
 	path := writeWorkflowJSON(t, dir, fmt.Sprintf(`{
@@ -66,4 +68,14 @@ func TestWorkflowRun_RetryKeepsStdoutStructured(t *testing.T) {
 	if !strings.Contains(stderr, "transient-404") || !strings.Contains(stderr, "linked") {
 		t.Fatalf("step output must stream to stderr, got %q", stderr)
 	}
+}
+
+func requireWorkflowShell(t *testing.T) {
+	t.Helper()
+	for _, shell := range []string{"bash", "sh"} {
+		if _, err := exec.LookPath(shell); err == nil {
+			return
+		}
+	}
+	t.Skip("asc workflow run requires bash or sh in PATH")
 }

--- a/internal/cli/cmdtest/workflow_test.go
+++ b/internal/cli/cmdtest/workflow_test.go
@@ -55,6 +55,9 @@ func TestWorkflow_ShowsHelp(t *testing.T) {
 	if !strings.Contains(stderr, `"BUILD_ID": "$.data.id"`) {
 		t.Fatalf("expected help example to extract build IDs from $.data.id, got %q", stderr)
 	}
+	if !strings.Contains(stderr, `"max_attempts": 6`) || !strings.Contains(stderr, `"timeout": "2m"`) {
+		t.Fatalf("expected help to document bounded run-step retry and timeout, got %q", stderr)
+	}
 	if !strings.Contains(stderr, "WORKFLOWS.md") {
 		t.Fatalf("expected help to link workflow docs, got %q", stderr)
 	}

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -47,6 +47,8 @@ Tips:
   Use asc workflow validate before running a new workflow file.
   Preview the plan with asc workflow run --dry-run <name>.
   Run-step outputs can be referenced later as ${steps.resolve_build.BUILD_ID}.
+  Run steps can opt into bounded retry with retry.max_attempts and retry.delay, plus a per-attempt timeout.
+  Retry uses a fixed delay with no jitter; choose it only for commands that are safe to repeat.
   Output-producing step names only need to stay unique across workflows that can execute together in the same run graph.
   For asc commands that declare outputs, usually pass --output json.
   A proven local Xcode -> TestFlight shape is: asc builds next-build-number --app $APP_ID -> asc xcode archive -> asc xcode export -> asc publish testflight --group ... --wait.
@@ -77,7 +79,12 @@ Example workflow file (.asc/workflow.json):
         },
         {
           "name": "add_build_to_group",
-          "run": "asc builds add-groups --build-id ${steps.resolve_build.BUILD_ID} --group $GROUP_ID"
+          "run": "asc builds add-groups --build-id ${steps.resolve_build.BUILD_ID} --group $GROUP_ID",
+          "retry": {
+            "max_attempts": 6,
+            "delay": "10s"
+          },
+          "timeout": "2m"
         }
       ]
     },
@@ -164,6 +171,11 @@ Do not pass extra KEY:VALUE params with --resume.
 If a step declares "outputs", the command must emit JSON on stdout; for asc commands,
 usually pass --output json.
 stdout stays machine-parseable JSON even on failure; step and hook output streams to stderr.
+Retry is opt-in on run steps. retry.max_attempts counts the initial attempt and
+retry.delay is a fixed delay between failures. timeout applies to each attempt.
+Attempt counts and delays are written to stderr and attempt outcomes are included
+in the structured result and persisted run state.
+Workflow-call steps and before_all/after_all/error hooks do not accept retry or timeout.
 
 Security note:
   Workflows intentionally execute arbitrary shell commands.
@@ -247,7 +259,7 @@ func workflowValidateCommand() *ffcli.Command {
 		Name:       "validate",
 		ShortUsage: "asc workflow validate [flags]",
 		ShortHelp:  "Validate workflow.json for errors and cycles.",
-		LongHelp: `Validate workflow.json for structure, references, cycles, and output declarations.
+		LongHelp: `Validate workflow.json for structure, references, cycles, output declarations, and run-step retry/timeout policies.
 This checks schema and wiring only; it does not assess shell-command safety.
 
 Examples:

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -175,6 +175,8 @@ Retry is opt-in on run steps. retry.max_attempts counts the initial attempt and
 retry.delay is a fixed delay between failures. timeout applies to each attempt.
 Attempt counts and delays are written to stderr and attempt outcomes are included
 in the structured result and persisted run state.
+If a successful command produces invalid declared outputs, the run is terminal and
+--resume refuses to repeat the possibly mutating command.
 Workflow-call steps and before_all/after_all/error hooks do not accept retry or timeout.
 
 Security note:

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -175,12 +175,15 @@ Retry is opt-in on run steps. retry.max_attempts counts the initial attempt and
 retry.delay is a fixed delay between failures. timeout applies to each attempt.
 Attempt counts and delays are written to stderr and attempt outcomes are included
 in the structured result and persisted run state.
+Failed-attempt diagnostics alone do not make a run resumable; recovery requires
+a successful checkpoint or a retry-enabled failed step.
 If a successful command produces invalid declared outputs, the run is terminal and
 --resume refuses to repeat the possibly mutating command.
 A timeout without retry is also terminal because the command may have completed
 remotely. A step with retry and timeout remains resumable because retry is the
 explicit repeat-safety opt-in.
 Workflow-call steps and before_all/after_all/error hooks do not accept retry or timeout.
+Omit retry or timeout to disable it; explicit null values are invalid.
 
 Security note:
   Workflows intentionally execute arbitrary shell commands.

--- a/internal/cli/workflow/workflow.go
+++ b/internal/cli/workflow/workflow.go
@@ -177,6 +177,9 @@ Attempt counts and delays are written to stderr and attempt outcomes are include
 in the structured result and persisted run state.
 If a successful command produces invalid declared outputs, the run is terminal and
 --resume refuses to repeat the possibly mutating command.
+A timeout without retry is also terminal because the command may have completed
+remotely. A step with retry and timeout remains resumable because retry is the
+explicit repeat-safety opt-in.
 Workflow-call steps and before_all/after_all/error hooks do not accept retry or timeout.
 
 Security note:

--- a/internal/workflow/env.go
+++ b/internal/workflow/env.go
@@ -116,6 +116,7 @@ func runShellCommand(ctx context.Context, command string, env map[string]string,
 	args := append(append([]string{}, flags...), command)
 
 	cmd := commandContextFn(ctx, shell, args...)
+	configureProcessTree(cmd)
 	cmd.Env = buildEnvSlice(env)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/internal/workflow/env.go
+++ b/internal/workflow/env.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +12,7 @@ import (
 	"time"
 )
 
-const shellWaitDelay = 5 * time.Second
+var shellWaitDelay = 5 * time.Second
 
 var (
 	lookPathFn       = exec.LookPath
@@ -124,7 +125,14 @@ func runShellCommand(ctx context.Context, command string, env map[string]string,
 	cmd.Env = buildEnvSlice(env)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	return cmd.Run()
+	err = cmd.Run()
+	if errors.Is(err, exec.ErrWaitDelay) && ctx.Err() == nil {
+		// The shell exited successfully, but a background descendant retained a
+		// captured output pipe. WaitDelay closed the pipe to bound cleanup; do not
+		// turn that completed command into a retryable failure.
+		return nil
+	}
+	return err
 }
 
 func resolveShell() (string, []string, error) {

--- a/internal/workflow/env.go
+++ b/internal/workflow/env.go
@@ -8,7 +8,10 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 )
+
+const shellWaitDelay = 5 * time.Second
 
 var (
 	lookPathFn       = exec.LookPath
@@ -117,6 +120,7 @@ func runShellCommand(ctx context.Context, command string, env map[string]string,
 
 	cmd := commandContextFn(ctx, shell, args...)
 	configureProcessTree(cmd)
+	cmd.WaitDelay = shellWaitDelay
 	cmd.Env = buildEnvSlice(env)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/internal/workflow/env_test.go
+++ b/internal/workflow/env_test.go
@@ -259,10 +259,12 @@ func TestRunShellCommand_UsesBashWithPipefailWhenAvailable(t *testing.T) {
 
 	var gotName string
 	var gotArgs []string
+	var gotCommand *exec.Cmd
 	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		gotName = name
 		gotArgs = append([]string{}, args...)
-		return exec.CommandContext(ctx, "go", "version")
+		gotCommand = exec.CommandContext(ctx, "go", "version")
+		return gotCommand
 	}
 
 	if err := runShellCommand(context.Background(), "echo hi", nil, nil, nil); err != nil {
@@ -275,6 +277,9 @@ func TestRunShellCommand_UsesBashWithPipefailWhenAvailable(t *testing.T) {
 	wantArgs := []string{"-o", "pipefail", "-c", "echo hi"}
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
 		t.Fatalf("args = %v, want %v", gotArgs, wantArgs)
+	}
+	if gotCommand.WaitDelay != shellWaitDelay {
+		t.Fatalf("WaitDelay = %s, want %s", gotCommand.WaitDelay, shellWaitDelay)
 	}
 }
 

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -546,6 +546,19 @@ func (r *runner) markFailure(err error, failedStep string) {
 	}
 }
 
+func (r *runner) setTerminalReason(reason string) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return
+	}
+	r.result.Terminal = true
+	r.result.TerminalReason = reason
+	if r.state != nil {
+		r.state.Status = "terminal"
+		r.state.TerminalReason = reason
+	}
+}
+
 func (r *runner) hasRecoverableState() bool {
 	if r.state == nil {
 		return false
@@ -565,6 +578,9 @@ func (r *runner) hasRecoverableState() bool {
 func terminalReasonForResult(result *RunResult) string {
 	if result == nil {
 		return ""
+	}
+	if reason := strings.TrimSpace(result.TerminalReason); reason != "" {
+		return reason
 	}
 	for _, step := range result.Steps {
 		if step.FailureReason != "output_error" {
@@ -602,6 +618,10 @@ func terminalReasonForState(state *persistedRunState) string {
 
 func terminalOutputReason(label string) string {
 	return fmt.Sprintf("step %q command completed but output extraction failed; automatic resume is disabled to avoid repeating possible side effects", label)
+}
+
+func terminalTimeoutReason(label string) string {
+	return fmt.Sprintf("step %q timed out without retry; automatic resume is disabled because the command may have completed remotely", label)
 }
 
 func (r *runner) resumeCommand() string {

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -1,7 +1,6 @@
 package workflow
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -36,8 +35,20 @@ type StepResult struct {
 	ParentWorkflow string            `json:"parent_workflow,omitempty"`
 	Status         string            `json:"status"`
 	DurationMS     int64             `json:"duration_ms"`
+	FailureReason  string            `json:"failure_reason,omitempty"`
 	Error          string            `json:"error,omitempty"`
+	Attempts       []AttemptResult   `json:"attempts,omitempty"`
 	Outputs        map[string]string `json:"outputs,omitempty"`
+}
+
+// AttemptResult records one configured run-step attempt.
+type AttemptResult struct {
+	Invocation    int    `json:"invocation"`
+	Attempt       int    `json:"attempt"`
+	Status        string `json:"status"`
+	DurationMS    int64  `json:"duration_ms"`
+	FailureReason string `json:"failure_reason,omitempty"`
+	Error         string `json:"error,omitempty"`
 }
 
 // HookResult records execution of a hook command (before_all/after_all/error).
@@ -273,7 +284,7 @@ func (r *runner) outputsFromState(state *persistedRunState) map[string]map[strin
 	}
 	for _, stepKey := range slices.Sorted(maps.Keys(state.Steps)) {
 		step := state.Steps[stepKey]
-		if strings.TrimSpace(step.Name) == "" || len(step.Outputs) == 0 {
+		if step.Status != "ok" || strings.TrimSpace(step.Name) == "" || len(step.Outputs) == 0 {
 			continue
 		}
 		outputs[step.Name] = cloneStringMap(step.Outputs)
@@ -357,6 +368,16 @@ func (r *runner) executeSteps(ctx context.Context, workflowName string, steps []
 		}
 
 		if ref := sr.Workflow; ref != "" {
+			if step.Retry != nil || step.Timeout != nil {
+				err := fmt.Errorf("workflow: %s step %d: retry and timeout are only supported on run steps", workflowName, idx)
+				sr.Status = "error"
+				sr.FailureReason = "invalid_policy"
+				sr.Error = "retry and timeout are only supported on run steps"
+				sr.DurationMS = time.Since(stepStart).Milliseconds()
+				r.result.Steps = append(r.result.Steps, sr)
+				r.result.FailedStep = failedStepName(step.Name, stepKey)
+				return err
+			}
 			if depth+1 > MaxCallDepth {
 				err := fmt.Errorf("workflow: %s step %d: max call depth %d exceeded", workflowName, idx, MaxCallDepth)
 				sr.Status = "error"
@@ -408,6 +429,7 @@ func (r *runner) executeSteps(ctx context.Context, workflowName string, steps []
 			if persisted, ok := r.state.Steps[stepKey]; ok && persisted.Status == "ok" {
 				sr.Status = "resumed"
 				sr.Outputs = cloneStringMap(persisted.Outputs)
+				sr.Attempts = cloneAttemptResults(persisted.Attempts)
 				sr.DurationMS = 0
 				r.result.Steps = append(r.result.Steps, sr)
 				if strings.TrimSpace(persisted.Name) != "" && len(persisted.Outputs) > 0 {
@@ -437,64 +459,41 @@ func (r *runner) executeSteps(ctx context.Context, workflowName string, steps []
 			return wrapped
 		}
 
-		stdout := r.opts.Stdout
-		var captured bytes.Buffer
-		if len(step.Outputs) > 0 {
-			stdout = io.MultiWriter(r.opts.Stdout, &captured)
-		}
-
-		if err := runShellCommand(ctx, command, env, stdout, r.opts.Stderr); err != nil {
-			wrapped := fmt.Errorf("workflow: %s step %d: %w", workflowName, idx, err)
-			sr.Status = "error"
-			sr.Error = err.Error()
+		if err := r.executeRunStep(ctx, workflowName, idx, stepKey, step, command, env, &sr); err != nil {
 			sr.DurationMS = time.Since(stepStart).Milliseconds()
 			r.result.Steps = append(r.result.Steps, sr)
 			r.result.FailedStep = failedStepName(step.Name, stepKey)
-			return wrapped
-		}
-
-		if len(step.Outputs) > 0 {
-			extracted, err := extractDeclaredOutputs(step.Outputs, captured.Bytes())
-			if err != nil {
-				wrapped := fmt.Errorf("workflow: %s step %d: %w", workflowName, idx, err)
-				sr.Status = "error"
-				sr.Error = err.Error()
-				sr.DurationMS = time.Since(stepStart).Milliseconds()
-				r.result.Steps = append(r.result.Steps, sr)
-				r.result.FailedStep = failedStepName(step.Name, stepKey)
-				return wrapped
-			}
-			sr.Outputs = extracted
-			if strings.TrimSpace(step.Name) != "" {
-				r.outputs[step.Name] = cloneStringMap(extracted)
-				r.result.Outputs = cloneNestedStringMap(r.outputs)
-			}
-		}
-
-		sr.Status = "ok"
-		sr.DurationMS = time.Since(stepStart).Milliseconds()
-		r.result.Steps = append(r.result.Steps, sr)
-
-		if err := r.persistStep(stepKey, sr); err != nil {
-			r.result.FailedStep = failedStepName(step.Name, stepKey)
 			return err
 		}
+
+		sr.DurationMS = time.Since(stepStart).Milliseconds()
+		r.result.Steps = append(r.result.Steps, sr)
 	}
 	return nil
 }
 
 func (r *runner) persistStep(stepKey string, sr StepResult) error {
-	if r.state == nil || sr.Status != "ok" {
+	if r.state == nil {
 		return nil
 	}
 	r.state.Steps[stepKey] = persistedStepState{
 		Name:           sr.Name,
 		Workflow:       sr.Workflow,
 		ParentWorkflow: sr.ParentWorkflow,
-		Status:         "ok",
+		Status:         sr.Status,
+		FailureReason:  sr.FailureReason,
+		Error:          sr.Error,
+		Attempts:       cloneAttemptResults(sr.Attempts),
 		Outputs:        cloneStringMap(sr.Outputs),
 	}
 	return saveRunState(r.statePath, *r.state)
+}
+
+func cloneAttemptResults(in []AttemptResult) []AttemptResult {
+	if len(in) == 0 {
+		return nil
+	}
+	return slices.Clone(in)
 }
 
 func (r *runner) finishSuccess() error {

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -73,19 +73,21 @@ type ResumeInfo struct {
 
 // RunResult is the structured output of a workflow execution.
 type RunResult struct {
-	Workflow    string                       `json:"workflow"`
-	Status      string                       `json:"status"`
-	Error       string                       `json:"error,omitempty"`
-	FailedStep  string                       `json:"failed_step,omitempty"`
-	Recoverable bool                         `json:"recoverable,omitempty"`
-	RunID       string                       `json:"run_id,omitempty"`
-	RunFile     string                       `json:"run_file,omitempty"`
-	Resumed     bool                         `json:"resumed,omitempty"`
-	Resume      *ResumeInfo                  `json:"resume,omitempty"`
-	Outputs     map[string]map[string]string `json:"outputs,omitempty"`
-	Hooks       *HooksResult                 `json:"hooks,omitempty"`
-	Steps       []StepResult                 `json:"steps"`
-	DurationMS  int64                        `json:"duration_ms"`
+	Workflow       string                       `json:"workflow"`
+	Status         string                       `json:"status"`
+	Error          string                       `json:"error,omitempty"`
+	FailedStep     string                       `json:"failed_step,omitempty"`
+	Recoverable    bool                         `json:"recoverable,omitempty"`
+	Terminal       bool                         `json:"terminal,omitempty"`
+	TerminalReason string                       `json:"terminal_reason,omitempty"`
+	RunID          string                       `json:"run_id,omitempty"`
+	RunFile        string                       `json:"run_file,omitempty"`
+	Resumed        bool                         `json:"resumed,omitempty"`
+	Resume         *ResumeInfo                  `json:"resume,omitempty"`
+	Outputs        map[string]map[string]string `json:"outputs,omitempty"`
+	Hooks          *HooksResult                 `json:"hooks,omitempty"`
+	Steps          []StepResult                 `json:"steps"`
+	DurationMS     int64                        `json:"duration_ms"`
 }
 
 type runner struct {
@@ -263,7 +265,10 @@ func newRunner(def *Definition, opts RunOptions, result *RunResult) (*runner, er
 }
 
 func (r *runner) validateResumeState(state *persistedRunState) error {
+	terminalReason := terminalReasonForState(state)
 	switch {
+	case terminalReason != "":
+		return fmt.Errorf("workflow: resume run %q cannot be resumed: %s", state.RunID, terminalReason)
 	case state.Workflow != r.opts.WorkflowName:
 		return fmt.Errorf("workflow: resume run %q belongs to workflow %q, not %q", state.RunID, state.Workflow, r.opts.WorkflowName)
 	case state.WorkflowFile != r.opts.WorkflowFile:
@@ -514,10 +519,24 @@ func (r *runner) markFailure(err error, failedStep string) {
 		r.result.FailedStep = failedStep
 	}
 
+	terminalReason := terminalReasonForState(r.state)
+	if terminalReason == "" {
+		terminalReason = terminalReasonForResult(r.result)
+	}
+	if terminalReason != "" {
+		r.result.Terminal = true
+		r.result.TerminalReason = terminalReason
+	}
+
 	if r.state == nil {
 		return
 	}
-	r.state.Status = "error"
+	if terminalReason != "" {
+		r.state.Status = "terminal"
+		r.state.TerminalReason = terminalReason
+	} else {
+		r.state.Status = "error"
+	}
 	r.state.FailedStep = r.result.FailedStep
 	_ = saveRunState(r.statePath, *r.state)
 
@@ -531,10 +550,58 @@ func (r *runner) hasRecoverableState() bool {
 	if r.state == nil {
 		return false
 	}
+	if r.result != nil && r.result.Terminal {
+		return false
+	}
+	if terminalReasonForState(r.state) != "" {
+		return false
+	}
 	if len(r.state.Steps) > 0 {
 		return true
 	}
 	return r.state.Hooks != nil && r.state.Hooks.BeforeAll != nil && r.state.Hooks.BeforeAll.Status == "ok"
+}
+
+func terminalReasonForResult(result *RunResult) string {
+	if result == nil {
+		return ""
+	}
+	for _, step := range result.Steps {
+		if step.FailureReason != "output_error" {
+			continue
+		}
+		label := strings.TrimSpace(step.Name)
+		if label == "" {
+			label = fmt.Sprintf("%d", step.Index)
+		}
+		return terminalOutputReason(label)
+	}
+	return ""
+}
+
+func terminalReasonForState(state *persistedRunState) string {
+	if state == nil {
+		return ""
+	}
+	if strings.TrimSpace(state.TerminalReason) != "" {
+		return state.TerminalReason
+	}
+	for _, stepKey := range slices.Sorted(maps.Keys(state.Steps)) {
+		step := state.Steps[stepKey]
+		if step.FailureReason != "output_error" {
+			continue
+		}
+		label := strings.TrimSpace(step.Name)
+		if label == "" {
+			label = stepKey
+		}
+		return terminalOutputReason(label)
+	}
+	return ""
+}
+
+func terminalOutputReason(label string) string {
+	return fmt.Sprintf("step %q command completed but output extraction failed; automatic resume is disabled to avoid repeating possible side effects", label)
 }
 
 func (r *runner) resumeCommand() string {

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -277,6 +277,8 @@ func (r *runner) validateResumeState(state *persistedRunState) error {
 		return fmt.Errorf("workflow: resume run %q does not match the current workflow definition", state.RunID)
 	case !maps.Equal(state.Params, r.opts.Params):
 		return fmt.Errorf("workflow: resume run %q does not match the current workflow parameters", state.RunID)
+	case !stateHasResumeCheckpoint(state):
+		return fmt.Errorf("workflow: resume run %q cannot be resumed: no successful checkpoint or retry-enabled failed step", state.RunID)
 	default:
 		return nil
 	}
@@ -477,7 +479,7 @@ func (r *runner) executeSteps(ctx context.Context, workflowName string, steps []
 	return nil
 }
 
-func (r *runner) persistStep(stepKey string, sr StepResult) error {
+func (r *runner) persistStep(stepKey string, sr StepResult, retryEnabled bool) error {
 	if r.state == nil {
 		return nil
 	}
@@ -488,6 +490,7 @@ func (r *runner) persistStep(stepKey string, sr StepResult) error {
 		Status:         sr.Status,
 		FailureReason:  sr.FailureReason,
 		Error:          sr.Error,
+		RetryEnabled:   retryEnabled,
 		Attempts:       cloneAttemptResults(sr.Attempts),
 		Outputs:        cloneStringMap(sr.Outputs),
 	}
@@ -569,10 +572,19 @@ func (r *runner) hasRecoverableState() bool {
 	if terminalReasonForState(r.state) != "" {
 		return false
 	}
-	if len(r.state.Steps) > 0 {
-		return true
+	return stateHasResumeCheckpoint(r.state)
+}
+
+func stateHasResumeCheckpoint(state *persistedRunState) bool {
+	if state == nil {
+		return false
 	}
-	return r.state.Hooks != nil && r.state.Hooks.BeforeAll != nil && r.state.Hooks.BeforeAll.Status == "ok"
+	for _, step := range state.Steps {
+		if step.Status == "ok" || step.RetryEnabled {
+			return true
+		}
+	}
+	return state.Hooks != nil && state.Hooks.BeforeAll != nil && state.Hooks.BeforeAll.Status == "ok"
 }
 
 func terminalReasonForResult(result *RunResult) string {

--- a/internal/workflow/process_tree_unix.go
+++ b/internal/workflow/process_tree_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package workflow
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureProcessTree(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/internal/workflow/process_tree_unix_test.go
+++ b/internal/workflow/process_tree_unix_test.go
@@ -1,0 +1,61 @@
+//go:build !windows
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRun_TimeoutTerminatesProcessTree(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := dir + "/child.pid"
+	def, _ := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+		"env": {"PID_PATH": %q},
+		"workflows": {
+			"main": {"steps": [{
+				"name": "tree",
+				"run": "sleep 10 & child=$!; printf '%%s' \"$child\" > \"$PID_PATH\"; wait \"$child\"",
+				"timeout": "50ms"
+			}]}
+		}
+	}`, pidPath))
+
+	result, err := Run(context.Background(), def, runOpts("main"))
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if result.Steps[0].FailureReason != "timeout" {
+		t.Fatalf("step = %+v", result.Steps[0])
+	}
+	data, readErr := os.ReadFile(pidPath)
+	if readErr != nil {
+		t.Fatalf("read child pid: %v", readErr)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+	if parseErr != nil {
+		t.Fatalf("parse child pid %q: %v", data, parseErr)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		killErr := syscall.Kill(pid, 0)
+		if errors.Is(killErr, syscall.ESRCH) {
+			break
+		}
+		if killErr != nil {
+			t.Fatalf("probe child process %d: %v", pid, killErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child process %d survived timeout", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/workflow/process_tree_unix_test.go
+++ b/internal/workflow/process_tree_unix_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func TestRun_TimeoutTerminatesProcessTree(t *testing.T) {
+func TestRun_CancellationTerminatesProcessTree(t *testing.T) {
 	dir := t.TempDir()
 	pidPath := dir + "/child.pid"
 	def, _ := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
@@ -23,16 +23,41 @@ func TestRun_TimeoutTerminatesProcessTree(t *testing.T) {
 			"main": {"steps": [{
 				"name": "tree",
 				"run": "sleep 10 & child=$!; printf '%%s' \"$child\" > \"$PID_PATH\"; wait \"$child\"",
-				"timeout": "50ms"
+				"timeout": "1h"
 			}]}
 		}
 	}`, pidPath))
 
-	result, err := Run(context.Background(), def, runOpts("main"))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pidReady := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(5 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			data, readErr := os.ReadFile(pidPath)
+			if readErr == nil && strings.TrimSpace(string(data)) != "" {
+				pidReady <- nil
+				cancel()
+				return
+			}
+			select {
+			case <-ctx.Done():
+				pidReady <- fmt.Errorf("wait for child pid: %w", ctx.Err())
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	result, err := Run(ctx, def, runOpts("main"))
 	if err == nil {
-		t.Fatal("expected timeout")
+		t.Fatal("expected cancellation")
 	}
-	if result.Steps[0].FailureReason != "timeout" {
+	if readyErr := <-pidReady; readyErr != nil {
+		t.Fatal(readyErr)
+	}
+	if result.Steps[0].FailureReason != "canceled" {
 		t.Fatalf("step = %+v", result.Steps[0])
 	}
 	data, readErr := os.ReadFile(pidPath)

--- a/internal/workflow/process_tree_windows.go
+++ b/internal/workflow/process_tree_windows.go
@@ -3,12 +3,16 @@
 package workflow
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
 	"strconv"
 	"syscall"
+	"time"
 )
+
+const taskkillTimeout = 5 * time.Second
 
 func configureProcessTree(command *exec.Cmd) {
 	command.SysProcAttr = &syscall.SysProcAttr{
@@ -20,7 +24,9 @@ func configureProcessTree(command *exec.Cmd) {
 			return os.ErrProcessDone
 		}
 
-		killer := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid))
+		ctx, cancel := context.WithTimeout(context.Background(), taskkillTimeout)
+		defer cancel()
+		killer := exec.CommandContext(ctx, "taskkill", "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid))
 		killer.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 		if err := killer.Run(); err == nil {
 			return nil

--- a/internal/workflow/process_tree_windows.go
+++ b/internal/workflow/process_tree_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package workflow
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+func configureProcessTree(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		HideWindow:    true,
+	}
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return os.ErrProcessDone
+		}
+
+		killer := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid))
+		killer.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+		if err := killer.Run(); err == nil {
+			return nil
+		}
+		if err := command.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return err
+		}
+		return nil
+	}
+}

--- a/internal/workflow/process_tree_windows.go
+++ b/internal/workflow/process_tree_windows.go
@@ -14,6 +14,17 @@ import (
 
 const taskkillTimeout = 5 * time.Second
 
+type taskkillProcess interface {
+	Start() error
+	Wait() error
+}
+
+var newTaskkillProcessFn = func(ctx context.Context, pid int) taskkillProcess {
+	killer := exec.CommandContext(ctx, "taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
+	killer.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return killer
+}
+
 func configureProcessTree(command *exec.Cmd) {
 	command.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
@@ -25,15 +36,24 @@ func configureProcessTree(command *exec.Cmd) {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), taskkillTimeout)
-		defer cancel()
-		killer := exec.CommandContext(ctx, "taskkill", "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid))
-		killer.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-		if err := killer.Run(); err == nil {
-			return nil
+		killer := newTaskkillProcessFn(ctx, command.Process.Pid)
+		if err := killer.Start(); err != nil {
+			cancel()
+			return killCommandProcess(command)
 		}
-		if err := command.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-			return err
-		}
+		go func() {
+			defer cancel()
+			if err := killer.Wait(); err != nil {
+				_ = killCommandProcess(command)
+			}
+		}()
 		return nil
 	}
+}
+
+func killCommandProcess(command *exec.Cmd) error {
+	if err := command.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
 }

--- a/internal/workflow/process_tree_windows_test.go
+++ b/internal/workflow/process_tree_windows_test.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package workflow
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestConfigureProcessTreeWindows(t *testing.T) {
+	command := exec.Command("cmd", "/c", "exit 0")
+	configureProcessTree(command)
+	if command.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil")
+	}
+	if command.SysProcAttr.CreationFlags&syscall.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Fatalf("CreationFlags = %#x, want CREATE_NEW_PROCESS_GROUP", command.SysProcAttr.CreationFlags)
+	}
+	if !command.SysProcAttr.HideWindow {
+		t.Fatal("HideWindow = false, want true")
+	}
+	if command.Cancel == nil {
+		t.Fatal("Cancel is nil")
+	}
+}

--- a/internal/workflow/process_tree_windows_test.go
+++ b/internal/workflow/process_tree_windows_test.go
@@ -3,10 +3,27 @@
 package workflow
 
 import (
+	"context"
+	"os"
 	"os/exec"
+	"sync"
 	"syscall"
 	"testing"
+	"time"
 )
+
+type blockingTaskkillProcess struct {
+	release <-chan struct{}
+}
+
+func (p *blockingTaskkillProcess) Start() error {
+	return nil
+}
+
+func (p *blockingTaskkillProcess) Wait() error {
+	<-p.release
+	return nil
+}
 
 func TestConfigureProcessTreeWindows(t *testing.T) {
 	command := exec.Command("cmd", "/c", "exit 0")
@@ -23,4 +40,55 @@ func TestConfigureProcessTreeWindows(t *testing.T) {
 	if command.Cancel == nil {
 		t.Fatal("Cancel is nil")
 	}
+}
+
+func TestConfigureProcessTreeWindowsCancelReturnsPromptly(t *testing.T) {
+	originalNewTaskkillProcessFn := newTaskkillProcessFn
+	t.Cleanup(func() {
+		newTaskkillProcessFn = originalNewTaskkillProcessFn
+	})
+
+	releaseTaskkill := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseTaskkill) })
+	}
+	t.Cleanup(release)
+	newTaskkillProcessFn = func(_ context.Context, _ int) taskkillProcess {
+		return &blockingTaskkillProcess{release: releaseTaskkill}
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=TestProcessTreeWindowsBlockingHelper")
+	command.Env = append(os.Environ(), "ASC_TEST_BLOCK_PROCESS=1")
+	configureProcessTree(command)
+	if err := command.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	})
+
+	cancelResult := make(chan error, 1)
+	go func() {
+		cancelResult <- command.Cancel()
+	}()
+	select {
+	case err := <-cancelResult:
+		if err != nil {
+			t.Fatalf("Cancel: %v", err)
+		}
+	case <-time.After(time.Second):
+		release()
+		<-cancelResult
+		t.Fatal("Cancel blocked on taskkill Wait")
+	}
+	release()
+}
+
+func TestProcessTreeWindowsBlockingHelper(t *testing.T) {
+	if os.Getenv("ASC_TEST_BLOCK_PROCESS") == "" {
+		return
+	}
+	time.Sleep(30 * time.Second)
 }

--- a/internal/workflow/retry.go
+++ b/internal/workflow/retry.go
@@ -106,7 +106,7 @@ func (r *runner) executeRunStep(
 					sr.Status = "error"
 					sr.FailureReason = "output_error"
 					sr.Error = extractErr.Error()
-					if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+					if persistErr := r.persistStep(stepKey, *sr, step.Retry != nil); persistErr != nil {
 						return persistErr
 					}
 					return fmt.Errorf("workflow: %s step %d: %w", workflowName, idx, extractErr)
@@ -129,7 +129,7 @@ func (r *runner) executeRunStep(
 			sr.Status = "ok"
 			sr.FailureReason = ""
 			sr.Error = ""
-			return r.persistStep(stepKey, *sr)
+			return r.persistStep(stepKey, *sr, step.Retry != nil)
 		}
 
 		failureReason, attemptError := classifyAttemptFailure(ctx, attemptContextErr, runErr, policy.timeout)
@@ -152,7 +152,7 @@ func (r *runner) executeRunStep(
 
 		if failureReason == "canceled" || attempt == policy.maxAttempts {
 			if recordAttempts {
-				if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+				if persistErr := r.persistStep(stepKey, *sr, step.Retry != nil); persistErr != nil {
 					return persistErr
 				}
 			}
@@ -160,7 +160,7 @@ func (r *runner) executeRunStep(
 		}
 
 		sr.Status = "retrying"
-		if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+		if persistErr := r.persistStep(stepKey, *sr, step.Retry != nil); persistErr != nil {
 			return persistErr
 		}
 		fmt.Fprintf(
@@ -176,7 +176,7 @@ func (r *runner) executeRunStep(
 			sr.Status = "error"
 			sr.FailureReason = "canceled"
 			sr.Error = "step canceled during retry delay: " + waitErr.Error()
-			if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+			if persistErr := r.persistStep(stepKey, *sr, step.Retry != nil); persistErr != nil {
 				return persistErr
 			}
 			return fmt.Errorf("workflow: %s step %d: %s", workflowName, idx, sr.Error)

--- a/internal/workflow/retry.go
+++ b/internal/workflow/retry.go
@@ -95,23 +95,19 @@ func (r *runner) executeRunStep(
 			if len(step.Outputs) > 0 {
 				extracted, extractErr := extractDeclaredOutputs(step.Outputs, captured.Bytes())
 				if extractErr != nil {
-					if recordAttempts {
-						sr.Attempts = append(sr.Attempts, AttemptResult{
-							Invocation:    invocation,
-							Attempt:       attempt,
-							Status:        "error",
-							DurationMS:    attemptDuration,
-							FailureReason: "output_error",
-							Error:         extractErr.Error(),
-						})
-					}
+					sr.Attempts = append(sr.Attempts, AttemptResult{
+						Invocation:    invocation,
+						Attempt:       attempt,
+						Status:        "error",
+						DurationMS:    attemptDuration,
+						FailureReason: "output_error",
+						Error:         extractErr.Error(),
+					})
 					sr.Status = "error"
 					sr.FailureReason = "output_error"
 					sr.Error = extractErr.Error()
-					if recordAttempts {
-						if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
-							return persistErr
-						}
+					if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+						return persistErr
 					}
 					return fmt.Errorf("workflow: %s step %d: %w", workflowName, idx, extractErr)
 				}

--- a/internal/workflow/retry.go
+++ b/internal/workflow/retry.go
@@ -1,0 +1,228 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type stepExecutionPolicy struct {
+	maxAttempts int
+	delay       time.Duration
+	timeout     time.Duration
+	configured  bool
+}
+
+func executionPolicyForStep(step Step) (stepExecutionPolicy, error) {
+	policy := stepExecutionPolicy{maxAttempts: 1}
+	if step.Retry != nil {
+		if step.Retry.MaxAttempts < minRetryAttempts || step.Retry.MaxAttempts > maxRetryAttempts {
+			return policy, fmt.Errorf("retry.max_attempts must be between %d and %d", minRetryAttempts, maxRetryAttempts)
+		}
+		delay, err := parsePositivePolicyDuration(step.Retry.Delay)
+		if err != nil {
+			return policy, fmt.Errorf("retry.delay: %w", err)
+		}
+		policy.maxAttempts = step.Retry.MaxAttempts
+		policy.delay = delay
+		policy.configured = true
+	}
+	if step.Timeout != nil {
+		timeout, err := parsePositivePolicyDuration(*step.Timeout)
+		if err != nil {
+			return policy, fmt.Errorf("timeout: %w", err)
+		}
+		policy.timeout = timeout
+		policy.configured = true
+	}
+	return policy, nil
+}
+
+func (r *runner) executeRunStep(
+	ctx context.Context,
+	workflowName string,
+	idx int,
+	stepKey string,
+	step Step,
+	command string,
+	env map[string]string,
+	sr *StepResult,
+) error {
+	policy, err := executionPolicyForStep(step)
+	if err != nil {
+		sr.Status = "error"
+		sr.FailureReason = "invalid_policy"
+		sr.Error = err.Error()
+		return fmt.Errorf("workflow: %s step %d: %w", workflowName, idx, err)
+	}
+
+	if r.state != nil {
+		if persisted, ok := r.state.Steps[stepKey]; ok && persisted.Status != "ok" {
+			sr.Attempts = cloneAttemptResults(persisted.Attempts)
+		}
+	}
+	invocation := nextAttemptInvocation(sr.Attempts)
+	recordAttempts := policy.configured || len(sr.Attempts) > 0
+	label := failedStepName(step.Name, stepKey)
+
+	for attempt := 1; attempt <= policy.maxAttempts; attempt++ {
+		if recordAttempts {
+			fmt.Fprintf(r.opts.Stderr, "[workflow] step %s: attempt %d/%d\n", label, attempt, policy.maxAttempts)
+		}
+
+		stdout := r.opts.Stdout
+		var captured bytes.Buffer
+		if len(step.Outputs) > 0 {
+			stdout = io.MultiWriter(r.opts.Stdout, &captured)
+		}
+
+		attemptCtx := ctx
+		cancel := func() {}
+		if policy.timeout > 0 {
+			attemptCtx, cancel = context.WithTimeout(ctx, policy.timeout)
+		}
+		attemptStart := time.Now()
+		runErr := runShellCommand(attemptCtx, command, env, stdout, r.opts.Stderr)
+		attemptDuration := time.Since(attemptStart).Milliseconds()
+		attemptContextErr := attemptCtx.Err()
+		cancel()
+
+		if runErr == nil {
+			if len(step.Outputs) > 0 {
+				extracted, extractErr := extractDeclaredOutputs(step.Outputs, captured.Bytes())
+				if extractErr != nil {
+					if recordAttempts {
+						sr.Attempts = append(sr.Attempts, AttemptResult{
+							Invocation:    invocation,
+							Attempt:       attempt,
+							Status:        "error",
+							DurationMS:    attemptDuration,
+							FailureReason: "output_error",
+							Error:         extractErr.Error(),
+						})
+					}
+					sr.Status = "error"
+					sr.FailureReason = "output_error"
+					sr.Error = extractErr.Error()
+					if recordAttempts {
+						if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+							return persistErr
+						}
+					}
+					return fmt.Errorf("workflow: %s step %d: %w", workflowName, idx, extractErr)
+				}
+				sr.Outputs = extracted
+				if strings.TrimSpace(step.Name) != "" {
+					r.outputs[step.Name] = cloneStringMap(extracted)
+					r.result.Outputs = cloneNestedStringMap(r.outputs)
+				}
+			}
+
+			if recordAttempts {
+				sr.Attempts = append(sr.Attempts, AttemptResult{
+					Invocation: invocation,
+					Attempt:    attempt,
+					Status:     "ok",
+					DurationMS: attemptDuration,
+				})
+			}
+			sr.Status = "ok"
+			sr.FailureReason = ""
+			sr.Error = ""
+			return r.persistStep(stepKey, *sr)
+		}
+
+		failureReason, attemptError := classifyAttemptFailure(ctx, attemptContextErr, runErr, policy.timeout)
+		if recordAttempts {
+			sr.Attempts = append(sr.Attempts, AttemptResult{
+				Invocation:    invocation,
+				Attempt:       attempt,
+				Status:        attemptStatus(failureReason),
+				DurationMS:    attemptDuration,
+				FailureReason: failureReason,
+				Error:         attemptError,
+			})
+		}
+		sr.Status = "error"
+		sr.FailureReason = failureReason
+		sr.Error = attemptError
+
+		if failureReason == "canceled" || attempt == policy.maxAttempts {
+			if recordAttempts {
+				if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+					return persistErr
+				}
+			}
+			return fmt.Errorf("workflow: %s step %d: %s", workflowName, idx, attemptError)
+		}
+
+		sr.Status = "retrying"
+		if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+			return persistErr
+		}
+		fmt.Fprintf(
+			r.opts.Stderr,
+			"[workflow] step %s: attempt %d/%d failed (%s); retrying in %s\n",
+			label,
+			attempt,
+			policy.maxAttempts,
+			failureReason,
+			policy.delay,
+		)
+		if waitErr := waitForRetry(ctx, policy.delay); waitErr != nil {
+			sr.Status = "error"
+			sr.FailureReason = "canceled"
+			sr.Error = "step canceled during retry delay: " + waitErr.Error()
+			if persistErr := r.persistStep(stepKey, *sr); persistErr != nil {
+				return persistErr
+			}
+			return fmt.Errorf("workflow: %s step %d: %s", workflowName, idx, sr.Error)
+		}
+	}
+
+	return fmt.Errorf("workflow: %s step %d: retry policy exhausted", workflowName, idx)
+}
+
+func nextAttemptInvocation(attempts []AttemptResult) int {
+	invocation := 1
+	for _, attempt := range attempts {
+		if attempt.Invocation >= invocation {
+			invocation = attempt.Invocation + 1
+		}
+	}
+	return invocation
+}
+
+func classifyAttemptFailure(ctx context.Context, attemptContextErr, runErr error, timeout time.Duration) (string, string) {
+	if ctx.Err() != nil {
+		return "canceled", "step canceled: " + ctx.Err().Error()
+	}
+	if errors.Is(attemptContextErr, context.DeadlineExceeded) {
+		return "timeout", "step timed out after " + timeout.String()
+	}
+	return "command_failed", runErr.Error()
+}
+
+func attemptStatus(failureReason string) string {
+	switch failureReason {
+	case "timeout", "canceled":
+		return failureReason
+	default:
+		return "error"
+	}
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/workflow/retry.go
+++ b/internal/workflow/retry.go
@@ -146,6 +146,9 @@ func (r *runner) executeRunStep(
 		sr.Status = "error"
 		sr.FailureReason = failureReason
 		sr.Error = attemptError
+		if failureReason == "timeout" && step.Retry == nil {
+			r.setTerminalReason(terminalTimeoutReason(label))
+		}
 
 		if failureReason == "canceled" || attempt == policy.maxAttempts {
 			if recordAttempts {

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -8,9 +8,25 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+type retrySignalWriter struct {
+	bytes.Buffer
+	needle string
+	ready  chan struct{}
+	once   sync.Once
+}
+
+func (w *retrySignalWriter) Write(p []byte) (int, error) {
+	n, err := w.Buffer.Write(p)
+	if strings.Contains(w.String(), w.needle) {
+		w.once.Do(func() { close(w.ready) })
+	}
+	return n, err
+}
 
 func loadWorkflowForRetryTest(t *testing.T, content string) (*Definition, string) {
 	t.Helper()
@@ -246,11 +262,29 @@ func TestRun_CancellationStopsDuringRetryDelay(t *testing.T) {
 		}
 	}`, counterPath))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	stderr := &retrySignalWriter{
+		needle: "retrying in 1h0m0s",
+		ready:  make(chan struct{}),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	result, err := Run(ctx, def, runOpts("main"))
+	go func() {
+		select {
+		case <-stderr.ready:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	opts := runOpts("main")
+	opts.Stderr = stderr
+	result, err := Run(ctx, def, opts)
 	if err == nil {
 		t.Fatal("expected cancellation")
+	}
+	select {
+	case <-stderr.ready:
+	default:
+		t.Fatalf("runner never entered retry delay; stderr = %q", stderr.String())
 	}
 	step := result.Steps[0]
 	if step.FailureReason != "canceled" || len(step.Attempts) != 1 {

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -287,6 +287,7 @@ func TestRun_CancellationStopsRunningAttempt(t *testing.T) {
 func TestRun_OutputExtractionFailureIsNotRetried(t *testing.T) {
 	dir := t.TempDir()
 	counterPath := filepath.Join(dir, "counter")
+	workflowPath := filepath.Join(dir, "workflow.json")
 	def, _ := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
 		"env": {"COUNTER_PATH": %q},
 		"workflows": {
@@ -299,7 +300,10 @@ func TestRun_OutputExtractionFailureIsNotRetried(t *testing.T) {
 		}
 	}`, counterPath))
 
-	result, err := Run(context.Background(), def, runOpts("main"))
+	opts := runOpts("main")
+	opts.WorkflowFile = workflowPath
+	opts.StateDir = filepath.Join(dir, "runs")
+	result, err := Run(context.Background(), def, opts)
 	if err == nil {
 		t.Fatal("expected output extraction failure")
 	}
@@ -309,6 +313,94 @@ func TestRun_OutputExtractionFailureIsNotRetried(t *testing.T) {
 	}
 	if got := readFileOrEmpty(t, counterPath); got != "x" {
 		t.Fatalf("successful command was retried after output failure: %q", got)
+	}
+	if !result.Terminal || result.TerminalReason == "" {
+		t.Fatalf("output failure result must be terminal: %+v", result)
+	}
+	if result.Recoverable || result.Resume != nil {
+		t.Fatalf("output failure must not expose automatic resume: %+v", result)
+	}
+
+	state, loadErr := loadRunState(result.RunFile)
+	if loadErr != nil {
+		t.Fatalf("loadRunState: %v", loadErr)
+	}
+	if state.Status != "terminal" || state.TerminalReason == "" {
+		t.Fatalf("output failure state must be terminal: %+v", state)
+	}
+	if got := state.Steps["main[1]"].FailureReason; got != "output_error" {
+		t.Fatalf("persisted failure reason = %q, want output_error", got)
+	}
+
+	resumeOpts := runOpts("main")
+	resumeOpts.WorkflowFile = workflowPath
+	resumeOpts.StateDir = opts.StateDir
+	resumeOpts.ResumeRunID = result.RunID
+	resumeResult, resumeErr := Run(context.Background(), def, resumeOpts)
+	if resumeErr == nil {
+		t.Fatal("expected terminal run resume to fail")
+	}
+	if !strings.Contains(resumeErr.Error(), "cannot be resumed") || !strings.Contains(resumeErr.Error(), "output extraction failed") {
+		t.Fatalf("resume error = %q, want terminal output diagnostic", resumeErr)
+	}
+	if resumeResult == nil || resumeResult.Status != "error" {
+		t.Fatalf("resume result = %+v, want structured error", resumeResult)
+	}
+	if got := readFileOrEmpty(t, counterPath); got != "x" {
+		t.Fatalf("resume reran command after output failure: %q", got)
+	}
+}
+
+func TestRun_OutputExtractionFailureWithoutPolicyIsTerminal(t *testing.T) {
+	dir := t.TempDir()
+	counterPath := filepath.Join(dir, "counter")
+	workflowPath := filepath.Join(dir, "workflow.json")
+	def := &Definition{Workflows: map[string]Workflow{
+		"main": {Steps: []Step{{
+			Name:    "ambiguous_mutation",
+			Run:     fmt.Sprintf("printf x >> %q; printf not-json", counterPath),
+			Outputs: map[string]string{"VALUE": "$.value"},
+		}}},
+	}}
+	opts := runOpts("main")
+	opts.WorkflowFile = workflowPath
+	opts.StateDir = filepath.Join(dir, "runs")
+	result, err := Run(context.Background(), def, opts)
+	if err == nil || !result.Terminal || result.Recoverable || result.Resume != nil {
+		t.Fatalf("output failure result = %+v, err = %v", result, err)
+	}
+	state, loadErr := loadRunState(result.RunFile)
+	if loadErr != nil || state.Status != "terminal" || state.Steps["main[1]"].FailureReason != "output_error" {
+		t.Fatalf("output failure state = %+v, err = %v", state, loadErr)
+	}
+
+	resumeOpts := runOpts("main")
+	resumeOpts.WorkflowFile = workflowPath
+	resumeOpts.StateDir = opts.StateDir
+	resumeOpts.ResumeRunID = result.RunID
+	_, resumeErr := Run(context.Background(), def, resumeOpts)
+	if resumeErr == nil || !strings.Contains(resumeErr.Error(), "cannot be resumed") {
+		t.Fatalf("resume error = %v, want terminal diagnostic", resumeErr)
+	}
+	if got := readFileOrEmpty(t, counterPath); got != "x" {
+		t.Fatalf("resume reran command after output failure: %q", got)
+	}
+}
+
+func TestRun_OutputExtractionFailureWithoutStateIsTerminal(t *testing.T) {
+	def := &Definition{Workflows: map[string]Workflow{
+		"main": {Steps: []Step{{
+			Name:    "invalid_output",
+			Run:     "printf not-json",
+			Outputs: map[string]string{"VALUE": "$.value"},
+		}}},
+	}}
+	result, err := Run(context.Background(), def, runOpts("main"))
+	if err == nil || !result.Terminal || result.TerminalReason == "" {
+		t.Fatalf("output failure result = %+v, err = %v", result, err)
+	}
+	if result.Recoverable || result.Resume != nil {
+		t.Fatalf("terminal output failure exposed resume: %+v", result)
 	}
 }
 

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -1,0 +1,427 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func loadWorkflowForRetryTest(t *testing.T, content string) (*Definition, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := writeWorkflowFile(t, dir, content)
+	def, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return def, path
+}
+
+func TestValidate_RetryAndTimeoutPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		stepJSON string
+		wantCode ValidationCode
+		wantPath string
+	}{
+		{"retry missing attempts", `{"run":"echo ok","retry":{"delay":"1s"}}`, "invalid_retry_max_attempts", "workflows.main.steps[0].retry.max_attempts"},
+		{"retry one attempt", `{"run":"echo ok","retry":{"max_attempts":1,"delay":"1s"}}`, "invalid_retry_max_attempts", "workflows.main.steps[0].retry.max_attempts"},
+		{"retry too many attempts", `{"run":"echo ok","retry":{"max_attempts":101,"delay":"1s"}}`, "invalid_retry_max_attempts", "workflows.main.steps[0].retry.max_attempts"},
+		{"retry missing delay", `{"run":"echo ok","retry":{"max_attempts":2}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
+		{"retry zero delay", `{"run":"echo ok","retry":{"max_attempts":2,"delay":"0s"}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
+		{"retry negative delay", `{"run":"echo ok","retry":{"max_attempts":2,"delay":"-1s"}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
+		{"retry invalid delay", `{"run":"echo ok","retry":{"max_attempts":2,"delay":"later"}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
+		{"retry excessive delay", `{"run":"echo ok","retry":{"max_attempts":2,"delay":"24h1s"}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
+		{"zero timeout", `{"run":"echo ok","timeout":"0s"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
+		{"negative timeout", `{"run":"echo ok","timeout":"-1s"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
+		{"invalid timeout", `{"run":"echo ok","timeout":"forever"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
+		{"excessive timeout", `{"run":"echo ok","timeout":"24h1s"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
+		{"empty timeout", `{"run":"echo ok","timeout":""}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
+		{"retry on workflow", `{"workflow":"child","retry":{"max_attempts":2,"delay":"1s"}}`, "step_retry_on_workflow", "workflows.main.steps[0].retry"},
+		{"timeout on workflow", `{"workflow":"child","timeout":"1s"}`, "step_timeout_on_workflow", "workflows.main.steps[0].timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeWorkflowFile(t, dir, fmt.Sprintf(`{
+				"workflows": {
+					"main": {"steps": [%s]},
+					"child": {"steps": ["echo child"]}
+				}
+			}`, tt.stepJSON))
+			def, err := LoadUnvalidated(path)
+			if err != nil {
+				t.Fatalf("LoadUnvalidated: %v", err)
+			}
+			errs := Validate(def)
+			var got *ValidationError
+			for _, validationErr := range errs {
+				if validationErr.Code == tt.wantCode {
+					got = validationErr
+					break
+				}
+			}
+			if got == nil {
+				t.Fatalf("validation errors = %+v, want code %q", errs, tt.wantCode)
+			}
+			if got.Path != tt.wantPath {
+				t.Fatalf("path = %q, want %q", got.Path, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestRun_RetryEventuallySucceedsAndCapturesOnlySuccessfulOutput(t *testing.T) {
+	dir := t.TempDir()
+	counterPath := filepath.Join(dir, "counter")
+	def, workflowPath := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+		"env": {"COUNTER_PATH": %q},
+		"workflows": {
+			"main": {
+				"steps": [{
+					"name": "eventual",
+					"run": "count=$(cat \"$COUNTER_PATH\" 2>/dev/null || echo 0); count=$((count+1)); printf '%%s' \"$count\" > \"$COUNTER_PATH\"; if [ \"$count\" -lt 3 ]; then printf '{\\\"value\\\":\\\"stale\\\"}'; exit 42; fi; printf '{\\\"value\\\":\\\"fresh\\\"}'",
+					"retry": {"max_attempts": 3, "delay": "1ms"},
+					"timeout": "2s",
+					"outputs": {"VALUE": "$.value"}
+				}]
+			}
+		}
+	}`, counterPath))
+
+	opts := runOpts("main")
+	opts.WorkflowFile = workflowPath
+	opts.StateDir = filepath.Join(dir, "runs")
+	result, err := Run(context.Background(), def, opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	step := result.Steps[0]
+	if step.Status != "ok" || len(step.Attempts) != 3 {
+		t.Fatalf("step = %+v, want three attempts and ok", step)
+	}
+	wantStatuses := []string{"error", "error", "ok"}
+	for i, want := range wantStatuses {
+		if step.Attempts[i].Attempt != i+1 || step.Attempts[i].Invocation != 1 || step.Attempts[i].Status != want {
+			t.Fatalf("attempt %d = %+v, want invocation=1 attempt=%d status=%s", i, step.Attempts[i], i+1, want)
+		}
+	}
+	if got := result.Outputs["eventual"]["VALUE"]; got != "fresh" {
+		t.Fatalf("captured output = %q, want fresh", got)
+	}
+	stderr := opts.Stderr.(*bytes.Buffer).String()
+	if !strings.Contains(stderr, "attempt 1/3") || !strings.Contains(stderr, "retrying in 1ms") {
+		t.Fatalf("stderr retry diagnostics = %q", stderr)
+	}
+
+	state, err := loadRunState(result.RunFile)
+	if err != nil {
+		t.Fatalf("loadRunState: %v", err)
+	}
+	persisted := state.Steps["main[1]"]
+	if persisted.Status != "ok" || len(persisted.Attempts) != 3 || persisted.Outputs["VALUE"] != "fresh" {
+		t.Fatalf("persisted step = %+v", persisted)
+	}
+}
+
+func TestRun_RetryExhaustionRunsErrorHookOnce(t *testing.T) {
+	dir := t.TempDir()
+	counterPath := filepath.Join(dir, "counter")
+	errorHookPath := filepath.Join(dir, "error-hook")
+	afterHookPath := filepath.Join(dir, "after-hook")
+	def, workflowPath := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+		"env": {
+			"COUNTER_PATH": %q,
+			"ERROR_HOOK_PATH": %q,
+			"AFTER_HOOK_PATH": %q
+		},
+		"error": "printf error >> \"$ERROR_HOOK_PATH\"",
+		"after_all": "printf after >> \"$AFTER_HOOK_PATH\"",
+		"workflows": {
+			"main": {"steps": [{
+				"name": "exhausted",
+				"run": "printf x >> \"$COUNTER_PATH\"; exit 7",
+				"retry": {"max_attempts": 3, "delay": "1ms"}
+			}]}
+		}
+	}`, counterPath, errorHookPath, afterHookPath))
+
+	opts := runOpts("main")
+	opts.WorkflowFile = workflowPath
+	opts.StateDir = filepath.Join(dir, "runs")
+	result, err := Run(context.Background(), def, opts)
+	if err == nil {
+		t.Fatal("expected retry exhaustion")
+	}
+	step := result.Steps[0]
+	if step.Status != "error" || step.FailureReason != "command_failed" || len(step.Attempts) != 3 {
+		t.Fatalf("step = %+v", step)
+	}
+	if !result.Recoverable || result.Resume == nil || strings.TrimSpace(result.Resume.Command) == "" {
+		t.Fatalf("exhausted configured step must be resumable, got %+v", result.Resume)
+	}
+	if got := readFileOrEmpty(t, counterPath); got != "xxx" {
+		t.Fatalf("attempt side effects = %q, want xxx", got)
+	}
+	if got := readFileOrEmpty(t, errorHookPath); got != "error" {
+		t.Fatalf("error hook output = %q, want one execution", got)
+	}
+	if _, statErr := os.Stat(afterHookPath); !os.IsNotExist(statErr) {
+		t.Fatalf("after_all must not run after exhaustion; stat error = %v", statErr)
+	}
+}
+
+func TestRun_FirstFailureWithoutPolicyKeepsExistingRecoveryBehavior(t *testing.T) {
+	dir := t.TempDir()
+	def := &Definition{
+		Workflows: map[string]Workflow{
+			"main": {Steps: []Step{{Name: "plain", Run: "exit 9"}}},
+		},
+	}
+	opts := runOpts("main")
+	opts.WorkflowFile = filepath.Join(dir, "workflow.json")
+	opts.StateDir = filepath.Join(dir, "runs")
+	result, err := Run(context.Background(), def, opts)
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if result.Recoverable || result.Resume != nil {
+		t.Fatalf("unconfigured first-step failure unexpectedly became recoverable: %+v", result)
+	}
+	state, loadErr := loadRunState(result.RunFile)
+	if loadErr != nil {
+		t.Fatalf("loadRunState: %v", loadErr)
+	}
+	if len(state.Steps) != 0 {
+		t.Fatalf("unconfigured failed step was persisted: %+v", state.Steps)
+	}
+}
+
+func TestRun_TimeoutHasStableStructuredFailure(t *testing.T) {
+	def, _ := loadWorkflowForRetryTest(t, `{
+		"workflows": {
+			"main": {"steps": [{
+				"name": "bounded",
+				"run": "sleep 10",
+				"timeout": "25ms"
+			}]}
+		}
+	}`)
+
+	start := time.Now()
+	result, err := Run(context.Background(), def, runOpts("main"))
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("timeout did not stop promptly: %s", time.Since(start))
+	}
+	step := result.Steps[0]
+	if step.Status != "error" || step.FailureReason != "timeout" || len(step.Attempts) != 1 {
+		t.Fatalf("step = %+v", step)
+	}
+	if step.Attempts[0].Status != "timeout" || step.Attempts[0].Error != "step timed out after 25ms" {
+		t.Fatalf("attempt = %+v", step.Attempts[0])
+	}
+}
+
+func TestRun_CancellationStopsDuringRetryDelay(t *testing.T) {
+	dir := t.TempDir()
+	counterPath := filepath.Join(dir, "counter")
+	def, _ := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+		"env": {"COUNTER_PATH": %q},
+		"workflows": {
+			"main": {"steps": [{
+				"name": "cancelled",
+				"run": "printf x >> \"$COUNTER_PATH\"; exit 8",
+				"retry": {"max_attempts": 5, "delay": "1h"}
+			}]}
+		}
+	}`, counterPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	result, err := Run(ctx, def, runOpts("main"))
+	if err == nil {
+		t.Fatal("expected cancellation")
+	}
+	step := result.Steps[0]
+	if step.FailureReason != "canceled" || len(step.Attempts) != 1 {
+		t.Fatalf("step = %+v, want canceled after one attempt", step)
+	}
+	if got := readFileOrEmpty(t, counterPath); got != "x" {
+		t.Fatalf("attempt side effects = %q, want one attempt", got)
+	}
+}
+
+func TestRun_CancellationStopsRunningAttempt(t *testing.T) {
+	def, _ := loadWorkflowForRetryTest(t, `{
+		"workflows": {
+			"main": {"steps": [{
+				"name": "cancelled",
+				"run": "sleep 10",
+				"timeout": "1h"
+			}]}
+		}
+	}`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	result, err := Run(ctx, def, runOpts("main"))
+	if err == nil {
+		t.Fatal("expected cancellation")
+	}
+	step := result.Steps[0]
+	if step.FailureReason != "canceled" || len(step.Attempts) != 1 || step.Attempts[0].Status != "canceled" {
+		t.Fatalf("step = %+v, want one canceled attempt", step)
+	}
+}
+
+func TestRun_OutputExtractionFailureIsNotRetried(t *testing.T) {
+	dir := t.TempDir()
+	counterPath := filepath.Join(dir, "counter")
+	def, _ := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+		"env": {"COUNTER_PATH": %q},
+		"workflows": {
+			"main": {"steps": [{
+				"name": "ambiguous_mutation",
+				"run": "printf x >> \"$COUNTER_PATH\"; printf not-json",
+				"retry": {"max_attempts": 3, "delay": "1ms"},
+				"outputs": {"VALUE": "$.value"}
+			}]}
+		}
+	}`, counterPath))
+
+	result, err := Run(context.Background(), def, runOpts("main"))
+	if err == nil {
+		t.Fatal("expected output extraction failure")
+	}
+	step := result.Steps[0]
+	if step.FailureReason != "output_error" || len(step.Attempts) != 1 || step.Attempts[0].FailureReason != "output_error" {
+		t.Fatalf("step = %+v", step)
+	}
+	if got := readFileOrEmpty(t, counterPath); got != "x" {
+		t.Fatalf("successful command was retried after output failure: %q", got)
+	}
+}
+
+func TestRun_ResumeSkipsSuccessAndPreservesAttemptHistory(t *testing.T) {
+	dir := t.TempDir()
+	firstCounter := filepath.Join(dir, "first-counter")
+	secondCounter := filepath.Join(dir, "second-counter")
+	allowPath := filepath.Join(dir, "allow")
+	workflowPath := filepath.Join(dir, "workflow.json")
+	definitionJSON := fmt.Sprintf(`{
+		"env": {
+			"FIRST_COUNTER": %q,
+			"SECOND_COUNTER": %q,
+			"ALLOW_PATH": %q
+		},
+		"workflows": {
+			"main": {"steps": [
+				{"name":"first","run":"printf x >> \"$FIRST_COUNTER\""},
+				{
+					"name":"eventual",
+					"run":"printf x >> \"$SECOND_COUNTER\"; test -f \"$ALLOW_PATH\"",
+					"retry":{"max_attempts":2,"delay":"1ms"}
+				}
+			]}
+		}
+	}`, firstCounter, secondCounter, allowPath)
+	if err := os.WriteFile(workflowPath, []byte(definitionJSON), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	def, err := Load(workflowPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	stateDir := filepath.Join(dir, "runs")
+	firstOpts := runOpts("main")
+	firstOpts.WorkflowFile = workflowPath
+	firstOpts.StateDir = stateDir
+	first, firstErr := Run(context.Background(), def, firstOpts)
+	if firstErr == nil {
+		t.Fatal("expected first run to exhaust retries")
+	}
+	if got := readFileOrEmpty(t, firstCounter); got != "x" {
+		t.Fatalf("first step executions = %q, want x", got)
+	}
+	if got := readFileOrEmpty(t, secondCounter); got != "xx" {
+		t.Fatalf("failed step executions = %q, want xx", got)
+	}
+	if err := os.WriteFile(allowPath, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write allow marker: %v", err)
+	}
+
+	resumeOpts := runOpts("main")
+	resumeOpts.WorkflowFile = workflowPath
+	resumeOpts.StateDir = stateDir
+	resumeOpts.ResumeRunID = first.RunID
+	resumed, resumeErr := Run(context.Background(), def, resumeOpts)
+	if resumeErr != nil {
+		t.Fatalf("resume Run: %v", resumeErr)
+	}
+	if resumed.Steps[0].Status != "resumed" {
+		t.Fatalf("first resumed step = %+v", resumed.Steps[0])
+	}
+	if got := readFileOrEmpty(t, firstCounter); got != "x" {
+		t.Fatalf("successful step re-ran: %q", got)
+	}
+	if got := readFileOrEmpty(t, secondCounter); got != "xxx" {
+		t.Fatalf("failed step resume executions = %q, want xxx", got)
+	}
+	attempts := resumed.Steps[1].Attempts
+	if len(attempts) != 3 || attempts[0].Invocation != 1 || attempts[1].Invocation != 1 || attempts[2].Invocation != 2 || attempts[2].Status != "ok" {
+		t.Fatalf("resumed attempt history = %+v", attempts)
+	}
+
+	state, loadErr := loadRunState(resumed.RunFile)
+	if loadErr != nil {
+		t.Fatalf("loadRunState: %v", loadErr)
+	}
+	if got := len(state.Steps["main[2]"].Attempts); got != 3 {
+		t.Fatalf("persisted attempt history length = %d, want 3", got)
+	}
+}
+
+func TestAttemptResultJSONUsesStableFields(t *testing.T) {
+	data, err := json.Marshal(AttemptResult{
+		Invocation:    2,
+		Attempt:       3,
+		Status:        "timeout",
+		DurationMS:    25,
+		FailureReason: "timeout",
+		Error:         "step timed out after 25ms",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	for _, key := range []string{"invocation", "attempt", "status", "duration_ms", "failure_reason", "error"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("attempt JSON missing %q: %s", key, data)
+		}
+	}
+}
+
+func readFileOrEmpty(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -54,11 +54,15 @@ func TestValidate_RetryAndTimeoutPaths(t *testing.T) {
 		{"retry negative delay", `{"run":"echo ok","retry":{"max_attempts":2,"delay":"-1s"}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
 		{"retry invalid delay", `{"run":"echo ok","retry":{"max_attempts":2,"delay":"later"}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
 		{"retry excessive delay", `{"run":"echo ok","retry":{"max_attempts":2,"delay":"24h1s"}}`, "invalid_retry_delay", "workflows.main.steps[0].retry.delay"},
+		{"null retry", `{"run":"echo ok","retry":null}`, "invalid_step_retry", "workflows.main.steps[0].retry"},
+		{"mixed-case null retry", `{"run":"echo ok","Retry":null}`, "invalid_step_retry", "workflows.main.steps[0].retry"},
 		{"zero timeout", `{"run":"echo ok","timeout":"0s"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
 		{"negative timeout", `{"run":"echo ok","timeout":"-1s"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
 		{"invalid timeout", `{"run":"echo ok","timeout":"forever"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
 		{"excessive timeout", `{"run":"echo ok","timeout":"24h1s"}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
 		{"empty timeout", `{"run":"echo ok","timeout":""}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
+		{"null timeout", `{"run":"echo ok","timeout":null}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
+		{"mixed-case null timeout", `{"run":"echo ok","Timeout":null}`, "invalid_step_timeout", "workflows.main.steps[0].timeout"},
 		{"retry on workflow", `{"workflow":"child","retry":{"max_attempts":2,"delay":"1s"}}`, "step_retry_on_workflow", "workflows.main.steps[0].retry"},
 		{"timeout on workflow", `{"workflow":"child","timeout":"1s"}`, "step_timeout_on_workflow", "workflows.main.steps[0].timeout"},
 	}
@@ -312,18 +316,18 @@ func TestRun_TimeoutHasStableStructuredFailure(t *testing.T) {
 	}
 }
 
-func TestRun_TimeoutWithoutRetryIsTerminalAndCannotResume(t *testing.T) {
+func TestRun_TimeoutPolicyWithoutRetryIsTerminalAndCannotResume(t *testing.T) {
 	tests := []struct {
 		name          string
 		steps         string
 		hasCheckpoint bool
 	}{
 		{
-			name:  "first step",
+			name:  "timeout first step",
 			steps: `[{"name":"bounded","run":"if [ -f \"$RESUME_MARKER\" ]; then printf x >> \"$REPLAY_COUNTER\"; fi; sleep 10","timeout":"250ms"}]`,
 		},
 		{
-			name:          "after completed checkpoint",
+			name:          "timeout after completed checkpoint",
 			steps:         `[{"name":"checkpoint","run":"printf x >> \"$CHECKPOINT_COUNTER\""},{"name":"bounded","run":"if [ -f \"$RESUME_MARKER\" ]; then printf x >> \"$REPLAY_COUNTER\"; fi; sleep 10","timeout":"250ms"}]`,
 			hasCheckpoint: true,
 		},
@@ -349,11 +353,11 @@ func TestRun_TimeoutWithoutRetryIsTerminalAndCannotResume(t *testing.T) {
 			opts.StateDir = filepath.Join(dir, "runs")
 			result, err := Run(context.Background(), def, opts)
 			if err == nil {
-				t.Fatal("expected timeout")
+				t.Fatal("expected step failure")
 			}
 			failed := result.Steps[len(result.Steps)-1]
-			if failed.FailureReason != "timeout" || len(failed.Attempts) != 1 || failed.Attempts[0].Status != "timeout" {
-				t.Fatalf("timeout step = %+v", failed)
+			if failed.FailureReason != "timeout" || len(failed.Attempts) != 1 || failed.Attempts[0].FailureReason != "timeout" {
+				t.Fatalf("failed step = %+v", failed)
 			}
 			if !result.Terminal || result.TerminalReason == "" || result.Recoverable || result.Resume != nil {
 				t.Fatalf("timeout-only result must be terminal and nonrecoverable: %+v", result)
@@ -391,6 +395,105 @@ func TestRun_TimeoutWithoutRetryIsTerminalAndCannotResume(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRun_TimeoutConfiguredCommandFailureNeedsRecoveryCheckpoint(t *testing.T) {
+	t.Run("first step is diagnostic only", func(t *testing.T) {
+		dir := t.TempDir()
+		markerPath := filepath.Join(dir, "resume-marker")
+		replayCounterPath := filepath.Join(dir, "replay-counter")
+		def, workflowPath := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+			"env": {"RESUME_MARKER": %q, "REPLAY_COUNTER": %q},
+			"workflows": {"main": {"steps": [{
+				"name": "bounded",
+				"run": "if [ -f \"$RESUME_MARKER\" ]; then printf x >> \"$REPLAY_COUNTER\"; fi; exit 7",
+				"timeout": "1s"
+			}]}}
+		}`, markerPath, replayCounterPath))
+
+		opts := runOpts("main")
+		opts.WorkflowFile = workflowPath
+		opts.StateDir = filepath.Join(dir, "runs")
+		result, err := Run(context.Background(), def, opts)
+		if err == nil || result.Steps[0].FailureReason != "command_failed" {
+			t.Fatalf("result = %+v, err = %v", result, err)
+		}
+		if result.Terminal || result.Recoverable || result.Resume != nil {
+			t.Fatalf("diagnostic-only failure must be nonrecoverable without becoming terminal: %+v", result)
+		}
+		state, loadErr := loadRunState(result.RunFile)
+		if loadErr != nil || len(state.Steps["main[1]"].Attempts) != 1 {
+			t.Fatalf("diagnostic attempt state = %+v, err = %v", state, loadErr)
+		}
+		if state.Steps["main[1]"].RetryEnabled {
+			t.Fatalf("diagnostic-only step persisted retry opt-in: %+v", state.Steps["main[1]"])
+		}
+
+		if writeErr := os.WriteFile(markerPath, []byte("resume"), 0o600); writeErr != nil {
+			t.Fatalf("write resume marker: %v", writeErr)
+		}
+		resumeOpts := runOpts("main")
+		resumeOpts.WorkflowFile = workflowPath
+		resumeOpts.StateDir = opts.StateDir
+		resumeOpts.ResumeRunID = result.RunID
+		resumeResult, resumeErr := Run(context.Background(), def, resumeOpts)
+		if resumeErr == nil || !strings.Contains(resumeErr.Error(), "cannot be resumed") || !strings.Contains(resumeErr.Error(), "checkpoint") {
+			t.Fatalf("resume error = %v, want missing-checkpoint diagnostic", resumeErr)
+		}
+		if resumeResult == nil || len(resumeResult.Steps) != 0 {
+			t.Fatalf("resume result = %+v, want rejection before workflow execution", resumeResult)
+		}
+		if got := readFileOrEmpty(t, replayCounterPath); got != "" {
+			t.Fatalf("resume reran diagnostic-only command: %q", got)
+		}
+	})
+
+	t.Run("completed checkpoint preserves resume", func(t *testing.T) {
+		dir := t.TempDir()
+		markerPath := filepath.Join(dir, "resume-marker")
+		replayCounterPath := filepath.Join(dir, "replay-counter")
+		checkpointCounterPath := filepath.Join(dir, "checkpoint-counter")
+		def, workflowPath := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+			"env": {
+				"RESUME_MARKER": %q,
+				"REPLAY_COUNTER": %q,
+				"CHECKPOINT_COUNTER": %q
+			},
+			"workflows": {"main": {"steps": [
+				{"name":"checkpoint","run":"printf x >> \"$CHECKPOINT_COUNTER\""},
+				{"name":"bounded","run":"if [ -f \"$RESUME_MARKER\" ]; then printf x >> \"$REPLAY_COUNTER\"; fi; exit 7","timeout":"1s"}
+			]}}
+		}`, markerPath, replayCounterPath, checkpointCounterPath))
+
+		opts := runOpts("main")
+		opts.WorkflowFile = workflowPath
+		opts.StateDir = filepath.Join(dir, "runs")
+		result, err := Run(context.Background(), def, opts)
+		if err == nil || !result.Recoverable || result.Resume == nil || result.Terminal {
+			t.Fatalf("checkpointed result = %+v, err = %v", result, err)
+		}
+		if got := readFileOrEmpty(t, checkpointCounterPath); got != "x" {
+			t.Fatalf("checkpoint executions = %q, want x", got)
+		}
+
+		if writeErr := os.WriteFile(markerPath, []byte("resume"), 0o600); writeErr != nil {
+			t.Fatalf("write resume marker: %v", writeErr)
+		}
+		resumeOpts := runOpts("main")
+		resumeOpts.WorkflowFile = workflowPath
+		resumeOpts.StateDir = opts.StateDir
+		resumeOpts.ResumeRunID = result.RunID
+		resumed, resumeErr := Run(context.Background(), def, resumeOpts)
+		if resumeErr == nil || resumed.Steps[0].Status != "resumed" || resumed.Steps[1].FailureReason != "command_failed" {
+			t.Fatalf("resumed result = %+v, err = %v", resumed, resumeErr)
+		}
+		if got := readFileOrEmpty(t, checkpointCounterPath); got != "x" {
+			t.Fatalf("resume reran checkpoint: %q", got)
+		}
+		if got := readFileOrEmpty(t, replayCounterPath); got != "x" {
+			t.Fatalf("resume did not rerun failed step exactly once: %q", got)
+		}
+	})
 }
 
 func TestRun_CancellationStopsDuringRetryDelay(t *testing.T) {

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -98,6 +98,88 @@ func TestValidate_RetryAndTimeoutPaths(t *testing.T) {
 	}
 }
 
+func TestValidate_RetryAndTimeoutCaseVariantLastValueWins(t *testing.T) {
+	tests := []struct {
+		name     string
+		stepJSON string
+		wantCode ValidationCode
+	}{
+		{
+			name:     "retry null then policy",
+			stepJSON: `{"run":"echo ok","retry":null,"Retry":{"max_attempts":2,"delay":"1s"}}`,
+		},
+		{
+			name:     "retry policy then null",
+			stepJSON: `{"run":"echo ok","Retry":{"max_attempts":2,"delay":"1s"},"retry":null}`,
+			wantCode: ErrInvalidStepRetry,
+		},
+		{
+			name:     "timeout null then duration",
+			stepJSON: `{"run":"echo ok","timeout":null,"Timeout":"1s"}`,
+		},
+		{
+			name:     "timeout duration then null",
+			stepJSON: `{"run":"echo ok","Timeout":"1s","timeout":null}`,
+			wantCode: ErrInvalidStepTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeWorkflowFile(t, dir, fmt.Sprintf(`{
+				"workflows": {"main": {"steps": [%s]}}
+			}`, tt.stepJSON))
+			def, err := LoadUnvalidated(path)
+			if err != nil {
+				t.Fatalf("LoadUnvalidated: %v", err)
+			}
+			errs := Validate(def)
+			if tt.wantCode == "" {
+				if len(errs) != 0 {
+					t.Fatalf("validation errors = %+v, want none", errs)
+				}
+				return
+			}
+			for _, validationErr := range errs {
+				if validationErr.Code == tt.wantCode {
+					return
+				}
+			}
+			t.Fatalf("validation errors = %+v, want code %q", errs, tt.wantCode)
+		})
+	}
+}
+
+func TestValidate_RetryPathEncodesUnsafeWorkflowName(t *testing.T) {
+	dir := t.TempDir()
+	path := writeWorkflowFile(t, dir, `{
+		"workflows": {
+			"unsafe\n.name]": {
+				"steps": [{"run":"echo ok","retry":null}]
+			}
+		}
+	}`)
+	def, err := LoadUnvalidated(path)
+	if err != nil {
+		t.Fatalf("LoadUnvalidated: %v", err)
+	}
+	for _, validationErr := range Validate(def) {
+		if validationErr.Code != ErrInvalidStepRetry {
+			continue
+		}
+		const wantPath = `workflows["unsafe\n.name]"].steps[0].retry`
+		if validationErr.Path != wantPath {
+			t.Fatalf("path = %q, want %q", validationErr.Path, wantPath)
+		}
+		if strings.ContainsRune(validationErr.Message, '\n') {
+			t.Fatalf("message contains raw newline: %q", validationErr.Message)
+		}
+		return
+	}
+	t.Fatalf("validation errors = %+v, want code %q", Validate(def), ErrInvalidStepRetry)
+}
+
 func TestRun_RetryEventuallySucceedsAndCapturesOnlySuccessfulOutput(t *testing.T) {
 	dir := t.TempDir()
 	counterPath := filepath.Join(dir, "counter")

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -206,7 +206,8 @@ func TestRun_RetryExhaustionRunsErrorHookOnce(t *testing.T) {
 			"main": {"steps": [{
 				"name": "exhausted",
 				"run": "printf x >> \"$COUNTER_PATH\"; exit 7",
-				"retry": {"max_attempts": 3, "delay": "1ms"}
+				"retry": {"max_attempts": 3, "delay": "1ms"},
+				"timeout": "1s"
 			}]}
 		}
 	}`, counterPath, errorHookPath, afterHookPath))
@@ -305,6 +306,90 @@ func TestRun_TimeoutHasStableStructuredFailure(t *testing.T) {
 	}
 	if step.Attempts[0].Status != "timeout" || step.Attempts[0].Error != "step timed out after 25ms" {
 		t.Fatalf("attempt = %+v", step.Attempts[0])
+	}
+	if !result.Terminal || result.TerminalReason == "" || result.Recoverable || result.Resume != nil {
+		t.Fatalf("timeout-only result must be terminal and nonrecoverable: %+v", result)
+	}
+}
+
+func TestRun_TimeoutWithoutRetryIsTerminalAndCannotResume(t *testing.T) {
+	tests := []struct {
+		name          string
+		steps         string
+		hasCheckpoint bool
+	}{
+		{
+			name:  "first step",
+			steps: `[{"name":"bounded","run":"if [ -f \"$RESUME_MARKER\" ]; then printf x >> \"$REPLAY_COUNTER\"; fi; sleep 10","timeout":"250ms"}]`,
+		},
+		{
+			name:          "after completed checkpoint",
+			steps:         `[{"name":"checkpoint","run":"printf x >> \"$CHECKPOINT_COUNTER\""},{"name":"bounded","run":"if [ -f \"$RESUME_MARKER\" ]; then printf x >> \"$REPLAY_COUNTER\"; fi; sleep 10","timeout":"250ms"}]`,
+			hasCheckpoint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			markerPath := filepath.Join(dir, "resume-marker")
+			replayCounterPath := filepath.Join(dir, "replay-counter")
+			checkpointCounterPath := filepath.Join(dir, "checkpoint-counter")
+			def, workflowPath := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+				"env": {
+					"RESUME_MARKER": %q,
+					"REPLAY_COUNTER": %q,
+					"CHECKPOINT_COUNTER": %q
+				},
+				"workflows": {"main": {"steps": %s}}
+			}`, markerPath, replayCounterPath, checkpointCounterPath, tt.steps))
+
+			opts := runOpts("main")
+			opts.WorkflowFile = workflowPath
+			opts.StateDir = filepath.Join(dir, "runs")
+			result, err := Run(context.Background(), def, opts)
+			if err == nil {
+				t.Fatal("expected timeout")
+			}
+			failed := result.Steps[len(result.Steps)-1]
+			if failed.FailureReason != "timeout" || len(failed.Attempts) != 1 || failed.Attempts[0].Status != "timeout" {
+				t.Fatalf("timeout step = %+v", failed)
+			}
+			if !result.Terminal || result.TerminalReason == "" || result.Recoverable || result.Resume != nil {
+				t.Fatalf("timeout-only result must be terminal and nonrecoverable: %+v", result)
+			}
+			state, loadErr := loadRunState(result.RunFile)
+			if loadErr != nil {
+				t.Fatalf("loadRunState: %v", loadErr)
+			}
+			if state.Status != "terminal" || state.TerminalReason == "" {
+				t.Fatalf("timeout-only state must be terminal: %+v", state)
+			}
+			if tt.hasCheckpoint && readFileOrEmpty(t, checkpointCounterPath) != "x" {
+				t.Fatalf("checkpoint did not complete before timeout: %q", readFileOrEmpty(t, checkpointCounterPath))
+			}
+
+			if writeErr := os.WriteFile(markerPath, []byte("resume"), 0o600); writeErr != nil {
+				t.Fatalf("write resume marker: %v", writeErr)
+			}
+			resumeOpts := runOpts("main")
+			resumeOpts.WorkflowFile = workflowPath
+			resumeOpts.StateDir = opts.StateDir
+			resumeOpts.ResumeRunID = result.RunID
+			resumeResult, resumeErr := Run(context.Background(), def, resumeOpts)
+			if resumeErr == nil || !strings.Contains(resumeErr.Error(), "cannot be resumed") || !strings.Contains(resumeErr.Error(), "timed out") {
+				t.Fatalf("resume error = %v, want terminal timeout diagnostic", resumeErr)
+			}
+			if resumeResult == nil || len(resumeResult.Steps) != 0 {
+				t.Fatalf("resume result = %+v, want rejection before workflow execution", resumeResult)
+			}
+			if got := readFileOrEmpty(t, replayCounterPath); got != "" {
+				t.Fatalf("resume reran timeout-only command: %q", got)
+			}
+			if tt.hasCheckpoint && readFileOrEmpty(t, checkpointCounterPath) != "x" {
+				t.Fatalf("resume reran completed checkpoint: %q", readFileOrEmpty(t, checkpointCounterPath))
+			}
+		})
 	}
 }
 

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -147,6 +147,48 @@ func TestRun_RetryEventuallySucceedsAndCapturesOnlySuccessfulOutput(t *testing.T
 	}
 }
 
+func TestRun_SuccessfulCommandWithBackgroundPipeHolderIsNotRetried(t *testing.T) {
+	originalWaitDelay := shellWaitDelay
+	shellWaitDelay = 20 * time.Millisecond
+	t.Cleanup(func() { shellWaitDelay = originalWaitDelay })
+
+	dir := t.TempDir()
+	counterPath := filepath.Join(dir, "counter")
+	def, _ := loadWorkflowForRetryTest(t, fmt.Sprintf(`{
+		"env": {"COUNTER_PATH": %q},
+		"workflows": {
+			"main": {"steps": [{
+				"name": "background",
+				"run": "printf x >> \"$COUNTER_PATH\"; sleep 1 & printf '{\"value\":\"ok\"}'",
+				"retry": {"max_attempts": 2, "delay": "1ms"},
+				"outputs": {"VALUE": "$.value"}
+			}]}
+		}
+	}`, counterPath))
+
+	result, err := Run(context.Background(), def, runOpts("main"))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Status != "ok" || len(result.Steps) != 1 {
+		t.Fatalf("result = %+v, want one successful step", result)
+	}
+	step := result.Steps[0]
+	if len(step.Attempts) != 1 || step.Attempts[0].Status != "ok" {
+		t.Fatalf("attempts = %+v, want one successful attempt", step.Attempts)
+	}
+	if got := result.Outputs["background"]["VALUE"]; got != "ok" {
+		t.Fatalf("output = %q, want ok", got)
+	}
+	data, readErr := os.ReadFile(counterPath)
+	if readErr != nil {
+		t.Fatalf("read counter: %v", readErr)
+	}
+	if got := string(data); got != "x" {
+		t.Fatalf("counter = %q, want one execution", got)
+	}
+}
+
 func TestRun_RetryExhaustionRunsErrorHookOnce(t *testing.T) {
 	dir := t.TempDir()
 	counterPath := filepath.Join(dir, "counter")

--- a/internal/workflow/retry_test.go
+++ b/internal/workflow/retry_test.go
@@ -220,6 +220,24 @@ func TestRun_FirstFailureWithoutPolicyKeepsExistingRecoveryBehavior(t *testing.T
 	}
 }
 
+func TestRun_WorkflowCallPolicyIsRejectedAtRuntime(t *testing.T) {
+	def := &Definition{Workflows: map[string]Workflow{
+		"main": {Steps: []Step{{
+			Name:     "invalid_call",
+			Workflow: "child",
+			Retry:    &RetryPolicy{MaxAttempts: 2, Delay: "1s"},
+		}}},
+		"child": {Private: true, Steps: []Step{{Run: "echo child"}}},
+	}}
+	result, err := Run(context.Background(), def, runOpts("main"))
+	if err == nil {
+		t.Fatal("expected workflow-call policy rejection")
+	}
+	if len(result.Steps) != 1 || result.Steps[0].FailureReason != "invalid_policy" {
+		t.Fatalf("result = %+v, want invalid_policy failure", result)
+	}
+}
+
 func TestRun_TimeoutHasStableStructuredFailure(t *testing.T) {
 	def, _ := loadWorkflowForRetryTest(t, `{
 		"workflows": {

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -28,6 +28,9 @@ type persistedStepState struct {
 	Workflow       string            `json:"workflow,omitempty"`
 	ParentWorkflow string            `json:"parent_workflow,omitempty"`
 	Status         string            `json:"status,omitempty"`
+	FailureReason  string            `json:"failure_reason,omitempty"`
+	Error          string            `json:"error,omitempty"`
+	Attempts       []AttemptResult   `json:"attempts,omitempty"`
 	Outputs        map[string]string `json:"outputs,omitempty"`
 }
 

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -42,6 +42,7 @@ type persistedRunState struct {
 	Params         map[string]string             `json:"params,omitempty"`
 	Status         string                        `json:"status,omitempty"`
 	FailedStep     string                        `json:"failed_step,omitempty"`
+	TerminalReason string                        `json:"terminal_reason,omitempty"`
 	Hooks          *persistedRunHooks            `json:"hooks,omitempty"`
 	Steps          map[string]persistedStepState `json:"steps,omitempty"`
 	CreatedAt      string                        `json:"created_at,omitempty"`

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -30,6 +30,7 @@ type persistedStepState struct {
 	Status         string            `json:"status,omitempty"`
 	FailureReason  string            `json:"failure_reason,omitempty"`
 	Error          string            `json:"error,omitempty"`
+	RetryEnabled   bool              `json:"retry_enabled,omitempty"`
 	Attempts       []AttemptResult   `json:"attempts,omitempty"`
 	Outputs        map[string]string `json:"outputs,omitempty"`
 }

--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -29,6 +29,7 @@ const (
 	ErrInvalidOutputExpr           ValidationCode = "invalid_output_expr"
 	ErrStepRetryOnWorkflow         ValidationCode = "step_retry_on_workflow"
 	ErrStepTimeoutOnWorkflow       ValidationCode = "step_timeout_on_workflow"
+	ErrInvalidStepRetry            ValidationCode = "invalid_step_retry"
 	ErrInvalidRetryMaxAttempts     ValidationCode = "invalid_retry_max_attempts"
 	ErrInvalidRetryDelay           ValidationCode = "invalid_retry_delay"
 	ErrInvalidStepTimeout          ValidationCode = "invalid_step_timeout"
@@ -142,7 +143,15 @@ func Validate(def *Definition) []*ValidationError {
 				})
 			}
 
-			if step.Retry != nil {
+			if step.retryExplicitNull {
+				errs = append(errs, &ValidationError{
+					Code:     ErrInvalidStepRetry,
+					Workflow: name,
+					Step:     idx,
+					Path:     stepPath + ".retry",
+					Message:  fmt.Sprintf("%s must be an object, not null", stepPath+".retry"),
+				})
+			} else if step.Retry != nil {
 				if !hasRun {
 					errs = append(errs, &ValidationError{
 						Code:     ErrStepRetryOnWorkflow,
@@ -173,7 +182,15 @@ func Validate(def *Definition) []*ValidationError {
 				}
 			}
 
-			if step.Timeout != nil {
+			if step.timeoutExplicitNull {
+				errs = append(errs, &ValidationError{
+					Code:     ErrInvalidStepTimeout,
+					Workflow: name,
+					Step:     idx,
+					Path:     stepPath + ".timeout",
+					Message:  fmt.Sprintf("%s must be a duration string, not null", stepPath+".timeout"),
+				})
+			} else if step.Timeout != nil {
 				if !hasRun {
 					errs = append(errs, &ValidationError{
 						Code:     ErrStepTimeoutOnWorkflow,

--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 )
 
 // ValidationCode classifies validation failures.
@@ -26,6 +27,17 @@ const (
 	ErrDuplicateOutputProducerName ValidationCode = "duplicate_output_producer_name"
 	ErrInvalidOutputName           ValidationCode = "invalid_output_name"
 	ErrInvalidOutputExpr           ValidationCode = "invalid_output_expr"
+	ErrStepRetryOnWorkflow         ValidationCode = "step_retry_on_workflow"
+	ErrStepTimeoutOnWorkflow       ValidationCode = "step_timeout_on_workflow"
+	ErrInvalidRetryMaxAttempts     ValidationCode = "invalid_retry_max_attempts"
+	ErrInvalidRetryDelay           ValidationCode = "invalid_retry_delay"
+	ErrInvalidStepTimeout          ValidationCode = "invalid_step_timeout"
+)
+
+const (
+	minRetryAttempts  = 2
+	maxRetryAttempts  = 100
+	maxPolicyDuration = 24 * time.Hour
 )
 
 // ValidationError describes a structured workflow validation failure.
@@ -33,6 +45,7 @@ type ValidationError struct {
 	Code     ValidationCode `json:"code"`
 	Workflow string         `json:"workflow,omitempty"`
 	Step     int            `json:"step,omitempty"`
+	Path     string         `json:"path,omitempty"`
 	Message  string         `json:"message"`
 }
 
@@ -88,6 +101,7 @@ func Validate(def *Definition) []*ValidationError {
 
 		for i, step := range wf.Steps {
 			idx := i + 1
+			stepPath := fmt.Sprintf("workflows.%s.steps[%d]", name, i)
 			hasRun := strings.TrimSpace(step.Run) != ""
 			hasWorkflow := strings.TrimSpace(step.Workflow) != ""
 			hasRawRun := step.Run != ""
@@ -126,6 +140,57 @@ func Validate(def *Definition) []*ValidationError {
 					Step:     idx,
 					Message:  fmt.Sprintf("workflow %q step %d has 'with' on a run step (only allowed on workflow steps)", name, idx),
 				})
+			}
+
+			if step.Retry != nil {
+				if !hasRun {
+					errs = append(errs, &ValidationError{
+						Code:     ErrStepRetryOnWorkflow,
+						Workflow: name,
+						Step:     idx,
+						Path:     stepPath + ".retry",
+						Message:  fmt.Sprintf("%s is only supported on run steps", stepPath+".retry"),
+					})
+				} else {
+					if step.Retry.MaxAttempts < minRetryAttempts || step.Retry.MaxAttempts > maxRetryAttempts {
+						errs = append(errs, &ValidationError{
+							Code:     ErrInvalidRetryMaxAttempts,
+							Workflow: name,
+							Step:     idx,
+							Path:     stepPath + ".retry.max_attempts",
+							Message:  fmt.Sprintf("%s must be between %d and %d and counts the initial attempt", stepPath+".retry.max_attempts", minRetryAttempts, maxRetryAttempts),
+						})
+					}
+					if _, err := parsePositivePolicyDuration(step.Retry.Delay); err != nil {
+						errs = append(errs, &ValidationError{
+							Code:     ErrInvalidRetryDelay,
+							Workflow: name,
+							Step:     idx,
+							Path:     stepPath + ".retry.delay",
+							Message:  fmt.Sprintf("%s must be a positive duration no greater than %s: %v", stepPath+".retry.delay", maxPolicyDuration, err),
+						})
+					}
+				}
+			}
+
+			if step.Timeout != nil {
+				if !hasRun {
+					errs = append(errs, &ValidationError{
+						Code:     ErrStepTimeoutOnWorkflow,
+						Workflow: name,
+						Step:     idx,
+						Path:     stepPath + ".timeout",
+						Message:  fmt.Sprintf("%s is only supported on run steps", stepPath+".timeout"),
+					})
+				} else if _, err := parsePositivePolicyDuration(*step.Timeout); err != nil {
+					errs = append(errs, &ValidationError{
+						Code:     ErrInvalidStepTimeout,
+						Workflow: name,
+						Step:     idx,
+						Path:     stepPath + ".timeout",
+						Message:  fmt.Sprintf("%s must be a positive duration no greater than %s: %v", stepPath+".timeout", maxPolicyDuration, err),
+					})
+				}
 			}
 
 			if len(step.Outputs) > 0 {
@@ -196,6 +261,24 @@ func Validate(def *Definition) []*ValidationError {
 	}
 
 	return errs
+}
+
+func parsePositivePolicyDuration(value string) (time.Duration, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, fmt.Errorf("duration is required")
+	}
+	duration, err := time.ParseDuration(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("parse duration %q: %w", trimmed, err)
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("duration must be greater than zero")
+	}
+	if duration > maxPolicyDuration {
+		return 0, fmt.Errorf("duration exceeds %s", maxPolicyDuration)
+	}
+	return duration, nil
 }
 
 func collectOutputProducerConflicts(def *Definition) map[string]map[int]string {

--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -102,7 +103,7 @@ func Validate(def *Definition) []*ValidationError {
 
 		for i, step := range wf.Steps {
 			idx := i + 1
-			stepPath := fmt.Sprintf("workflows.%s.steps[%d]", name, i)
+			stepPath := fmt.Sprintf("%s.steps[%d]", workflowValidationPath(name), i)
 			hasRun := strings.TrimSpace(step.Run) != ""
 			hasWorkflow := strings.TrimSpace(step.Workflow) != ""
 			hasRawRun := step.Run != ""
@@ -278,6 +279,13 @@ func Validate(def *Definition) []*ValidationError {
 	}
 
 	return errs
+}
+
+func workflowValidationPath(name string) string {
+	if validWorkflowName.MatchString(name) {
+		return "workflows." + name
+	}
+	return "workflows[" + strconv.Quote(name) + "]"
 }
 
 func parsePositivePolicyDuration(value string) (time.Duration, error) {

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -27,6 +27,12 @@ type Workflow struct {
 	Steps       []Step            `json:"steps"`
 }
 
+// RetryPolicy configures explicit bounded retries for a run step.
+type RetryPolicy struct {
+	MaxAttempts int    `json:"max_attempts"`
+	Delay       string `json:"delay"`
+}
+
 // Step is one executable action in a workflow.
 // Bare JSON strings unmarshal to Step{Run: "..."} as shorthand.
 type Step struct {
@@ -36,6 +42,8 @@ type Step struct {
 	If       string            `json:"if,omitempty"`
 	With     map[string]string `json:"with,omitempty"`
 	Outputs  map[string]string `json:"outputs,omitempty"`
+	Retry    *RetryPolicy      `json:"retry,omitempty"`
+	Timeout  *string           `json:"timeout,omitempty"`
 }
 
 // UnmarshalJSON handles the flexible step format:

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -76,20 +76,49 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("step must be a single JSON value: trailing data")
 	}
 	*s = Step(alias)
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(data, &fields); err != nil {
+	retryNull, timeoutNull, err := explicitNullPolicyFields(data)
+	if err != nil {
 		return fmt.Errorf("step must be an object: %w", err)
 	}
-	s.retryExplicitNull = rawFieldExplicitNull(fields, "retry")
-	s.timeoutExplicitNull = rawFieldExplicitNull(fields, "timeout")
+	s.retryExplicitNull = retryNull
+	s.timeoutExplicitNull = timeoutNull
 	return nil
 }
 
-func rawFieldExplicitNull(fields map[string]json.RawMessage, name string) bool {
-	for key, data := range fields {
-		if strings.EqualFold(key, name) && bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
-			return true
+func explicitNullPolicyFields(data []byte) (bool, bool, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	start, err := dec.Token()
+	if err != nil {
+		return false, false, err
+	}
+	if delim, ok := start.(json.Delim); !ok || delim != '{' {
+		return false, false, fmt.Errorf("expected object")
+	}
+
+	var retryNull, timeoutNull bool
+	for dec.More() {
+		keyToken, err := dec.Token()
+		if err != nil {
+			return false, false, err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false, false, fmt.Errorf("expected object field name")
+		}
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return false, false, err
+		}
+		isNull := bytes.Equal(bytes.TrimSpace(value), []byte("null"))
+		switch {
+		case strings.EqualFold(key, "retry"):
+			retryNull = isNull
+		case strings.EqualFold(key, "timeout"):
+			timeoutNull = isNull
 		}
 	}
-	return false
+	if _, err := dec.Token(); err != nil {
+		return false, false, err
+	}
+	return retryNull, timeoutNull, nil
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Definition is the top-level .asc/workflow.json schema.
@@ -36,14 +37,16 @@ type RetryPolicy struct {
 // Step is one executable action in a workflow.
 // Bare JSON strings unmarshal to Step{Run: "..."} as shorthand.
 type Step struct {
-	Run      string            `json:"run,omitempty"`
-	Workflow string            `json:"workflow,omitempty"`
-	Name     string            `json:"name,omitempty"`
-	If       string            `json:"if,omitempty"`
-	With     map[string]string `json:"with,omitempty"`
-	Outputs  map[string]string `json:"outputs,omitempty"`
-	Retry    *RetryPolicy      `json:"retry,omitempty"`
-	Timeout  *string           `json:"timeout,omitempty"`
+	Run                 string            `json:"run,omitempty"`
+	Workflow            string            `json:"workflow,omitempty"`
+	Name                string            `json:"name,omitempty"`
+	If                  string            `json:"if,omitempty"`
+	With                map[string]string `json:"with,omitempty"`
+	Outputs             map[string]string `json:"outputs,omitempty"`
+	Retry               *RetryPolicy      `json:"retry,omitempty"`
+	Timeout             *string           `json:"timeout,omitempty"`
+	retryExplicitNull   bool
+	timeoutExplicitNull bool
 }
 
 // UnmarshalJSON handles the flexible step format:
@@ -73,5 +76,20 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("step must be a single JSON value: trailing data")
 	}
 	*s = Step(alias)
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return fmt.Errorf("step must be an object: %w", err)
+	}
+	s.retryExplicitNull = rawFieldExplicitNull(fields, "retry")
+	s.timeoutExplicitNull = rawFieldExplicitNull(fields, "timeout")
 	return nil
+}
+
+func rawFieldExplicitNull(fields map[string]json.RawMessage, name string) bool {
+	for key, data := range fields {
+		if strings.EqualFold(key, name) && bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- add opt-in run-step `retry` with bounded `max_attempts` and fixed `delay`
- add per-attempt `timeout` with caller-aware cancellation and process-tree termination
- persist attempt diagnostics while capturing outputs only from successful attempts
- document validation limits, resume behavior, hook/workflow-call scope, and a concise transient-404 workflow example

## Schema

```json
{
  "retry": {
    "max_attempts": 6,
    "delay": "10s"
  },
  "timeout": "2m"
}
```

`max_attempts` includes the initial attempt. Retry is never implicit, delay is fixed with no jitter, each duration must be positive and at most 24 hours, and workflow-call steps reject both fields. Hooks remain single-run commands.

## Verification

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go test -race ./internal/workflow`
- focused built-CLI fixture: validation JSON, eventual success, fresh-only output capture, resume without rerun, and structured timeout failure
- Windows and Linux workflow test cross-compilation

No live App Store Connect mutation was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788900217&installation_model_id=10418&pr_number=1909&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1909&signature=c9c987b5baf2e199dd061d45e06d59fecb07046feee6cd096c5ac6da82fb07ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workflow `run` steps support bounded retries with fixed delays and per-attempt timeouts.
  - Attempt history, outputs, diagnostics, and failure details are persisted for resume operations.
  - Canceled commands now terminate associated child processes.

- **Bug Fixes**
  - Added validation for retry and timeout settings, including duration limits and explicit `null` handling.
  - Unsupported workflow-call and lifecycle-hook configurations are rejected.
  - Output-extraction failures produce terminal, non-resumable results.
  - Structured output remains separate from retry diagnostics.
  - Workflow conditions now use environment-variable truthiness consistently.

- **Documentation**
  - Updated workflow guides, examples, command help, and design documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->