### PR TITLE
Keep Xcode Cloud artifact writes atomic

### DIFF
--- a/internal/cli/xcodecloud/xcode_cloud_artifacts.go
+++ b/internal/cli/xcodecloud/xcode_cloud_artifacts.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -148,6 +147,9 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --path is required")
 				return shared.MissingRequiredUsageError()
 			}
+			if err := validateArtifactDestination(pathValue, *overwrite); err != nil {
+				return fmt.Errorf("xcode-cloud artifacts download: %w", err)
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -192,73 +194,35 @@ Examples:
 	}
 }
 
-func writeArtifactFile(path string, reader io.Reader, overwrite bool) (int64, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return 0, err
+func validateArtifactDestination(path string, overwrite bool) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
 	}
-
+	if err != nil {
+		return err
+	}
 	if !overwrite {
-		file, err := shared.OpenNewFileNoFollow(path, 0o600)
-		if err != nil {
-			if errors.Is(err, os.ErrExist) {
-				return 0, fmt.Errorf("output file already exists: %w", err)
-			}
-			return 0, err
-		}
-		defer file.Close()
+		return fmt.Errorf("output file already exists: %w", os.ErrExist)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to overwrite symlink %q", path)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("output path %q is a directory", path)
+	}
+	return nil
+}
 
-		n, err := io.Copy(file, reader)
-		if err != nil {
-			return 0, err
-		}
-		if err := file.Sync(); err != nil {
-			return 0, err
-		}
-		return n, nil
-	}
-
-	if info, err := os.Lstat(path); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return 0, fmt.Errorf("refusing to overwrite symlink %q", path)
-		}
-		if info.IsDir() {
-			return 0, fmt.Errorf("output path %q is a directory", path)
-		}
-		if err := os.Remove(path); err != nil {
-			return 0, err
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return 0, err
-	}
-
-	tempFile, err := os.CreateTemp(filepath.Dir(path), ".asc-artifact-*")
-	if err != nil {
-		return 0, err
-	}
-	defer tempFile.Close()
-
-	tempPath := tempFile.Name()
-	success := false
-	defer func() {
-		if !success {
-			_ = os.Remove(tempPath)
-		}
-	}()
-
-	n, err := io.Copy(tempFile, reader)
-	if err != nil {
-		return 0, err
-	}
-	if err := tempFile.Sync(); err != nil {
-		return 0, err
-	}
-	if err := tempFile.Close(); err != nil {
-		return 0, err
-	}
-	if err := os.Rename(tempPath, path); err != nil {
-		return 0, err
-	}
-
-	success = true
-	return n, nil
+func writeArtifactFile(path string, reader io.Reader, overwrite bool) (int64, error) {
+	return shared.SafeWriteFileNoSymlink(
+		path,
+		0o600,
+		overwrite,
+		".asc-artifact-*",
+		".asc-artifact-backup-*",
+		func(file *os.File) (int64, error) {
+			return io.Copy(file, reader)
+		},
+	)
 }

--- a/internal/cli/xcodecloud/xcode_cloud_artifacts_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_artifacts_test.go
@@ -1,0 +1,103 @@
+package xcodecloud
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+var errArtifactRead = errors.New("artifact read failed")
+
+type failingArtifactReader struct {
+	delivered bool
+}
+
+func (r *failingArtifactReader) Read(p []byte) (int, error) {
+	if r.delivered {
+		return 0, errArtifactRead
+	}
+	r.delivered = true
+	return copy(p, "replacement"), nil
+}
+
+func TestWriteArtifactFileOverwritePreservesExistingFileOnReadFailure(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "artifact.zip")
+	if err := os.WriteFile(target, []byte("original"), 0o600); err != nil {
+		t.Fatalf("write original artifact: %v", err)
+	}
+
+	_, err := writeArtifactFile(target, &failingArtifactReader{}, true)
+	if !errors.Is(err, errArtifactRead) {
+		t.Fatalf("writeArtifactFile error = %v, want %v", err, errArtifactRead)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read preserved artifact: %v", err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("preserved artifact = %q, want %q", got, "original")
+	}
+}
+
+func TestWriteArtifactFileOverwriteReplacesCompletedFile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "artifact.zip")
+	if err := os.WriteFile(target, []byte("original"), 0o644); err != nil {
+		t.Fatalf("write original artifact: %v", err)
+	}
+
+	written, err := writeArtifactFile(target, strings.NewReader("replacement"), true)
+	if err != nil {
+		t.Fatalf("writeArtifactFile error: %v", err)
+	}
+	if written != int64(len("replacement")) {
+		t.Fatalf("bytes written = %d, want %d", written, len("replacement"))
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read replacement artifact: %v", err)
+	}
+	if string(got) != "replacement" {
+		t.Fatalf("replacement artifact = %q, want %q", got, "replacement")
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat replacement artifact: %v", err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0o600 {
+		t.Fatalf("replacement mode = %o, want 600", gotMode)
+	}
+}
+
+func TestArtifactsDownloadExistingDestinationFailsBeforeClientCreation(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "artifact.zip")
+	if err := os.WriteFile(target, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("write existing artifact: %v", err)
+	}
+
+	clientCalls := 0
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientCalls++
+		return nil, errors.New("client factory should not be called")
+	})
+	t.Cleanup(restore)
+
+	err := XcodeCloudArtifactsDownloadCommand().ParseAndRun(context.Background(), []string{
+		"--id", "artifact-1",
+		"--path", target,
+	})
+	if err == nil || !strings.Contains(err.Error(), "output file already exists") {
+		t.Fatalf("command error = %v, want existing destination error", err)
+	}
+	if clientCalls != 0 {
+		t.Fatalf("client factory calls = %d, want 0", clientCalls)
+	}
+}


### PR DESCRIPTION
## Summary

- reject an existing artifact destination before client setup when `--overwrite` is absent
- stage overwrite downloads until the complete payload is durable, preserving the prior file if reading fails
- reuse the shared safe-write path and remove the command-local replacement logic

## Verification

- added a regression test with a reader that fails after partial data and verified the original file survives
- added command coverage proving an existing non-overwrite target fails before client creation
- added successful overwrite coverage for content, byte count, and `0600` mode
- `go test ./internal/cli/xcodecloud -count=1`
- `go test ./internal/cli/cmdtest -run TestXcodeCloudValidationErrors -count=1`
- `go test ./internal/asc -run TestGetCiArtifact -count=1`
- built `/tmp/asc` and verified the real command exits nonzero with empty stdout while leaving an existing destination untouched
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Live verification

Not run. This change is deterministic local filesystem behavior, and the client-factory regression test establishes that the preflight failure occurs before any API client or request can be created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact downloads by rejecting invalid destinations, including existing files without overwrite permission, symlinks, and directories.
  * Ensured failed overwrite attempts preserve the original file.
  * Downloaded artifacts now use secure temporary-file handling and consistent restrictive file permissions.
  * Validates the destination before contacting the artifact service, avoiding unnecessary requests for invalid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->