### PR TITLE
feat(release): reconcile routing coverage during staging

### DIFF
--- a/commands/release.mdx
+++ b/commands/release.mdx
@@ -24,8 +24,9 @@ Run a deterministic pre-submit staging pipeline:
 
 1. Ensure or create the version
 2. Apply metadata/localizations or copy from another version
-3. Attach a selected build
-4. Run readiness checks
+3. Reconcile routing app coverage when `--routing-coverage-file` is set
+4. Attach a selected build
+5. Run readiness checks
 
 Stops before creating a review submission.
 
@@ -42,6 +43,7 @@ asc release stage \
   --version "2.4.0" \
   --build "BUILD_ID" \
   --metadata-dir "./metadata/version/2.4.0" \
+  --routing-coverage-file "./coverage.geojson" \
   --confirm
 ```
 
@@ -51,6 +53,7 @@ asc release stage \
 * `--version` - App Store version string
 * `--build` - Build ID to attach
 * `--metadata-dir` - Metadata directory to apply
+* `--routing-coverage-file` - [experimental] Routing app coverage GeoJSON file to reconcile before build attachment and readiness
 * `--copy-metadata-from` - Source version string to copy localization metadata from
 * `--copy-fields` - Comma-separated metadata fields to copy
 * `--exclude-fields` - Comma-separated metadata fields to exclude from copy

--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -230,8 +230,9 @@ type AppMediaAssetState struct {
 
 // StateDetail represents details about a state (errors, warnings, infos).
 type StateDetail struct {
-	Code    string `json:"code,omitempty"`
-	Message string `json:"message,omitempty"`
+	Code        string `json:"code,omitempty"`
+	Description string `json:"description,omitempty"`
+	Message     string `json:"message,omitempty"`
 }
 
 // GetBuilds retrieves the list of builds for an app

--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -79,8 +79,27 @@ func newUploadClient() *http.Client {
 
 // ExecuteUploadOperations performs the file uploads for the provided operations.
 func ExecuteUploadOperations(ctx context.Context, filePath string, operations []UploadOperation, opts ...UploadOption) error {
+	if len(operations) == 0 {
+		return errors.New("no upload operations provided")
+	}
+
+	file, err := openUploadSourceFile(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return ExecuteUploadOperationsFromFile(ctx, file, operations, opts...)
+}
+
+// ExecuteUploadOperationsFromFile performs upload operations against an
+// already-opened source file. The caller retains ownership of file.
+func ExecuteUploadOperationsFromFile(ctx context.Context, file *os.File, operations []UploadOperation, opts ...UploadOption) error {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if file == nil {
+		return errors.New("upload source file is required")
 	}
 	if len(operations) == 0 {
 		return errors.New("no upload operations provided")
@@ -105,18 +124,12 @@ func ExecuteUploadOperations(ctx context.Context, filePath string, operations []
 		uploadOpts.Concurrency = len(operations)
 	}
 
-	file, err := openUploadSourceFile(filePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
 	info, err := file.Stat()
 	if err != nil {
 		return fmt.Errorf("stat file: %w", err)
 	}
 	if info.IsDir() {
-		return fmt.Errorf("path %q is a directory", filePath)
+		return fmt.Errorf("path %q is a directory", file.Name())
 	}
 	size := info.Size()
 

--- a/internal/cli/release/checkpoint_binding.go
+++ b/internal/cli/release/checkpoint_binding.go
@@ -46,7 +46,7 @@ func verifyResumedCheckpointBinding(
 		if name == stepSubmitReview && !opts.SubmitForReview {
 			return fmt.Errorf("checkpoint completed step %q requires resuming with --submit-for-review", name)
 		}
-		if !isReleasePipelineStep(name, opts.SubmitForReview) {
+		if !isReleasePipelineStep(name, opts.SubmitForReview, strings.TrimSpace(opts.RoutingCoverageFile) != "") {
 			return fmt.Errorf("checkpoint records unknown completed step %q", name)
 		}
 	}
@@ -73,12 +73,16 @@ func verifyResumedCheckpointBinding(
 	}
 
 	// These completions cannot be authenticated from current remote state.
-	// Metadata input may have changed since the checkpoint was written, and
+	// Local inputs may have changed since the checkpoint was written, and
 	// readiness is a point-in-time observation rather than a durable server
-	// state. An unsigned checkpoint must never be able to suppress either.
+	// state. An unsigned checkpoint must never be able to suppress these steps.
 	if checkpoint.Completed[stepApplyMetadata] {
 		delete(checkpoint.Completed, stepApplyMetadata)
 		emitMessage("Rechecking %s: an unsigned checkpoint cannot prove the current metadata input was applied.", stepApplyMetadata)
+	}
+	if checkpoint.Completed[stepApplyRoutingCoverage] {
+		delete(checkpoint.Completed, stepApplyRoutingCoverage)
+		emitMessage("Rechecking %s: an unsigned checkpoint cannot prove the current routing coverage file was applied.", stepApplyRoutingCoverage)
 	}
 	if checkpoint.Completed[stepValidateReadiness] {
 		delete(checkpoint.Completed, stepValidateReadiness)
@@ -118,7 +122,11 @@ func verifyResumedCheckpointBinding(
 	// pipeline would then apply the missing mutation and skip readiness, leaving
 	// the version unvalidated against the state that mutation produced.
 	if checkpoint.Completed[stepValidateReadiness] {
-		for _, prerequisite := range []string{stepEnsureVersion, stepApplyMetadata, stepAttachBuild} {
+		prerequisites := []string{stepEnsureVersion, stepApplyMetadata, stepAttachBuild}
+		if strings.TrimSpace(opts.RoutingCoverageFile) != "" {
+			prerequisites = append(prerequisites, stepApplyRoutingCoverage)
+		}
+		for _, prerequisite := range prerequisites {
 			if checkpoint.Completed[prerequisite] {
 				continue
 			}
@@ -189,10 +197,12 @@ func verifyResumedCheckpointBinding(
 	return nil
 }
 
-func isReleasePipelineStep(name string, submitForReview bool) bool {
+func isReleasePipelineStep(name string, submitForReview, hasRoutingCoverage bool) bool {
 	switch name {
 	case stepEnsureVersion, stepApplyMetadata, stepAttachBuild, stepValidateReadiness:
 		return true
+	case stepApplyRoutingCoverage:
+		return hasRoutingCoverage
 	case stepSubmitReview:
 		return submitForReview
 	default:

--- a/internal/cli/release/release.go
+++ b/internal/cli/release/release.go
@@ -22,8 +22,9 @@ func ReleaseCommand() *ffcli.Command {
 release stage prepares a version for review without submitting it. It orchestrates:
   1. Ensure/create version
   2. Apply metadata and localizations
-  3. Attach selected build
-  4. Run readiness checks
+  3. Reconcile optional routing app coverage
+  4. Attach selected build
+  5. Run readiness checks
 
 For the canonical App Store shipping command, use:
   asc publish appstore --app "APP_ID" --ipa app.ipa --version "VERSION" --submit --confirm

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -250,6 +250,153 @@ func TestCheckpointModeMatches(t *testing.T) {
 	}
 }
 
+func TestExecuteStageResumesPartialCheckpointAfterRemovingRoutingCoverage(t *testing.T) {
+	originalClientFactory := releaseClientFactory
+	originalCopyExecutor := metadataCopyExecutor
+	originalReadinessBuilder := readinessReportBuilder
+	t.Cleanup(func() {
+		releaseClientFactory = originalClientFactory
+		metadataCopyExecutor = originalCopyExecutor
+		readinessReportBuilder = originalReadinessBuilder
+	})
+
+	client := newCheckpointBindingClient(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"2.4.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_123"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/build":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"BUILD_123","attributes":{"processingState":"VALID"}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+	releaseClientFactory = func() (*asc.Client, error) { return client, nil }
+	metadataRuns := 0
+	metadataCopyExecutor = func(context.Context, *asc.Client, metadataCopyOptions) (*asc.AppStoreVersionMetadataCopySummary, error) {
+		metadataRuns++
+		return &asc.AppStoreVersionMetadataCopySummary{CopiedLocales: 1}, nil
+	}
+	readinessRuns := 0
+	readinessReportBuilder = func(context.Context, validatecli.ReadinessOptions) (validation.Report, error) {
+		readinessRuns++
+		return validation.Report{Summary: validation.Summary{}}, nil
+	}
+
+	checkpointPath := filepath.Join(t.TempDir(), "stage-checkpoint.json")
+	if err := saveCheckpoint(checkpointPath, runCheckpoint{
+		AppID:               "APP_123",
+		Version:             "2.4.0",
+		BuildID:             "BUILD_123",
+		CopyMetadataFrom:    "2.3.2",
+		RoutingCoverageFile: filepath.Join(t.TempDir(), "invalid-coverage.geojson"),
+		Platform:            "IOS",
+		VersionID:           "VERSION_123",
+		Mode:                releaseModeStage,
+		Completed: map[string]bool{
+			stepEnsureVersion: true,
+			stepApplyMetadata: true,
+		},
+	}); err != nil {
+		t.Fatalf("save checkpoint: %v", err)
+	}
+
+	result, err := executeStage(context.Background(), runOptions{
+		AppID:            "APP_123",
+		Version:          "2.4.0",
+		BuildID:          "BUILD_123",
+		CopyMetadataFrom: "2.3.2",
+		Platform:         "IOS",
+		Timeout:          releaseRunTimeout,
+		Confirm:          true,
+		CheckpointFile:   checkpointPath,
+	})
+	if err != nil {
+		t.Fatalf("executeStage() error: %v", err)
+	}
+	if !result.Resumed {
+		t.Fatal("executeStage() resumed = false, want true")
+	}
+	if len(result.Steps) != 4 {
+		t.Fatalf("executeStage() steps = %#v, want four steps without routing coverage", result.Steps)
+	}
+	for _, step := range result.Steps {
+		if step.Name == stepApplyRoutingCoverage {
+			t.Fatalf("executeStage() retained removed routing coverage step: %#v", result.Steps)
+		}
+	}
+	if metadataRuns != 1 || readinessRuns != 1 {
+		t.Fatalf("executeStage() reruns metadata=%d readiness=%d, want 1 each", metadataRuns, readinessRuns)
+	}
+	saved, err := loadCheckpoint(checkpointPath)
+	if err != nil {
+		t.Fatalf("load checkpoint: %v", err)
+	}
+	if saved == nil {
+		t.Fatal("load checkpoint = nil")
+	}
+	if saved.RoutingCoverageFile != "" {
+		t.Fatalf("saved routingCoverageFile = %q, want empty", saved.RoutingCoverageFile)
+	}
+	if saved.Completed[stepApplyRoutingCoverage] {
+		t.Fatalf("saved checkpoint claims removed routing coverage complete: %#v", saved.Completed)
+	}
+}
+
+func TestExecuteStageRejectsRemovingRoutingCoverageAfterCompletedOrUnknownStep(t *testing.T) {
+	originalClientFactory := releaseClientFactory
+	t.Cleanup(func() { releaseClientFactory = originalClientFactory })
+
+	for _, completedStep := range []string{
+		stepApplyRoutingCoverage,
+		stepAttachBuild,
+		stepValidateReadiness,
+		stepSubmitReview,
+		"unrecognized_step",
+	} {
+		t.Run(completedStep, func(t *testing.T) {
+			clientCalled := false
+			releaseClientFactory = func() (*asc.Client, error) {
+				clientCalled = true
+				return nil, errors.New("client must not be created")
+			}
+			checkpointPath := filepath.Join(t.TempDir(), "stage-checkpoint.json")
+			if err := saveCheckpoint(checkpointPath, runCheckpoint{
+				AppID:               "APP_123",
+				Version:             "2.4.0",
+				BuildID:             "BUILD_123",
+				CopyMetadataFrom:    "2.3.2",
+				RoutingCoverageFile: filepath.Join(t.TempDir(), "coverage.geojson"),
+				Platform:            "IOS",
+				VersionID:           "VERSION_123",
+				Mode:                releaseModeStage,
+				Completed: map[string]bool{
+					stepEnsureVersion: true,
+					completedStep:     true,
+				},
+			}); err != nil {
+				t.Fatalf("save checkpoint: %v", err)
+			}
+
+			_, err := executeStage(context.Background(), runOptions{
+				AppID:            "APP_123",
+				Version:          "2.4.0",
+				BuildID:          "BUILD_123",
+				CopyMetadataFrom: "2.3.2",
+				Platform:         "IOS",
+				Timeout:          releaseRunTimeout,
+				Confirm:          true,
+				CheckpointFile:   checkpointPath,
+			})
+			if err == nil || !strings.Contains(err.Error(), "checkpoint does not match current run arguments") {
+				t.Fatalf("executeStage() error = %v, want checkpoint mismatch", err)
+			}
+			if clientCalled {
+				t.Fatal("executeStage() created a client before rejecting unsafe checkpoint transition")
+			}
+		})
+	}
+}
+
 func TestExecuteRun_ResumesCompletedCheckpoint(t *testing.T) {
 	origClientFactory := releaseClientFactory
 	origMetadataExecutor := metadataPushExecutor

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,6 +71,53 @@ func captureReleaseStderr(t *testing.T, fn func()) string {
 
 func newReleaseTestClient(t *testing.T) *asc.Client {
 	t.Helper()
+	pemBytes := newReleaseTestPrivateKeyPEM(t)
+
+	client, err := asc.NewClientFromPEM("KEY_ID", "ISSUER_ID", string(pemBytes))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client
+}
+
+func newReleaseTestServerClient(t *testing.T, handler http.Handler) (*asc.Client, string) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	serverTransport := server.Client().Transport
+	httpClient := &http.Client{Transport: releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = target.Scheme
+		cloned.URL.Host = target.Host
+		cloned.Host = target.Host
+		return serverTransport.RoundTrip(cloned)
+	})}
+
+	pemBytes := newReleaseTestPrivateKeyPEM(t)
+	keyPath := filepath.Join(t.TempDir(), "AuthKey_TEST.p8")
+	if err := os.WriteFile(keyPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	client, err := asc.NewClientWithHTTPClient("KEY_ID", "ISSUER_ID", keyPath, httpClient)
+	if err != nil {
+		t.Fatalf("new client with test server: %v", err)
+	}
+	return client, server.URL
+}
+
+func writeReleaseTestJSON(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, body)
+}
+
+func newReleaseTestPrivateKeyPEM(t *testing.T) []byte {
+	t.Helper()
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -82,12 +131,7 @@ func newReleaseTestClient(t *testing.T) *asc.Client {
 	if pemBytes == nil {
 		t.Fatal("encode pem: nil")
 	}
-
-	client, err := asc.NewClientFromPEM("KEY_ID", "ISSUER_ID", string(pemBytes))
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	return client
+	return pemBytes
 }
 
 func TestReleaseCommandShape(t *testing.T) {

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -168,6 +168,9 @@ func TestReleaseStageCommandExposesRoutingCoverageFile(t *testing.T) {
 	if flag == nil {
 		t.Fatal("expected --routing-coverage-file flag")
 	}
+	if !strings.HasPrefix(flag.Usage, "[experimental] ") {
+		t.Fatalf("expected --routing-coverage-file to be introduced as experimental, got %q", flag.Usage)
+	}
 	if !strings.Contains(flag.Usage, "before readiness") {
 		t.Fatalf("expected routing coverage timing in flag help, got %q", flag.Usage)
 	}

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -142,6 +142,7 @@ func TestReleaseStageCommandValidatesRoutingCoverageBeforePipeline(t *testing.T)
 	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":`), 0o600); err != nil {
 		t.Fatalf("write routing coverage fixture: %v", err)
 	}
+	t.Chdir(filepath.Dir(coveragePath))
 
 	cmd := ReleaseStageCommand()
 	if err := cmd.FlagSet.Parse([]string{
@@ -567,6 +568,7 @@ func TestExecuteStageAppliesRoutingCoverageBeforeReadiness(t *testing.T) {
 	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
 		t.Fatalf("write routing coverage fixture: %v", err)
 	}
+	t.Chdir(filepath.Dir(coveragePath))
 
 	metadataCopyExecutor = func(context.Context, *asc.Client, metadataCopyOptions) (*asc.AppStoreVersionMetadataCopySummary, error) {
 		return &asc.AppStoreVersionMetadataCopySummary{CopiedLocales: 1}, nil

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -129,6 +129,47 @@ func TestReleaseStageCommandExposesRoutingCoverageFile(t *testing.T) {
 	}
 }
 
+func TestReleaseStageCommandValidatesRoutingCoverageBeforePipeline(t *testing.T) {
+	originalClientFactory := releaseClientFactory
+	t.Cleanup(func() { releaseClientFactory = originalClientFactory })
+	clientCalled := false
+	releaseClientFactory = func() (*asc.Client, error) {
+		clientCalled = true
+		return nil, errors.New("client must not be created")
+	}
+
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":`), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+
+	cmd := ReleaseStageCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "APP_123",
+		"--version", "2.4.0",
+		"--build", "BUILD_123",
+		"--copy-metadata-from", "2.3.2",
+		"--routing-coverage-file", coveragePath,
+		"--dry-run",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	var execErr error
+	stderr := captureReleaseStderr(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if !errors.Is(execErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", execErr)
+	}
+	if !strings.Contains(stderr, "--routing-coverage-file is not usable") || !strings.Contains(stderr, "invalid JSON") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+	if clientCalled {
+		t.Fatal("release pipeline started before routing coverage validation")
+	}
+}
+
 func TestDefaultCheckpointPathSanitizesValues(t *testing.T) {
 	path := defaultCheckpointPath("app/123", "1.2.3-beta", "build#12", "IOS")
 	want := filepath.Join(".asc", "release", "checkpoints", "app_123_1.2.3-beta_build_12_IOS.json")
@@ -523,7 +564,7 @@ func TestExecuteStageAppliesRoutingCoverageBeforeReadiness(t *testing.T) {
 	})
 
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
-	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
 		t.Fatalf("write routing coverage fixture: %v", err)
 	}
 
@@ -552,7 +593,7 @@ func TestExecuteStageAppliesRoutingCoverageBeforeReadiness(t *testing.T) {
 			if !oldCoverageDeleted {
 				t.Fatal("new routing coverage was created before the old asset was deleted")
 			}
-			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":40,"offset":0}]}}}`)
+			return releaseJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":%d,"offset":0}]}}}`, len(validReleaseRoutingCoverageGeoJSON)))
 		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
 			return releaseJSONResponse(http.StatusOK, `{}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -118,6 +118,17 @@ func TestReleaseStageCommand_MissingRequiredFlags(t *testing.T) {
 	}
 }
 
+func TestReleaseStageCommandExposesRoutingCoverageFile(t *testing.T) {
+	cmd := ReleaseStageCommand()
+	flag := cmd.FlagSet.Lookup("routing-coverage-file")
+	if flag == nil {
+		t.Fatal("expected --routing-coverage-file flag")
+	}
+	if !strings.Contains(flag.Usage, "before readiness") {
+		t.Fatalf("expected routing coverage timing in flag help, got %q", flag.Usage)
+	}
+}
+
 func TestDefaultCheckpointPathSanitizesValues(t *testing.T) {
 	path := defaultCheckpointPath("app/123", "1.2.3-beta", "build#12", "IOS")
 	want := filepath.Join(".asc", "release", "checkpoints", "app_123_1.2.3-beta_build_12_IOS.json")
@@ -496,6 +507,92 @@ func TestExecuteStage_CopyMetadataSuccessPath(t *testing.T) {
 	}
 	if result.Steps[3].Message != "readiness checks passed with 1 advisory; App Privacy may still block submission" {
 		t.Fatalf("expected readiness advisory message, got %q", result.Steps[3].Message)
+	}
+}
+
+func TestExecuteStageAppliesRoutingCoverageBeforeReadiness(t *testing.T) {
+	origClientFactory := releaseClientFactory
+	origMetadataCopyExecutor := metadataCopyExecutor
+	origReadinessBuilder := readinessReportBuilder
+	origTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		releaseClientFactory = origClientFactory
+		metadataCopyExecutor = origMetadataCopyExecutor
+		readinessReportBuilder = origReadinessBuilder
+		http.DefaultTransport = origTransport
+	})
+
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+
+	metadataCopyExecutor = func(context.Context, *asc.Client, metadataCopyOptions) (*asc.AppStoreVersionMetadataCopySummary, error) {
+		return &asc.AppStoreVersionMetadataCopySummary{CopiedLocales: 1}, nil
+	}
+	coverageCommitted := false
+	oldCoverageDeleted := false
+	readinessReportBuilder = func(context.Context, validatecli.ReadinessOptions) (validation.Report, error) {
+		if !coverageCommitted {
+			t.Fatal("readiness ran before routing coverage completed")
+		}
+		return validation.Report{Summary: validation.Summary{}}, nil
+	}
+
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_123/appStoreVersions":
+			return releaseJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"2.4.0","platform":"IOS","appStoreState":"PREPARE_FOR_SUBMISSION"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"old-checksum","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
+			oldCoverageDeleted = true
+			return releaseJSONResponse(http.StatusNoContent, "")
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			if !oldCoverageDeleted {
+				t.Fatal("new routing coverage was created before the old asset was deleted")
+			}
+			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":40,"offset":0}]}}}`)
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return releaseJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
+			coverageCommitted = true
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/build":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"BUILD_123","attributes":{"processingState":"VALID"}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	releaseClientFactory = func() (*asc.Client, error) { return newReleaseTestClient(t), nil }
+	result, err := executeStage(context.Background(), runOptions{
+		AppID:               "APP_123",
+		Version:             "2.4.0",
+		BuildID:             "BUILD_123",
+		CopyMetadataFrom:    "2.3.2",
+		Platform:            "IOS",
+		RoutingCoverageFile: coveragePath,
+		Timeout:             releaseRunTimeout,
+		Confirm:             true,
+		CheckpointFile:      filepath.Join(t.TempDir(), "stage-checkpoint.json"),
+	})
+	if err != nil {
+		t.Fatalf("executeStage() error: %v", err)
+	}
+	if len(result.Steps) != 5 {
+		t.Fatalf("expected five stage steps, got %#v", result.Steps)
+	}
+	wantSteps := []string{stepEnsureVersion, stepApplyMetadata, stepApplyRoutingCoverage, stepAttachBuild, stepValidateReadiness}
+	for i, want := range wantSteps {
+		if result.Steps[i].Name != want {
+			t.Fatalf("step %d = %q, want %q", i, result.Steps[i].Name, want)
+		}
+	}
+	if result.RoutingCoverageFile != coveragePath {
+		t.Fatalf("routingCoverageFile = %q, want %q", result.RoutingCoverageFile, coveragePath)
 	}
 }
 

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -397,6 +397,151 @@ func TestExecuteStageRejectsRemovingRoutingCoverageAfterCompletedOrUnknownStep(t
 	}
 }
 
+func TestExecuteStageResumesCheckpointAfterAddingRoutingCoverage(t *testing.T) {
+	originalClientFactory := releaseClientFactory
+	originalCopyExecutor := metadataCopyExecutor
+	originalReadinessBuilder := readinessReportBuilder
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		releaseClientFactory = originalClientFactory
+		metadataCopyExecutor = originalCopyExecutor
+		readinessReportBuilder = originalReadinessBuilder
+		http.DefaultTransport = originalTransport
+	})
+
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	checkpointPath := filepath.Join(t.TempDir(), "stage-checkpoint.json")
+	if err := saveCheckpoint(checkpointPath, runCheckpoint{
+		AppID:            "APP_123",
+		Version:          "2.4.0",
+		BuildID:          "BUILD_123",
+		CopyMetadataFrom: "2.3.2",
+		Platform:         "IOS",
+		VersionID:        "VERSION_123",
+		Mode:             releaseModeStage,
+		Completed: map[string]bool{
+			stepEnsureVersion:     true,
+			stepApplyMetadata:     true,
+			stepAttachBuild:       true,
+			stepValidateReadiness: true,
+		},
+	}); err != nil {
+		t.Fatalf("save checkpoint: %v", err)
+	}
+
+	metadataRuns := 0
+	metadataCopyExecutor = func(context.Context, *asc.Client, metadataCopyOptions) (*asc.AppStoreVersionMetadataCopySummary, error) {
+		metadataRuns++
+		return &asc.AppStoreVersionMetadataCopySummary{CopiedLocales: 1}, nil
+	}
+	coverageCommitted := false
+	readinessRuns := 0
+	readinessReportBuilder = func(context.Context, validatecli.ReadinessOptions) (validation.Report, error) {
+		readinessRuns++
+		if !coverageCommitted {
+			t.Fatal("readiness ran before newly added routing coverage completed")
+		}
+		return validation.Report{Summary: validation.Summary{}}, nil
+	}
+
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"2.4.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_123"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/build":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"BUILD_123","attributes":{"processingState":"VALID"}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404"}]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			return releaseJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":%d,"offset":0}]}}}`, len(validReleaseRoutingCoverageGeoJSON)))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return releaseJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
+			coverageCommitted = true
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	releaseClientFactory = func() (*asc.Client, error) { return newReleaseTestClient(t), nil }
+
+	result, err := executeStage(context.Background(), runOptions{
+		AppID:               "APP_123",
+		Version:             "2.4.0",
+		BuildID:             "BUILD_123",
+		CopyMetadataFrom:    "2.3.2",
+		RoutingCoverageFile: coveragePath,
+		Platform:            "IOS",
+		Timeout:             releaseRunTimeout,
+		Confirm:             true,
+		CheckpointFile:      checkpointPath,
+	})
+	if err != nil {
+		t.Fatalf("executeStage() error: %v", err)
+	}
+	if !result.Resumed {
+		t.Fatal("executeStage() resumed = false, want true")
+	}
+	if metadataRuns != 1 || readinessRuns != 1 || !coverageCommitted {
+		t.Fatalf("executeStage() metadata=%d readiness=%d coverageCommitted=%t, want 1, 1, true", metadataRuns, readinessRuns, coverageCommitted)
+	}
+	if len(result.Steps) != 5 {
+		t.Fatalf("executeStage() steps = %#v, want five steps", result.Steps)
+	}
+	if result.Steps[0].Status != "skipped" || result.Steps[3].Status != "skipped" {
+		t.Fatalf("executeStage() did not preserve verified ensure/build completions: %#v", result.Steps)
+	}
+	if result.Steps[2].Name != stepApplyRoutingCoverage || result.Steps[2].Status != "ok" {
+		t.Fatalf("executeStage() routing step = %#v, want newly applied coverage", result.Steps[2])
+	}
+
+	saved, err := loadCheckpoint(checkpointPath)
+	if err != nil {
+		t.Fatalf("load checkpoint: %v", err)
+	}
+	if saved == nil || saved.RoutingCoverageFile != coveragePath {
+		t.Fatalf("saved checkpoint = %#v, want routing file %q", saved, coveragePath)
+	}
+	for _, step := range []string{stepEnsureVersion, stepApplyMetadata, stepApplyRoutingCoverage, stepAttachBuild, stepValidateReadiness} {
+		if !saved.Completed[step] {
+			t.Fatalf("saved checkpoint missing completed step %q: %#v", step, saved.Completed)
+		}
+	}
+}
+
+func TestCheckpointRejectsAddingRoutingCoverageAfterUnsafeCompletion(t *testing.T) {
+	for _, completedStep := range []string{stepApplyRoutingCoverage, stepSubmitReview, "unrecognized_step"} {
+		t.Run(completedStep, func(t *testing.T) {
+			existing := &runCheckpoint{
+				AppID:            "APP_123",
+				Version:          "2.4.0",
+				BuildID:          "BUILD_123",
+				CopyMetadataFrom: "2.3.2",
+				Platform:         "IOS",
+				Mode:             releaseModeStage,
+				Completed:        map[string]bool{completedStep: true},
+			}
+			opts := runOptions{
+				AppID:               "APP_123",
+				Version:             "2.4.0",
+				BuildID:             "BUILD_123",
+				CopyMetadataFrom:    "2.3.2",
+				RoutingCoverageFile: "/tmp/coverage.geojson",
+				Platform:            "IOS",
+				Mode:                releaseModeStage,
+			}
+			if checkpointMatchesRunArguments(existing, opts) {
+				t.Fatalf("checkpointMatchesRunArguments() = true with unsafe completed step %q", completedStep)
+			}
+		})
+	}
+}
+
 func TestExecuteRun_ResumesCompletedCheckpoint(t *testing.T) {
 	origClientFactory := releaseClientFactory
 	origMetadataExecutor := metadataPushExecutor

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -1,0 +1,190 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	routingcoveragecli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/routingcoverage"
+)
+
+const routingCoveragePollInterval = 2 * time.Second
+
+type routingCoverageStepDetails struct {
+	Action        string `json:"action"`
+	CoverageID    string `json:"coverageId,omitempty"`
+	FileName      string `json:"fileName"`
+	Checksum      string `json:"checksum"`
+	DeliveryState string `json:"deliveryState,omitempty"`
+}
+
+func applyRoutingCoverageStep(ctx context.Context, client *asc.Client, versionID, filePath string, dryRun bool) (stepOutcome, error) {
+	prepared, err := routingcoveragecli.PrepareRoutingCoverageFile(filePath)
+	if err != nil {
+		return stepOutcome{}, err
+	}
+	if strings.TrimSpace(versionID) == "" {
+		if dryRun {
+			return stepOutcome{
+				Status:  "dry-run",
+				Message: "routing coverage plan deferred until version exists",
+				Details: routingCoverageStepDetails{
+					Action:   "deferred",
+					FileName: prepared.FileName,
+					Checksum: prepared.Checksum,
+				},
+			}, nil
+		}
+		return stepOutcome{}, fmt.Errorf("resolved version ID is empty")
+	}
+
+	existing, err := client.GetRoutingAppCoverageForVersion(ctx, versionID)
+	if err != nil && !asc.IsNotFound(err) {
+		return stepOutcome{}, fmt.Errorf("fetch current routing coverage: %w", err)
+	}
+	if asc.IsNotFound(err) {
+		existing = nil
+	}
+	if existing != nil && strings.TrimSpace(existing.Data.ID) == "" {
+		existing = nil
+	}
+
+	details := routingCoverageStepDetails{
+		Action:   "create",
+		FileName: prepared.FileName,
+		Checksum: prepared.Checksum,
+	}
+	if existing != nil {
+		details.CoverageID = strings.TrimSpace(existing.Data.ID)
+		details.DeliveryState = routingCoverageDeliveryState(existing)
+		sameChecksum := strings.EqualFold(
+			strings.TrimSpace(existing.Data.Attributes.SourceFileChecksum),
+			strings.TrimSpace(prepared.Checksum),
+		)
+		if sameChecksum && details.DeliveryState == "COMPLETE" {
+			details.Action = "reuse"
+			status := "skipped"
+			message := "routing coverage already in sync"
+			if dryRun {
+				status = "dry-run"
+				message += " (no action needed)"
+			}
+			return stepOutcome{Status: status, Message: message, Details: details, Persist: !dryRun}, nil
+		}
+		if sameChecksum && details.DeliveryState == "UPLOAD_COMPLETE" {
+			details.Action = "wait"
+			if dryRun {
+				return stepOutcome{
+					Status:  "dry-run",
+					Message: "would wait for matching routing coverage to finish processing",
+					Details: details,
+				}, nil
+			}
+			state, waitErr := waitForRoutingCoverageDelivery(ctx, client, existing.Data.ID)
+			details.DeliveryState = state
+			if waitErr != nil {
+				return stepOutcome{Details: details}, waitErr
+			}
+			details.Action = "reuse"
+			return stepOutcome{
+				Status:  "skipped",
+				Message: "routing coverage finished processing",
+				Details: details,
+				Persist: true,
+			}, nil
+		}
+		details.Action = "replace"
+	}
+
+	if dryRun {
+		message := "would upload routing coverage"
+		if details.Action == "replace" {
+			message = "would replace routing coverage"
+		}
+		return stepOutcome{Status: "dry-run", Message: message, Details: details}, nil
+	}
+
+	if existing != nil {
+		if err := client.DeleteRoutingAppCoverage(ctx, existing.Data.ID); err != nil {
+			return stepOutcome{Details: details}, fmt.Errorf("delete current routing coverage %s: %w", existing.Data.ID, err)
+		}
+	}
+
+	committed, err := routingcoveragecli.UploadPreparedRoutingCoverageFile(ctx, client, versionID, prepared)
+	if err != nil {
+		return stepOutcome{Details: details}, err
+	}
+	details.CoverageID = committed.Data.ID
+	details.DeliveryState = routingCoverageDeliveryState(committed)
+	state, err := waitForRoutingCoverageDelivery(ctx, client, committed.Data.ID)
+	details.DeliveryState = state
+	if err != nil {
+		return stepOutcome{Details: details}, err
+	}
+
+	message := "uploaded routing coverage"
+	if details.Action == "replace" {
+		message = "replaced routing coverage"
+	}
+	return stepOutcome{
+		Status:  "ok",
+		Message: message,
+		Details: details,
+		Persist: true,
+	}, nil
+}
+
+func waitForRoutingCoverageDelivery(ctx context.Context, client *asc.Client, coverageID string) (string, error) {
+	lastState := ""
+	_, err := asc.PollUntil(ctx, routingCoveragePollInterval, func(ctx context.Context) (struct{}, bool, error) {
+		response, err := client.GetRoutingAppCoverage(ctx, coverageID)
+		if err != nil {
+			return struct{}{}, false, err
+		}
+		lastState = routingCoverageDeliveryState(response)
+		switch lastState {
+		case "COMPLETE":
+			return struct{}{}, true, nil
+		case "FAILED":
+			return struct{}{}, false, fmt.Errorf("routing coverage %s delivery failed%s", coverageID, routingCoverageDeliveryErrors(response))
+		default:
+			return struct{}{}, false, nil
+		}
+	})
+	if err != nil {
+		return lastState, err
+	}
+	return lastState, nil
+}
+
+func routingCoverageDeliveryState(response *asc.RoutingAppCoverageResponse) string {
+	if response == nil || response.Data.Attributes.AssetDeliveryState == nil || response.Data.Attributes.AssetDeliveryState.State == nil {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(*response.Data.Attributes.AssetDeliveryState.State))
+}
+
+func routingCoverageDeliveryErrors(response *asc.RoutingAppCoverageResponse) string {
+	if response == nil || response.Data.Attributes.AssetDeliveryState == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(response.Data.Attributes.AssetDeliveryState.Errors))
+	for _, item := range response.Data.Attributes.AssetDeliveryState.Errors {
+		message := strings.TrimSpace(item.Message)
+		code := strings.TrimSpace(item.Code)
+		switch {
+		case code != "" && message != "":
+			parts = append(parts, code+": "+message)
+		case message != "":
+			parts = append(parts, message)
+		case code != "":
+			parts = append(parts, code)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return ": " + strings.Join(parts, "; ")
+}

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -118,6 +118,10 @@ func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, v
 		committed, err = routingcoveragecli.UploadPreparedRoutingCoverageFile(ctx, client, versionID, prepared)
 	}
 	if err != nil {
+		if committed != nil && strings.TrimSpace(committed.Data.ID) != "" {
+			details.CoverageID = strings.TrimSpace(committed.Data.ID)
+			details.DeliveryState = routingCoverageDeliveryState(committed)
+		}
 		return stepOutcome{Details: details}, err
 	}
 	details.CoverageID = committed.Data.ID

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -20,11 +20,7 @@ type routingCoverageStepDetails struct {
 	DeliveryState string `json:"deliveryState,omitempty"`
 }
 
-func applyRoutingCoverageStep(ctx context.Context, client *asc.Client, versionID, filePath string, dryRun bool) (stepOutcome, error) {
-	prepared, err := routingcoveragecli.PrepareRoutingCoverageFile(filePath)
-	if err != nil {
-		return stepOutcome{}, err
-	}
+func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, versionID string, prepared routingcoveragecli.PreparedRoutingCoverageFile, dryRun bool) (stepOutcome, error) {
 	if strings.TrimSpace(versionID) == "" {
 		if dryRun {
 			return stepOutcome{

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -72,7 +72,7 @@ func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, v
 			}
 			return stepOutcome{Status: status, Message: message, Details: details, Persist: !dryRun}, nil
 		}
-		if sameChecksum && details.DeliveryState == "UPLOAD_COMPLETE" {
+		if sameChecksum && details.DeliveryState != "AWAITING_UPLOAD" && details.DeliveryState != "FAILED" {
 			if err := routingcoveragecli.RevalidatePreparedRoutingCoverageFile(prepared); err != nil {
 				return stepOutcome{Details: details}, err
 			}

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -190,13 +190,16 @@ func routingCoverageDeliveryErrors(response *asc.RoutingAppCoverageResponse) str
 	}
 	parts := make([]string, 0, len(response.Data.Attributes.AssetDeliveryState.Errors))
 	for _, item := range response.Data.Attributes.AssetDeliveryState.Errors {
-		message := strings.TrimSpace(item.Message)
+		description := strings.TrimSpace(item.Description)
+		if description == "" {
+			description = strings.TrimSpace(item.Message)
+		}
 		code := strings.TrimSpace(item.Code)
 		switch {
-		case code != "" && message != "":
-			parts = append(parts, code+": "+message)
-		case message != "":
-			parts = append(parts, message)
+		case code != "" && description != "":
+			parts = append(parts, code+": "+description)
+		case description != "":
+			parts = append(parts, description)
 		case code != "":
 			parts = append(parts, code)
 		}

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -60,6 +60,9 @@ func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, v
 			strings.TrimSpace(prepared.Checksum),
 		)
 		if sameChecksum && details.DeliveryState == "COMPLETE" {
+			if err := routingcoveragecli.RevalidatePreparedRoutingCoverageFile(prepared); err != nil {
+				return stepOutcome{Details: details}, err
+			}
 			details.Action = "reuse"
 			status := "skipped"
 			message := "routing coverage already in sync"
@@ -70,6 +73,9 @@ func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, v
 			return stepOutcome{Status: status, Message: message, Details: details, Persist: !dryRun}, nil
 		}
 		if sameChecksum && details.DeliveryState == "UPLOAD_COMPLETE" {
+			if err := routingcoveragecli.RevalidatePreparedRoutingCoverageFile(prepared); err != nil {
+				return stepOutcome{Details: details}, err
+			}
 			details.Action = "wait"
 			if dryRun {
 				return stepOutcome{
@@ -82,6 +88,9 @@ func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, v
 			details.DeliveryState = state
 			if waitErr != nil {
 				return stepOutcome{Details: details}, waitErr
+			}
+			if err := routingcoveragecli.RevalidatePreparedRoutingCoverageFile(prepared); err != nil {
+				return stepOutcome{Details: details}, err
 			}
 			details.Action = "reuse"
 			return stepOutcome{

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -102,13 +102,12 @@ func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, v
 		return stepOutcome{Status: "dry-run", Message: message, Details: details}, nil
 	}
 
+	var committed *asc.RoutingAppCoverageResponse
 	if existing != nil {
-		if err := client.DeleteRoutingAppCoverage(ctx, existing.Data.ID); err != nil {
-			return stepOutcome{Details: details}, fmt.Errorf("delete current routing coverage %s: %w", existing.Data.ID, err)
-		}
+		committed, err = routingcoveragecli.ReplaceRoutingCoverageWithPreparedFile(ctx, client, versionID, existing.Data.ID, prepared)
+	} else {
+		committed, err = routingcoveragecli.UploadPreparedRoutingCoverageFile(ctx, client, versionID, prepared)
 	}
-
-	committed, err := routingcoveragecli.UploadPreparedRoutingCoverageFile(ctx, client, versionID, prepared)
 	if err != nil {
 		return stepOutcome{Details: details}, err
 	}

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -59,6 +59,16 @@ func applyPreparedRoutingCoverageStep(ctx context.Context, client *asc.Client, v
 			strings.TrimSpace(existing.Data.Attributes.SourceFileChecksum),
 			strings.TrimSpace(prepared.Checksum),
 		)
+		if sameChecksum && details.DeliveryState == "" {
+			refreshed, refreshErr := client.GetRoutingAppCoverage(ctx, existing.Data.ID)
+			if refreshErr != nil {
+				return stepOutcome{Details: details}, fmt.Errorf("fetch routing coverage %s delivery state: %w", existing.Data.ID, refreshErr)
+			}
+			details.DeliveryState = routingCoverageDeliveryState(refreshed)
+			if details.DeliveryState == "" {
+				return stepOutcome{Details: details}, fmt.Errorf("routing coverage %s response is missing a delivery state", existing.Data.ID)
+			}
+		}
 		if sameChecksum && details.DeliveryState == "COMPLETE" {
 			if err := routingcoveragecli.RevalidatePreparedRoutingCoverageFile(prepared); err != nil {
 				return stepOutcome{Details: details}, err

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -343,6 +343,39 @@ func TestApplyRoutingCoverageStepCleansFailedReservation(t *testing.T) {
 	}
 }
 
+func TestApplyRoutingCoverageStepReportsNewIDWhenReservationCleanupFails(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"old-checksum","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
+			return releaseJSONResponse(http.StatusNoContent, "")
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[]}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			return releaseJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","detail":"cleanup unavailable"}]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	outcome, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepareReleaseRoutingCoverage(t, coveragePath), false)
+	if err == nil || !strings.Contains(err.Error(), "also failed to delete routing coverage reservation COVERAGE_NEW") {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want retained-reservation diagnostic", err)
+	}
+	details, ok := outcome.Details.(routingCoverageStepDetails)
+	if !ok || details.Action != "replace" || details.CoverageID != "COVERAGE_NEW" {
+		t.Fatalf("expected cleanup error details to preserve the new coverage ID, got %#v", outcome.Details)
+	}
+}
+
 func TestApplyRoutingCoverageStepRevalidatesBeforeDeletingExistingCoverage(t *testing.T) {
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
 	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -17,6 +17,7 @@ const validReleaseRoutingCoverageGeoJSON = `{"type":"MultiPolygon","coordinates"
 
 func prepareReleaseRoutingCoverage(t *testing.T, path string) routingcoveragecli.PreparedRoutingCoverageFile {
 	t.Helper()
+	t.Chdir(filepath.Dir(path))
 	prepared, err := routingcoveragecli.PrepareRoutingCoverageFile(path)
 	if err != nil {
 		t.Fatalf("PrepareRoutingCoverageFile() error: %v", err)
@@ -138,6 +139,75 @@ func TestApplyRoutingCoverageStepCleansFailedReservation(t *testing.T) {
 	}
 	if !deleted {
 		t.Fatal("expected failed routing coverage reservation to be deleted")
+	}
+}
+
+func TestApplyRoutingCoverageStepRevalidatesBeforeDeletingExistingCoverage(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON+"\n"), 0o600); err != nil {
+		t.Fatalf("change routing coverage fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	deleted := false
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"old-checksum","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
+			deleted = true
+			return releaseJSONResponse(http.StatusNoContent, "")
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	if err == nil || !strings.Contains(err.Error(), "file changed after validation") {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want changed-file diagnostic", err)
+	}
+	if deleted {
+		t.Fatal("existing routing coverage was deleted before the prepared file was revalidated")
+	}
+}
+
+func TestUploadPreparedRoutingCoverageFileDoesNotDeleteAfterAmbiguousCommitResponse(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+
+	originalTransport := http.DefaultTransport
+	deleted := false
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			return releaseJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":%d,"offset":0}]}}}`, len(validReleaseRoutingCoverageGeoJSON)))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return releaseJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			deleted = true
+			return releaseJSONResponse(http.StatusNoContent, "")
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	_, err := routingcoveragecli.UploadPreparedRoutingCoverageFile(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared)
+	if err == nil || !strings.Contains(err.Error(), "committed routing coverage response is missing an ID") {
+		t.Fatalf("UploadPreparedRoutingCoverageFile() error = %v, want missing-ID diagnostic", err)
+	}
+	if deleted {
+		t.Fatal("routing coverage was deleted after an ambiguous successful commit response")
 	}
 }
 

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	routingcoveragecli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/routingcoverage"
@@ -113,7 +114,7 @@ func TestApplyRoutingCoverageStepRevalidatesAfterWaitingForMatchingAsset(t *test
 	}
 }
 
-func TestApplyRoutingCoverageStepWaitsWhenMatchingRelationshipOmitsDeliveryState(t *testing.T) {
+func TestApplyRoutingCoverageStepRefreshesWhenMatchingRelationshipOmitsDeliveryState(t *testing.T) {
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
 	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
 		t.Fatalf("write routing coverage fixture: %v", err)
@@ -144,6 +145,92 @@ func TestApplyRoutingCoverageStepWaitsWhenMatchingRelationshipOmitsDeliveryState
 	details, ok := outcome.Details.(routingCoverageStepDetails)
 	if !ok || details.Action != "reuse" || details.DeliveryState != "COMPLETE" {
 		t.Fatalf("unexpected reuse details: %#v", outcome.Details)
+	}
+	wantPaths := "GET /v1/appStoreVersions/VERSION_123/routingAppCoverage,GET /v1/routingAppCoverages/COVERAGE_123"
+	if strings.Join(requestPaths, ",") != wantPaths {
+		t.Fatalf("unexpected reconciliation requests: %v", requestPaths)
+	}
+}
+
+func TestApplyRoutingCoverageStepReplacesMatchingAwaitingUploadWhenRelationshipOmitsDeliveryState(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+	requestPaths := []string{}
+
+	var serverURL string
+	client, serverURL := newReleaseTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestPaths = append(requestPaths, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			writeReleaseTestJSON(w, http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":%q}}}`, prepared.Checksum))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"","assetDeliveryState":{"state":"AWAITING_UPLOAD"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
+			w.WriteHeader(http.StatusNoContent)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			writeReleaseTestJSON(w, http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[{"method":"PUT","url":%q,"length":%d,"offset":0}]}}}`, serverURL+"/upload/coverage", len(validReleaseRoutingCoverageGeoJSON)))
+		case req.Method == http.MethodPut && req.URL.Path == "/upload/coverage":
+			if _, err := io.Copy(io.Discard, req.Body); err != nil {
+				t.Errorf("read upload body: %v", err)
+				http.Error(w, "read failed", http.StatusInternalServerError)
+				return
+			}
+			writeReleaseTestJSON(w, http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	outcome, err := applyPreparedRoutingCoverageStep(ctx, client, "VERSION_123", prepared, false)
+	if err != nil {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error: %v", err)
+	}
+	details, ok := outcome.Details.(routingCoverageStepDetails)
+	if outcome.Status != "ok" || !outcome.Persist || !ok || details.Action != "replace" || details.CoverageID != "COVERAGE_NEW" {
+		t.Fatalf("unexpected replacement outcome: %#v", outcome)
+	}
+	wantPaths := "GET /v1/appStoreVersions/VERSION_123/routingAppCoverage,GET /v1/routingAppCoverages/COVERAGE_OLD,DELETE /v1/routingAppCoverages/COVERAGE_OLD,POST /v1/routingAppCoverages,PUT /upload/coverage,PATCH /v1/routingAppCoverages/COVERAGE_NEW,GET /v1/routingAppCoverages/COVERAGE_NEW"
+	if strings.Join(requestPaths, ",") != wantPaths {
+		t.Fatalf("unexpected reconciliation requests: %v", requestPaths)
+	}
+}
+
+func TestApplyRoutingCoverageStepRejectsMatchingCoverageWhenFullResourceOmitsDeliveryState(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+	requestPaths := []string{}
+
+	client, _ := newReleaseTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestPaths = append(requestPaths, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			writeReleaseTestJSON(w, http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q}}}`, prepared.Checksum))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{}}}`)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := applyPreparedRoutingCoverageStep(ctx, client, "VERSION_123", prepared, false)
+	if err == nil || !strings.Contains(err.Error(), "response is missing a delivery state") {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want missing-state diagnostic", err)
 	}
 	wantPaths := "GET /v1/appStoreVersions/VERSION_123/routingAppCoverage,GET /v1/routingAppCoverages/COVERAGE_123"
 	if strings.Join(requestPaths, ",") != wantPaths {

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -59,6 +59,26 @@ func TestApplyRoutingCoverageStepReusesMatchingCompleteAsset(t *testing.T) {
 	}
 }
 
+func TestWaitForRoutingCoverageDeliveryIncludesSchemaErrorDescriptions(t *testing.T) {
+	client, _ := newReleaseTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/routingAppCoverages/COVERAGE_123" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"FAILED","errors":[{"code":"FILE_INVALID","description":"The GeoJSON is invalid."},{"description":"Try another file."}]}}}}`)
+	}))
+
+	state, err := waitForRoutingCoverageDelivery(context.Background(), client, "COVERAGE_123")
+	if state != "FAILED" {
+		t.Fatalf("waitForRoutingCoverageDelivery() state = %q, want FAILED", state)
+	}
+	const want = "routing coverage COVERAGE_123 delivery failed: FILE_INVALID: The GeoJSON is invalid.; Try another file."
+	if err == nil || err.Error() != want {
+		t.Fatalf("waitForRoutingCoverageDelivery() error = %v, want %q", err, want)
+	}
+}
+
 func TestApplyRoutingCoverageStepRevalidatesBeforeReusingCompleteAsset(t *testing.T) {
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
 	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -113,6 +113,44 @@ func TestApplyRoutingCoverageStepRevalidatesAfterWaitingForMatchingAsset(t *test
 	}
 }
 
+func TestApplyRoutingCoverageStepWaitsWhenMatchingRelationshipOmitsDeliveryState(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+	requestPaths := []string{}
+
+	client, _ := newReleaseTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestPaths = append(requestPaths, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			writeReleaseTestJSON(w, http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q}}}`, prepared.Checksum))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+
+	outcome, err := applyPreparedRoutingCoverageStep(context.Background(), client, "VERSION_123", prepared, false)
+	if err != nil {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error: %v", err)
+	}
+	if outcome.Status != "skipped" || !outcome.Persist {
+		t.Fatalf("expected persisted reuse outcome, got %#v", outcome)
+	}
+	details, ok := outcome.Details.(routingCoverageStepDetails)
+	if !ok || details.Action != "reuse" || details.DeliveryState != "COMPLETE" {
+		t.Fatalf("unexpected reuse details: %#v", outcome.Details)
+	}
+	wantPaths := "GET /v1/appStoreVersions/VERSION_123/routingAppCoverage,GET /v1/routingAppCoverages/COVERAGE_123"
+	if strings.Join(requestPaths, ",") != wantPaths {
+		t.Fatalf("unexpected reconciliation requests: %v", requestPaths)
+	}
+}
+
 func TestApplyRoutingCoverageStepDryRunPlansReplacementWithoutMutation(t *testing.T) {
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
 	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -54,6 +55,60 @@ func TestApplyRoutingCoverageStepReusesMatchingCompleteAsset(t *testing.T) {
 	details, ok := outcome.Details.(routingCoverageStepDetails)
 	if !ok || details.Action != "reuse" || details.CoverageID != "COVERAGE_123" {
 		t.Fatalf("unexpected reuse details: %#v", outcome.Details)
+	}
+}
+
+func TestApplyRoutingCoverageStepRevalidatesBeforeReusingCompleteAsset(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON+"\n"), 0o600); err != nil {
+		t.Fatalf("change routing coverage fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/VERSION_123/routingAppCoverage" {
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return releaseJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q,"assetDeliveryState":{"state":"COMPLETE"}}}}`, prepared.Checksum))
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	if err == nil || !strings.Contains(err.Error(), "file changed after validation") {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want changed-file diagnostic", err)
+	}
+}
+
+func TestApplyRoutingCoverageStepRevalidatesAfterWaitingForMatchingAsset(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q,"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`, prepared.Checksum))
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
+			if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON+"\n"), 0o600); err != nil {
+				return nil, err
+			}
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	if err == nil || !strings.Contains(err.Error(), "file changed after validation") {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want changed-file diagnostic", err)
 	}
 }
 
@@ -173,6 +228,78 @@ func TestApplyRoutingCoverageStepRevalidatesBeforeDeletingExistingCoverage(t *te
 	}
 	if deleted {
 		t.Fatal("existing routing coverage was deleted before the prepared file was revalidated")
+	}
+}
+
+func TestReplaceRoutingCoverageRejectsEmptyVersionBeforeDeletingExistingCoverage(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	_, err := routingcoveragecli.ReplaceRoutingCoverageWithPreparedFile(context.Background(), newReleaseTestClient(t), " \t ", "COVERAGE_OLD", prepared)
+	if err == nil || !strings.Contains(err.Error(), "version ID is required") {
+		t.Fatalf("ReplaceRoutingCoverageWithPreparedFile() error = %v, want version ID diagnostic", err)
+	}
+}
+
+func TestApplyRoutingCoverageStepUploadsSnapshotAfterDeletingExistingCoverage(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	originalContent := []byte(validReleaseRoutingCoverageGeoJSON)
+	changedContent := []byte(strings.Replace(validReleaseRoutingCoverageGeoJSON, "77.5", "78.5", 1))
+	if len(changedContent) != len(originalContent) {
+		t.Fatalf("fixture sizes differ: changed=%d original=%d", len(changedContent), len(originalContent))
+	}
+	if err := os.WriteFile(coveragePath, originalContent, 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+
+	var uploaded []byte
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"old-checksum","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
+			if err := os.WriteFile(coveragePath, changedContent, 0o600); err != nil {
+				return nil, err
+			}
+			return releaseJSONResponse(http.StatusNoContent, "")
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			return releaseJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":%d,"offset":0}]}}}`, len(originalContent)))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			var err error
+			uploaded, err = io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			return releaseJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			return releaseJSONResponse(http.StatusNoContent, "")
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	if err != nil {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error: %v", err)
+	}
+	if string(uploaded) != string(originalContent) {
+		t.Fatalf("uploaded content = %q, want prepared snapshot %q", uploaded, originalContent)
 	}
 }
 

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -10,11 +10,23 @@ import (
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	routingcoveragecli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/routingcoverage"
 )
+
+const validReleaseRoutingCoverageGeoJSON = `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.7,13.1],[77.5,12.9]]]]}`
+
+func prepareReleaseRoutingCoverage(t *testing.T, path string) routingcoveragecli.PreparedRoutingCoverageFile {
+	t.Helper()
+	prepared, err := routingcoveragecli.PrepareRoutingCoverageFile(path)
+	if err != nil {
+		t.Fatalf("PrepareRoutingCoverageFile() error: %v", err)
+	}
+	return prepared
+}
 
 func TestApplyRoutingCoverageStepReusesMatchingCompleteAsset(t *testing.T) {
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
-	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
 		t.Fatalf("write routing coverage fixture: %v", err)
 	}
 	checksum, err := asc.ComputeFileChecksum(coveragePath, asc.ChecksumAlgorithmMD5)
@@ -31,7 +43,7 @@ func TestApplyRoutingCoverageStepReusesMatchingCompleteAsset(t *testing.T) {
 	})
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
-	outcome, err := applyRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", coveragePath, false)
+	outcome, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepareReleaseRoutingCoverage(t, coveragePath), false)
 	if err != nil {
 		t.Fatalf("applyRoutingCoverageStep() error: %v", err)
 	}
@@ -46,7 +58,7 @@ func TestApplyRoutingCoverageStepReusesMatchingCompleteAsset(t *testing.T) {
 
 func TestApplyRoutingCoverageStepDryRunPlansReplacementWithoutMutation(t *testing.T) {
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
-	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
 		t.Fatalf("write routing coverage fixture: %v", err)
 	}
 
@@ -59,7 +71,7 @@ func TestApplyRoutingCoverageStepDryRunPlansReplacementWithoutMutation(t *testin
 	})
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
-	outcome, err := applyRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", coveragePath, true)
+	outcome, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepareReleaseRoutingCoverage(t, coveragePath), true)
 	if err != nil {
 		t.Fatalf("applyRoutingCoverageStep() error: %v", err)
 	}
@@ -74,7 +86,7 @@ func TestApplyRoutingCoverageStepDryRunPlansReplacementWithoutMutation(t *testin
 
 func TestApplyRoutingCoverageStepTreatsNullRelationshipAsMissing(t *testing.T) {
 	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
-	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
 		t.Fatalf("write routing coverage fixture: %v", err)
 	}
 
@@ -87,13 +99,45 @@ func TestApplyRoutingCoverageStepTreatsNullRelationshipAsMissing(t *testing.T) {
 	})
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
-	outcome, err := applyRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", coveragePath, true)
+	outcome, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepareReleaseRoutingCoverage(t, coveragePath), true)
 	if err != nil {
 		t.Fatalf("applyRoutingCoverageStep() error: %v", err)
 	}
 	details, ok := outcome.Details.(routingCoverageStepDetails)
 	if !ok || details.Action != "create" || details.CoverageID != "" {
 		t.Fatalf("unexpected null-relationship plan: %#v", outcome.Details)
+	}
+}
+
+func TestApplyRoutingCoverageStepCleansFailedReservation(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	deleted := false
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusOK, `{"data":null}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			return releaseJSONResponse(http.StatusCreated, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[]}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			deleted = true
+			return releaseJSONResponse(http.StatusNoContent, "")
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepareReleaseRoutingCoverage(t, coveragePath), false)
+	if err == nil || !strings.Contains(err.Error(), "no upload operations returned") {
+		t.Fatalf("applyRoutingCoverageStep() error = %v, want missing upload operations", err)
+	}
+	if !deleted {
+		t.Fatal("expected failed routing coverage reservation to be deleted")
 	}
 }
 

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -381,6 +381,42 @@ func TestUploadPreparedRoutingCoverageFileDoesNotDeleteAfterAmbiguousCommitRespo
 	}
 }
 
+func TestApplyRoutingCoverageStepReportsNewIDAfterAmbiguousReplacementCommit(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"old-checksum","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
+			return releaseJSONResponse(http.StatusNoContent, "")
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
+			return releaseJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":%d,"offset":0}]}}}`, len(validReleaseRoutingCoverageGeoJSON)))
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			return releaseJSONResponse(http.StatusOK, `{}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	outcome, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	if err == nil || !strings.Contains(err.Error(), "committed routing coverage response is missing an ID") {
+		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want missing-ID diagnostic", err)
+	}
+	details, ok := outcome.Details.(routingCoverageStepDetails)
+	if !ok || details.Action != "replace" || details.CoverageID != "COVERAGE_NEW" {
+		t.Fatalf("expected replacement error details to preserve the new coverage ID, got %#v", outcome.Details)
+	}
+}
+
 func TestVerifyResumedCheckpointRechecksRoutingCoverageInput(t *testing.T) {
 	client := newCheckpointBindingClient(t, func(req *http.Request) (*http.Response, error) {
 		switch {

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -1,0 +1,138 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestApplyRoutingCoverageStepReusesMatchingCompleteAsset(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+	checksum, err := asc.ComputeFileChecksum(coveragePath, asc.ChecksumAlgorithmMD5)
+	if err != nil {
+		t.Fatalf("compute routing coverage checksum: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/VERSION_123/routingAppCoverage" {
+			t.Fatalf("unexpected mutation while reusing routing coverage: %s %s", req.Method, req.URL.String())
+		}
+		return releaseJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"fileName":"coverage.geojson","sourceFileChecksum":%q,"assetDeliveryState":{"state":"COMPLETE"}}}}`, checksum.Hash))
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	outcome, err := applyRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", coveragePath, false)
+	if err != nil {
+		t.Fatalf("applyRoutingCoverageStep() error: %v", err)
+	}
+	if outcome.Status != "skipped" || !outcome.Persist {
+		t.Fatalf("expected persisted reuse outcome, got %#v", outcome)
+	}
+	details, ok := outcome.Details.(routingCoverageStepDetails)
+	if !ok || details.Action != "reuse" || details.CoverageID != "COVERAGE_123" {
+		t.Fatalf("unexpected reuse details: %#v", outcome.Details)
+	}
+}
+
+func TestApplyRoutingCoverageStepDryRunPlansReplacementWithoutMutation(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/VERSION_123/routingAppCoverage" {
+			t.Fatalf("unexpected mutation during routing coverage dry-run: %s %s", req.Method, req.URL.String())
+		}
+		return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"different","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	outcome, err := applyRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", coveragePath, true)
+	if err != nil {
+		t.Fatalf("applyRoutingCoverageStep() error: %v", err)
+	}
+	if outcome.Status != "dry-run" || outcome.Persist {
+		t.Fatalf("expected non-persisted dry-run outcome, got %#v", outcome)
+	}
+	details, ok := outcome.Details.(routingCoverageStepDetails)
+	if !ok || details.Action != "replace" {
+		t.Fatalf("unexpected dry-run details: %#v", outcome.Details)
+	}
+}
+
+func TestApplyRoutingCoverageStepTreatsNullRelationshipAsMissing(t *testing.T) {
+	coveragePath := filepath.Join(t.TempDir(), "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(`{"type":"MultiPolygon","coordinates":[]}`), 0o600); err != nil {
+		t.Fatalf("write routing coverage fixture: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/VERSION_123/routingAppCoverage" {
+			t.Fatalf("unexpected mutation during routing coverage dry-run: %s %s", req.Method, req.URL.String())
+		}
+		return releaseJSONResponse(http.StatusOK, `{"data":null}`)
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	outcome, err := applyRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", coveragePath, true)
+	if err != nil {
+		t.Fatalf("applyRoutingCoverageStep() error: %v", err)
+	}
+	details, ok := outcome.Details.(routingCoverageStepDetails)
+	if !ok || details.Action != "create" || details.CoverageID != "" {
+		t.Fatalf("unexpected null-relationship plan: %#v", outcome.Details)
+	}
+}
+
+func TestVerifyResumedCheckpointRechecksRoutingCoverageInput(t *testing.T) {
+	client := newCheckpointBindingClient(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"2.4.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_123"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/build":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"BUILD_123"}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+	opts := checkpointBindingOptions()
+	opts.RoutingCoverageFile = "/tmp/coverage.geojson"
+	checkpoint := runCheckpoint{
+		VersionID: "VERSION_123",
+		Completed: map[string]bool{
+			stepEnsureVersion:        true,
+			stepApplyMetadata:        true,
+			stepApplyRoutingCoverage: true,
+			stepAttachBuild:          true,
+			stepValidateReadiness:    true,
+		},
+	}
+	messages := []string{}
+	if err := verifyResumedCheckpointBinding(context.Background(), client, opts, &checkpoint, func(message string) {
+		messages = append(messages, message)
+	}); err != nil {
+		t.Fatalf("verifyResumedCheckpointBinding() error: %v", err)
+	}
+	if checkpoint.Completed[stepApplyRoutingCoverage] || checkpoint.Completed[stepValidateReadiness] {
+		t.Fatalf("expected routing coverage and readiness to be rechecked, got %#v", checkpoint.Completed)
+	}
+	if !checkpoint.Completed[stepEnsureVersion] || !checkpoint.Completed[stepAttachBuild] {
+		t.Fatalf("expected remotely verified steps to survive, got %#v", checkpoint.Completed)
+	}
+	if !strings.Contains(strings.Join(messages, "\n"), stepApplyRoutingCoverage) {
+		t.Fatalf("expected routing coverage recheck diagnostic, got %v", messages)
+	}
+}

--- a/internal/cli/release/routing_coverage_test.go
+++ b/internal/cli/release/routing_coverage_test.go
@@ -68,16 +68,16 @@ func TestApplyRoutingCoverageStepRevalidatesBeforeReusingCompleteAsset(t *testin
 		t.Fatalf("change routing coverage fixture: %v", err)
 	}
 
-	originalTransport := http.DefaultTransport
-	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client, _ := newReleaseTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/VERSION_123/routingAppCoverage" {
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
 		}
-		return releaseJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q,"assetDeliveryState":{"state":"COMPLETE"}}}}`, prepared.Checksum))
-	})
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+		writeReleaseTestJSON(w, http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q,"assetDeliveryState":{"state":"COMPLETE"}}}}`, prepared.Checksum))
+	}))
 
-	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), client, "VERSION_123", prepared, false)
 	if err == nil || !strings.Contains(err.Error(), "file changed after validation") {
 		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want changed-file diagnostic", err)
 	}
@@ -90,23 +90,24 @@ func TestApplyRoutingCoverageStepRevalidatesAfterWaitingForMatchingAsset(t *test
 	}
 	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
 
-	originalTransport := http.DefaultTransport
-	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client, _ := newReleaseTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
-			return releaseJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q,"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`, prepared.Checksum))
+			writeReleaseTestJSON(w, http.StatusOK, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"sourceFileChecksum":%q,"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`, prepared.Checksum))
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_123":
 			if err := os.WriteFile(coveragePath, []byte(validReleaseRoutingCoverageGeoJSON+"\n"), 0o600); err != nil {
-				return nil, err
+				t.Errorf("change routing coverage fixture: %v", err)
+				http.Error(w, "fixture write failed", http.StatusInternalServerError)
+				return
 			}
-			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_123","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
 		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
 		}
-	})
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	}))
 
-	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), client, "VERSION_123", prepared, false)
 	if err == nil || !strings.Contains(err.Error(), "file changed after validation") {
 		t.Fatalf("applyPreparedRoutingCoverageStep() error = %v, want changed-file diagnostic", err)
 	}
@@ -263,38 +264,42 @@ func TestApplyRoutingCoverageStepUploadsSnapshotAfterDeletingExistingCoverage(t 
 	prepared := prepareReleaseRoutingCoverage(t, coveragePath)
 
 	var uploaded []byte
-	originalTransport := http.DefaultTransport
-	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	var serverURL string
+	client, serverURL := newReleaseTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/routingAppCoverage":
-			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"old-checksum","assetDeliveryState":{"state":"COMPLETE"}}}}`)
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_OLD","attributes":{"sourceFileChecksum":"old-checksum","assetDeliveryState":{"state":"COMPLETE"}}}}`)
 		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_OLD":
 			if err := os.WriteFile(coveragePath, changedContent, 0o600); err != nil {
-				return nil, err
+				t.Errorf("change routing coverage fixture: %v", err)
+				http.Error(w, "fixture write failed", http.StatusInternalServerError)
+				return
 			}
-			return releaseJSONResponse(http.StatusNoContent, "")
+			w.WriteHeader(http.StatusNoContent)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/routingAppCoverages":
-			return releaseJSONResponse(http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/coverage","length":%d,"offset":0}]}}}`, len(originalContent)))
-		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			writeReleaseTestJSON(w, http.StatusCreated, fmt.Sprintf(`{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"uploadOperations":[{"method":"PUT","url":%q,"length":%d,"offset":0}]}}}`, serverURL+"/upload/coverage", len(originalContent)))
+		case req.Method == http.MethodPut && req.URL.Path == "/upload/coverage":
 			var err error
 			uploaded, err = io.ReadAll(req.Body)
 			if err != nil {
-				return nil, err
+				t.Errorf("read upload body: %v", err)
+				http.Error(w, "read failed", http.StatusInternalServerError)
+				return
 			}
-			return releaseJSONResponse(http.StatusOK, `{}`)
+			writeReleaseTestJSON(w, http.StatusOK, `{}`)
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
-			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"UPLOAD_COMPLETE"}}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
-			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
+			writeReleaseTestJSON(w, http.StatusOK, `{"data":{"type":"routingAppCoverages","id":"COVERAGE_NEW","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`)
 		case req.Method == http.MethodDelete && req.URL.Path == "/v1/routingAppCoverages/COVERAGE_NEW":
-			return releaseJSONResponse(http.StatusNoContent, "")
+			w.WriteHeader(http.StatusNoContent)
 		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
 		}
-	})
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	}))
 
-	_, err := applyPreparedRoutingCoverageStep(context.Background(), newReleaseTestClient(t), "VERSION_123", prepared, false)
+	_, err := applyPreparedRoutingCoverageStep(context.Background(), client, "VERSION_123", prepared, false)
 	if err != nil {
 		t.Fatalf("applyPreparedRoutingCoverageStep() error: %v", err)
 	}

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -741,7 +741,8 @@ func checkpointMatchesRunArguments(existing *runCheckpoint, opts runOptions) boo
 	if existing.RoutingCoverageFile == opts.RoutingCoverageFile {
 		return true
 	}
-	return checkpointCanDropPendingRoutingCoverage(existing, opts.RoutingCoverageFile)
+	return checkpointCanDropPendingRoutingCoverage(existing, opts.RoutingCoverageFile) ||
+		checkpointCanAddRoutingCoverage(existing, opts.RoutingCoverageFile)
 }
 
 func checkpointCanDropPendingRoutingCoverage(existing *runCheckpoint, desiredFile string) bool {
@@ -754,6 +755,23 @@ func checkpointCanDropPendingRoutingCoverage(existing *runCheckpoint, desiredFil
 		}
 		switch name {
 		case stepEnsureVersion, stepApplyMetadata:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func checkpointCanAddRoutingCoverage(existing *runCheckpoint, desiredFile string) bool {
+	if strings.TrimSpace(existing.RoutingCoverageFile) != "" || strings.TrimSpace(desiredFile) == "" {
+		return false
+	}
+	for name, completed := range existing.Completed {
+		if !completed {
+			continue
+		}
+		switch name {
+		case stepEnsureVersion, stepApplyMetadata, stepAttachBuild, stepValidateReadiness:
 		default:
 			return false
 		}

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -186,21 +186,14 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 			return result, err
 		}
 		if existing != nil {
-			if existing.AppID != opts.AppID ||
-				existing.Version != opts.Version ||
-				existing.BuildID != opts.BuildID ||
-				existing.Platform != opts.Platform ||
-				existing.MetadataDir != opts.MetadataDir ||
-				existing.CopyMetadataFrom != opts.CopyMetadataFrom ||
-				existing.RoutingCoverageFile != opts.RoutingCoverageFile ||
-				!equalStringSlices(existing.SelectedCopyFields, opts.SelectedCopyFields) ||
-				!checkpointModeMatches(existing.Mode, opts.Mode) {
+			if !checkpointMatchesRunArguments(existing, opts) {
 				err := fmt.Errorf("checkpoint does not match current run arguments")
 				result.Status = "error"
 				result.Error = err.Error()
 				return result, err
 			}
 			checkpoint = *existing
+			checkpoint.RoutingCoverageFile = opts.RoutingCoverageFile
 			if checkpoint.Completed == nil {
 				checkpoint.Completed = map[string]bool{}
 			}
@@ -731,6 +724,41 @@ func checkpointModeMatches(existingMode, desiredMode string) bool {
 	default:
 		return normalizedExistingMode == desiredMode
 	}
+}
+
+func checkpointMatchesRunArguments(existing *runCheckpoint, opts runOptions) bool {
+	if existing == nil ||
+		existing.AppID != opts.AppID ||
+		existing.Version != opts.Version ||
+		existing.BuildID != opts.BuildID ||
+		existing.Platform != opts.Platform ||
+		existing.MetadataDir != opts.MetadataDir ||
+		existing.CopyMetadataFrom != opts.CopyMetadataFrom ||
+		!equalStringSlices(existing.SelectedCopyFields, opts.SelectedCopyFields) ||
+		!checkpointModeMatches(existing.Mode, opts.Mode) {
+		return false
+	}
+	if existing.RoutingCoverageFile == opts.RoutingCoverageFile {
+		return true
+	}
+	return checkpointCanDropPendingRoutingCoverage(existing, opts.RoutingCoverageFile)
+}
+
+func checkpointCanDropPendingRoutingCoverage(existing *runCheckpoint, desiredFile string) bool {
+	if strings.TrimSpace(existing.RoutingCoverageFile) == "" || strings.TrimSpace(desiredFile) != "" {
+		return false
+	}
+	for name, completed := range existing.Completed {
+		if !completed {
+			continue
+		}
+		switch name {
+		case stepEnsureVersion, stepApplyMetadata:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func equalStringSlices(a, b []string) bool {

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -20,14 +20,15 @@ import (
 )
 
 const (
-	stepEnsureVersion     = "ensure_version"
-	stepApplyMetadata     = "apply_metadata"
-	stepAttachBuild       = "attach_build"
-	stepValidateReadiness = "validate_readiness"
-	stepSubmitReview      = "submit_review"
-	releaseModeRun        = "run"
-	releaseModeStage      = "stage"
-	releaseRunTimeout     = 30 * time.Minute
+	stepEnsureVersion        = "ensure_version"
+	stepApplyMetadata        = "apply_metadata"
+	stepApplyRoutingCoverage = "apply_routing_coverage"
+	stepAttachBuild          = "attach_build"
+	stepValidateReadiness    = "validate_readiness"
+	stepSubmitReview         = "submit_review"
+	releaseModeRun           = "run"
+	releaseModeStage         = "stage"
+	releaseRunTimeout        = 30 * time.Minute
 )
 
 var (
@@ -40,20 +41,21 @@ var (
 type metadataCopyOptions = shared.VersionMetadataCopyOptions
 
 type runOptions struct {
-	AppID              string
-	Version            string
-	BuildID            string
-	MetadataDir        string
-	CopyMetadataFrom   string
-	SelectedCopyFields []string
-	Platform           string
-	Timeout            time.Duration
-	DryRun             bool
-	Confirm            bool
-	StrictValidate     bool
-	CheckpointFile     string
-	Mode               string
-	SubmitForReview    bool
+	AppID               string
+	Version             string
+	BuildID             string
+	MetadataDir         string
+	CopyMetadataFrom    string
+	SelectedCopyFields  []string
+	RoutingCoverageFile string
+	Platform            string
+	Timeout             time.Duration
+	DryRun              bool
+	Confirm             bool
+	StrictValidate      bool
+	CheckpointFile      string
+	Mode                string
+	SubmitForReview     bool
 }
 
 type stepResult struct {
@@ -66,37 +68,39 @@ type stepResult struct {
 }
 
 type runResult struct {
-	AppID            string       `json:"appId"`
-	Version          string       `json:"version"`
-	VersionID        string       `json:"versionId,omitempty"`
-	BuildID          string       `json:"buildId"`
-	SubmissionID     string       `json:"submissionId,omitempty"`
-	MetadataDir      string       `json:"metadataDir,omitempty"`
-	CopyMetadataFrom string       `json:"copyMetadataFrom,omitempty"`
-	Platform         string       `json:"platform"`
-	DryRun           bool         `json:"dryRun"`
-	StrictValidate   bool         `json:"strictValidate,omitempty"`
-	CheckpointFile   string       `json:"checkpointFile,omitempty"`
-	Resumed          bool         `json:"resumed,omitempty"`
-	Status           string       `json:"status"`
-	FailedStep       string       `json:"failedStep,omitempty"`
-	Error            string       `json:"error,omitempty"`
-	Steps            []stepResult `json:"steps"`
+	AppID               string       `json:"appId"`
+	Version             string       `json:"version"`
+	VersionID           string       `json:"versionId,omitempty"`
+	BuildID             string       `json:"buildId"`
+	SubmissionID        string       `json:"submissionId,omitempty"`
+	MetadataDir         string       `json:"metadataDir,omitempty"`
+	CopyMetadataFrom    string       `json:"copyMetadataFrom,omitempty"`
+	RoutingCoverageFile string       `json:"routingCoverageFile,omitempty"`
+	Platform            string       `json:"platform"`
+	DryRun              bool         `json:"dryRun"`
+	StrictValidate      bool         `json:"strictValidate,omitempty"`
+	CheckpointFile      string       `json:"checkpointFile,omitempty"`
+	Resumed             bool         `json:"resumed,omitempty"`
+	Status              string       `json:"status"`
+	FailedStep          string       `json:"failedStep,omitempty"`
+	Error               string       `json:"error,omitempty"`
+	Steps               []stepResult `json:"steps"`
 }
 
 type runCheckpoint struct {
-	AppID              string          `json:"appId"`
-	Version            string          `json:"version"`
-	BuildID            string          `json:"buildId"`
-	MetadataDir        string          `json:"metadataDir,omitempty"`
-	CopyMetadataFrom   string          `json:"copyMetadataFrom,omitempty"`
-	SelectedCopyFields []string        `json:"selectedCopyFields,omitempty"`
-	Platform           string          `json:"platform"`
-	VersionID          string          `json:"versionId,omitempty"`
-	SubmissionID       string          `json:"submissionId,omitempty"`
-	Mode               string          `json:"mode,omitempty"`
-	Completed          map[string]bool `json:"completed"`
-	UpdatedAt          string          `json:"updatedAt,omitempty"`
+	AppID               string          `json:"appId"`
+	Version             string          `json:"version"`
+	BuildID             string          `json:"buildId"`
+	MetadataDir         string          `json:"metadataDir,omitempty"`
+	CopyMetadataFrom    string          `json:"copyMetadataFrom,omitempty"`
+	SelectedCopyFields  []string        `json:"selectedCopyFields,omitempty"`
+	RoutingCoverageFile string          `json:"routingCoverageFile,omitempty"`
+	Platform            string          `json:"platform"`
+	VersionID           string          `json:"versionId,omitempty"`
+	SubmissionID        string          `json:"submissionId,omitempty"`
+	Mode                string          `json:"mode,omitempty"`
+	Completed           map[string]bool `json:"completed"`
+	UpdatedAt           string          `json:"updatedAt,omitempty"`
 }
 
 type stepOutcome struct {
@@ -122,36 +126,41 @@ func executeStage(ctx context.Context, opts runOptions) (runResult, error) {
 
 func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 	stepCapacity := 4
+	if strings.TrimSpace(opts.RoutingCoverageFile) != "" {
+		stepCapacity++
+	}
 	if opts.SubmitForReview {
-		stepCapacity = 5
+		stepCapacity++
 	}
 	result := runResult{
-		AppID:            opts.AppID,
-		Version:          opts.Version,
-		BuildID:          opts.BuildID,
-		MetadataDir:      opts.MetadataDir,
-		CopyMetadataFrom: opts.CopyMetadataFrom,
-		Platform:         opts.Platform,
-		DryRun:           opts.DryRun,
-		StrictValidate:   opts.StrictValidate,
-		CheckpointFile:   opts.CheckpointFile,
-		Status:           "ok",
-		Steps:            make([]stepResult, 0, stepCapacity),
+		AppID:               opts.AppID,
+		Version:             opts.Version,
+		BuildID:             opts.BuildID,
+		MetadataDir:         opts.MetadataDir,
+		CopyMetadataFrom:    opts.CopyMetadataFrom,
+		RoutingCoverageFile: opts.RoutingCoverageFile,
+		Platform:            opts.Platform,
+		DryRun:              opts.DryRun,
+		StrictValidate:      opts.StrictValidate,
+		CheckpointFile:      opts.CheckpointFile,
+		Status:              "ok",
+		Steps:               make([]stepResult, 0, stepCapacity),
 	}
 	if opts.DryRun {
 		result.Status = "dry-run"
 	}
 
 	checkpoint := runCheckpoint{
-		AppID:              opts.AppID,
-		Version:            opts.Version,
-		BuildID:            opts.BuildID,
-		MetadataDir:        opts.MetadataDir,
-		CopyMetadataFrom:   opts.CopyMetadataFrom,
-		SelectedCopyFields: append([]string(nil), opts.SelectedCopyFields...),
-		Platform:           opts.Platform,
-		Mode:               opts.Mode,
-		Completed:          map[string]bool{},
+		AppID:               opts.AppID,
+		Version:             opts.Version,
+		BuildID:             opts.BuildID,
+		MetadataDir:         opts.MetadataDir,
+		CopyMetadataFrom:    opts.CopyMetadataFrom,
+		SelectedCopyFields:  append([]string(nil), opts.SelectedCopyFields...),
+		RoutingCoverageFile: opts.RoutingCoverageFile,
+		Platform:            opts.Platform,
+		Mode:                opts.Mode,
+		Completed:           map[string]bool{},
 	}
 
 	if !opts.DryRun {
@@ -168,6 +177,7 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 				existing.Platform != opts.Platform ||
 				existing.MetadataDir != opts.MetadataDir ||
 				existing.CopyMetadataFrom != opts.CopyMetadataFrom ||
+				existing.RoutingCoverageFile != opts.RoutingCoverageFile ||
 				!equalStringSlices(existing.SelectedCopyFields, opts.SelectedCopyFields) ||
 				!checkpointModeMatches(existing.Mode, opts.Mode) {
 				err := fmt.Errorf("checkpoint does not match current run arguments")
@@ -442,6 +452,18 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 		}, nil
 	}); err != nil {
 		return result, err
+	}
+
+	if strings.TrimSpace(opts.RoutingCoverageFile) != "" {
+		if err := runStep(stepApplyRoutingCoverage, "Fix the routing coverage file or remove --routing-coverage-file and rerun.", func() (stepOutcome, error) {
+			outcome, err := applyRoutingCoverageStep(requestCtx, client, versionID, opts.RoutingCoverageFile, opts.DryRun)
+			if err != nil {
+				return outcome, fmt.Errorf("apply routing coverage: %w", err)
+			}
+			return outcome, nil
+		}); err != nil {
+			return result, err
+		}
 	}
 
 	if err := runStep(stepAttachBuild, "Ensure --build points to a valid processed build for this app.", func() (stepOutcome, error) {

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/metadata"
+	routingcoveragecli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/routingcoverage"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	submitcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/submit"
 	validatecli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/validate"
@@ -41,21 +42,22 @@ var (
 type metadataCopyOptions = shared.VersionMetadataCopyOptions
 
 type runOptions struct {
-	AppID               string
-	Version             string
-	BuildID             string
-	MetadataDir         string
-	CopyMetadataFrom    string
-	SelectedCopyFields  []string
-	RoutingCoverageFile string
-	Platform            string
-	Timeout             time.Duration
-	DryRun              bool
-	Confirm             bool
-	StrictValidate      bool
-	CheckpointFile      string
-	Mode                string
-	SubmitForReview     bool
+	AppID                       string
+	Version                     string
+	BuildID                     string
+	MetadataDir                 string
+	CopyMetadataFrom            string
+	SelectedCopyFields          []string
+	RoutingCoverageFile         string
+	PreparedRoutingCoverageFile *routingcoveragecli.PreparedRoutingCoverageFile
+	Platform                    string
+	Timeout                     time.Duration
+	DryRun                      bool
+	Confirm                     bool
+	StrictValidate              bool
+	CheckpointFile              string
+	Mode                        string
+	SubmitForReview             bool
 }
 
 type stepResult struct {
@@ -148,6 +150,19 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 	}
 	if opts.DryRun {
 		result.Status = "dry-run"
+	}
+	if strings.TrimSpace(opts.RoutingCoverageFile) != "" {
+		if opts.PreparedRoutingCoverageFile == nil {
+			prepared, err := routingcoveragecli.PrepareRoutingCoverageFile(opts.RoutingCoverageFile)
+			if err != nil {
+				result.Status = "error"
+				result.Error = err.Error()
+				return result, err
+			}
+			opts.PreparedRoutingCoverageFile = &prepared
+		}
+		opts.RoutingCoverageFile = opts.PreparedRoutingCoverageFile.Path
+		result.RoutingCoverageFile = opts.RoutingCoverageFile
 	}
 
 	checkpoint := runCheckpoint{
@@ -456,7 +471,7 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 
 	if strings.TrimSpace(opts.RoutingCoverageFile) != "" {
 		if err := runStep(stepApplyRoutingCoverage, "Fix the routing coverage file or remove --routing-coverage-file and rerun.", func() (stepOutcome, error) {
-			outcome, err := applyRoutingCoverageStep(requestCtx, client, versionID, opts.RoutingCoverageFile, opts.DryRun)
+			outcome, err := applyPreparedRoutingCoverageStep(requestCtx, client, versionID, *opts.PreparedRoutingCoverageFile, opts.DryRun)
 			if err != nil {
 				return outcome, fmt.Errorf("apply routing coverage: %w", err)
 			}

--- a/internal/cli/release/stage.go
+++ b/internal/cli/release/stage.go
@@ -20,6 +20,7 @@ func ReleaseStageCommand() *ffcli.Command {
 	version := fs.String("version", "", "App Store version string (required)")
 	buildID := fs.String("build", "", "Build ID to attach (required)")
 	metadataDir := fs.String("metadata-dir", "", "Metadata directory to apply")
+	routingCoverageFile := fs.String("routing-coverage-file", "", "Routing app coverage GeoJSON file to reconcile before readiness")
 	copyMetadataFrom := fs.String("copy-metadata-from", "", "Copy localization metadata from this source version string")
 	copyFields := fs.String("copy-fields", "", "Comma-separated metadata fields to copy: description, keywords, marketingUrl, promotionalText, supportUrl, whatsNew")
 	excludeFields := fs.String("exclude-fields", "", "Comma-separated metadata fields to exclude from copy")
@@ -33,13 +34,14 @@ func ReleaseStageCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "stage",
-		ShortUsage: "asc release stage --app \"APP_ID\" --version \"2.4.0\" --build \"BUILD_ID\" (--metadata-dir \"./metadata/version/2.4.0\" | --copy-metadata-from \"2.3.2\") [flags]",
+		ShortUsage: "asc release stage --app \"APP_ID\" --version \"2.4.0\" --build \"BUILD_ID\" (--metadata-dir \"./metadata/version/2.4.0\" | --copy-metadata-from \"2.3.2\") [--routing-coverage-file \"./coverage.geojson\"] [flags]",
 		ShortHelp:  "Run version + metadata + attach + validate.",
 		LongHelp: `Run a deterministic pre-submit App Store staging pipeline:
 1. Ensure/create version
 2. Apply metadata/localizations or copy metadata from another version
-3. Attach selected build
-4. Run readiness checks
+3. Reconcile routing app coverage when --routing-coverage-file is set
+4. Attach selected build
+5. Run readiness checks
 
 Stops before creating a review submission.
 Supports dry-run planning, step-level structured output, and checkpointed resume.
@@ -47,7 +49,8 @@ Supports dry-run planning, step-level structured output, and checkpointed resume
 Examples:
   asc release stage --app "APP_ID" --version "2.4.0" --build "BUILD_ID" --copy-metadata-from "2.3.2" --dry-run
   asc release stage --app "APP_ID" --version "2.4.0" --build "BUILD_ID" --copy-metadata-from "2.3.2" --confirm
-  asc release stage --app "APP_ID" --version "2.4.0" --build "BUILD_ID" --metadata-dir "./metadata/version/2.4.0" --confirm`,
+  asc release stage --app "APP_ID" --version "2.4.0" --build "BUILD_ID" --metadata-dir "./metadata/version/2.4.0" --confirm
+  asc release stage --app "APP_ID" --version "2.4.0" --build "BUILD_ID" --copy-metadata-from "2.3.2" --routing-coverage-file "./coverage.geojson" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -106,6 +109,14 @@ Examples:
 				}
 			}
 
+			trimmedRoutingCoverageFile := strings.TrimSpace(*routingCoverageFile)
+			if trimmedRoutingCoverageFile != "" {
+				trimmedRoutingCoverageFile, err = filepath.Abs(trimmedRoutingCoverageFile)
+				if err != nil {
+					return fmt.Errorf("release stage: resolve routing coverage path: %w", err)
+				}
+			}
+
 			checkpointPath := strings.TrimSpace(*checkpointFile)
 			if checkpointPath == "" {
 				checkpointPath = defaultStageCheckpointPath(resolvedAppID, trimmedVersion, trimmedBuildID, normalizedPlatform)
@@ -116,18 +127,19 @@ Examples:
 			}
 
 			result, runErr := executeStage(ctx, runOptions{
-				AppID:              resolvedAppID,
-				Version:            trimmedVersion,
-				BuildID:            trimmedBuildID,
-				MetadataDir:        trimmedMetadataDir,
-				CopyMetadataFrom:   trimmedCopyMetadataFrom,
-				SelectedCopyFields: selectedCopyFields,
-				Platform:           normalizedPlatform,
-				Timeout:            *timeout,
-				DryRun:             *dryRun,
-				Confirm:            *confirm,
-				StrictValidate:     *strictValidate,
-				CheckpointFile:     absCheckpointPath,
+				AppID:               resolvedAppID,
+				Version:             trimmedVersion,
+				BuildID:             trimmedBuildID,
+				MetadataDir:         trimmedMetadataDir,
+				CopyMetadataFrom:    trimmedCopyMetadataFrom,
+				SelectedCopyFields:  selectedCopyFields,
+				RoutingCoverageFile: trimmedRoutingCoverageFile,
+				Platform:            normalizedPlatform,
+				Timeout:             *timeout,
+				DryRun:              *dryRun,
+				Confirm:             *confirm,
+				StrictValidate:      *strictValidate,
+				CheckpointFile:      absCheckpointPath,
 			})
 			if printErr := shared.PrintOutput(result, *output.Output, *output.Pretty); printErr != nil {
 				return printErr

--- a/internal/cli/release/stage.go
+++ b/internal/cli/release/stage.go
@@ -21,7 +21,7 @@ func ReleaseStageCommand() *ffcli.Command {
 	version := fs.String("version", "", "App Store version string (required)")
 	buildID := fs.String("build", "", "Build ID to attach (required)")
 	metadataDir := fs.String("metadata-dir", "", "Metadata directory to apply")
-	routingCoverageFile := fs.String("routing-coverage-file", "", "Routing app coverage GeoJSON file to reconcile before readiness")
+	routingCoverageFile := fs.String("routing-coverage-file", "", "[experimental] Routing app coverage GeoJSON file to reconcile before readiness")
 	copyMetadataFrom := fs.String("copy-metadata-from", "", "Copy localization metadata from this source version string")
 	copyFields := fs.String("copy-fields", "", "Comma-separated metadata fields to copy: description, keywords, marketingUrl, promotionalText, supportUrl, whatsNew")
 	excludeFields := fs.String("exclude-fields", "", "Comma-separated metadata fields to exclude from copy")

--- a/internal/cli/release/stage.go
+++ b/internal/cli/release/stage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	routingcoveragecli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/routingcoverage"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -110,11 +111,14 @@ Examples:
 			}
 
 			trimmedRoutingCoverageFile := strings.TrimSpace(*routingCoverageFile)
+			var preparedRoutingCoverageFile *routingcoveragecli.PreparedRoutingCoverageFile
 			if trimmedRoutingCoverageFile != "" {
-				trimmedRoutingCoverageFile, err = filepath.Abs(trimmedRoutingCoverageFile)
-				if err != nil {
-					return fmt.Errorf("release stage: resolve routing coverage path: %w", err)
+				prepared, prepareErr := routingcoveragecli.PrepareRoutingCoverageFile(trimmedRoutingCoverageFile)
+				if prepareErr != nil {
+					return shared.UsageError(fmt.Sprintf("--routing-coverage-file is not usable: %v", prepareErr))
 				}
+				trimmedRoutingCoverageFile = prepared.Path
+				preparedRoutingCoverageFile = &prepared
 			}
 
 			checkpointPath := strings.TrimSpace(*checkpointFile)
@@ -127,19 +131,20 @@ Examples:
 			}
 
 			result, runErr := executeStage(ctx, runOptions{
-				AppID:               resolvedAppID,
-				Version:             trimmedVersion,
-				BuildID:             trimmedBuildID,
-				MetadataDir:         trimmedMetadataDir,
-				CopyMetadataFrom:    trimmedCopyMetadataFrom,
-				SelectedCopyFields:  selectedCopyFields,
-				RoutingCoverageFile: trimmedRoutingCoverageFile,
-				Platform:            normalizedPlatform,
-				Timeout:             *timeout,
-				DryRun:              *dryRun,
-				Confirm:             *confirm,
-				StrictValidate:      *strictValidate,
-				CheckpointFile:      absCheckpointPath,
+				AppID:                       resolvedAppID,
+				Version:                     trimmedVersion,
+				BuildID:                     trimmedBuildID,
+				MetadataDir:                 trimmedMetadataDir,
+				CopyMetadataFrom:            trimmedCopyMetadataFrom,
+				SelectedCopyFields:          selectedCopyFields,
+				RoutingCoverageFile:         trimmedRoutingCoverageFile,
+				PreparedRoutingCoverageFile: preparedRoutingCoverageFile,
+				Platform:                    normalizedPlatform,
+				Timeout:                     *timeout,
+				DryRun:                      *dryRun,
+				Confirm:                     *confirm,
+				StrictValidate:              *strictValidate,
+				CheckpointFile:              absCheckpointPath,
 			})
 			if printErr := shared.PrintOutput(result, *output.Output, *output.Pretty); printErr != nil {
 				return printErr

--- a/internal/cli/routingcoverage/routing_coverage.go
+++ b/internal/cli/routingcoverage/routing_coverage.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -155,18 +154,9 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
-			info, err := os.Lstat(pathValue)
+			prepared, err := PrepareRoutingCoverageFile(pathValue)
 			if err != nil {
 				return fmt.Errorf("routing-coverage create: %w", err)
-			}
-			if info.Mode()&os.ModeSymlink != 0 {
-				return fmt.Errorf("routing-coverage create: refusing to read symlink %q", pathValue)
-			}
-			if info.IsDir() {
-				return fmt.Errorf("routing-coverage create: %q is a directory", pathValue)
-			}
-			if info.Size() <= 0 {
-				return fmt.Errorf("routing-coverage create: file size must be greater than 0")
 			}
 
 			client, err := shared.GetASCClient()
@@ -174,40 +164,9 @@ Examples:
 				return fmt.Errorf("routing-coverage create: %w", err)
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
-			resp, err := client.CreateRoutingAppCoverage(requestCtx, versionValue, filepath.Base(pathValue), info.Size())
+			commitResp, err := UploadPreparedRoutingCoverageFile(ctx, client, versionValue, prepared)
 			if err != nil {
-				return fmt.Errorf("routing-coverage create: failed to create: %w", err)
-			}
-			if resp == nil || len(resp.Data.Attributes.UploadOperations) == 0 {
-				return fmt.Errorf("routing-coverage create: no upload operations returned")
-			}
-
-			uploadCtx, uploadCancel := shared.ContextWithUploadTimeout(ctx)
-			err = asc.ExecuteUploadOperations(uploadCtx, pathValue, resp.Data.Attributes.UploadOperations)
-			uploadCancel()
-			if err != nil {
-				return fmt.Errorf("routing-coverage create: upload failed: %w", err)
-			}
-
-			checksum, err := asc.ComputeFileChecksum(pathValue, asc.ChecksumAlgorithmMD5)
-			if err != nil {
-				return fmt.Errorf("routing-coverage create: checksum failed: %w", err)
-			}
-
-			uploaded := true
-			updateAttrs := asc.RoutingAppCoverageUpdateAttributes{
-				SourceFileChecksum: &checksum.Hash,
-				Uploaded:           &uploaded,
-			}
-
-			commitCtx, commitCancel := shared.ContextWithUploadTimeout(ctx)
-			commitResp, err := client.UpdateRoutingAppCoverage(commitCtx, resp.Data.ID, updateAttrs)
-			commitCancel()
-			if err != nil {
-				return fmt.Errorf("routing-coverage create: failed to commit upload: %w", err)
+				return fmt.Errorf("routing-coverage create: %w", err)
 			}
 
 			return shared.PrintOutput(commitResp, *output.Output, *output.Pretty)

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -27,6 +27,7 @@ func TestPrepareRoutingCoverageFileValidatesGeoJSON(t *testing.T) {
 		{name: "no polygons", content: `{"type":"MultiPolygon","coordinates":[]}`, want: "at least one Polygon"},
 		{name: "short ring", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.5,12.9]]]]}`, want: "at least four coordinate points"},
 		{name: "open ring", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.7,13.1],[77.6,12.8]]]]}`, want: "start and end coordinate points"},
+		{name: "null coordinate component", content: `{"type":"MultiPolygon","coordinates":[[[[null,12.9],[77.7,12.9],[77.7,13.1],[null,12.9]]]]}`, want: "coordinate component 0 must be a number"},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -4,8 +4,95 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
+
+const validRoutingCoverageGeoJSON = `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.7,13.1],[77.5,12.9]]]]}`
+
+func TestPrepareRoutingCoverageFileValidatesGeoJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "malformed JSON", content: `{"type":`, want: "invalid JSON"},
+		{name: "wrong geometry type", content: `{"type":"Polygon","coordinates":[]}`, want: "MultiPolygon"},
+		{name: "no polygons", content: `{"type":"MultiPolygon","coordinates":[]}`, want: "at least one Polygon"},
+		{name: "short ring", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.5,12.9]]]]}`, want: "at least four coordinate points"},
+		{name: "open ring", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.7,13.1],[77.6,12.8]]]]}`, want: "start and end coordinate points"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "coverage.geojson")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+
+			_, err := PrepareRoutingCoverageFile(path)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("PrepareRoutingCoverageFile() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrepareRoutingCoverageFileRejectsSymlinkedParent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "coverage.geojson"), []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+	t.Chdir(root)
+
+	_, err := PrepareRoutingCoverageFile(filepath.Join("linked", "coverage.geojson"))
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("PrepareRoutingCoverageFile() error = %v, want rootfs.ErrSymlink", err)
+	}
+}
+
+func TestPreparedRoutingCoverageFileRechecksRootedParent(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	if err := os.Mkdir(sourceDir, 0o700); err != nil {
+		t.Fatalf("create source directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "coverage.geojson"), []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Chdir(root)
+	prepared, err := PrepareRoutingCoverageFile(filepath.Join("source", "coverage.geojson"))
+	if err != nil {
+		t.Fatalf("PrepareRoutingCoverageFile() error: %v", err)
+	}
+
+	if err := os.Rename(sourceDir, filepath.Join(root, "original")); err != nil {
+		t.Fatalf("move source directory: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "coverage.geojson"), []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write replacement fixture: %v", err)
+	}
+	if err := os.Symlink(outside, sourceDir); err != nil {
+		t.Fatalf("replace source with symlink: %v", err)
+	}
+
+	file, err := prepared.openSource()
+	if file != nil {
+		_ = file.Close()
+	}
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("openSource() error = %v, want rootfs.ErrSymlink", err)
+	}
+}
 
 func TestRoutingCoverageCommandShape(t *testing.T) {
 	cmd := RoutingCoverageCommand()

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -76,6 +76,77 @@ func TestPrepareRoutingCoverageFileFingerprintsValidatedSnapshot(t *testing.T) {
 	}
 }
 
+func TestPrepareRoutingCoverageFileAcceptsOutOfWorkingDirectoryRegularFiles(t *testing.T) {
+	base := t.TempDir()
+	workingDir := filepath.Join(base, "work")
+	inputDir := filepath.Join(base, "inputs")
+	if err := os.MkdirAll(workingDir, 0o700); err != nil {
+		t.Fatalf("create working directory: %v", err)
+	}
+	if err := os.MkdirAll(inputDir, 0o700); err != nil {
+		t.Fatalf("create input directory: %v", err)
+	}
+	coveragePath := filepath.Join(inputDir, "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Chdir(workingDir)
+
+	for _, path := range []string{
+		coveragePath,
+		filepath.Join("..", "inputs", "coverage.geojson"),
+	} {
+		prepared, err := PrepareRoutingCoverageFile(path)
+		if err != nil {
+			t.Fatalf("PrepareRoutingCoverageFile(%q) error: %v", path, err)
+		}
+		if prepared.Path != coveragePath {
+			t.Fatalf("PrepareRoutingCoverageFile(%q) path = %q, want %q", path, prepared.Path, coveragePath)
+		}
+	}
+}
+
+func TestPrepareRoutingCoverageFileRejectsOutOfWorkingDirectorySymlinks(t *testing.T) {
+	base := t.TempDir()
+	workingDir := filepath.Join(base, "work")
+	inputDir := filepath.Join(base, "inputs")
+	outsideDir := filepath.Join(base, "outside")
+	for _, dir := range []string{workingDir, inputDir, outsideDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("create directory %q: %v", dir, err)
+		}
+	}
+	targetPath := filepath.Join(outsideDir, "coverage.geojson")
+	if err := os.WriteFile(targetPath, []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	finalLink := filepath.Join(inputDir, "coverage.geojson")
+	if err := os.Symlink(targetPath, finalLink); err != nil {
+		t.Skipf("create final symlink: %v", err)
+	}
+	parentLink := filepath.Join(base, "linked-inputs")
+	if err := os.Symlink(outsideDir, parentLink); err != nil {
+		t.Skipf("create parent symlink: %v", err)
+	}
+	t.Chdir(workingDir)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "absolute final symlink", path: finalLink},
+		{name: "parent-relative symlinked parent", path: filepath.Join("..", "linked-inputs", "coverage.geojson")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PrepareRoutingCoverageFile(tt.path)
+			if !errors.Is(err, rootfs.ErrSymlink) {
+				t.Fatalf("PrepareRoutingCoverageFile(%q) error = %v, want rootfs.ErrSymlink", tt.path, err)
+			}
+		})
+	}
+}
+
 func TestPrepareRoutingCoverageFileRejectsSymlinkedParent(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
@@ -40,6 +42,37 @@ func TestPrepareRoutingCoverageFileValidatesGeoJSON(t *testing.T) {
 				t.Fatalf("PrepareRoutingCoverageFile() error = %v, want substring %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestPrepareRoutingCoverageFileFingerprintsValidatedSnapshot(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "coverage.geojson")
+	originalContent := validRoutingCoverageGeoJSON
+	changedContent := strings.Replace(originalContent, "MultiPolygon", "InvalidShape", 1)
+	if len(changedContent) != len(originalContent) {
+		t.Fatalf("fixture sizes differ: changed=%d original=%d", len(changedContent), len(originalContent))
+	}
+	if err := os.WriteFile(path, []byte(originalContent), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Chdir(root)
+
+	prepared, err := prepareRoutingCoverageFile(path, func(reader io.Reader, algorithm asc.ChecksumAlgorithm) (*asc.Checksum, error) {
+		if err := os.WriteFile(path, []byte(changedContent), 0o600); err != nil {
+			return nil, err
+		}
+		return asc.ComputeChecksumFromReader(reader, algorithm)
+	})
+	if err != nil {
+		t.Fatalf("PrepareRoutingCoverageFile() error: %v", err)
+	}
+	expected, err := asc.ComputeChecksumFromReader(strings.NewReader(originalContent), asc.ChecksumAlgorithmMD5)
+	if err != nil {
+		t.Fatalf("compute expected checksum: %v", err)
+	}
+	if prepared.Checksum != expected.Hash {
+		t.Fatalf("prepared checksum = %q, want validated snapshot checksum %q", prepared.Checksum, expected.Hash)
 	}
 }
 

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -28,6 +28,10 @@ func TestPrepareRoutingCoverageFileValidatesGeoJSON(t *testing.T) {
 		{name: "short ring", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.5,12.9]]]]}`, want: "at least four coordinate points"},
 		{name: "open ring", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,12.9],[77.7,12.9],[77.7,13.1],[77.6,12.8]]]]}`, want: "start and end coordinate points"},
 		{name: "null coordinate component", content: `{"type":"MultiPolygon","coordinates":[[[[null,12.9],[77.7,12.9],[77.7,13.1],[null,12.9]]]]}`, want: "coordinate component 0 must be a number"},
+		{name: "longitude above range", content: `{"type":"MultiPolygon","coordinates":[[[[181,12.9],[77.7,12.9],[77.7,13.1],[181,12.9]]]]}`, want: "longitude must be between -180 and 180"},
+		{name: "longitude below range", content: `{"type":"MultiPolygon","coordinates":[[[[-181,12.9],[77.7,12.9],[77.7,13.1],[-181,12.9]]]]}`, want: "longitude must be between -180 and 180"},
+		{name: "latitude above range", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,91],[77.7,12.9],[77.7,13.1],[77.5,91]]]]}`, want: "latitude must be between -90 and 90"},
+		{name: "latitude below range", content: `{"type":"MultiPolygon","coordinates":[[[[77.5,-91],[77.7,12.9],[77.7,13.1],[77.5,-91]]]]}`, want: "latitude must be between -90 and 90"},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -145,6 +145,46 @@ func TestPreparedRoutingCoverageFileRechecksRootedParent(t *testing.T) {
 	}
 }
 
+func TestVerifyPreparedRoutingCoverageSourceRejectsAppendDuringChecksum(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "coverage.geojson")
+	if err := os.WriteFile(path, []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Chdir(root)
+	prepared, err := PrepareRoutingCoverageFile(path)
+	if err != nil {
+		t.Fatalf("PrepareRoutingCoverageFile() error: %v", err)
+	}
+	source, err := prepared.openSource()
+	if err != nil {
+		t.Fatalf("openSource() error: %v", err)
+	}
+	defer source.Close()
+
+	err = verifyPreparedRoutingCoverageSourceWithChecksum(source, prepared, func(file *os.File, size int64) (*asc.Checksum, error) {
+		checksum, checksumErr := checksumOpenedFile(file, size)
+		if checksumErr != nil {
+			return nil, checksumErr
+		}
+		appender, appendErr := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+		if appendErr != nil {
+			return nil, appendErr
+		}
+		if _, appendErr = appender.WriteString("\n"); appendErr != nil {
+			_ = appender.Close()
+			return nil, appendErr
+		}
+		if appendErr = appender.Close(); appendErr != nil {
+			return nil, appendErr
+		}
+		return checksum, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "file changed after validation") {
+		t.Fatalf("verifyPreparedRoutingCoverageSourceWithChecksum() error = %v, want changed-file diagnostic", err)
+	}
+}
+
 func TestRoutingCoverageCommandShape(t *testing.T) {
 	cmd := RoutingCoverageCommand()
 	if cmd == nil {

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -106,6 +106,66 @@ func TestPrepareRoutingCoverageFileAcceptsOutOfWorkingDirectoryRegularFiles(t *t
 	}
 }
 
+func TestPrepareRoutingCoverageFileAcceptsAbsoluteFileThroughHostTempAlias(t *testing.T) {
+	tempAlias := filepath.Join(string(filepath.Separator), "tmp")
+	aliasInfo, err := os.Lstat(tempAlias)
+	if err != nil {
+		t.Skipf("inspect host temp alias: %v", err)
+	}
+	if aliasInfo.Mode()&os.ModeSymlink == 0 {
+		t.Skipf("host temp path %q is not a symlink alias", tempAlias)
+	}
+
+	inputDir, err := os.MkdirTemp(tempAlias, "asc-routing-coverage-")
+	if err != nil {
+		t.Fatalf("create input directory through host temp alias: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(inputDir) })
+	coveragePath := filepath.Join(inputDir, "coverage.geojson")
+	if err := os.WriteFile(coveragePath, []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	workingDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve unrelated working directory: %v", err)
+	}
+	t.Chdir(workingDir)
+
+	prepared, err := PrepareRoutingCoverageFile(coveragePath)
+	if err != nil {
+		t.Fatalf("PrepareRoutingCoverageFile(%q) error: %v", coveragePath, err)
+	}
+	if prepared.Path != coveragePath {
+		t.Fatalf("PrepareRoutingCoverageFile(%q) path = %q, want %q", coveragePath, prepared.Path, coveragePath)
+	}
+	if err := RevalidatePreparedRoutingCoverageFile(prepared); err != nil {
+		t.Fatalf("RevalidatePreparedRoutingCoverageFile() error: %v", err)
+	}
+
+	finalLink := filepath.Join(inputDir, "final-link.geojson")
+	if err := os.Symlink(coveragePath, finalLink); err != nil {
+		t.Fatalf("create final symlink: %v", err)
+	}
+	parentTarget := filepath.Join(inputDir, "parent-target")
+	if err := os.Mkdir(parentTarget, 0o700); err != nil {
+		t.Fatalf("create parent target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentTarget, "coverage.geojson"), []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write parent target fixture: %v", err)
+	}
+	parentLink := filepath.Join(inputDir, "parent-link")
+	if err := os.Symlink(parentTarget, parentLink); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+
+	for _, path := range []string{finalLink, filepath.Join(parentLink, "coverage.geojson")} {
+		if _, err := PrepareRoutingCoverageFile(path); !errors.Is(err, rootfs.ErrSymlink) {
+			t.Fatalf("PrepareRoutingCoverageFile(%q) error = %v, want rootfs.ErrSymlink", path, err)
+		}
+	}
+}
+
 func TestPrepareRoutingCoverageFileRejectsOutOfWorkingDirectorySymlinks(t *testing.T) {
 	base := t.TempDir()
 	workingDir := filepath.Join(base, "work")

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -33,6 +33,7 @@ func TestPrepareRoutingCoverageFileValidatesGeoJSON(t *testing.T) {
 			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
 				t.Fatalf("write fixture: %v", err)
 			}
+			t.Chdir(filepath.Dir(path))
 
 			_, err := PrepareRoutingCoverageFile(path)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
@@ -54,6 +55,23 @@ func TestPrepareRoutingCoverageFileRejectsSymlinkedParent(t *testing.T) {
 	t.Chdir(root)
 
 	_, err := PrepareRoutingCoverageFile(filepath.Join("linked", "coverage.geojson"))
+	if !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("PrepareRoutingCoverageFile() error = %v, want rootfs.ErrSymlink", err)
+	}
+}
+
+func TestPrepareRoutingCoverageFileRejectsAbsoluteSymlinkedParent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "coverage.geojson"), []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Fatalf("create parent symlink: %v", err)
+	}
+	t.Chdir(root)
+
+	_, err := PrepareRoutingCoverageFile(filepath.Join(root, "linked", "coverage.geojson"))
 	if !errors.Is(err, rootfs.ErrSymlink) {
 		t.Fatalf("PrepareRoutingCoverageFile() error = %v, want rootfs.ErrSymlink", err)
 	}

--- a/internal/cli/routingcoverage/routing_coverage_test.go
+++ b/internal/cli/routingcoverage/routing_coverage_test.go
@@ -50,6 +50,18 @@ func TestPrepareRoutingCoverageFileValidatesGeoJSON(t *testing.T) {
 	}
 }
 
+func TestPrepareRoutingCoverageFileRejectsNonGeoJSONExtension(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coverage.json")
+	if err := os.WriteFile(path, []byte(validRoutingCoverageGeoJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	_, err := PrepareRoutingCoverageFile(path)
+	if err == nil || !strings.Contains(err.Error(), ".geojson") {
+		t.Fatalf("PrepareRoutingCoverageFile() error = %v, want .geojson extension error", err)
+	}
+}
+
 func TestPrepareRoutingCoverageFileFingerprintsValidatedSnapshot(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "coverage.geojson")

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -219,6 +219,14 @@ func validateRoutingCoverageGeoJSON(reader io.Reader) error {
 						return fmt.Errorf("polygon %d ring %d point %d coordinate component %d must be a number", polygonIndex, ringIndex, pointIndex, componentIndex)
 					}
 				}
+				longitude := *point[0]
+				if longitude < -180 || longitude > 180 {
+					return fmt.Errorf("polygon %d ring %d point %d longitude must be between -180 and 180 (got %g)", polygonIndex, ringIndex, pointIndex, longitude)
+				}
+				latitude := *point[1]
+				if latitude < -90 || latitude > 90 {
+					return fmt.Errorf("polygon %d ring %d point %d latitude must be between -90 and 90 (got %g)", polygonIndex, ringIndex, pointIndex, latitude)
+				}
 			}
 			if !equalCoordinates(ring[0], ring[len(ring)-1]) {
 				return fmt.Errorf("polygon %d ring %d start and end coordinate points must be the same", polygonIndex, ringIndex)

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -28,8 +28,8 @@ type PreparedRoutingCoverageFile struct {
 }
 
 type routingCoverageGeoJSON struct {
-	Type        string          `json:"type"`
-	Coordinates [][][][]float64 `json:"coordinates"`
+	Type        string           `json:"type"`
+	Coordinates [][][][]*float64 `json:"coordinates"`
 }
 
 var errRoutingCoverageSourceChanged = errors.New("routing coverage source changed while reading")
@@ -214,6 +214,11 @@ func validateRoutingCoverageGeoJSON(reader io.Reader) error {
 				if len(point) < 2 {
 					return fmt.Errorf("polygon %d ring %d point %d must contain longitude and latitude", polygonIndex, ringIndex, pointIndex)
 				}
+				for componentIndex, component := range point {
+					if component == nil {
+						return fmt.Errorf("polygon %d ring %d point %d coordinate component %d must be a number", polygonIndex, ringIndex, pointIndex, componentIndex)
+					}
+				}
 			}
 			if !equalCoordinates(ring[0], ring[len(ring)-1]) {
 				return fmt.Errorf("polygon %d ring %d start and end coordinate points must be the same", polygonIndex, ringIndex)
@@ -223,12 +228,12 @@ func validateRoutingCoverageGeoJSON(reader io.Reader) error {
 	return nil
 }
 
-func equalCoordinates(left, right []float64) bool {
+func equalCoordinates(left, right []*float64) bool {
 	if len(left) != len(right) {
 		return false
 	}
 	for i := range left {
-		if left[i] != right[i] {
+		if *left[i] != *right[i] {
 			return false
 		}
 	}

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -1,0 +1,103 @@
+package routingcoverage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// PreparedRoutingCoverageFile is a validated routing coverage upload source.
+type PreparedRoutingCoverageFile struct {
+	Path     string
+	FileName string
+	FileSize int64
+	Checksum string
+}
+
+// PrepareRoutingCoverageFile validates and fingerprints a routing coverage file.
+func PrepareRoutingCoverageFile(path string) (PreparedRoutingCoverageFile, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("file is required")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return PreparedRoutingCoverageFile{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("refusing to read symlink %q", path)
+	}
+	if !info.Mode().IsRegular() {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("expected regular file: %q", path)
+	}
+	if info.Size() <= 0 {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("file size must be greater than 0")
+	}
+
+	checksum, err := asc.ComputeFileChecksum(path, asc.ChecksumAlgorithmMD5)
+	if err != nil {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("checksum failed: %w", err)
+	}
+	return PreparedRoutingCoverageFile{
+		Path:     filepath.Clean(path),
+		FileName: filepath.Base(path),
+		FileSize: info.Size(),
+		Checksum: checksum.Hash,
+	}, nil
+}
+
+// UploadPreparedRoutingCoverageFile creates, uploads, and commits routing coverage.
+func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, versionID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	response, err := client.CreateRoutingAppCoverage(requestCtx, versionID, file.FileName, file.FileSize)
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create: %w", err)
+	}
+	if response == nil || len(response.Data.Attributes.UploadOperations) == 0 {
+		return nil, fmt.Errorf("no upload operations returned")
+	}
+	if strings.TrimSpace(response.Data.ID) == "" {
+		return nil, fmt.Errorf("created routing coverage response is missing an ID")
+	}
+
+	uploadCtx, uploadCancel := shared.ContextWithUploadTimeout(ctx)
+	err = asc.ExecuteUploadOperations(uploadCtx, file.Path, response.Data.Attributes.UploadOperations)
+	uploadCancel()
+	if err != nil {
+		return nil, fmt.Errorf("upload failed: %w", err)
+	}
+
+	uploadedChecksum, err := asc.ComputeFileChecksum(file.Path, asc.ChecksumAlgorithmMD5)
+	if err != nil {
+		return nil, fmt.Errorf("checksum failed: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(uploadedChecksum.Hash), strings.TrimSpace(file.Checksum)) {
+		return nil, fmt.Errorf("file changed during upload: %q", file.Path)
+	}
+
+	uploaded := true
+	attributes := asc.RoutingAppCoverageUpdateAttributes{
+		SourceFileChecksum: &file.Checksum,
+		Uploaded:           &uploaded,
+	}
+	commitCtx, commitCancel := shared.ContextWithUploadTimeout(ctx)
+	committed, err := client.UpdateRoutingAppCoverage(commitCtx, response.Data.ID, attributes)
+	commitCancel()
+	if err != nil {
+		return nil, fmt.Errorf("failed to commit upload: %w", err)
+	}
+	if committed == nil || strings.TrimSpace(committed.Data.ID) == "" {
+		return nil, fmt.Errorf("committed routing coverage response is missing an ID")
+	}
+	return committed, nil
+}

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -77,12 +77,6 @@ func resolveRoutingCoverageSource(path string) (string, string, string, error) {
 		return "", "", "", fmt.Errorf("file is required")
 	}
 
-	if filepath.IsAbs(path) {
-		absolutePath := filepath.Clean(path)
-		rootPath := filepath.Dir(absolutePath)
-		return rootPath, filepath.Base(absolutePath), absolutePath, nil
-	}
-
 	rootPath, err := os.Getwd()
 	if err != nil {
 		return "", "", "", fmt.Errorf("resolve current directory: %w", err)
@@ -91,10 +85,13 @@ func resolveRoutingCoverageSource(path string) (string, string, string, error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	relativePath := filepath.Clean(path)
-	absolutePath, err := root.Resolve(relativePath)
+	absolutePath, err := root.Resolve(path)
 	if err != nil {
 		return "", "", "", err
+	}
+	relativePath, err := filepath.Rel(root.Path(), absolutePath)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve file relative to current directory: %w", err)
 	}
 	return root.Path(), relativePath, absolutePath, nil
 }
@@ -174,6 +171,21 @@ func checksumOpenedFile(file *os.File, size int64) (*asc.Checksum, error) {
 
 // UploadPreparedRoutingCoverageFile creates, uploads, and commits routing coverage.
 func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, versionID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
+	return uploadPreparedRoutingCoverageFile(ctx, client, versionID, "", file)
+}
+
+// ReplaceRoutingCoverageWithPreparedFile revalidates the upload source before
+// deleting the current routing coverage, then creates, uploads, and commits its
+// replacement from the same open source handle.
+func ReplaceRoutingCoverageWithPreparedFile(ctx context.Context, client *asc.Client, versionID, currentCoverageID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
+	currentCoverageID = strings.TrimSpace(currentCoverageID)
+	if currentCoverageID == "" {
+		return nil, fmt.Errorf("current routing coverage ID is required")
+	}
+	return uploadPreparedRoutingCoverageFile(ctx, client, versionID, currentCoverageID, file)
+}
+
+func uploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, versionID, currentCoverageID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client is required")
 	}
@@ -199,6 +211,14 @@ func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 	}
 	if !strings.EqualFold(strings.TrimSpace(currentChecksum.Hash), strings.TrimSpace(file.Checksum)) {
 		return nil, fmt.Errorf("file changed after validation: %q", file.Path)
+	}
+	if currentCoverageID != "" {
+		deleteCtx, deleteCancel := shared.ContextWithTimeout(ctx)
+		deleteErr := client.DeleteRoutingAppCoverage(deleteCtx, currentCoverageID)
+		deleteCancel()
+		if deleteErr != nil {
+			return nil, fmt.Errorf("delete current routing coverage %s: %w", currentCoverageID, deleteErr)
+		}
 	}
 
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -258,10 +278,10 @@ func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 	committed, err := client.UpdateRoutingAppCoverage(commitCtx, coverageID, attributes)
 	commitCancel()
 	if err != nil {
-		return nil, cleanupFailure(fmt.Errorf("failed to commit upload: %w", err))
+		return nil, fmt.Errorf("failed to commit upload: %w", err)
 	}
 	if committed == nil || strings.TrimSpace(committed.Data.ID) == "" {
-		return nil, cleanupFailure(fmt.Errorf("committed routing coverage response is missing an ID"))
+		return nil, fmt.Errorf("committed routing coverage response is missing an ID")
 	}
 	return committed, nil
 }

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -169,6 +169,68 @@ func checksumOpenedFile(file *os.File, size int64) (*asc.Checksum, error) {
 	return asc.ComputeChecksumFromReader(io.NewSectionReader(file, 0, size), asc.ChecksumAlgorithmMD5)
 }
 
+func verifyPreparedRoutingCoverageSource(source *os.File, file PreparedRoutingCoverageFile) error {
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+	if info.Size() != file.FileSize {
+		return fmt.Errorf("file changed after validation: %q", file.Path)
+	}
+	currentChecksum, err := checksumOpenedFile(source, info.Size())
+	if err != nil {
+		return fmt.Errorf("checksum failed: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(currentChecksum.Hash), strings.TrimSpace(file.Checksum)) {
+		return fmt.Errorf("file changed after validation: %q", file.Path)
+	}
+	return nil
+}
+
+// RevalidatePreparedRoutingCoverageFile verifies that the prepared source has
+// not changed since it was initially validated.
+func RevalidatePreparedRoutingCoverageFile(file PreparedRoutingCoverageFile) error {
+	source, err := file.openSource()
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer source.Close()
+	return verifyPreparedRoutingCoverageSource(source, file)
+}
+
+func snapshotPreparedRoutingCoverageFile(file PreparedRoutingCoverageFile) (*os.File, error) {
+	source, err := file.openSource()
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+	defer source.Close()
+
+	snapshot, err := os.CreateTemp("", "asc-routing-coverage-*.geojson")
+	if err != nil {
+		return nil, fmt.Errorf("create upload snapshot: %w", err)
+	}
+	cleanup := func() {
+		name := snapshot.Name()
+		_ = snapshot.Close()
+		_ = os.Remove(name)
+	}
+
+	written, err := io.Copy(snapshot, io.LimitReader(source, file.FileSize+1))
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("snapshot file: %w", err)
+	}
+	if written != file.FileSize {
+		cleanup()
+		return nil, fmt.Errorf("file changed after validation: %q", file.Path)
+	}
+	if err := verifyPreparedRoutingCoverageSource(snapshot, file); err != nil {
+		cleanup()
+		return nil, err
+	}
+	return snapshot, nil
+}
+
 // UploadPreparedRoutingCoverageFile creates, uploads, and commits routing coverage.
 func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, versionID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
 	return uploadPreparedRoutingCoverageFile(ctx, client, versionID, "", file)
@@ -189,29 +251,23 @@ func uploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 	if client == nil {
 		return nil, fmt.Errorf("client is required")
 	}
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("version ID is required")
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	source, err := file.openSource()
+	source, err := snapshotPreparedRoutingCoverageFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("open file: %w", err)
+		return nil, err
 	}
-	defer source.Close()
-	info, err := source.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat file: %w", err)
-	}
-	if info.Size() != file.FileSize {
-		return nil, fmt.Errorf("file changed after validation: %q", file.Path)
-	}
-	currentChecksum, err := checksumOpenedFile(source, info.Size())
-	if err != nil {
-		return nil, fmt.Errorf("checksum failed: %w", err)
-	}
-	if !strings.EqualFold(strings.TrimSpace(currentChecksum.Hash), strings.TrimSpace(file.Checksum)) {
-		return nil, fmt.Errorf("file changed after validation: %q", file.Path)
-	}
+	defer func() {
+		name := source.Name()
+		_ = source.Close()
+		_ = os.Remove(name)
+	}()
 	if currentCoverageID != "" {
 		deleteCtx, deleteCancel := shared.ContextWithTimeout(ctx)
 		deleteErr := client.DeleteRoutingAppCoverage(deleteCtx, currentCoverageID)

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -3,6 +3,7 @@ package routingcoverage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,8 +31,14 @@ type routingCoverageGeoJSON struct {
 	Coordinates [][][][]float64 `json:"coordinates"`
 }
 
+var errRoutingCoverageSourceChanged = errors.New("routing coverage source changed while reading")
+
 // PrepareRoutingCoverageFile validates and fingerprints a routing coverage file.
 func PrepareRoutingCoverageFile(path string) (PreparedRoutingCoverageFile, error) {
+	return prepareRoutingCoverageFile(path, asc.ComputeChecksumFromReader)
+}
+
+func prepareRoutingCoverageFile(path string, checksumFunc func(io.Reader, asc.ChecksumAlgorithm) (*asc.Checksum, error)) (PreparedRoutingCoverageFile, error) {
 	rootPath, relativePath, absolutePath, err := resolveRoutingCoverageSource(path)
 	if err != nil {
 		return PreparedRoutingCoverageFile{}, err
@@ -53,11 +60,19 @@ func PrepareRoutingCoverageFile(path string) (PreparedRoutingCoverageFile, error
 	if info.Size() <= 0 {
 		return PreparedRoutingCoverageFile{}, fmt.Errorf("file size must be greater than 0")
 	}
-	if err := validateRoutingCoverageGeoJSON(io.NewSectionReader(file, 0, info.Size())); err != nil {
+	snapshot, err := snapshotOpenedRoutingCoverageSource(file, info.Size())
+	if err != nil {
+		if errors.Is(err, errRoutingCoverageSourceChanged) {
+			return PreparedRoutingCoverageFile{}, fmt.Errorf("file changed while reading: %q", absolutePath)
+		}
+		return PreparedRoutingCoverageFile{}, err
+	}
+	defer discardRoutingCoverageSnapshot(snapshot)
+	if err := validateRoutingCoverageGeoJSON(io.NewSectionReader(snapshot, 0, info.Size())); err != nil {
 		return PreparedRoutingCoverageFile{}, fmt.Errorf("invalid routing coverage GeoJSON: %w", err)
 	}
 
-	checksum, err := asc.ComputeChecksumFromReader(io.NewSectionReader(file, 0, info.Size()), asc.ChecksumAlgorithmMD5)
+	checksum, err := checksumFunc(io.NewSectionReader(snapshot, 0, info.Size()), asc.ChecksumAlgorithmMD5)
 	if err != nil {
 		return PreparedRoutingCoverageFile{}, fmt.Errorf("checksum failed: %w", err)
 	}
@@ -169,6 +184,48 @@ func checksumOpenedFile(file *os.File, size int64) (*asc.Checksum, error) {
 	return asc.ComputeChecksumFromReader(io.NewSectionReader(file, 0, size), asc.ChecksumAlgorithmMD5)
 }
 
+func snapshotOpenedRoutingCoverageSource(source *os.File, expectedSize int64) (*os.File, error) {
+	snapshot, err := os.CreateTemp("", "asc-routing-coverage-*.geojson")
+	if err != nil {
+		return nil, fmt.Errorf("create upload snapshot: %w", err)
+	}
+	snapshotPath := snapshot.Name()
+	_ = os.Remove(snapshotPath)
+	cleanup := func() {
+		_ = snapshot.Close()
+		_ = os.Remove(snapshotPath)
+	}
+
+	if expectedSize < 0 {
+		cleanup()
+		return nil, errRoutingCoverageSourceChanged
+	}
+	if _, err := io.CopyN(snapshot, source, expectedSize); err != nil {
+		cleanup()
+		if errors.Is(err, io.EOF) {
+			return nil, errRoutingCoverageSourceChanged
+		}
+		return nil, fmt.Errorf("snapshot file: %w", err)
+	}
+	if _, err := io.CopyN(io.Discard, source, 1); err == nil {
+		cleanup()
+		return nil, errRoutingCoverageSourceChanged
+	} else if !errors.Is(err, io.EOF) {
+		cleanup()
+		return nil, fmt.Errorf("check snapshot size: %w", err)
+	}
+	return snapshot, nil
+}
+
+func discardRoutingCoverageSnapshot(snapshot *os.File) {
+	if snapshot == nil {
+		return
+	}
+	path := snapshot.Name()
+	_ = snapshot.Close()
+	_ = os.Remove(path)
+}
+
 func verifyPreparedRoutingCoverageSource(source *os.File, file PreparedRoutingCoverageFile) error {
 	info, err := source.Stat()
 	if err != nil {
@@ -205,27 +262,15 @@ func snapshotPreparedRoutingCoverageFile(file PreparedRoutingCoverageFile) (*os.
 	}
 	defer source.Close()
 
-	snapshot, err := os.CreateTemp("", "asc-routing-coverage-*.geojson")
+	snapshot, err := snapshotOpenedRoutingCoverageSource(source, file.FileSize)
 	if err != nil {
-		return nil, fmt.Errorf("create upload snapshot: %w", err)
-	}
-	cleanup := func() {
-		name := snapshot.Name()
-		_ = snapshot.Close()
-		_ = os.Remove(name)
-	}
-
-	written, err := io.Copy(snapshot, io.LimitReader(source, file.FileSize+1))
-	if err != nil {
-		cleanup()
-		return nil, fmt.Errorf("snapshot file: %w", err)
-	}
-	if written != file.FileSize {
-		cleanup()
-		return nil, fmt.Errorf("file changed after validation: %q", file.Path)
+		if errors.Is(err, errRoutingCoverageSourceChanged) {
+			return nil, fmt.Errorf("file changed after validation: %q", file.Path)
+		}
+		return nil, err
 	}
 	if err := verifyPreparedRoutingCoverageSource(snapshot, file); err != nil {
-		cleanup()
+		discardRoutingCoverageSnapshot(snapshot)
 		return nil, err
 	}
 	return snapshot, nil
@@ -263,11 +308,7 @@ func uploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		name := source.Name()
-		_ = source.Close()
-		_ = os.Remove(name)
-	}()
+	defer discardRoutingCoverageSnapshot(source)
 	if currentCoverageID != "" {
 		deleteCtx, deleteCancel := shared.ContextWithTimeout(ctx)
 		deleteErr := client.DeleteRoutingAppCoverage(deleteCtx, currentCoverageID)

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -125,9 +126,10 @@ func routingCoverageSourceRoot(workingDir, absolutePath string) (string, error) 
 		return "", fmt.Errorf("resolve current directory: %w", err)
 	}
 	absolutePath = filepath.Clean(absolutePath)
+	volumeRoot := filepath.Clean(filepath.VolumeName(absolutePath) + string(filepath.Separator))
 	for {
 		if routingCoveragePathWithinRoot(rootPath, absolutePath) {
-			return rootPath, nil
+			return routingCoverageTrustedRoot(rootPath, volumeRoot, absolutePath)
 		}
 		parent := filepath.Dir(rootPath)
 		if parent == rootPath {
@@ -136,11 +138,41 @@ func routingCoverageSourceRoot(workingDir, absolutePath string) (string, error) 
 		rootPath = parent
 	}
 
-	volumeRoot := filepath.VolumeName(absolutePath) + string(filepath.Separator)
 	if !routingCoveragePathWithinRoot(volumeRoot, absolutePath) {
 		return "", fmt.Errorf("resolve trusted root for file %q", absolutePath)
 	}
-	return filepath.Clean(volumeRoot), nil
+	return routingCoverageTrustedRoot(volumeRoot, volumeRoot, absolutePath)
+}
+
+func routingCoverageTrustedRoot(commonRoot, volumeRoot, absolutePath string) (string, error) {
+	commonRoot = filepath.Clean(commonRoot)
+	if commonRoot != volumeRoot {
+		return commonRoot, nil
+	}
+
+	relativePath, err := filepath.Rel(volumeRoot, absolutePath)
+	if err != nil {
+		return "", fmt.Errorf("resolve file relative to volume root: %w", err)
+	}
+	firstSeparator := strings.IndexRune(relativePath, filepath.Separator)
+	if firstSeparator < 0 {
+		return volumeRoot, nil
+	}
+	topLevelRoot := filepath.Join(volumeRoot, relativePath[:firstSeparator])
+	if runtime.GOOS == "darwin" {
+		// macOS exposes protected volume-root aliases such as /tmp and /var.
+		// Trust only that immediate alias as the root; nested and final symlinks
+		// remain below it and are still rejected by rootfs.OpenFile.
+		volumeInfo, volumeErr := os.Stat(volumeRoot)
+		aliasInfo, aliasErr := os.Lstat(topLevelRoot)
+		targetInfo, targetErr := os.Stat(topLevelRoot)
+		if volumeErr == nil && volumeInfo.IsDir() && volumeInfo.Mode().Perm()&0o022 == 0 &&
+			aliasErr == nil && aliasInfo.Mode()&os.ModeSymlink != 0 &&
+			targetErr == nil && targetInfo.IsDir() {
+			return topLevelRoot, nil
+		}
+	}
+	return volumeRoot, nil
 }
 
 func routingCoveragePathWithinRoot(rootPath, path string) bool {

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -92,23 +92,63 @@ func resolveRoutingCoverageSource(path string) (string, string, string, error) {
 		return "", "", "", fmt.Errorf("file is required")
 	}
 
-	rootPath, err := os.Getwd()
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve file path: %w", err)
+	}
+	workingDir, err := os.Getwd()
 	if err != nil {
 		return "", "", "", fmt.Errorf("resolve current directory: %w", err)
+	}
+	rootPath, err := routingCoverageSourceRoot(workingDir, absolutePath)
+	if err != nil {
+		return "", "", "", err
 	}
 	root, err := rootfs.New(rootPath)
 	if err != nil {
 		return "", "", "", err
 	}
-	absolutePath, err := root.Resolve(path)
+	relativePath, err := filepath.Rel(root.Path(), absolutePath)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve file relative to trusted root: %w", err)
+	}
+	resolvedPath, err := root.Resolve(relativePath)
 	if err != nil {
 		return "", "", "", err
 	}
-	relativePath, err := filepath.Rel(root.Path(), absolutePath)
+	return root.Path(), relativePath, resolvedPath, nil
+}
+
+func routingCoverageSourceRoot(workingDir, absolutePath string) (string, error) {
+	rootPath, err := filepath.Abs(workingDir)
 	if err != nil {
-		return "", "", "", fmt.Errorf("resolve file relative to current directory: %w", err)
+		return "", fmt.Errorf("resolve current directory: %w", err)
 	}
-	return root.Path(), relativePath, absolutePath, nil
+	absolutePath = filepath.Clean(absolutePath)
+	for {
+		if routingCoveragePathWithinRoot(rootPath, absolutePath) {
+			return rootPath, nil
+		}
+		parent := filepath.Dir(rootPath)
+		if parent == rootPath {
+			break
+		}
+		rootPath = parent
+	}
+
+	volumeRoot := filepath.VolumeName(absolutePath) + string(filepath.Separator)
+	if !routingCoveragePathWithinRoot(volumeRoot, absolutePath) {
+		return "", fmt.Errorf("resolve trusted root for file %q", absolutePath)
+	}
+	return filepath.Clean(volumeRoot), nil
+}
+
+func routingCoveragePathWithinRoot(rootPath, path string) bool {
+	relative, err := filepath.Rel(rootPath, path)
+	if err != nil || filepath.IsAbs(relative) {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func validateRoutingCoverageGeoJSON(reader io.Reader) error {

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -227,6 +227,14 @@ func discardRoutingCoverageSnapshot(snapshot *os.File) {
 }
 
 func verifyPreparedRoutingCoverageSource(source *os.File, file PreparedRoutingCoverageFile) error {
+	return verifyPreparedRoutingCoverageSourceWithChecksum(source, file, checksumOpenedFile)
+}
+
+func verifyPreparedRoutingCoverageSourceWithChecksum(
+	source *os.File,
+	file PreparedRoutingCoverageFile,
+	checksumFunc func(*os.File, int64) (*asc.Checksum, error),
+) error {
 	info, err := source.Stat()
 	if err != nil {
 		return fmt.Errorf("stat file: %w", err)
@@ -234,9 +242,24 @@ func verifyPreparedRoutingCoverageSource(source *os.File, file PreparedRoutingCo
 	if info.Size() != file.FileSize {
 		return fmt.Errorf("file changed after validation: %q", file.Path)
 	}
-	currentChecksum, err := checksumOpenedFile(source, info.Size())
+	currentChecksum, err := checksumFunc(source, info.Size())
 	if err != nil {
 		return fmt.Errorf("checksum failed: %w", err)
+	}
+	postChecksumInfo, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat file after checksum: %w", err)
+	}
+	if postChecksumInfo.Size() != info.Size() {
+		return fmt.Errorf("file changed after validation: %q", file.Path)
+	}
+	var trailing [1]byte
+	read, readErr := source.ReadAt(trailing[:], info.Size())
+	if read > 0 || readErr == nil {
+		return fmt.Errorf("file changed after validation: %q", file.Path)
+	}
+	if !errors.Is(readErr, io.EOF) {
+		return fmt.Errorf("check file size after checksum: %w", readErr)
 	}
 	if !strings.EqualFold(strings.TrimSpace(currentChecksum.Hash), strings.TrimSpace(file.Checksum)) {
 		return fmt.Errorf("file changed after validation: %q", file.Path)

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -2,13 +2,16 @@ package routingcoverage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 // PreparedRoutingCoverageFile is a validated routing coverage upload source.
@@ -17,44 +20,185 @@ type PreparedRoutingCoverageFile struct {
 	FileName string
 	FileSize int64
 	Checksum string
+
+	rootPath     string
+	relativePath string
+}
+
+type routingCoverageGeoJSON struct {
+	Type        string          `json:"type"`
+	Coordinates [][][][]float64 `json:"coordinates"`
 }
 
 // PrepareRoutingCoverageFile validates and fingerprints a routing coverage file.
 func PrepareRoutingCoverageFile(path string) (PreparedRoutingCoverageFile, error) {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return PreparedRoutingCoverageFile{}, fmt.Errorf("file is required")
-	}
-	info, err := os.Lstat(path)
+	rootPath, relativePath, absolutePath, err := resolveRoutingCoverageSource(path)
 	if err != nil {
 		return PreparedRoutingCoverageFile{}, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return PreparedRoutingCoverageFile{}, fmt.Errorf("refusing to read symlink %q", path)
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return PreparedRoutingCoverageFile{}, err
 	}
-	if !info.Mode().IsRegular() {
-		return PreparedRoutingCoverageFile{}, fmt.Errorf("expected regular file: %q", path)
+	file, err := root.OpenFile(relativePath)
+	if err != nil {
+		return PreparedRoutingCoverageFile{}, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("stat file: %w", err)
 	}
 	if info.Size() <= 0 {
 		return PreparedRoutingCoverageFile{}, fmt.Errorf("file size must be greater than 0")
 	}
+	if err := validateRoutingCoverageGeoJSON(io.NewSectionReader(file, 0, info.Size())); err != nil {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("invalid routing coverage GeoJSON: %w", err)
+	}
 
-	checksum, err := asc.ComputeFileChecksum(path, asc.ChecksumAlgorithmMD5)
+	checksum, err := asc.ComputeChecksumFromReader(io.NewSectionReader(file, 0, info.Size()), asc.ChecksumAlgorithmMD5)
 	if err != nil {
 		return PreparedRoutingCoverageFile{}, fmt.Errorf("checksum failed: %w", err)
 	}
 	return PreparedRoutingCoverageFile{
-		Path:     filepath.Clean(path),
-		FileName: filepath.Base(path),
-		FileSize: info.Size(),
-		Checksum: checksum.Hash,
+		Path:         absolutePath,
+		FileName:     filepath.Base(absolutePath),
+		FileSize:     info.Size(),
+		Checksum:     checksum.Hash,
+		rootPath:     root.Path(),
+		relativePath: relativePath,
 	}, nil
+}
+
+func resolveRoutingCoverageSource(path string) (string, string, string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", "", "", fmt.Errorf("file is required")
+	}
+
+	if filepath.IsAbs(path) {
+		absolutePath := filepath.Clean(path)
+		rootPath := filepath.Dir(absolutePath)
+		return rootPath, filepath.Base(absolutePath), absolutePath, nil
+	}
+
+	rootPath, err := os.Getwd()
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve current directory: %w", err)
+	}
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return "", "", "", err
+	}
+	relativePath := filepath.Clean(path)
+	absolutePath, err := root.Resolve(relativePath)
+	if err != nil {
+		return "", "", "", err
+	}
+	return root.Path(), relativePath, absolutePath, nil
+}
+
+func validateRoutingCoverageGeoJSON(reader io.Reader) error {
+	decoder := json.NewDecoder(reader)
+	var document routingCoverageGeoJSON
+	if err := decoder.Decode(&document); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("invalid JSON: multiple top-level values")
+		}
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	if document.Type != "MultiPolygon" {
+		return fmt.Errorf("top-level type must be MultiPolygon")
+	}
+	if len(document.Coordinates) == 0 {
+		return fmt.Errorf("MultiPolygon must contain at least one Polygon")
+	}
+	for polygonIndex, polygon := range document.Coordinates {
+		if len(polygon) == 0 {
+			return fmt.Errorf("polygon %d must contain at least one linear ring", polygonIndex)
+		}
+		for ringIndex, ring := range polygon {
+			if len(ring) < 4 {
+				return fmt.Errorf("polygon %d ring %d must contain at least four coordinate points", polygonIndex, ringIndex)
+			}
+			for pointIndex, point := range ring {
+				if len(point) < 2 {
+					return fmt.Errorf("polygon %d ring %d point %d must contain longitude and latitude", polygonIndex, ringIndex, pointIndex)
+				}
+			}
+			if !equalCoordinates(ring[0], ring[len(ring)-1]) {
+				return fmt.Errorf("polygon %d ring %d start and end coordinate points must be the same", polygonIndex, ringIndex)
+			}
+		}
+	}
+	return nil
+}
+
+func equalCoordinates(left, right []float64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (file PreparedRoutingCoverageFile) openSource() (*os.File, error) {
+	rootPath := file.rootPath
+	relativePath := file.relativePath
+	if rootPath == "" || relativePath == "" {
+		var err error
+		rootPath, relativePath, _, err = resolveRoutingCoverageSource(file.Path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return nil, err
+	}
+	return root.OpenFile(relativePath)
+}
+
+func checksumOpenedFile(file *os.File, size int64) (*asc.Checksum, error) {
+	return asc.ComputeChecksumFromReader(io.NewSectionReader(file, 0, size), asc.ChecksumAlgorithmMD5)
 }
 
 // UploadPreparedRoutingCoverageFile creates, uploads, and commits routing coverage.
 func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, versionID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	source, err := file.openSource()
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+	if info.Size() != file.FileSize {
+		return nil, fmt.Errorf("file changed after validation: %q", file.Path)
+	}
+	currentChecksum, err := checksumOpenedFile(source, info.Size())
+	if err != nil {
+		return nil, fmt.Errorf("checksum failed: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(currentChecksum.Hash), strings.TrimSpace(file.Checksum)) {
+		return nil, fmt.Errorf("file changed after validation: %q", file.Path)
 	}
 
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -63,26 +207,46 @@ func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create: %w", err)
 	}
-	if response == nil || len(response.Data.Attributes.UploadOperations) == 0 {
-		return nil, fmt.Errorf("no upload operations returned")
+	if response == nil {
+		return nil, fmt.Errorf("created routing coverage response is empty")
 	}
-	if strings.TrimSpace(response.Data.ID) == "" {
+	coverageID := strings.TrimSpace(response.Data.ID)
+	if coverageID == "" {
 		return nil, fmt.Errorf("created routing coverage response is missing an ID")
+	}
+	cleanupFailure := func(original error) error {
+		cleanupCtx, cleanupCancel := shared.ContextWithTimeout(context.WithoutCancel(ctx))
+		cleanupErr := client.DeleteRoutingAppCoverage(cleanupCtx, coverageID)
+		cleanupCancel()
+		if cleanupErr != nil && !asc.IsNotFound(cleanupErr) {
+			return fmt.Errorf("%w (also failed to delete routing coverage reservation %s: %w)", original, coverageID, cleanupErr)
+		}
+		return original
+	}
+	if len(response.Data.Attributes.UploadOperations) == 0 {
+		return nil, cleanupFailure(fmt.Errorf("no upload operations returned"))
 	}
 
 	uploadCtx, uploadCancel := shared.ContextWithUploadTimeout(ctx)
-	err = asc.ExecuteUploadOperations(uploadCtx, file.Path, response.Data.Attributes.UploadOperations)
+	err = asc.ExecuteUploadOperationsFromFile(uploadCtx, source, response.Data.Attributes.UploadOperations)
 	uploadCancel()
 	if err != nil {
-		return nil, fmt.Errorf("upload failed: %w", err)
+		return nil, cleanupFailure(fmt.Errorf("upload failed: %w", err))
 	}
 
-	uploadedChecksum, err := asc.ComputeFileChecksum(file.Path, asc.ChecksumAlgorithmMD5)
+	uploadedInfo, err := source.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("checksum failed: %w", err)
+		return nil, cleanupFailure(fmt.Errorf("stat file: %w", err))
+	}
+	if uploadedInfo.Size() != file.FileSize {
+		return nil, cleanupFailure(fmt.Errorf("file changed during upload: %q", file.Path))
+	}
+	uploadedChecksum, err := checksumOpenedFile(source, uploadedInfo.Size())
+	if err != nil {
+		return nil, cleanupFailure(fmt.Errorf("checksum failed: %w", err))
 	}
 	if !strings.EqualFold(strings.TrimSpace(uploadedChecksum.Hash), strings.TrimSpace(file.Checksum)) {
-		return nil, fmt.Errorf("file changed during upload: %q", file.Path)
+		return nil, cleanupFailure(fmt.Errorf("file changed during upload: %q", file.Path))
 	}
 
 	uploaded := true
@@ -91,13 +255,13 @@ func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 		Uploaded:           &uploaded,
 	}
 	commitCtx, commitCancel := shared.ContextWithUploadTimeout(ctx)
-	committed, err := client.UpdateRoutingAppCoverage(commitCtx, response.Data.ID, attributes)
+	committed, err := client.UpdateRoutingAppCoverage(commitCtx, coverageID, attributes)
 	commitCancel()
 	if err != nil {
-		return nil, fmt.Errorf("failed to commit upload: %w", err)
+		return nil, cleanupFailure(fmt.Errorf("failed to commit upload: %w", err))
 	}
 	if committed == nil || strings.TrimSpace(committed.Data.ID) == "" {
-		return nil, fmt.Errorf("committed routing coverage response is missing an ID")
+		return nil, cleanupFailure(fmt.Errorf("committed routing coverage response is missing an ID"))
 	}
 	return committed, nil
 }

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -300,13 +300,16 @@ func snapshotPreparedRoutingCoverageFile(file PreparedRoutingCoverageFile) (*os.
 }
 
 // UploadPreparedRoutingCoverageFile creates, uploads, and commits routing coverage.
+// A post-create commit error returns the retained reservation response alongside
+// the error so callers can report its ID.
 func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, versionID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
 	return uploadPreparedRoutingCoverageFile(ctx, client, versionID, "", file)
 }
 
 // ReplaceRoutingCoverageWithPreparedFile revalidates the upload source before
 // deleting the current routing coverage, then creates, uploads, and commits its
-// replacement from the same open source handle.
+// replacement from the same open source handle. A post-create commit error
+// returns the retained replacement response alongside the error.
 func ReplaceRoutingCoverageWithPreparedFile(ctx context.Context, client *asc.Client, versionID, currentCoverageID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
 	currentCoverageID = strings.TrimSpace(currentCoverageID)
 	if currentCoverageID == "" {
@@ -398,10 +401,10 @@ func uploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 	committed, err := client.UpdateRoutingAppCoverage(commitCtx, coverageID, attributes)
 	commitCancel()
 	if err != nil {
-		return nil, fmt.Errorf("failed to commit upload: %w", err)
+		return response, fmt.Errorf("failed to commit upload: %w", err)
 	}
 	if committed == nil || strings.TrimSpace(committed.Data.ID) == "" {
-		return nil, fmt.Errorf("committed routing coverage response is missing an ID")
+		return response, fmt.Errorf("committed routing coverage response is missing an ID")
 	}
 	return committed, nil
 }

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -44,6 +44,10 @@ func prepareRoutingCoverageFile(path string, checksumFunc func(io.Reader, asc.Ch
 	if err != nil {
 		return PreparedRoutingCoverageFile{}, err
 	}
+	fileName := filepath.Base(absolutePath)
+	if !strings.EqualFold(filepath.Ext(fileName), ".geojson") {
+		return PreparedRoutingCoverageFile{}, fmt.Errorf("file must use the .geojson extension: %q", absolutePath)
+	}
 	root, err := rootfs.New(rootPath)
 	if err != nil {
 		return PreparedRoutingCoverageFile{}, err
@@ -79,7 +83,7 @@ func prepareRoutingCoverageFile(path string, checksumFunc func(io.Reader, asc.Ch
 	}
 	return PreparedRoutingCoverageFile{
 		Path:         absolutePath,
-		FileName:     filepath.Base(absolutePath),
+		FileName:     fileName,
 		FileSize:     info.Size(),
 		Checksum:     checksum.Hash,
 		rootPath:     root.Path(),

--- a/internal/cli/routingcoverage/upload.go
+++ b/internal/cli/routingcoverage/upload.go
@@ -377,16 +377,16 @@ func snapshotPreparedRoutingCoverageFile(file PreparedRoutingCoverageFile) (*os.
 }
 
 // UploadPreparedRoutingCoverageFile creates, uploads, and commits routing coverage.
-// A post-create commit error returns the retained reservation response alongside
-// the error so callers can report its ID.
+// A post-create error returns the reservation response alongside the error when
+// cleanup cannot remove it, so callers can report the retained reservation ID.
 func UploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, versionID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
 	return uploadPreparedRoutingCoverageFile(ctx, client, versionID, "", file)
 }
 
 // ReplaceRoutingCoverageWithPreparedFile revalidates the upload source before
 // deleting the current routing coverage, then creates, uploads, and commits its
-// replacement from the same open source handle. A post-create commit error
-// returns the retained replacement response alongside the error.
+// replacement from the same open source handle. A post-create error returns the
+// replacement response alongside the error when cleanup cannot remove it.
 func ReplaceRoutingCoverageWithPreparedFile(ctx context.Context, client *asc.Client, versionID, currentCoverageID string, file PreparedRoutingCoverageFile) (*asc.RoutingAppCoverageResponse, error) {
 	currentCoverageID = strings.TrimSpace(currentCoverageID)
 	if currentCoverageID == "" {
@@ -434,39 +434,39 @@ func uploadPreparedRoutingCoverageFile(ctx context.Context, client *asc.Client, 
 	if coverageID == "" {
 		return nil, fmt.Errorf("created routing coverage response is missing an ID")
 	}
-	cleanupFailure := func(original error) error {
+	cleanupFailure := func(original error) (*asc.RoutingAppCoverageResponse, error) {
 		cleanupCtx, cleanupCancel := shared.ContextWithTimeout(context.WithoutCancel(ctx))
 		cleanupErr := client.DeleteRoutingAppCoverage(cleanupCtx, coverageID)
 		cleanupCancel()
 		if cleanupErr != nil && !asc.IsNotFound(cleanupErr) {
-			return fmt.Errorf("%w (also failed to delete routing coverage reservation %s: %w)", original, coverageID, cleanupErr)
+			return response, fmt.Errorf("%w (also failed to delete routing coverage reservation %s: %w)", original, coverageID, cleanupErr)
 		}
-		return original
+		return nil, original
 	}
 	if len(response.Data.Attributes.UploadOperations) == 0 {
-		return nil, cleanupFailure(fmt.Errorf("no upload operations returned"))
+		return cleanupFailure(fmt.Errorf("no upload operations returned"))
 	}
 
 	uploadCtx, uploadCancel := shared.ContextWithUploadTimeout(ctx)
 	err = asc.ExecuteUploadOperationsFromFile(uploadCtx, source, response.Data.Attributes.UploadOperations)
 	uploadCancel()
 	if err != nil {
-		return nil, cleanupFailure(fmt.Errorf("upload failed: %w", err))
+		return cleanupFailure(fmt.Errorf("upload failed: %w", err))
 	}
 
 	uploadedInfo, err := source.Stat()
 	if err != nil {
-		return nil, cleanupFailure(fmt.Errorf("stat file: %w", err))
+		return cleanupFailure(fmt.Errorf("stat file: %w", err))
 	}
 	if uploadedInfo.Size() != file.FileSize {
-		return nil, cleanupFailure(fmt.Errorf("file changed during upload: %q", file.Path))
+		return cleanupFailure(fmt.Errorf("file changed during upload: %q", file.Path))
 	}
 	uploadedChecksum, err := checksumOpenedFile(source, uploadedInfo.Size())
 	if err != nil {
-		return nil, cleanupFailure(fmt.Errorf("checksum failed: %w", err))
+		return cleanupFailure(fmt.Errorf("checksum failed: %w", err))
 	}
 	if !strings.EqualFold(strings.TrimSpace(uploadedChecksum.Hash), strings.TrimSpace(file.Checksum)) {
-		return nil, cleanupFailure(fmt.Errorf("file changed during upload: %q", file.Path))
+		return cleanupFailure(fmt.Errorf("file changed during upload: %q", file.Path))
 	}
 
 	uploaded := true


### PR DESCRIPTION
## Summary

- add optional routing coverage reconciliation to `release stage` before build attachment and readiness validation
- reuse matching completed coverage, wait for matching uploads, and replace stale or incomplete coverage
- share the validated create/upload/commit path with the standalone routing coverage command
- recheck local routing coverage input when resuming from an unsigned checkpoint

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- live create, checksum/state verification, and delete on the designated test app
- verified the API empty relationship response (HTTP 200 with `data: null`) and covered it with a regression test

The temporary live-test coverage was deleted after verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788900254&installation_model_id=10418&pr_number=1910&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1910&signature=cbf833b2f1d0631a322ad697cc53f584595f3142713c409630dc5edbd7dc84c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional routing coverage support to release staging with the `--routing-coverage-file` option.
  * Automatically reuses matching coverage, waits for in-progress uploads, or replaces outdated coverage.
  * Added checksum verification, delivery status reporting, and dry-run replacement planning.

* **Bug Fixes**
  * Added validation for single-document GeoJSON MultiPolygon files with closed rings.
  * Readiness and resumed checkpoint validation now account for configured routing coverage.
  * Improved cleanup and error handling for failed or interrupted uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->