### PR TITLE
fix(auth): normalize identifiers before token signing

### DIFF
--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -71,13 +71,19 @@ func (c *Client) generateJWT() (string, error) {
 
 // GenerateJWT generates a JWT for ASC API authentication.
 func GenerateJWT(keyID, issuerID string, privateKey *ecdsa.PrivateKey) (string, error) {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		return "", ErrMissingKeyID
+	}
+	issuerID = strings.TrimSpace(issuerID)
+
 	now := time.Now()
 	claims := jwt.RegisteredClaims{
 		Audience:  jwt.ClaimStrings{"appstoreconnect-v1"},
 		IssuedAt:  jwt.NewNumericDate(now),
 		ExpiresAt: jwt.NewNumericDate(now.Add(tokenLifetime)),
 	}
-	if strings.TrimSpace(issuerID) == "" {
+	if issuerID == "" {
 		claims.Subject = "user"
 	} else {
 		claims.Issuer = issuerID

--- a/internal/asc/client_http_jwt_test.go
+++ b/internal/asc/client_http_jwt_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -23,6 +24,26 @@ func TestGenerateJWT_TeamKeyUsesIssuerClaim(t *testing.T) {
 	}
 	if claims.Subject != "" {
 		t.Fatalf("subject claim = %q, want empty", claims.Subject)
+	}
+}
+
+func TestGenerateJWT_NormalizesTeamKeyIdentifiers(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	tokenString, err := GenerateJWT("  KEY123\n", "\tISS456  ", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateJWT() error: %v", err)
+	}
+
+	token, claims := parseJWT(t, tokenString, privateKey)
+	if claims.Issuer != "ISS456" {
+		t.Fatalf("issuer claim = %q, want ISS456", claims.Issuer)
+	}
+	if claims.Subject != "" {
+		t.Fatalf("subject claim = %q, want empty", claims.Subject)
+	}
+	if keyID, ok := token.Header["kid"].(string); !ok || keyID != "KEY123" {
+		t.Fatalf("key ID header = %#v, want KEY123", token.Header["kid"])
 	}
 }
 
@@ -46,6 +67,38 @@ func TestGenerateJWT_IndividualKeyUsesUserSubjectClaim(t *testing.T) {
 	}
 }
 
+func TestGenerateJWT_WhitespaceIssuerUsesUserSubjectClaim(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	tokenString, err := GenerateJWT("KEY123", " \t\n ", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateJWT() error: %v", err)
+	}
+
+	claims := parseJWTClaims(t, tokenString, privateKey)
+	if claims.Issuer != "" {
+		t.Fatalf("issuer claim = %q, want empty", claims.Issuer)
+	}
+	if claims.Subject != "user" {
+		t.Fatalf("subject claim = %q, want user", claims.Subject)
+	}
+}
+
+func TestGenerateJWT_RejectsWhitespaceKeyID(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	_, err := GenerateJWT(" \t\n ", "ISS456", privateKey)
+	if err == nil {
+		t.Fatal("GenerateJWT() error = nil, want key ID error")
+	}
+	if !errors.Is(err, ErrMissingKeyID) {
+		t.Fatalf("GenerateJWT() error = %v, want ErrMissingKeyID", err)
+	}
+	if err.Error() != "key ID is required" {
+		t.Fatalf("GenerateJWT() error = %q, want %q", err, "key ID is required")
+	}
+}
+
 func testJWTPrivateKey(t *testing.T) *ecdsa.PrivateKey {
 	t.Helper()
 
@@ -59,6 +112,13 @@ func testJWTPrivateKey(t *testing.T) *ecdsa.PrivateKey {
 func parseJWTClaims(t *testing.T, tokenString string, privateKey *ecdsa.PrivateKey) jwt.RegisteredClaims {
 	t.Helper()
 
+	_, claims := parseJWT(t, tokenString, privateKey)
+	return claims
+}
+
+func parseJWT(t *testing.T, tokenString string, privateKey *ecdsa.PrivateKey) (*jwt.Token, jwt.RegisteredClaims) {
+	t.Helper()
+
 	claims := jwt.RegisteredClaims{}
 	token, err := jwt.ParseWithClaims(tokenString, &claims, func(token *jwt.Token) (any, error) {
 		return &privateKey.PublicKey, nil
@@ -69,7 +129,7 @@ func parseJWTClaims(t *testing.T, tokenString string, privateKey *ecdsa.PrivateK
 	if !token.Valid {
 		t.Fatal("expected token to be valid")
 	}
-	return claims
+	return token, claims
 }
 
 func jwtAudienceContains(audience jwt.ClaimStrings, value string) bool {

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrForbidden             = errors.New("forbidden")
 	ErrBadRequest            = errors.New("bad request")
 	ErrConflict              = errors.New("resource conflict")
+	ErrMissingKeyID          = errors.New("key ID is required")
 	ErrRepeatedPaginationURL = errors.New("detected repeated pagination URL")
 )
 

--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -127,6 +127,12 @@ type S3Credentials struct {
 // GenerateNotaryJWT generates a JWT for the Notary API.
 // It is identical to GenerateJWT but includes the "scope" claim required by the Notary API.
 func GenerateNotaryJWT(keyID, issuerID string, privateKey any) (string, error) {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		return "", ErrMissingKeyID
+	}
+	issuerID = strings.TrimSpace(issuerID)
+
 	now := time.Now()
 	claims := jwt.MapClaims{
 		"iss":   issuerID,

--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -135,11 +135,15 @@ func GenerateNotaryJWT(keyID, issuerID string, privateKey any) (string, error) {
 
 	now := time.Now()
 	claims := jwt.MapClaims{
-		"iss":   issuerID,
 		"aud":   "appstoreconnect-v1",
 		"iat":   jwt.NewNumericDate(now),
 		"exp":   jwt.NewNumericDate(now.Add(tokenLifetime)),
 		"scope": []string{"/notary/v2"},
+	}
+	if issuerID == "" {
+		claims["sub"] = "user"
+	} else {
+		claims["iss"] = issuerID
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -76,6 +76,23 @@ func TestGenerateNotaryJWT_NormalizesIdentifiers(t *testing.T) {
 	}
 }
 
+func TestGenerateNotaryJWT_WhitespaceIssuerUsesUserSubjectClaim(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	tokenString, err := GenerateNotaryJWT("KEY123", " \t\n ", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateNotaryJWT() error: %v", err)
+	}
+
+	_, claims := parseJWT(t, tokenString, privateKey)
+	if claims.Issuer != "" {
+		t.Fatalf("issuer claim = %q, want empty", claims.Issuer)
+	}
+	if claims.Subject != "user" {
+		t.Fatalf("subject claim = %q, want user", claims.Subject)
+	}
+}
+
 func TestGenerateNotaryJWT_RejectsWhitespaceKeyID(t *testing.T) {
 	privateKey := testJWTPrivateKey(t)
 

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -55,6 +56,32 @@ func TestGenerateNotaryJWT(t *testing.T) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		t.Fatalf("expected 3 token parts, got %d", len(parts))
+	}
+}
+
+func TestGenerateNotaryJWT_NormalizesIdentifiers(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	tokenString, err := GenerateNotaryJWT("  KEY123\n", "\tISS456  ", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateNotaryJWT() error: %v", err)
+	}
+
+	token, claims := parseJWT(t, tokenString, privateKey)
+	if claims.Issuer != "ISS456" {
+		t.Fatalf("issuer claim = %q, want ISS456", claims.Issuer)
+	}
+	if keyID, ok := token.Header["kid"].(string); !ok || keyID != "KEY123" {
+		t.Fatalf("key ID header = %#v, want KEY123", token.Header["kid"])
+	}
+}
+
+func TestGenerateNotaryJWT_RejectsWhitespaceKeyID(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	_, err := GenerateNotaryJWT(" \t\n ", "ISS456", privateKey)
+	if !errors.Is(err, ErrMissingKeyID) {
+		t.Fatalf("GenerateNotaryJWT() error = %v, want ErrMissingKeyID", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- normalize key and issuer identifiers at the App Store Connect and notarization JWT signing boundaries
- preserve individual-key subject behavior when issuer input is only whitespace
- reject an empty normalized key ID with a stable, matchable error

## Why

Stored credentials can retain surrounding whitespace from copy and paste or file-backed configuration. Canonicalizing identifiers at signing time repairs existing profiles and direct signer callers without changing command flags or output formats.

## Testing

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run '^(TestGenerateJWT|TestGenerateNotaryJWT)' -count=1`\n- offline generated-key `auth login` and `auth token` exercise with sanitized claim inspection\n- `make format`\n- `make check-docs`\n- `make lint`\n- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JWT authentication by ignoring accidental whitespace around key and issuer identifiers.
  - Added validation to reject missing or whitespace-only key identifiers with a clear error.
  - Ensured issuer claims are handled correctly when the issuer value is blank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->