### PR TITLE
fix(testflight): renew tester batch request deadlines

### DIFF
--- a/internal/cli/cmdtest/testflight_beta_testers_csv_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_csv_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func readCSVRecords(t *testing.T, path string) [][]string {
@@ -207,6 +208,85 @@ func TestTestFlightBetaTestersExport_IncludeGroupsAddsColumn(t *testing.T) {
 		{"email", "first_name", "last_name", "groups"},
 		{"a@example.com", "A", "Aye", "Alpha;Beta"},
 		{"b@example.com", "B", "Bee", "Beta"},
+	}
+	if got := strings.TrimSpace(csvRecordsToString(records)); got != strings.TrimSpace(csvRecordsToString(want)) {
+		t.Fatalf("CSV records mismatch\nwant:\n%s\ngot:\n%s", csvRecordsToString(want), csvRecordsToString(records))
+	}
+}
+
+func TestTestFlightBetaTestersExport_IncludeGroupsRenewsRequestTimeout(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "500ms")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	const requestDelay = 300 * time.Millisecond
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/betaGroups" {
+				t.Fatalf("unexpected request 1: %s %s", req.Method, req.URL.Path)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"Alpha"}},{"type":"betaGroups","id":"group-2","attributes":{"name":"Beta"}}]}`), nil
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("unexpected request 2: %s %s", req.Method, req.URL.Path)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaTesters","id":"tester-1","attributes":{"email":"a@example.com","firstName":"A","lastName":"Aye"}}]}`), nil
+		case 3, 4:
+			groupID := "group-1"
+			if callCount == 4 {
+				groupID = "group-2"
+			}
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/betaGroups/"+groupID+"/betaTesters" {
+				t.Fatalf("unexpected request %d: %s %s", callCount, req.Method, req.URL.Path)
+			}
+			select {
+			case <-time.After(requestDelay):
+				return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaTesters","id":"tester-1"}]}`), nil
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	outPath := filepath.Join(t.TempDir(), "testers.csv")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "testers", "export", "--app", "app-1", "--output", outPath, "--include-groups"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"includeGroups":true`) {
+		t.Fatalf("expected includeGroups true in summary, got %q", stdout)
+	}
+	if callCount != 4 {
+		t.Fatalf("expected four HTTP requests, got %d", callCount)
+	}
+
+	records := readCSVRecords(t, outPath)
+	want := [][]string{
+		{"email", "first_name", "last_name", "groups"},
+		{"a@example.com", "A", "Aye", "Alpha;Beta"},
 	}
 	if got := strings.TrimSpace(csvRecordsToString(records)); got != strings.TrimSpace(csvRecordsToString(want)) {
 		t.Fatalf("CSV records mismatch\nwant:\n%s\ngot:\n%s", csvRecordsToString(want), csvRecordsToString(records))
@@ -431,6 +511,86 @@ func TestTestFlightBetaTestersImport_CreateAssignAndInvite(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"created":1`) || !strings.Contains(stdout, `"invited":1`) {
 		t.Fatalf("expected created=1 and invited=1, got %q", stdout)
+	}
+}
+
+func TestTestFlightBetaTestersImport_RenewsRequestTimeoutForEachMutation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "500ms")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	const requestDelay = 300 * time.Millisecond
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("unexpected request 1: %s %s", req.Method, req.URL.Path)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":[]}`), nil
+		case 2, 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("unexpected request %d: %s %s", callCount, req.Method, req.URL.Path)
+			}
+			select {
+			case <-time.After(requestDelay):
+				testerID := "tester-1"
+				if callCount == 3 {
+					testerID = "tester-2"
+				}
+				return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"betaTesters","id":"`+testerID+`"}}`), nil
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+		default:
+			t.Fatalf("unexpected request count %d", callCount)
+			return nil, nil
+		}
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "input.csv")
+	if err := os.WriteFile(csvPath, []byte("email\none@example.com\ntwo@example.com\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	type importSummary struct {
+		Total   int `json:"total"`
+		Created int `json:"created"`
+		Failed  int `json:"failed"`
+	}
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "testers", "import", "--app", "app-1", "--input", csvPath, "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected three HTTP requests, got %d", callCount)
+	}
+
+	var summary importSummary
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("failed to parse JSON summary: %v (stdout=%q)", err, stdout)
+	}
+	if summary.Total != 2 || summary.Created != 2 || summary.Failed != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
 	}
 }
 

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -118,12 +118,9 @@ Examples:
 				return fmt.Errorf("beta-testers export: %w", err)
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
 			var groupResolver *betaGroupResolver
 			if strings.TrimSpace(*group) != "" || *includeGroups {
-				groupResolver, err = newBetaGroupResolver(requestCtx, client, resolvedAppID)
+				groupResolver, err = newBetaGroupResolver(ctx, client, resolvedAppID)
 				if err != nil {
 					return fmt.Errorf("beta-testers export: %w", err)
 				}
@@ -144,13 +141,17 @@ Examples:
 				opts = append(opts, asc.WithBetaTestersGroupIDs([]string{id}))
 			}
 
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			firstPage, err := client.GetBetaTesters(requestCtx, resolvedAppID, opts...)
+			cancel()
 			if err != nil {
 				return fmt.Errorf("beta-testers export: failed to fetch: %w", err)
 			}
 
-			all, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-				return client.GetBetaTesters(ctx, resolvedAppID, asc.WithBetaTestersNextURL(nextURL))
+			all, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+				requestCtx, cancel := shared.ContextWithTimeout(ctx)
+				defer cancel()
+				return client.GetBetaTesters(requestCtx, resolvedAppID, asc.WithBetaTestersNextURL(nextURL))
 			})
 			if err != nil {
 				return fmt.Errorf("beta-testers export: %w", err)
@@ -163,7 +164,7 @@ Examples:
 
 			var groupMembership map[string][]string
 			if *includeGroups {
-				groupMembership, err = fetchTesterGroupMemberships(requestCtx, client, groupResolver)
+				groupMembership, err = fetchTesterGroupMemberships(ctx, client, groupResolver)
 				if err != nil {
 					return fmt.Errorf("beta-testers export: %w", err)
 				}
@@ -316,9 +317,6 @@ Examples:
 				return fmt.Errorf("beta-testers import: %w", err)
 			}
 
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
-
 			parsedRows, err := readBetaTestersCSV(inputValue)
 			if err != nil {
 				return fmt.Errorf("beta-testers import: %w", err)
@@ -338,7 +336,7 @@ Examples:
 			var groupResolver *betaGroupResolver
 			appliedGroupID := ""
 			if needsGroups {
-				groupResolver, err = newBetaGroupResolver(requestCtx, client, resolvedAppID)
+				groupResolver, err = newBetaGroupResolver(ctx, client, resolvedAppID)
 				if err != nil {
 					return fmt.Errorf("beta-testers import: %w", err)
 				}
@@ -352,7 +350,7 @@ Examples:
 				}
 			}
 
-			existingByEmail, err := fetchExistingTestersByEmail(requestCtx, client, resolvedAppID)
+			existingByEmail, err := fetchExistingTestersByEmail(ctx, client, resolvedAppID)
 			if err != nil {
 				return fmt.Errorf("beta-testers import: %w", err)
 			}
@@ -445,7 +443,10 @@ Examples:
 						continue
 					}
 
-					if err := client.AddBetaTesterToGroups(requestCtx, testerID, groupIDs); err != nil {
+					requestCtx, cancel := shared.ContextWithTimeout(ctx)
+					err := client.AddBetaTesterToGroups(requestCtx, testerID, groupIDs)
+					cancel()
+					if err != nil {
 						if errors.Is(err, asc.ErrConflict) {
 							// Relationship already exists; treat as idempotent success.
 							summary.Updated++
@@ -471,7 +472,9 @@ Examples:
 					continue
 				}
 
+				requestCtx, cancel := shared.ContextWithTimeout(ctx)
 				created, err := client.CreateBetaTester(requestCtx, emailValue, row.firstName, row.lastName, groupIDs)
+				cancel()
 				if err != nil {
 					summary.Failed++
 					summary.Failures = append(summary.Failures, betaTestersImportFailure{
@@ -502,7 +505,9 @@ Examples:
 				existingByEmail[emailLower] = testerID
 
 				if *invite {
+					requestCtx, cancel := shared.ContextWithTimeout(ctx)
 					invitation, err := client.CreateBetaTesterInvitation(requestCtx, resolvedAppID, testerID)
+					cancel()
 					if err != nil {
 						summary.Failed++
 						summary.Failures = append(summary.Failures, betaTestersImportFailure{
@@ -607,12 +612,16 @@ func newBetaGroupResolver(ctx context.Context, client *asc.Client, appID string)
 		return nil, fmt.Errorf("app ID is required")
 	}
 
-	firstPage, err := client.GetBetaGroups(ctx, appID, asc.WithBetaGroupsLimit(200))
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	firstPage, err := client.GetBetaGroups(requestCtx, appID, asc.WithBetaGroupsLimit(200))
+	cancel()
 	if err != nil {
 		return nil, err
 	}
 	all, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		return client.GetBetaGroups(ctx, appID, asc.WithBetaGroupsNextURL(nextURL))
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		return client.GetBetaGroups(requestCtx, appID, asc.WithBetaGroupsNextURL(nextURL))
 	})
 	if err != nil {
 		return nil, err
@@ -711,12 +720,16 @@ func (r *betaGroupResolver) exportValueForID(groupID string) string {
 }
 
 func fetchExistingTestersByEmail(ctx context.Context, client *asc.Client, appID string) (map[string]string, error) {
-	first, err := client.GetBetaTesters(ctx, appID, asc.WithBetaTestersLimit(200))
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	first, err := client.GetBetaTesters(requestCtx, appID, asc.WithBetaTestersLimit(200))
+	cancel()
 	if err != nil {
 		return nil, err
 	}
 	all, err := asc.PaginateAll(ctx, first, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		return client.GetBetaTesters(ctx, appID, asc.WithBetaTestersNextURL(nextURL))
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		return client.GetBetaTesters(requestCtx, appID, asc.WithBetaTestersNextURL(nextURL))
 	})
 	if err != nil {
 		return nil, err
@@ -753,12 +766,16 @@ func fetchTesterGroupMemberships(ctx context.Context, client *asc.Client, resolv
 	for _, groupID := range resolver.sortedGroupIDs {
 		exportValue := resolver.exportValueForID(groupID)
 
-		firstPage, err := client.GetBetaGroupTesters(ctx, groupID, asc.WithBetaGroupTestersLimit(200))
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		firstPage, err := client.GetBetaGroupTesters(requestCtx, groupID, asc.WithBetaGroupTestersLimit(200))
+		cancel()
 		if err != nil {
 			return nil, err
 		}
 		all, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-			return client.GetBetaGroupTesters(ctx, groupID, asc.WithBetaGroupTestersNextURL(nextURL))
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			return client.GetBetaGroupTesters(requestCtx, groupID, asc.WithBetaGroupTestersNextURL(nextURL))
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

- give every tester import and export API call its own ASC_TIMEOUT budget
- renew deadlines across pagination, group membership reads, tester creation, group assignment, and invitations
- retain the existing validation, partial-failure summary, output, and exit behavior

## Testing

- deterministic command tests with two sequential 300ms requests under a 500ms per-request timeout
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- go build -o /tmp/asc .
- built-binary import validation returned exit 2 before authentication when --input was omitted

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788917824&installation_model_id=10418&pr_number=1918&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1918&signature=ba7f88e72b8ea4f6522543a90ee4bd40dd8d9c623099b784781bcde9bb1bd7b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of TestFlight beta tester imports and exports when individual API requests are delayed.
  - Operations now manage request timeouts independently, reducing failures during longer-running exports, group membership lookups, tester creation, invitations, and updates.
  - Added coverage to verify successful completion, expected results, and accurate summaries and CSV output under delayed-response conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->