### PR TITLE
fix(screenshots): validate frame watch options

### DIFF
--- a/internal/cli/cmdtest/shots_frame_test.go
+++ b/internal/cli/cmdtest/shots_frame_test.go
@@ -768,6 +768,124 @@ func TestShotsFrame_WatchWithoutInputOrConfig(t *testing.T) {
 	}
 }
 
+func TestShotsFrame_RejectsInvalidWatchOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name: "review directory without watch",
+			args: []string{
+				"--watch-review-dir", "/tmp/review",
+			},
+			wantStderr: "--watch-review-dir requires --watch",
+		},
+		{
+			name: "raw directory without review regeneration",
+			args: []string{
+				"--watch",
+				"--watch-raw-dir", "/tmp/raw",
+			},
+			wantStderr: "--watch-raw-dir requires --watch-review-dir",
+		},
+		{
+			name: "zero debounce",
+			args: []string{
+				"--watch",
+				"--watch-debounce", "0s",
+			},
+			wantStderr: "--watch-debounce must be greater than 0",
+		},
+		{
+			name: "negative debounce",
+			args: []string{
+				"--watch",
+				"--watch-debounce", "-1s",
+			},
+			wantStderr: "--watch-debounce must be greater than 0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			configPath := filepath.Join(t.TempDir(), "missing-frame.yaml")
+			args := []string{"screenshots", "frame", "--config", configPath}
+			args = append(args, test.args...)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantStderr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantStderr, stderr)
+			}
+		})
+	}
+}
+
+func TestShotsFrame_AcceptsValidWatchOptions(t *testing.T) {
+	frameCommand := shots.ShotsFrameCommand()
+	debounceFlag := frameCommand.FlagSet.Lookup("watch-debounce")
+	if debounceFlag == nil || debounceFlag.DefValue != "500ms" {
+		t.Fatalf("watch debounce default = %v, want 500ms", debounceFlag)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "omitted options keep defaults"},
+		{
+			name: "explicit valid options",
+			args: []string{
+				"--watch-debounce", "750ms",
+				"--watch-review-dir", "/tmp/review",
+				"--watch-raw-dir", "/tmp/raw",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			configPath := filepath.Join(t.TempDir(), "missing-frame.yaml")
+			args := []string{"screenshots", "frame", "--config", configPath, "--watch"}
+			args = append(args, test.args...)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if err == nil || errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "config file not found") {
+					t.Fatalf("expected valid options to reach watcher, got %v", err)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+		})
+	}
+}
+
 func installMockFrame(t *testing.T, fn func(context.Context, screenshots.FrameRequest) (*screenshots.FrameResult, error)) {
 	t.Helper()
 

--- a/internal/cli/cmdtest/shots_frame_test.go
+++ b/internal/cli/cmdtest/shots_frame_test.go
@@ -782,6 +782,20 @@ func TestShotsFrame_RejectsInvalidWatchOptions(t *testing.T) {
 			wantStderr: "--watch-review-dir requires --watch",
 		},
 		{
+			name: "debounce without watch",
+			args: []string{
+				"--watch-debounce", "750ms",
+			},
+			wantStderr: "--watch-debounce requires --watch",
+		},
+		{
+			name: "raw directory without watch",
+			args: []string{
+				"--watch-raw-dir", "/tmp/raw",
+			},
+			wantStderr: "--watch-raw-dir requires --watch",
+		},
+		{
 			name: "raw directory without review regeneration",
 			args: []string{
 				"--watch",
@@ -823,6 +837,9 @@ func TestShotsFrame_RejectsInvalidWatchOptions(t *testing.T) {
 				err := root.Run(context.Background())
 				if !errors.Is(err, flag.ErrHelp) {
 					t.Fatalf("expected ErrHelp, got %v", err)
+				}
+				if err.Error() != test.wantStderr {
+					t.Fatalf("error = %q, want %q", err, test.wantStderr)
 				}
 			})
 

--- a/internal/cli/shots/shots_frame.go
+++ b/internal/cli/shots/shots_frame.go
@@ -60,6 +60,19 @@ framed screenshots whenever the YAML config or referenced raw assets change.`,
 		Exec: func(ctx context.Context, args []string) error {
 			configVal := strings.TrimSpace(*configPath)
 			inputVal := strings.TrimSpace(*inputPath)
+			watchDebounceSet := false
+			watchReviewDirSet := false
+			watchRawDirSet := false
+			fs.Visit(func(flagValue *flag.Flag) {
+				switch flagValue.Name {
+				case "watch-debounce":
+					watchDebounceSet = true
+				case "watch-review-dir":
+					watchReviewDirSet = true
+				case "watch-raw-dir":
+					watchRawDirSet = true
+				}
+			})
 			if configVal == "" && inputVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --input is required when --config is not set")
 				return shared.MissingRequiredUsageError()
@@ -71,6 +84,22 @@ framed screenshots whenever the YAML config or referenced raw assets change.`,
 			if *watch && configVal == "" {
 				fmt.Fprintln(os.Stderr, "Error: --watch requires --config")
 				return flag.ErrHelp
+			}
+			if !*watch {
+				switch {
+				case watchDebounceSet:
+					return shared.UsageError("--watch-debounce requires --watch")
+				case watchReviewDirSet:
+					return shared.UsageError("--watch-review-dir requires --watch")
+				case watchRawDirSet:
+					return shared.UsageError("--watch-raw-dir requires --watch")
+				}
+			}
+			if watchRawDirSet && strings.TrimSpace(*watchReviewDir) == "" {
+				return shared.UsageError("--watch-raw-dir requires --watch-review-dir")
+			}
+			if watchDebounceSet && *watchDebounce <= 0 {
+				return shared.UsageError("--watch-debounce must be greater than 0")
 			}
 			if configVal != "" {
 				absConfig, err := filepath.Abs(configVal)


### PR DESCRIPTION
## Summary

- reject frame watch-only flags when watch mode is disabled
- require review regeneration before accepting a raw review directory
- reject explicitly nonpositive debounce durations while preserving the omitted 500ms default

## Compatibility

Previously accepted inert flag combinations now return a usage error. Valid watch invocations and the omitted debounce default are unchanged.

## Validation

- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- focused command-level watch-option tests
- built-binary invalid and valid invocation checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788917855&installation_model_id=10418&pr_number=1919&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1919&signature=da15f8cc4ca76ac49994195afe25fd53bc12cedddeecdc6e35072805d7d7c560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for watch mode options.
  * Watch-specific settings are now rejected when watch mode is disabled.
  * Requiring a review directory when a raw directory is specified prevents invalid configurations.
  * Debounce durations must now be greater than zero.
  * Valid watch configurations, including custom directories and debounce settings, are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->