### PR TITLE
feat(testflight): list groups containing a build

### DIFF
--- a/commands/testflight.mdx
+++ b/commands/testflight.mdx
@@ -18,10 +18,38 @@ Create and manage internal or external beta groups:
 
 ```bash  theme={null}
 asc testflight groups list --app APP_ID
+asc testflight groups list --build-id BUILD_ID
 asc testflight groups create --app APP_ID --name "Beta Testers"
 asc testflight groups create --app APP_ID --name "Internal Testers" --internal
 asc testflight groups view --id GROUP_ID
 ```
+
+### Find the groups that contain a build
+
+Use an App Store Connect build ID to list explicit group membership and implicit
+access from groups configured for all builds:
+
+```bash  theme={null}
+asc testflight groups list --build-id BUILD_ID --output table
+asc testflight groups list --build-id BUILD_ID --output json
+```
+
+The result includes stable group IDs, names, `internal` or `external` type,
+`hasAccessToAllBuilds`, and a membership value of `explicit`, `all-builds`, or
+`explicit-and-all-builds`. A complete lookup with no matches exits `0` and
+returns an empty `groups` array.
+
+App Store Connect has no `GET /v1/builds/{id}/relationships/betaGroups`.
+The command resolves the build's app and prefers Apple's documented
+`filter[builds]` beta-group collection filter. It automatically paginates every
+required collection. Because Apple can omit an explicit relationship for a
+group that also has all-build access, any such group omitted by the filter is
+verified through `GET /v1/betaGroups/{id}/relationships/builds`. If Apple rejects
+the collection filter, the command transparently falls back to the same inverse
+relationship for every group. It downloads relationship IDs rather than full
+build resources, but can require one or more requests per checked group and
+build page. A partial lookup prints the matches and per-group failures with
+`complete: false`, then exits nonzero.
 
 ### Testers
 

--- a/commands/testflight.mdx
+++ b/commands/testflight.mdx
@@ -24,10 +24,11 @@ asc testflight groups create --app APP_ID --name "Internal Testers" --internal
 asc testflight groups view --id GROUP_ID
 ```
 
-### Find the groups that contain a build
+### Find the groups that contain a build (experimental)
 
-Use an App Store Connect build ID to list explicit group membership and implicit
-access from groups configured for all builds:
+The `--build-id` lookup is experimental. Use an App Store Connect build ID to
+list explicit group membership and implicit access from groups configured for
+all builds:
 
 ```bash  theme={null}
 asc testflight groups list --build-id BUILD_ID --output table

--- a/internal/asc/client_query_testflight.go
+++ b/internal/asc/client_query_testflight.go
@@ -62,6 +62,9 @@ type betaTesterUsagesQuery struct {
 type betaGroupsQuery struct {
 	listQuery
 	isInternalGroup *bool
+	appIDs          []string
+	buildIDs        []string
+	fields          []string
 }
 
 type betaGroupBuildsQuery struct {
@@ -172,6 +175,9 @@ func buildCrashQuery(query *crashQuery) string {
 
 func buildBetaGroupsQuery(query *betaGroupsQuery) string {
 	values := url.Values{}
+	addCSV(values, "filter[app]", query.appIDs)
+	addCSV(values, "filter[builds]", query.buildIDs)
+	addCSV(values, "fields[betaGroups]", query.fields)
 	addLimit(values, query.limit)
 	if query.isInternalGroup != nil {
 		values.Set("filter[isInternalGroup]", strconv.FormatBool(*query.isInternalGroup))
@@ -544,6 +550,27 @@ func WithBetaGroupsNextURL(next string) BetaGroupsOption {
 func WithBetaGroupsIsInternal(isInternal bool) BetaGroupsOption {
 	return func(q *betaGroupsQuery) {
 		q.isInternalGroup = &isInternal
+	}
+}
+
+// WithBetaGroupsApps filters beta groups by related app IDs.
+func WithBetaGroupsApps(appIDs []string) BetaGroupsOption {
+	return func(q *betaGroupsQuery) {
+		q.appIDs = normalizeList(appIDs)
+	}
+}
+
+// WithBetaGroupsBuilds filters beta groups by related build IDs.
+func WithBetaGroupsBuilds(buildIDs []string) BetaGroupsOption {
+	return func(q *betaGroupsQuery) {
+		q.buildIDs = normalizeList(buildIDs)
+	}
+}
+
+// WithBetaGroupsFields selects a sparse beta group fieldset.
+func WithBetaGroupsFields(fields []string) BetaGroupsOption {
+	return func(q *betaGroupsQuery) {
+		q.fields = normalizeList(fields)
 	}
 }
 

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -299,6 +299,9 @@ func TestBuildCrashQueryIncludeBuildAndTester(t *testing.T) {
 func TestBuildBetaGroupsQuery(t *testing.T) {
 	query := &betaGroupsQuery{}
 	WithBetaGroupsLimit(10)(query)
+	WithBetaGroupsApps([]string{" app-1 ", "app-2"})(query)
+	WithBetaGroupsBuilds([]string{"build-1"})(query)
+	WithBetaGroupsFields([]string{"name", "isInternalGroup", "hasAccessToAllBuilds"})(query)
 
 	values, err := url.ParseQuery(buildBetaGroupsQuery(query))
 	if err != nil {
@@ -306,6 +309,15 @@ func TestBuildBetaGroupsQuery(t *testing.T) {
 	}
 	if got := values.Get("limit"); got != "10" {
 		t.Fatalf("expected limit=10, got %q", got)
+	}
+	if got := values.Get("filter[app]"); got != "app-1,app-2" {
+		t.Fatalf("expected filter[app]=app-1,app-2, got %q", got)
+	}
+	if got := values.Get("filter[builds]"); got != "build-1" {
+		t.Fatalf("expected filter[builds]=build-1, got %q", got)
+	}
+	if got := values.Get("fields[betaGroups]"); got != "name,isInternalGroup,hasAccessToAllBuilds" {
+		t.Fatalf("unexpected beta group fields %q", got)
 	}
 }
 

--- a/internal/asc/output_beta.go
+++ b/internal/asc/output_beta.go
@@ -48,6 +48,36 @@ type AppBetaTestersUpdateResult struct {
 	Action    string   `json:"action"`
 }
 
+// BuildBetaGroupMembershipResult describes the TestFlight groups that give a
+// build access, including explicit relationship membership and all-build access.
+type BuildBetaGroupMembershipResult struct {
+	BuildID      string                            `json:"buildId"`
+	AppID        string                            `json:"appId"`
+	Complete     bool                              `json:"complete"`
+	LookupMethod string                            `json:"lookupMethod"`
+	GroupCount   int                               `json:"groupCount"`
+	Groups       []BuildBetaGroupMembershipGroup   `json:"groups"`
+	Failures     []BuildBetaGroupMembershipFailure `json:"failures,omitempty"`
+}
+
+// BuildBetaGroupMembershipGroup is one group that contains or implicitly
+// receives a build.
+type BuildBetaGroupMembershipGroup struct {
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	Type                 string `json:"type"`
+	Membership           string `json:"membership"`
+	HasAccessToAllBuilds bool   `json:"hasAccessToAllBuilds"`
+}
+
+// BuildBetaGroupMembershipFailure records an inverse relationship lookup that
+// could not be completed.
+type BuildBetaGroupMembershipFailure struct {
+	GroupID   string `json:"groupId"`
+	GroupName string `json:"groupName,omitempty"`
+	Error     string `json:"error"`
+}
+
 // BetaFeedbackSubmissionDeleteResult represents CLI output for beta feedback deletions.
 type BetaFeedbackSubmissionDeleteResult struct {
 	ID      string `json:"id"`
@@ -79,6 +109,38 @@ func betaGroupsRows(resp *BetaGroupsResponse) ([]string, [][]string) {
 			fmt.Sprintf("%t", item.Attributes.IsInternalGroup),
 			fmt.Sprintf("%t", item.Attributes.PublicLinkEnabled),
 			item.Attributes.PublicLink,
+		})
+	}
+	return headers, rows
+}
+
+func buildBetaGroupMembershipRows(result *BuildBetaGroupMembershipResult) ([]string, [][]string) {
+	headers := []string{"Build ID", "App ID", "Group ID", "Name", "Type", "Membership", "All Builds", "Complete", "Error"}
+	rows := make([][]string, 0, len(result.Groups)+len(result.Failures))
+	for _, group := range result.Groups {
+		rows = append(rows, []string{
+			result.BuildID,
+			result.AppID,
+			group.ID,
+			compactWhitespace(group.Name),
+			group.Type,
+			group.Membership,
+			fmt.Sprintf("%t", group.HasAccessToAllBuilds),
+			fmt.Sprintf("%t", result.Complete),
+			"",
+		})
+	}
+	for _, failure := range result.Failures {
+		rows = append(rows, []string{
+			result.BuildID,
+			result.AppID,
+			failure.GroupID,
+			compactWhitespace(failure.GroupName),
+			"",
+			"error",
+			"",
+			"false",
+			compactWhitespace(failure.Error),
 		})
 	}
 	return headers, rows

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -161,6 +161,7 @@ func registerAllOutputRenderers() {
 	registerRowsWithSingleResourceAdapter(appPreviewSetsRows)
 	registerRowsWithSingleResourceAdapter(appPreviewsRows)
 	registerRowsWithSingleResourceAdapter(betaGroupsRows)
+	registerRows(buildBetaGroupMembershipRows)
 	registerRowsWithSingleResourceAdapter(betaTestersRows)
 	registerRowsWithSingleResourceAdapter(usersRows)
 	registerRowsWithSingleResourceAdapter(actorsRows)

--- a/internal/cli/cmdtest/testflight_build_group_membership_test.go
+++ b/internal/cli/cmdtest/testflight_build_group_membership_test.go
@@ -37,6 +37,21 @@ type buildGroupMembershipFailure struct {
 	Error   string `json:"error"`
 }
 
+func TestTestFlightGroupsListBuildMembershipFlagIsExperimental(t *testing.T) {
+	root := RootCommand("1.2.3")
+	list := findCommand(root, "testflight", "groups", "list")
+	if list == nil {
+		t.Fatal("expected testflight groups list command")
+	}
+	buildID := list.FlagSet.Lookup("build-id")
+	if buildID == nil {
+		t.Fatal("expected --build-id flag")
+	}
+	if !strings.HasPrefix(buildID.Usage, "[experimental] ") {
+		t.Fatalf("--build-id usage = %q, want [experimental] prefix", buildID.Usage)
+	}
+}
+
 func TestTestFlightGroupsListBuildMembershipUsesOfficialFilterAndPaginates(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/testflight_build_group_membership_test.go
+++ b/internal/cli/cmdtest/testflight_build_group_membership_test.go
@@ -40,6 +40,7 @@ type buildGroupMembershipFailure struct {
 func TestTestFlightGroupsListBuildMembershipUsesOfficialFilterAndPaginates(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "ambient-app-must-not-be-an-assertion")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -146,7 +147,7 @@ func TestTestFlightGroupsListBuildMembershipUsesOfficialFilterAndPaginates(t *te
 	}
 }
 
-func TestTestFlightGroupsListBuildMembershipRejectsExplicitBlankBuildID(t *testing.T) {
+func TestTestFlightGroupsListBuildMembershipRejectsExplicitBlankIDs(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -157,23 +158,36 @@ func TestTestFlightGroupsListBuildMembershipRejectsExplicitBlankBuildID(t *testi
 		return nil, nil
 	})
 
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-	var runErr error
-	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "groups", "list", "--app", "app-1", "--build-id", " "}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		runErr = root.Run(context.Background())
-	})
-	if !errors.Is(runErr, flag.ErrHelp) {
-		t.Fatalf("expected usage error, got %v", runErr)
+	tests := []struct {
+		name       string
+		args       []string
+		diagnostic string
+	}{
+		{name: "build ID", args: []string{"--app", "app-1", "--build-id", " "}, diagnostic: "--build-id cannot be empty"},
+		{name: "app assertion", args: []string{"--build-id", "build-1", "--app", " "}, diagnostic: "--app cannot be empty"},
 	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	if !strings.Contains(stderr, "--build-id cannot be empty") {
-		t.Fatalf("expected blank build ID diagnostic, got %q", stderr)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			args := append([]string{"testflight", "groups", "list"}, test.args...)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected usage error, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.diagnostic) {
+				t.Fatalf("expected %q diagnostic, got %q", test.diagnostic, stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/testflight_build_group_membership_test.go
+++ b/internal/cli/cmdtest/testflight_build_group_membership_test.go
@@ -146,6 +146,37 @@ func TestTestFlightGroupsListBuildMembershipUsesOfficialFilterAndPaginates(t *te
 	}
 }
 
+func TestTestFlightGroupsListBuildMembershipRejectsExplicitBlankBuildID(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("blank build ID must fail before HTTP request: %s", req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "groups", "list", "--app", "app-1", "--build-id", " "}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--build-id cannot be empty") {
+		t.Fatalf("expected blank build ID diagnostic, got %q", stderr)
+	}
+}
+
 func TestTestFlightGroupsListBuildMembershipEmptyIsSuccessful(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/testflight_build_group_membership_test.go
+++ b/internal/cli/cmdtest/testflight_build_group_membership_test.go
@@ -1,0 +1,437 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type buildGroupMembershipOutput struct {
+	BuildID      string                        `json:"buildId"`
+	AppID        string                        `json:"appId"`
+	Complete     bool                          `json:"complete"`
+	LookupMethod string                        `json:"lookupMethod"`
+	GroupCount   int                           `json:"groupCount"`
+	Groups       []buildGroupMembershipRecord  `json:"groups"`
+	Failures     []buildGroupMembershipFailure `json:"failures"`
+}
+
+type buildGroupMembershipRecord struct {
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	Type                 string `json:"type"`
+	Membership           string `json:"membership"`
+	HasAccessToAllBuilds bool   `json:"hasAccessToAllBuilds"`
+}
+
+type buildGroupMembershipFailure struct {
+	GroupID string `json:"groupId"`
+	Error   string `json:"error"`
+}
+
+func TestTestFlightGroupsListBuildMembershipUsesOfficialFilterAndPaginates(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	const appNext = "https://api.appstoreconnect.apple.com/v1/betaGroups?cursor=app-next"
+	const buildNext = "https://api.appstoreconnect.apple.com/v1/betaGroups?cursor=build-next"
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/relationships/app" {
+				t.Fatalf("unexpected app lookup: %s %s", req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			assertBuildMembershipGroupQuery(t, req.URL, "filter[app]", "app-1")
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"betaGroups","id":"group-explicit","attributes":{"name":"External QA","isInternalGroup":false}},
+					{"type":"betaGroups","id":"group-all","attributes":{"name":"Internal All Builds","isInternalGroup":true,"hasAccessToAllBuilds":true}}
+				],
+				"links":{"next":"`+appNext+`"}
+			}`), nil
+		case 3:
+			if req.URL.String() != appNext {
+				t.Fatalf("unexpected app groups next URL: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"betaGroups","id":"group-explicit","attributes":{"name":"External QA duplicate","isInternalGroup":false}},
+					{"type":"betaGroups","id":"group-both","attributes":{"name":"Partner Preview","isInternalGroup":false,"hasAccessToAllBuilds":true}},
+					{"type":"betaGroups","id":"group-none","attributes":{"name":"Old Group","isInternalGroup":false}}
+				]
+			}`), nil
+		case 4:
+			assertBuildMembershipGroupQuery(t, req.URL, "filter[builds]", "build-1")
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"betaGroups","id":"group-explicit","attributes":{"name":"External QA","isInternalGroup":false}}
+				],
+				"links":{"next":"`+buildNext+`"}
+			}`), nil
+		case 5:
+			if req.URL.String() != buildNext {
+				t.Fatalf("unexpected build-filter next URL: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-explicit","attributes":{"name":"duplicate"}}]}`), nil
+		case 6:
+			if req.URL.Path != "/v1/betaGroups/group-all/relationships/builds" {
+				t.Fatalf("unexpected all-build verification: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[]}`), nil
+		case 7:
+			if req.URL.Path != "/v1/betaGroups/group-both/relationships/builds" {
+				t.Fatalf("unexpected explicit all-build verification: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1"}]}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "groups", "list", "--build-id", "build-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 7 {
+		t.Fatalf("expected seven requests, got %d", requestCount)
+	}
+
+	var got buildGroupMembershipOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if got.BuildID != "build-1" || got.AppID != "app-1" || !got.Complete || got.LookupMethod != "server_filter_with_inverse_all_builds" {
+		t.Fatalf("unexpected lookup context: %#v", got)
+	}
+	if got.GroupCount != 3 || len(got.Groups) != 3 {
+		t.Fatalf("expected three deduplicated groups, got %#v", got.Groups)
+	}
+	want := []buildGroupMembershipRecord{
+		{ID: "group-explicit", Name: "External QA", Type: "external", Membership: "explicit", HasAccessToAllBuilds: false},
+		{ID: "group-all", Name: "Internal All Builds", Type: "internal", Membership: "all-builds", HasAccessToAllBuilds: true},
+		{ID: "group-both", Name: "Partner Preview", Type: "external", Membership: "explicit-and-all-builds", HasAccessToAllBuilds: true},
+	}
+	for i := range want {
+		if got.Groups[i] != want[i] {
+			t.Fatalf("group %d = %#v, want %#v", i, got.Groups[i], want[i])
+		}
+	}
+}
+
+func TestTestFlightGroupsListBuildMembershipEmptyIsSuccessful(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-none","attributes":{"name":"No Access"}}]}`), nil
+		case 3:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s", req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "groups", "list", "--build-id", "build-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("empty membership must succeed, got %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got buildGroupMembershipOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if !got.Complete || got.GroupCount != 0 || got.Groups == nil || len(got.Groups) != 0 {
+		t.Fatalf("expected complete empty result, got %#v", got)
+	}
+}
+
+func TestTestFlightGroupsListBuildMembershipRendersTable(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2, 3:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s", req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "groups", "list", "--build-id", "build-1", "--output", "table"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"Build ID", "Group ID", "Membership", "build-1", "group-1", "explicit", "External QA"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected table to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTestFlightGroupsListBuildMembershipFallsBackAndFindsLargeGroupMatch(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/betaGroups/group-large/relationships/builds?cursor=next"
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-large","attributes":{"name":"Large External","isInternalGroup":false}}]}`), nil
+		case 3:
+			return jsonHTTPResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"PARAMETER_ERROR","title":"Unsupported filter"}]}`), nil
+		case 4:
+			if req.URL.Path != "/v1/betaGroups/group-large/relationships/builds" || req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("unexpected inverse lookup: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, buildLinkagesPage(200, "other", nextURL)), nil
+		case 5:
+			if req.URL.String() != nextURL {
+				t.Fatalf("unexpected inverse next URL: %s", req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s", req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "groups", "list", "--build-id", "build-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if !strings.Contains(stderr, "falling back to inverse group build relationships") {
+		t.Fatalf("expected transparent fallback warning, got %q", stderr)
+	}
+
+	var got buildGroupMembershipOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if !got.Complete || got.LookupMethod != "inverse_relationships" || got.GroupCount != 1 || got.Groups[0].ID != "group-large" {
+		t.Fatalf("unexpected fallback result: %#v", got)
+	}
+}
+
+func TestTestFlightGroupsListBuildMembershipPreservesPartialResultAndFails(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[
+				{"type":"betaGroups","id":"group-all","attributes":{"name":"All Builds","isInternalGroup":true,"hasAccessToAllBuilds":true}},
+				{"type":"betaGroups","id":"group-explicit","attributes":{"name":"Explicit","isInternalGroup":false}},
+				{"type":"betaGroups","id":"group-failed","attributes":{"name":"Failed","isInternalGroup":false}}
+			]}`), nil
+		case 3:
+			return jsonHTTPResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"PARAMETER_ERROR","title":"Unsupported filter"}]}`), nil
+		case 4:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[]}`), nil
+		case 5:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1"}]}`), nil
+		case 6:
+			return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","title":"Temporary failure"}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s", req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "groups", "list", "--build-id", "build-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected incomplete lookup to fail")
+	}
+	if !strings.Contains(runErr.Error(), "membership lookup incomplete") {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if !strings.Contains(stderr, "1 group relationship lookup failed") {
+		t.Fatalf("expected partial failure diagnostic, got %q", stderr)
+	}
+
+	var got buildGroupMembershipOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if got.Complete || got.GroupCount != 2 || len(got.Failures) != 1 || got.Failures[0].GroupID != "group-failed" {
+		t.Fatalf("unexpected partial result: %#v", got)
+	}
+	if got.Groups[0].ID != "group-all" || got.Groups[0].Membership != "all-builds" || got.Groups[1].ID != "group-explicit" {
+		t.Fatalf("unexpected partial memberships: %#v", got.Groups)
+	}
+}
+
+func TestTestFlightGroupsListBuildMembershipRejectsPageControlsAndGlobal(t *testing.T) {
+	tests := [][]string{
+		{"--global"},
+		{"--global=false"},
+		{"--limit", "20"},
+		{"--limit", "0"},
+		{"--paginate"},
+		{"--paginate=false"},
+		{"--next", "https://api.appstoreconnect.apple.com/v1/betaGroups?cursor=next"},
+		{"--next", ""},
+	}
+
+	for _, extra := range tests {
+		t.Run(strings.TrimPrefix(strings.Join(extra, "_"), "--"), func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			args := append([]string{"testflight", "groups", "list", "--build-id", "build-1"}, extra...)
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected usage error, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "cannot be used with --build-id") {
+				t.Fatalf("expected incompatibility diagnostic, got %q", stderr)
+			}
+		})
+	}
+}
+
+func assertBuildMembershipGroupQuery(t *testing.T, requestURL *url.URL, filterName, filterValue string) {
+	t.Helper()
+	if requestURL.Path != "/v1/betaGroups" {
+		t.Fatalf("unexpected beta groups path: %s", requestURL.String())
+	}
+	query := requestURL.Query()
+	if query.Get(filterName) != filterValue {
+		t.Fatalf("%s = %q, want %q in %s", filterName, query.Get(filterName), filterValue, requestURL.String())
+	}
+	if query.Get("limit") != "200" {
+		t.Fatalf("limit = %q, want 200", query.Get("limit"))
+	}
+	if query.Get("fields[betaGroups]") != "name,isInternalGroup,hasAccessToAllBuilds" {
+		t.Fatalf("unexpected sparse fields: %q", query.Get("fields[betaGroups]"))
+	}
+}
+
+func buildLinkagesPage(count int, prefix, next string) string {
+	data := make([]map[string]string, 0, count)
+	for i := 0; i < count; i++ {
+		data = append(data, map[string]string{
+			"type": "builds",
+			"id":   fmt.Sprintf("%s-%03d", prefix, i),
+		})
+	}
+	payload := struct {
+		Data  []map[string]string `json:"data"`
+		Links map[string]string   `json:"links,omitempty"`
+	}{Data: data}
+	if next != "" {
+		payload.Links = map[string]string{"next": next}
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -62,7 +62,7 @@ func BetaGroupsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
-	buildID := fs.String("build-id", "", "List groups that contain this build ID")
+	buildID := fs.String("build-id", "", "[experimental] List groups that contain this build ID")
 	global := fs.Bool("global", false, "List beta groups across all apps (top-level endpoint)")
 	internal := fs.Bool("internal", false, "Filter to internal groups only")
 	external := fs.Bool("external", false, "Filter to external groups only")
@@ -77,11 +77,12 @@ func BetaGroupsListCommand() *ffcli.Command {
 		ShortHelp:  "List TestFlight beta groups for an app or globally.",
 		LongHelp: `List TestFlight beta groups for an app or globally.
 
-With --build-id, the command resolves the build's app, automatically paginates
-the app's groups, and returns both explicit build relationships and groups with
-all-build access. App Store Connect does not expose a build-side GET for beta
-groups, so the command prefers the documented betaGroups build filter. If Apple
-rejects that filter, it falls back to the inverse group-to-build relationship.
+The --build-id lookup is experimental. It resolves the build's app and
+automatically paginates the app's groups, returning both explicit build
+relationships and groups with all-build access. App Store Connect does not
+expose a build-side GET for beta groups, so the command prefers the documented
+betaGroups build filter. If that filter is rejected, the command falls back to
+the inverse group-to-build relationship.
 All-build groups omitted by the filter are also checked through that inverse
 linkage because Apple can omit their explicit relationships. These checks scan
 linkage IDs only; cost scales with the checked groups and their build page count.

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -118,10 +118,13 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --internal and --external are mutually exclusive")
 				return flag.ErrHelp
 			}
+			appIDSet := false
 			buildIDSet := false
 			membershipPageControlSet := false
 			fs.Visit(func(value *flag.Flag) {
 				switch value.Name {
+				case "app":
+					appIDSet = true
 				case "build-id":
 					buildIDSet = true
 				case "global", "limit", "next", "paginate":
@@ -132,12 +135,20 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --build-id cannot be empty")
 				return flag.ErrHelp
 			}
+			if resolvedBuildID != "" && appIDSet && strings.TrimSpace(*appID) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app cannot be empty when used with --build-id")
+				return flag.ErrHelp
+			}
 			if resolvedBuildID != "" && membershipPageControlSet {
 				fmt.Fprintln(os.Stderr, "Error: --global, --limit, --next, and --paginate cannot be used with --build-id; membership lookup always fetches all required pages")
 				return flag.ErrHelp
 			}
 
 			if resolvedBuildID != "" {
+				expectedAppID := ""
+				if appIDSet {
+					expectedAppID = strings.TrimSpace(*appID)
+				}
 				client, err := shared.GetASCClient()
 				if err != nil {
 					return fmt.Errorf("beta-groups list: %w", err)
@@ -159,7 +170,7 @@ Examples:
 					requestCtx,
 					client,
 					resolvedBuildID,
-					resolvedAppID,
+					expectedAppID,
 					internalFilter,
 				)
 				if usedFallback {

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -25,6 +25,7 @@ func BetaGroupsCommand() *ffcli.Command {
 
 Examples:
   asc testflight beta-groups list --app "APP_ID"
+  asc testflight beta-groups list --build-id "BUILD_ID"
   asc testflight beta-groups list --app "APP_ID" --internal
   asc testflight beta-groups list --global --internal
   asc testflight beta-groups create --app "APP_ID" --name "Beta Testers"
@@ -58,6 +59,7 @@ func BetaGroupsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	buildID := fs.String("build-id", "", "List groups that contain this build ID")
 	global := fs.Bool("global", false, "List beta groups across all apps (top-level endpoint)")
 	internal := fs.Bool("internal", false, "Filter to internal groups only")
 	external := fs.Bool("external", false, "Filter to external groups only")
@@ -72,8 +74,23 @@ func BetaGroupsListCommand() *ffcli.Command {
 		ShortHelp:  "List TestFlight beta groups for an app or globally.",
 		LongHelp: `List TestFlight beta groups for an app or globally.
 
+With --build-id, the command resolves the build's app, automatically paginates
+the app's groups, and returns both explicit build relationships and groups with
+all-build access. App Store Connect does not expose a build-side GET for beta
+groups, so the command prefers the documented betaGroups build filter. If Apple
+rejects that filter, it falls back to the inverse group-to-build relationship.
+All-build groups omitted by the filter are also checked through that inverse
+linkage because Apple can omit their explicit relationships. These checks scan
+linkage IDs only; cost scales with the checked groups and their build page count.
+
+A complete lookup with no memberships prints an empty groups array and exits 0.
+If an inverse relationship cannot be read, available matches and failures are
+printed with complete=false and the command exits nonzero.
+
 Examples:
   asc testflight beta-groups list --app "APP_ID"
+  asc testflight beta-groups list --build-id "BUILD_ID"
+  asc testflight beta-groups list --build-id "BUILD_ID" --internal
   asc testflight beta-groups list --app "APP_ID" --internal
   asc testflight beta-groups list --app "APP_ID" --external
   asc testflight beta-groups list --app "APP_ID" --limit 10
@@ -92,10 +109,63 @@ Examples:
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
+			resolvedBuildID := strings.TrimSpace(*buildID)
 
 			if *internal && *external {
 				fmt.Fprintln(os.Stderr, "Error: --internal and --external are mutually exclusive")
 				return flag.ErrHelp
+			}
+			membershipPageControlSet := false
+			fs.Visit(func(value *flag.Flag) {
+				switch value.Name {
+				case "global", "limit", "next", "paginate":
+					membershipPageControlSet = true
+				}
+			})
+			if resolvedBuildID != "" && membershipPageControlSet {
+				fmt.Fprintln(os.Stderr, "Error: --global, --limit, --next, and --paginate cannot be used with --build-id; membership lookup always fetches all required pages")
+				return flag.ErrHelp
+			}
+
+			if resolvedBuildID != "" {
+				client, err := shared.GetASCClient()
+				if err != nil {
+					return fmt.Errorf("beta-groups list: %w", err)
+				}
+
+				requestCtx, cancel := shared.ContextWithTimeout(ctx)
+				defer cancel()
+
+				var internalFilter *bool
+				if *internal {
+					value := true
+					internalFilter = &value
+				} else if *external {
+					value := false
+					internalFilter = &value
+				}
+
+				result, usedFallback, lookupErr := lookupBuildGroupMembership(
+					requestCtx,
+					client,
+					resolvedBuildID,
+					resolvedAppID,
+					internalFilter,
+				)
+				if usedFallback {
+					fmt.Fprintln(os.Stderr, "Apple rejected the documented betaGroups build filter; falling back to inverse group build relationships (cost scales with groups and build pages)")
+				}
+				if result == nil {
+					return fmt.Errorf("beta-groups list: %w", lookupErr)
+				}
+				if err := shared.PrintOutput(result, *output.Output, *output.Pretty); err != nil {
+					return err
+				}
+				if lookupErr != nil {
+					fmt.Fprintf(os.Stderr, "%d group relationship lookup failed; membership result is incomplete\n", len(result.Failures))
+					return shared.NewReportedError(lookupErr)
+				}
+				return nil
 			}
 
 			// Reject --global + --app combination (check explicit flag, not resolved value)

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+const buildGroupMembershipTimeout = 5 * time.Minute
 
 // BetaGroupsCommand returns the beta groups command with subcommands.
 func BetaGroupsCommand() *ffcli.Command {
@@ -115,13 +118,20 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --internal and --external are mutually exclusive")
 				return flag.ErrHelp
 			}
+			buildIDSet := false
 			membershipPageControlSet := false
 			fs.Visit(func(value *flag.Flag) {
 				switch value.Name {
+				case "build-id":
+					buildIDSet = true
 				case "global", "limit", "next", "paginate":
 					membershipPageControlSet = true
 				}
 			})
+			if buildIDSet && resolvedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build-id cannot be empty")
+				return flag.ErrHelp
+			}
 			if resolvedBuildID != "" && membershipPageControlSet {
 				fmt.Fprintln(os.Stderr, "Error: --global, --limit, --next, and --paginate cannot be used with --build-id; membership lookup always fetches all required pages")
 				return flag.ErrHelp
@@ -133,7 +143,7 @@ Examples:
 					return fmt.Errorf("beta-groups list: %w", err)
 				}
 
-				requestCtx, cancel := shared.ContextWithTimeout(ctx)
+				requestCtx, cancel := contextWithBuildGroupMembershipTimeout(ctx)
 				defer cancel()
 
 				var internalFilter *bool
@@ -317,6 +327,10 @@ Examples:
 			return shared.PrintOutput(groups, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func contextWithBuildGroupMembershipTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return shared.ContextWithResolvedTimeout(ctx, buildGroupMembershipTimeout)
 }
 
 // BetaGroupsCreateCommand returns the beta groups create subcommand.

--- a/internal/cli/testflight/beta_groups_timeout_test.go
+++ b/internal/cli/testflight/beta_groups_timeout_test.go
@@ -1,0 +1,32 @@
+package testflight
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestContextWithBuildGroupMembershipTimeoutUsesBulkDefault(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+
+	ctx, cancel := contextWithBuildGroupMembershipTimeout(context.Background())
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok || time.Until(deadline) < 4*time.Minute {
+		t.Fatalf("expected five-minute bulk timeout, deadline=%v, present=%t", deadline, ok)
+	}
+}
+
+func TestContextWithBuildGroupMembershipTimeoutHonorsASCOverride(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "90s")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+
+	ctx, cancel := contextWithBuildGroupMembershipTimeout(context.Background())
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	remaining := time.Until(deadline)
+	if !ok || remaining < 89*time.Second || remaining > 91*time.Second {
+		t.Fatalf("expected ASC_TIMEOUT override near 90s, remaining=%v, present=%t", remaining, ok)
+	}
+}

--- a/internal/cli/testflight/beta_groups_timeout_test.go
+++ b/internal/cli/testflight/beta_groups_timeout_test.go
@@ -13,8 +13,9 @@ func TestContextWithBuildGroupMembershipTimeoutUsesBulkDefault(t *testing.T) {
 	ctx, cancel := contextWithBuildGroupMembershipTimeout(context.Background())
 	defer cancel()
 	deadline, ok := ctx.Deadline()
-	if !ok || time.Until(deadline) < 4*time.Minute {
-		t.Fatalf("expected five-minute bulk timeout, deadline=%v, present=%t", deadline, ok)
+	remaining := time.Until(deadline)
+	if !ok || remaining < 299*time.Second || remaining > 301*time.Second {
+		t.Fatalf("expected five-minute bulk timeout, remaining=%v, present=%t", remaining, ok)
 	}
 }
 

--- a/internal/cli/testflight/build_group_membership.go
+++ b/internal/cli/testflight/build_group_membership.go
@@ -1,0 +1,265 @@
+package testflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+const (
+	buildGroupLookupServerFilter         = "server_filter_with_inverse_all_builds"
+	buildGroupLookupInverseRelationships = "inverse_relationships"
+
+	buildGroupMembershipExplicit             = "explicit"
+	buildGroupMembershipAllBuilds            = "all-builds"
+	buildGroupMembershipExplicitAndAllBuilds = "explicit-and-all-builds"
+)
+
+var buildGroupSparseFields = []string{"name", "isInternalGroup", "hasAccessToAllBuilds"}
+
+func lookupBuildGroupMembership(
+	ctx context.Context,
+	client *asc.Client,
+	buildID string,
+	expectedAppID string,
+	internalFilter *bool,
+) (*asc.BuildBetaGroupMembershipResult, bool, error) {
+	appLinkage, err := client.GetBuildAppRelationship(ctx, buildID)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to resolve app for build %q: %w", buildID, err)
+	}
+	appID := strings.TrimSpace(appLinkage.Data.ID)
+	if appID == "" {
+		return nil, false, fmt.Errorf("build %q is missing related app ID", buildID)
+	}
+	if expected := strings.TrimSpace(expectedAppID); expected != "" && expected != appID {
+		return nil, false, fmt.Errorf("build %q belongs to app %q, not requested app %q", buildID, appID, expected)
+	}
+
+	appOptions := []asc.BetaGroupsOption{
+		asc.WithBetaGroupsApps([]string{appID}),
+		asc.WithBetaGroupsFields(buildGroupSparseFields),
+		asc.WithBetaGroupsLimit(200),
+	}
+	if internalFilter != nil {
+		appOptions = append(appOptions, asc.WithBetaGroupsIsInternal(*internalFilter))
+	}
+	appGroups, err := listAllBetaGroups(ctx, client, appOptions...)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to list groups for app %q: %w", appID, err)
+	}
+
+	groupByID := deduplicateBetaGroups(appGroups.Data)
+	explicitGroups, filterErr := listAllBetaGroups(
+		ctx,
+		client,
+		asc.WithBetaGroupsBuilds([]string{buildID}),
+		asc.WithBetaGroupsFields(buildGroupSparseFields),
+		asc.WithBetaGroupsLimit(200),
+	)
+	if filterErr == nil {
+		explicitIDs := make(map[string]struct{}, len(explicitGroups.Data))
+		for _, group := range explicitGroups.Data {
+			groupID := strings.TrimSpace(group.ID)
+			if groupID == "" || !matchesInternalFilter(group, internalFilter) {
+				continue
+			}
+			explicitIDs[groupID] = struct{}{}
+			if _, ok := groupByID[groupID]; !ok {
+				groupByID[groupID] = group
+			}
+		}
+
+		allBuildGroups := make(map[string]asc.Resource[asc.BetaGroupAttributes])
+		for groupID, group := range groupByID {
+			if group.Attributes.HasAccessToAllBuilds {
+				if _, alreadyExplicit := explicitIDs[groupID]; alreadyExplicit {
+					continue
+				}
+				allBuildGroups[groupID] = group
+			}
+		}
+		allBuildExplicitIDs, failures := lookupBuildGroupMembershipByInverseRelationships(ctx, client, buildID, allBuildGroups)
+		for groupID := range allBuildExplicitIDs {
+			explicitIDs[groupID] = struct{}{}
+		}
+		result := buildGroupMembershipResult(buildID, appID, groupByID, explicitIDs, failures, buildGroupLookupServerFilter)
+		if len(failures) > 0 {
+			return result, false, fmt.Errorf("membership lookup incomplete: %d all-build group relationship lookup failed", len(failures))
+		}
+		return result, false, nil
+	}
+	if !isHTTPBadRequest(filterErr) {
+		return nil, false, fmt.Errorf("failed to filter groups for build %q: %w", buildID, filterErr)
+	}
+
+	explicitIDs, failures := lookupBuildGroupMembershipByInverseRelationships(ctx, client, buildID, groupByID)
+	result := buildGroupMembershipResult(buildID, appID, groupByID, explicitIDs, failures, buildGroupLookupInverseRelationships)
+	if len(failures) > 0 {
+		return result, true, fmt.Errorf("membership lookup incomplete: %d group relationship lookup failed", len(failures))
+	}
+	return result, true, nil
+}
+
+func listAllBetaGroups(ctx context.Context, client *asc.Client, opts ...asc.BetaGroupsOption) (*asc.BetaGroupsResponse, error) {
+	firstPage, err := client.ListBetaGroups(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	all, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.ListBetaGroups(ctx, asc.WithBetaGroupsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+	groups, ok := all.(*asc.BetaGroupsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected beta groups response type %T", all)
+	}
+	return groups, nil
+}
+
+func deduplicateBetaGroups(groups []asc.Resource[asc.BetaGroupAttributes]) map[string]asc.Resource[asc.BetaGroupAttributes] {
+	result := make(map[string]asc.Resource[asc.BetaGroupAttributes], len(groups))
+	for _, group := range groups {
+		groupID := strings.TrimSpace(group.ID)
+		if groupID == "" {
+			continue
+		}
+		if _, exists := result[groupID]; !exists {
+			result[groupID] = group
+		}
+	}
+	return result
+}
+
+func matchesInternalFilter(group asc.Resource[asc.BetaGroupAttributes], internalFilter *bool) bool {
+	return internalFilter == nil || group.Attributes.IsInternalGroup == *internalFilter
+}
+
+func lookupBuildGroupMembershipByInverseRelationships(
+	ctx context.Context,
+	client *asc.Client,
+	buildID string,
+	groups map[string]asc.Resource[asc.BetaGroupAttributes],
+) (map[string]struct{}, []asc.BuildBetaGroupMembershipFailure) {
+	groupIDs := make([]string, 0, len(groups))
+	for groupID := range groups {
+		groupIDs = append(groupIDs, groupID)
+	}
+	sort.Strings(groupIDs)
+
+	explicitIDs := make(map[string]struct{})
+	failures := make([]asc.BuildBetaGroupMembershipFailure, 0)
+	for _, groupID := range groupIDs {
+		contains, err := betaGroupContainsBuild(ctx, client, groupID, buildID)
+		if err != nil {
+			failures = append(failures, asc.BuildBetaGroupMembershipFailure{
+				GroupID:   groupID,
+				GroupName: groups[groupID].Attributes.Name,
+				Error:     err.Error(),
+			})
+			continue
+		}
+		if contains {
+			explicitIDs[groupID] = struct{}{}
+		}
+	}
+	return explicitIDs, failures
+}
+
+func betaGroupContainsBuild(ctx context.Context, client *asc.Client, groupID, buildID string) (bool, error) {
+	page, err := client.GetBetaGroupBuildsRelationships(ctx, groupID, asc.WithLinkagesLimit(200))
+	if err != nil {
+		return false, err
+	}
+	seenNext := make(map[string]struct{})
+	pageNumber := 1
+	for {
+		for _, linkage := range page.Data {
+			if strings.TrimSpace(linkage.ID) == buildID {
+				return true, nil
+			}
+		}
+		nextURL := strings.TrimSpace(page.Links.Next)
+		if nextURL == "" {
+			return false, nil
+		}
+		if _, seen := seenNext[nextURL]; seen {
+			return false, fmt.Errorf("page %d: %w", pageNumber+1, asc.ErrRepeatedPaginationURL)
+		}
+		seenNext[nextURL] = struct{}{}
+		pageNumber++
+		page, err = client.GetBetaGroupBuildsRelationships(ctx, groupID, asc.WithLinkagesNextURL(nextURL))
+		if err != nil {
+			return false, fmt.Errorf("page %d: %w", pageNumber, err)
+		}
+	}
+}
+
+func buildGroupMembershipResult(
+	buildID string,
+	appID string,
+	groups map[string]asc.Resource[asc.BetaGroupAttributes],
+	explicitIDs map[string]struct{},
+	failures []asc.BuildBetaGroupMembershipFailure,
+	lookupMethod string,
+) *asc.BuildBetaGroupMembershipResult {
+	memberships := make([]asc.BuildBetaGroupMembershipGroup, 0, len(groups))
+	for groupID, group := range groups {
+		_, explicit := explicitIDs[groupID]
+		allBuilds := group.Attributes.HasAccessToAllBuilds
+		membership := ""
+		switch {
+		case explicit && allBuilds:
+			membership = buildGroupMembershipExplicitAndAllBuilds
+		case explicit:
+			membership = buildGroupMembershipExplicit
+		case allBuilds:
+			membership = buildGroupMembershipAllBuilds
+		default:
+			continue
+		}
+
+		groupType := "external"
+		if group.Attributes.IsInternalGroup {
+			groupType = "internal"
+		}
+		memberships = append(memberships, asc.BuildBetaGroupMembershipGroup{
+			ID:                   groupID,
+			Name:                 group.Attributes.Name,
+			Type:                 groupType,
+			Membership:           membership,
+			HasAccessToAllBuilds: allBuilds,
+		})
+	}
+	sort.Slice(memberships, func(i, j int) bool {
+		leftName := strings.ToLower(strings.TrimSpace(memberships[i].Name))
+		rightName := strings.ToLower(strings.TrimSpace(memberships[j].Name))
+		if leftName == rightName {
+			return memberships[i].ID < memberships[j].ID
+		}
+		return leftName < rightName
+	})
+	if failures == nil {
+		failures = []asc.BuildBetaGroupMembershipFailure{}
+	}
+	return &asc.BuildBetaGroupMembershipResult{
+		BuildID:      buildID,
+		AppID:        appID,
+		Complete:     len(failures) == 0,
+		LookupMethod: lookupMethod,
+		GroupCount:   len(memberships),
+		Groups:       memberships,
+		Failures:     failures,
+	}
+}
+
+func isHTTPBadRequest(err error) bool {
+	var apiErr *asc.APIError
+	return errors.As(err, &apiErr) && apiErr.HTTPStatusCode() == 400
+}


### PR DESCRIPTION
## Summary

- add `asc testflight groups list --build-id BUILD_ID` with JSON/table output and an optional `--app` assertion
- return explicit, all-build, and combined membership context with stable group IDs and partial-result semantics
- paginate documented beta-group filters and inverse relationship IDs, falling back transparently when Apple rejects `filter[builds]`
- document why the lookup uses inverse group-to-build relationships and their cost

## API behavior

App Store Connect does not expose `GET /v1/builds/{id}/relationships/betaGroups`. The command resolves the build app, uses the documented `GET /v1/betaGroups?filter[builds]=...` filter, and checks inverse `GET /v1/betaGroups/{id}/relationships/builds` linkage IDs for all-build groups omitted by that filter. If the server rejects the filter, it uses the inverse linkage for all candidate groups.

## Verification

- `go test ./internal/cli/cmdtest -run TestTestFlightGroupsListBuildMembership -count=1`
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-command help and argument validation
- read-only live verification with explicit existing build/app IDs; anonymized assertion confirmed the known explicit group, a complete result, and no failures

No App Store Connect mutations were performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788900494&installation_model_id=10418&pr_number=1912&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1912&signature=46f9c48b83ecad1d80ec936009fcb1b61a23b352a9262d20de27d1e44b7cf509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `testflight groups list --build-id` to find TestFlight groups associated with a build.
  * Supports table and JSON output, pagination, filtering, membership details, and empty results.
  * Reports partial lookup failures while preserving successful results.
  * Added fallback handling when direct relationship queries are unavailable.
  * Validates incompatible options and supports configurable request timeouts.

* **Documentation**
  * Documented build-based TestFlight group lookup, output formats, relationship handling, and expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->