### PR TITLE
fix(notarization): preserve archive identity during submission

### DIFF
--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -302,17 +301,15 @@ func (c *Client) ListNotarizations(ctx context.Context) (*NotarySubmissionsListR
 	return &response, nil
 }
 
-// ComputeFileSHA256 computes the SHA-256 hex digest of a file.
-func ComputeFileSHA256(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", fmt.Errorf("open file: %w", err)
-	}
-	defer f.Close()
-
+// ComputeFileSHA256 computes the SHA-256 hex digest of an opened file and
+// rewinds it so the same descriptor can be uploaded.
+func ComputeFileSHA256(file io.ReadSeeker) (string, error) {
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
+	if _, err := io.Copy(h, file); err != nil {
 		return "", fmt.Errorf("read file: %w", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("rewind file: %w", err)
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -1,6 +1,7 @@
 package asc
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -12,8 +13,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -360,15 +359,9 @@ func TestListNotarizations_ErrorResponse(t *testing.T) {
 }
 
 func TestComputeFileSHA256(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "test.txt")
-
 	content := []byte("hello world")
-	if err := os.WriteFile(path, content, 0o644); err != nil {
-		t.Fatalf("write file: %v", err)
-	}
-
-	got, err := ComputeFileSHA256(path)
+	file := bytes.NewReader(content)
+	got, err := ComputeFileSHA256(file)
 	if err != nil {
 		t.Fatalf("ComputeFileSHA256() error: %v", err)
 	}
@@ -380,24 +373,17 @@ func TestComputeFileSHA256(t *testing.T) {
 	if got != want {
 		t.Errorf("got %s, want %s", got, want)
 	}
-}
-
-func TestComputeFileSHA256_FileNotFound(t *testing.T) {
-	_, err := ComputeFileSHA256("/nonexistent/file.txt")
-	if err == nil {
-		t.Fatal("expected error for nonexistent file")
+	replayed, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("read rewound file: %v", err)
+	}
+	if !bytes.Equal(replayed, content) {
+		t.Fatalf("rewound contents = %q, want %q", replayed, content)
 	}
 }
 
 func TestComputeFileSHA256_EmptyFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "empty.txt")
-
-	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
-		t.Fatalf("write file: %v", err)
-	}
-
-	got, err := ComputeFileSHA256(path)
+	got, err := ComputeFileSHA256(bytes.NewReader(nil))
 	if err != nil {
 		t.Fatalf("ComputeFileSHA256() error: %v", err)
 	}

--- a/internal/cli/notarization/notarization.go
+++ b/internal/cli/notarization/notarization.go
@@ -101,6 +101,12 @@ Examples:
 			if pathInfo.Mode()&os.ModeSymlink != 0 {
 				return fmt.Errorf("notarization submit: refusing to read symlink %q", pathValue)
 			}
+			if pathInfo.IsDir() {
+				return fmt.Errorf("notarization submit: %q is a directory", pathValue)
+			}
+			if !pathInfo.Mode().IsRegular() {
+				return fmt.Errorf("notarization submit: %q is not a regular file", pathValue)
+			}
 
 			fileHandle, err := secureopen.OpenExistingNoFollow(pathValue)
 			if err != nil {
@@ -114,6 +120,9 @@ Examples:
 			}
 			if info.IsDir() {
 				return fmt.Errorf("notarization submit: %q is a directory", pathValue)
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("notarization submit: %q is not a regular file", pathValue)
 			}
 			if info.Size() <= 0 {
 				return fmt.Errorf("notarization submit: file must not be empty")

--- a/internal/cli/notarization/notarization.go
+++ b/internal/cli/notarization/notarization.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 // NotarizationCommand returns the notarization command group.
@@ -91,13 +92,25 @@ Examples:
 				return fmt.Errorf("notarization submit: --timeout must be a valid positive duration (e.g. 30m, 1h)")
 			}
 
-			// Validate file
-			info, err := os.Lstat(pathValue)
+			// Preserve the explicit symlink error while relying on the no-follow
+			// open below for the actual security boundary.
+			pathInfo, err := os.Lstat(pathValue)
 			if err != nil {
 				return fmt.Errorf("notarization submit: %w", err)
 			}
-			if info.Mode()&os.ModeSymlink != 0 {
+			if pathInfo.Mode()&os.ModeSymlink != 0 {
 				return fmt.Errorf("notarization submit: refusing to read symlink %q", pathValue)
+			}
+
+			fileHandle, err := secureopen.OpenExistingNoFollow(pathValue)
+			if err != nil {
+				return fmt.Errorf("notarization submit: failed to open file: %w", err)
+			}
+			defer fileHandle.Close()
+
+			info, err := fileHandle.Stat()
+			if err != nil {
+				return fmt.Errorf("notarization submit: failed to stat opened file: %w", err)
 			}
 			if info.IsDir() {
 				return fmt.Errorf("notarization submit: %q is a directory", pathValue)
@@ -115,7 +128,7 @@ Examples:
 			if shared.ProgressEnabled() {
 				fmt.Fprintf(os.Stderr, "Computing SHA-256 hash of %s...\n", pathValue)
 			}
-			sha256Hash, err := asc.ComputeFileSHA256(pathValue)
+			sha256Hash, err := asc.ComputeFileSHA256(fileHandle)
 			if err != nil {
 				return fmt.Errorf("notarization submit: failed to compute SHA-256: %w", err)
 			}
@@ -148,12 +161,6 @@ Examples:
 			if shared.ProgressEnabled() {
 				fmt.Fprintf(os.Stderr, "Uploading %s to Apple...\n", submissionName)
 			}
-
-			fileHandle, err := os.Open(pathValue)
-			if err != nil {
-				return fmt.Errorf("notarization submit: failed to open file: %w", err)
-			}
-			defer fileHandle.Close()
 
 			uploadCtx, uploadCancel := shared.ContextWithUploadTimeout(ctx)
 			defer uploadCancel()

--- a/internal/cli/notarization/notarization_nonregular_unix_test.go
+++ b/internal/cli/notarization/notarization_nonregular_unix_test.go
@@ -33,7 +33,7 @@ func TestNotarizationSubmitRejectsNonRegularArchiveWithoutBlocking(t *testing.T)
 		if err == nil || !strings.Contains(err.Error(), "is not a regular file") {
 			t.Fatalf("submit error = %v, want non-regular file rejection", err)
 		}
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("notarization submit blocked opening a non-regular file")
 	}
 }

--- a/internal/cli/notarization/notarization_nonregular_unix_test.go
+++ b/internal/cli/notarization/notarization_nonregular_unix_test.go
@@ -1,0 +1,39 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package notarization
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNotarizationSubmitRejectsNonRegularArchiveWithoutBlocking(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "archive.pkg")
+	if err := unix.Mkfifo(archivePath, 0o600); err != nil {
+		t.Skipf("mkfifo not supported: %v", err)
+	}
+
+	cmd := submitCommand()
+	if err := cmd.FlagSet.Parse([]string{"--file", archivePath}); err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Exec(context.Background(), nil)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "is not a regular file") {
+			t.Fatalf("submit error = %v, want non-regular file rejection", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("notarization submit blocked opening a non-regular file")
+	}
+}

--- a/internal/cli/notarization/notarization_test.go
+++ b/internal/cli/notarization/notarization_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -41,6 +42,10 @@ func TestNotarizationSubmitValidation(t *testing.T) {
 }
 
 func TestNotarizationSubmitUploadsOpenedArchiveAfterPathReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not permit replacing an open file")
+	}
+
 	originalContents := []byte("AAAAAAAAAAAAAAAA")
 	replacementContents := []byte("BBBBBBBBBBBBBBBB")
 

--- a/internal/cli/notarization/notarization_test.go
+++ b/internal/cli/notarization/notarization_test.go
@@ -1,11 +1,34 @@
 package notarization
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+type notaryRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn notaryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
 
 func TestNotarizationSubmitValidation(t *testing.T) {
 	cmd := submitCommand()
@@ -15,4 +38,157 @@ func TestNotarizationSubmitValidation(t *testing.T) {
 	if err := cmd.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected ErrHelp, got %v", err)
 	}
+}
+
+func TestNotarizationSubmitUploadsOpenedArchiveAfterPathReplacement(t *testing.T) {
+	originalContents := []byte("AAAAAAAAAAAAAAAA")
+	replacementContents := []byte("BBBBBBBBBBBBBBBB")
+
+	tests := []struct {
+		name        string
+		replacePath func(t *testing.T, archivePath, preservedPath string, replacement []byte)
+	}{
+		{
+			name: "regular file",
+			replacePath: func(t *testing.T, archivePath, preservedPath string, replacement []byte) {
+				t.Helper()
+				if err := os.Rename(archivePath, preservedPath); err != nil {
+					t.Errorf("rename original archive: %v", err)
+					return
+				}
+				if err := os.WriteFile(archivePath, replacement, 0o600); err != nil {
+					t.Errorf("write replacement archive: %v", err)
+				}
+			},
+		},
+		{
+			name: "symlink",
+			replacePath: func(t *testing.T, archivePath, preservedPath string, replacement []byte) {
+				t.Helper()
+				replacementPath := filepath.Join(filepath.Dir(archivePath), "replacement.zip")
+				if err := os.WriteFile(replacementPath, replacement, 0o600); err != nil {
+					t.Errorf("write symlink target: %v", err)
+					return
+				}
+				if err := os.Rename(archivePath, preservedPath); err != nil {
+					t.Errorf("rename original archive: %v", err)
+					return
+				}
+				if err := os.Symlink(replacementPath, archivePath); err != nil {
+					t.Errorf("create replacement symlink: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			archivePath := filepath.Join(dir, "archive.zip")
+			preservedPath := filepath.Join(dir, "original.zip")
+			if err := os.WriteFile(archivePath, originalContents, 0o600); err != nil {
+				t.Fatalf("write original archive: %v", err)
+			}
+
+			expectedHashBytes := sha256.Sum256(originalContents)
+			expectedHash := hex.EncodeToString(expectedHashBytes[:])
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != http.MethodPost || req.URL.Path != "/notary/v2/submissions" {
+					t.Errorf("notary request = %s %s, want POST /notary/v2/submissions", req.Method, req.URL.Path)
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+					return
+				}
+
+				var payload asc.NotarySubmissionRequest
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Errorf("decode notary request: %v", err)
+					http.Error(w, "invalid request", http.StatusBadRequest)
+					return
+				}
+				if payload.Sha256 != expectedHash {
+					t.Errorf("submitted hash = %q, want %q", payload.Sha256, expectedHash)
+				}
+
+				test.replacePath(t, archivePath, preservedPath, replacementContents)
+
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(asc.NotarySubmissionResponse{
+					Data: asc.NotarySubmissionResponseData{
+						Type: "newSubmissions",
+						ID:   "submission-1",
+						Attributes: asc.NotarySubmissionResponseAttributes{
+							AwsAccessKeyID:     "access-key",
+							AwsSecretAccessKey: "secret-key",
+							AwsSessionToken:    "session-token",
+							Bucket:             "notary-bucket",
+							Object:             "notary-object",
+						},
+					},
+				}); err != nil {
+					t.Errorf("encode notary response: %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			client := newNotarizationTestClient(t, server)
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				return client, nil
+			}))
+
+			var uploadedContents []byte
+			originalTransport := http.DefaultClient.Transport
+			http.DefaultClient.Transport = notaryRoundTripper(func(req *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				uploadedContents = body
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+					Request:    req,
+				}, nil
+			})
+			t.Cleanup(func() {
+				http.DefaultClient.Transport = originalTransport
+			})
+
+			cmd := submitCommand()
+			if err := cmd.FlagSet.Parse([]string{"--file", archivePath, "--output", "json"}); err != nil {
+				t.Fatalf("parse command: %v", err)
+			}
+			if err := cmd.Exec(context.Background(), nil); err != nil {
+				t.Fatalf("submit command: %v", err)
+			}
+			if !bytes.Equal(uploadedContents, originalContents) {
+				t.Fatalf("uploaded contents = %q, want originally opened archive %q", uploadedContents, originalContents)
+			}
+		})
+	}
+}
+
+func newNotarizationTestClient(t *testing.T, server *httptest.Server) *asc.Client {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "AuthKey_TEST.p8")
+	keyData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(keyPath, keyData, 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+
+	client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", keyPath, server.Client())
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	client.SetNotaryBaseURL(server.URL)
+	return client
 }


### PR DESCRIPTION
## Summary

- open notarization archives through the no-follow helper before hashing
- derive file metadata and hash from one descriptor, rewind it, and upload through that same descriptor
- cover regular-file and symlink pathname replacement during submission

## Verification

- deterministic regression test failed before the fix for both replacement modes and passes after it
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc ./internal/secureopen ./internal/cli/notarization -count=1
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run Notarization -count=1
- go build -o /tmp/asc .
- built command rejects a symlink archive before authentication with exit code 1
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788917384&installation_model_id=10418&pr_number=1915&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1915&signature=e8a58f587f18bda179beb23daf29cd070295231923cb51bee216e05cb36642d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved notarization file handling by securely opening and validating archives before processing.
  * Ensured hashing and uploading use the same verified file contents, even if the original path changes.
  * Rejected non-regular archive files, such as FIFOs, before processing.

* **Bug Fixes**
  * File hashing now reliably resets the reader, allowing subsequent operations to read the complete archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->