### PR TITLE
fix(builds): preserve next-number safety on restricted accounts

### DIFF
--- a/internal/cli/cmdtest/builds_next_number_test.go
+++ b/internal/cli/cmdtest/builds_next_number_test.go
@@ -10,6 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestBuildsNextBuildNumberUsesUploadsAndBuilds(t *testing.T) {
@@ -139,6 +142,85 @@ func TestBuildsNextBuildNumberRejectsInvalidInitialBuildNumber(t *testing.T) {
 	}
 	if strings.Contains(stderr, "missing authentication") {
 		t.Fatalf("expected validation before auth resolution, got %q", stderr)
+	}
+}
+
+func TestBuildsNextBuildNumberExplainsUnavailableUploadHistory(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		responseBody string
+		wantCause    error
+		wantExitCode int
+	}{
+		{
+			name:         "forbidden",
+			status:       http.StatusForbidden,
+			responseBody: `{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden"}]}`,
+			wantCause:    asc.ErrForbidden,
+			wantExitCode: cmd.ExitAuth,
+		},
+		{
+			name:         "not found",
+			status:       http.StatusNotFound,
+			responseBody: `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`,
+			wantCause:    asc.ErrNotFound,
+			wantExitCode: cmd.ExitNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}]}`), nil
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
+					return jsonHTTPResponse(tt.status, tt.responseBody), nil
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+					return nil, nil
+				}
+			})
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{"builds", "next-build-number", "--app", "100000001"}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected unavailable upload history to fail")
+			}
+			if !errors.Is(runErr, tt.wantCause) {
+				t.Fatalf("expected %v in error chain, got %v", tt.wantCause, runErr)
+			}
+			if got := cmd.ExitCodeFromError(runErr); got != tt.wantExitCode {
+				t.Fatalf("exit code = %d, want %d", got, tt.wantExitCode)
+			}
+			for _, want := range []string{
+				`build upload history is unavailable for app "100000001"`,
+				"refusing to guess because an in-flight upload may already use the next number",
+				`asc builds uploads list --app "100000001"`,
+			} {
+				if !strings.Contains(runErr.Error(), want) {
+					t.Fatalf("expected error to contain %q, got %v", want, runErr)
+				}
+			}
+			if stdout != "" || stderr != "" {
+				t.Fatalf("expected no partial output, got stdout=%q stderr=%q", stdout, stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/builds_next_number_test.go
+++ b/internal/cli/cmdtest/builds_next_number_test.go
@@ -150,20 +150,37 @@ func TestBuildsNextBuildNumberExplainsUnavailableUploadHistory(t *testing.T) {
 		name         string
 		status       int
 		responseBody string
+		paginate     bool
 		wantCause    error
 		wantExitCode int
 	}{
 		{
-			name:         "forbidden",
+			name:         "initial request forbidden",
 			status:       http.StatusForbidden,
 			responseBody: `{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden"}]}`,
 			wantCause:    asc.ErrForbidden,
 			wantExitCode: cmd.ExitAuth,
 		},
 		{
-			name:         "not found",
+			name:         "initial request not found",
 			status:       http.StatusNotFound,
 			responseBody: `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`,
+			wantCause:    asc.ErrNotFound,
+			wantExitCode: cmd.ExitNotFound,
+		},
+		{
+			name:         "next page forbidden",
+			status:       http.StatusForbidden,
+			responseBody: `{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden"}]}`,
+			paginate:     true,
+			wantCause:    asc.ErrForbidden,
+			wantExitCode: cmd.ExitAuth,
+		},
+		{
+			name:         "next page not found",
+			status:       http.StatusNotFound,
+			responseBody: `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`,
+			paginate:     true,
 			wantCause:    asc.ErrNotFound,
 			wantExitCode: cmd.ExitNotFound,
 		},
@@ -180,6 +197,8 @@ func TestBuildsNextBuildNumberExplainsUnavailableUploadHistory(t *testing.T) {
 				switch {
 				case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
 					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}]}`), nil
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads" && tt.paginate && req.URL.Query().Get("cursor") == "":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps/100000001/buildUploads?cursor=next-page"}}`), nil
 				case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
 					return jsonHTTPResponse(tt.status, tt.responseBody), nil
 				default:

--- a/internal/cli/cmdtest/builds_next_number_test.go
+++ b/internal/cli/cmdtest/builds_next_number_test.go
@@ -230,7 +230,7 @@ func TestBuildsNextBuildNumberExplainsUnavailableUploadHistory(t *testing.T) {
 			for _, want := range []string{
 				`build upload history is unavailable for app "100000001"`,
 				"refusing to guess because an in-flight upload may already use the next number",
-				`asc builds uploads list --app "100000001"`,
+				`asc builds uploads list --app "100000001" --paginate`,
 			} {
 				if !strings.Contains(runErr.Error(), want) {
 					t.Fatalf("expected error to contain %q, got %v", want, runErr)

--- a/internal/cli/shared/build_numbers.go
+++ b/internal/cli/shared/build_numbers.go
@@ -545,7 +545,7 @@ func buildUploadHistoryError(appID, operation string, err error) error {
 	}
 
 	return fmt.Errorf(
-		"build upload history is unavailable for app %q; refusing to guess because an in-flight upload may already use the next number. Verify access with asc builds uploads list --app %q: %w",
+		"build upload history is unavailable for app %q; refusing to guess because an in-flight upload may already use the next number. Verify access with asc builds uploads list --app %q --paginate: %w",
 		appID,
 		appID,
 		err,

--- a/internal/cli/shared/build_numbers.go
+++ b/internal/cli/shared/build_numbers.go
@@ -497,7 +497,7 @@ func findLatestBuildUploadNumber(ctx context.Context, client *asc.Client, appID,
 
 	uploads, err := client.GetBuildUploads(ctx, appID, opts...)
 	if err != nil {
-		return buildNumber{}, nil, false, fmt.Errorf("failed to fetch build uploads: %w", err)
+		return buildNumber{}, nil, false, buildUploadHistoryError(appID, "failed to fetch build uploads", err)
 	}
 
 	var latestUploadValue buildNumber
@@ -533,10 +533,23 @@ func findLatestBuildUploadNumber(ctx context.Context, client *asc.Client, appID,
 		return processPage(resp)
 	})
 	if err != nil {
-		return buildNumber{}, nil, false, fmt.Errorf("failed to paginate build uploads: %w", err)
+		return buildNumber{}, nil, false, buildUploadHistoryError(appID, "failed to paginate build uploads", err)
 	}
 
 	return latestUploadValue, latestUploadNumber, hasUpload, nil
+}
+
+func buildUploadHistoryError(appID, operation string, err error) error {
+	if !errors.Is(err, asc.ErrForbidden) && !asc.IsNotFound(err) {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+
+	return fmt.Errorf(
+		"build upload history is unavailable for app %q; refusing to guess because an in-flight upload may already use the next number. Verify access with asc builds uploads list --app %q: %w",
+		appID,
+		appID,
+		err,
+	)
 }
 
 func isNonPositiveNumericBuildNumber(raw string) bool {


### PR DESCRIPTION
## Summary

- keep next-build-number fail-closed when in-flight upload history cannot be inspected
- explain the collision risk for forbidden and missing upload-history responses
- provide the exact read-only uploads-list command for checking API key access
- preserve typed error causes, exit codes, and empty stdout on failure

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- live upload-history and next-number checks on the designated test app

The live app had no processed or in-flight builds, and the command returned `1` with an empty source list.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788900784&installation_model_id=10418&pr_number=1913&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1913&signature=4532a3d52d2d33bd1ae71c5da01d9ba974d5d4f43858431cbd2e6e115f37e17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when build-upload history is unavailable.
  * Clearly explains when access is forbidden or history cannot be found, with guidance to verify permissions.
  * Preserves detailed context for other build-upload retrieval and pagination failures.
  * Prevents partial output when the build number cannot be determined.
  * Provides consistent behavior for both initial and subsequent history requests.
  * Makes failed build-number lookups easier to diagnose from the command-line output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->