### PR TITLE
fix(xcode): honor reported validation failures

### DIFF
--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -3,6 +3,7 @@ package xcode
 import (
 	"archive/zip"
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -767,43 +768,124 @@ func runXcodebuildForBuild(ctx context.Context, args []string, logWriter io.Writ
 }
 
 func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) error {
-	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
-	captureWriter := io.Writer(outputTail)
-	if logWriter != nil {
-		captureWriter = io.MultiWriter(logWriter, outputTail)
-	}
-	if err := runCommandWithTail(ctx, "xcrun", args, captureWriter, "validate", "xcrun altool"); err != nil {
+	validationOutput := newAltoolValidationOutputWriter(logWriter)
+	if err := runCommandWithTail(ctx, "xcrun", args, validationOutput, "validate", "xcrun altool"); err != nil {
 		return err
 	}
 
-	details := parseAltoolValidationErrors(outputTail.String())
+	details := validationOutput.Details()
 	if len(details) == 0 {
 		return nil
 	}
 	return fmt.Errorf("xcrun altool validate failed: %s", strings.Join(details, "; "))
 }
 
-func parseAltoolValidationErrors(output string) []string {
-	details := make([]string, 0)
-	for _, line := range strings.Split(output, "\n") {
-		markerEnd := -1
-		for _, pattern := range altoolValidationErrorPrefixes {
-			if match := pattern.FindStringIndex(line); match != nil {
-				markerEnd = match[1]
-				break
-			}
-		}
-		if markerEnd < 0 {
-			continue
-		}
+type altoolValidationOutputWriter struct {
+	logWriter   io.Writer
+	line        []byte
+	details     []string
+	seen        map[string]struct{}
+	detailBytes int
+}
 
-		detail := strings.TrimSpace(line[markerEnd:])
-		if detail == "" {
-			detail = "altool reported an unspecified validation error"
-		}
-		details = append(details, detail)
+func newAltoolValidationOutputWriter(logWriter io.Writer) *altoolValidationOutputWriter {
+	return &altoolValidationOutputWriter{
+		logWriter: logWriter,
+		seen:      make(map[string]struct{}),
 	}
-	return UniqueDiagnosticDetails(details)
+}
+
+func (w *altoolValidationOutputWriter) Write(p []byte) (int, error) {
+	written := len(p)
+	var err error
+	if w.logWriter != nil {
+		written, err = w.logWriter.Write(p)
+	}
+	w.consume(p[:written])
+	return written, err
+}
+
+func (w *altoolValidationOutputWriter) Details() []string {
+	if len(w.line) > 0 {
+		w.recordLine()
+	}
+	return append([]string(nil), w.details...)
+}
+
+func (w *altoolValidationOutputWriter) consume(p []byte) {
+	for len(p) > 0 {
+		newline := bytes.IndexByte(p, '\n')
+		if newline < 0 {
+			w.appendLine(p)
+			return
+		}
+		w.appendLine(p[:newline])
+		w.recordLine()
+		p = p[newline+1:]
+	}
+}
+
+func (w *altoolValidationOutputWriter) appendLine(fragment []byte) {
+	remaining := xcodebuildErrorTailLimit - len(w.line)
+	if remaining <= 0 {
+		return
+	}
+	if len(fragment) > remaining {
+		fragment = fragment[:remaining]
+	}
+	w.line = append(w.line, fragment...)
+}
+
+func (w *altoolValidationOutputWriter) recordLine() {
+	detail, ok := parseAltoolValidationErrorLine(string(w.line))
+	w.line = w.line[:0]
+	if !ok {
+		return
+	}
+
+	separatorBytes := 0
+	if len(w.details) > 0 {
+		separatorBytes = len("; ")
+	}
+	remaining := xcodebuildErrorTailLimit - w.detailBytes - separatorBytes
+	if remaining <= 0 {
+		return
+	}
+	detail = truncateUTF8Prefix(detail, remaining)
+	if detail == "" {
+		return
+	}
+	if _, exists := w.seen[detail]; exists {
+		return
+	}
+	w.seen[detail] = struct{}{}
+	w.details = append(w.details, detail)
+	w.detailBytes += separatorBytes + len(detail)
+}
+
+func parseAltoolValidationErrorLine(line string) (string, bool) {
+	for _, pattern := range altoolValidationErrorPrefixes {
+		if match := pattern.FindStringIndex(line); match != nil {
+			detail := strings.TrimSpace(line[match[1]:])
+			if detail == "" {
+				detail = "altool reported an unspecified validation error"
+			}
+			return detail, true
+		}
+	}
+	return "", false
+}
+
+func truncateUTF8Prefix(value string, limit int) string {
+	value = strings.ToValidUTF8(value, "\uFFFD")
+	if len(value) <= limit {
+		return value
+	}
+	prefix := []byte(value[:limit])
+	for len(prefix) > 0 && !utf8.Valid(prefix) {
+		prefix = prefix[:len(prefix)-1]
+	}
+	return string(prefix)
 }
 
 func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer, action string) (string, error) {

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -768,16 +769,61 @@ func runXcodebuildForBuild(ctx context.Context, args []string, logWriter io.Writ
 }
 
 func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) error {
-	validationOutput := newAltoolValidationOutputWriter(logWriter)
-	if err := runCommandWithTail(ctx, "xcrun", args, validationOutput, "validate", "xcrun altool"); err != nil {
-		return err
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := commandContextFn(ctx, "xcrun", args...)
+	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
+	combinedOutput := io.Writer(outputTail)
+	if logWriter != nil {
+		combinedOutput = io.MultiWriter(logWriter, outputTail)
+	}
+	serializedOutput := &synchronizedWriter{writer: combinedOutput}
+	stdoutOutput := newAltoolValidationOutputWriter(serializedOutput)
+	stderrOutput := newAltoolValidationOutputWriter(serializedOutput)
+	cmd.Stdout = stdoutOutput
+	cmd.Stderr = stderrOutput
+	if err := runXcodeCommand(cmd); err != nil {
+		return formatCommandTailError(ctx, err, outputTail, "validate", "xcrun altool", false)
 	}
 
-	details := validationOutput.Details()
+	details := append(stdoutOutput.Details(), stderrOutput.Details()...)
+	details = UniqueDiagnosticDetails(details)
+	details = boundDiagnosticDetails(details, xcodebuildErrorTailLimit)
 	if len(details) == 0 {
 		return nil
 	}
 	return fmt.Errorf("xcrun altool validate failed: %s", strings.Join(details, "; "))
+}
+
+func boundDiagnosticDetails(details []string, maxBytes int) []string {
+	if maxBytes <= 0 {
+		return nil
+	}
+
+	bounded := make([]string, 0, len(details))
+	usedBytes := 0
+	for _, detail := range details {
+		separatorBytes := 0
+		if len(bounded) > 0 {
+			separatorBytes = len("; ")
+		}
+		remaining := maxBytes - usedBytes - separatorBytes
+		if remaining <= 0 {
+			break
+		}
+
+		boundedDetail := truncateUTF8Prefix(detail, remaining)
+		if boundedDetail == "" {
+			break
+		}
+		bounded = append(bounded, boundedDetail)
+		usedBytes += separatorBytes + len(boundedDetail)
+		if len(boundedDetail) < len(detail) {
+			break
+		}
+	}
+	return bounded
 }
 
 type altoolValidationOutputWriter struct {
@@ -786,6 +832,17 @@ type altoolValidationOutputWriter struct {
 	details     []string
 	seen        map[string]struct{}
 	detailBytes int
+}
+
+type synchronizedWriter struct {
+	mu     sync.Mutex
+	writer io.Writer
+}
+
+func (w *synchronizedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writer.Write(p)
 }
 
 func newAltoolValidationOutputWriter(logWriter io.Writer) *altoolValidationOutputWriter {
@@ -1207,51 +1264,55 @@ func runCommandWithTailMode(ctx context.Context, name string, args []string, log
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	if err := runXcodeCommand(cmd); err != nil {
-		detail := strings.TrimSpace(outputTail.String())
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			if detail != "" {
-				if outputTail.Truncated() {
-					return fmt.Errorf(
-						"%s %s timed out or was canceled (showing last %d bytes): %s: %w",
-						commandLabel,
-						action,
-						xcodebuildErrorTailLimit,
-						detail,
-						ctxErr,
-					)
-				}
-				return fmt.Errorf("%s %s timed out or was canceled: %s: %w", commandLabel, action, detail, ctxErr)
-			}
-			return fmt.Errorf("%s %s timed out or was canceled: %w", commandLabel, action, ctxErr)
-		}
+		return formatCommandTailError(ctx, err, outputTail, action, commandLabel, preserveProcessError)
+	}
+	return nil
+}
+
+func formatCommandTailError(ctx context.Context, err error, outputTail *tailBuffer, action string, commandLabel string, preserveProcessError bool) error {
+	detail := strings.TrimSpace(outputTail.String())
+	if ctxErr := ctx.Err(); ctxErr != nil {
 		if detail != "" {
 			if outputTail.Truncated() {
-				if preserveProcessError {
-					return fmt.Errorf(
-						"%s %s failed (showing last %d bytes): %s: %w",
-						commandLabel,
-						action,
-						xcodebuildErrorTailLimit,
-						detail,
-						err,
-					)
-				}
 				return fmt.Errorf(
-					"%s %s failed (showing last %d bytes): %s",
+					"%s %s timed out or was canceled (showing last %d bytes): %s: %w",
 					commandLabel,
 					action,
 					xcodebuildErrorTailLimit,
 					detail,
+					ctxErr,
 				)
 			}
-			if preserveProcessError {
-				return fmt.Errorf("%s %s failed: %s: %w", commandLabel, action, detail, err)
-			}
-			return fmt.Errorf("%s %s failed: %s", commandLabel, action, detail)
+			return fmt.Errorf("%s %s timed out or was canceled: %s: %w", commandLabel, action, detail, ctxErr)
 		}
-		return fmt.Errorf("%s %s failed: %w", commandLabel, action, err)
+		return fmt.Errorf("%s %s timed out or was canceled: %w", commandLabel, action, ctxErr)
 	}
-	return nil
+	if detail != "" {
+		if outputTail.Truncated() {
+			if preserveProcessError {
+				return fmt.Errorf(
+					"%s %s failed (showing last %d bytes): %s: %w",
+					commandLabel,
+					action,
+					xcodebuildErrorTailLimit,
+					detail,
+					err,
+				)
+			}
+			return fmt.Errorf(
+				"%s %s failed (showing last %d bytes): %s",
+				commandLabel,
+				action,
+				xcodebuildErrorTailLimit,
+				detail,
+			)
+		}
+		if preserveProcessError {
+			return fmt.Errorf("%s %s failed: %s: %w", commandLabel, action, detail, err)
+		}
+		return fmt.Errorf("%s %s failed: %s", commandLabel, action, detail)
+	}
+	return fmt.Errorf("%s %s failed: %w", commandLabel, action, err)
 }
 
 type tailBuffer struct {

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"unicode"
@@ -27,6 +28,11 @@ var (
 	commandContextFn     = exec.CommandContext
 	activeDeveloperDirFn = activeDeveloperDir
 	altoolHelpOutputFn   = readAltoolHelpOutput
+
+	altoolValidationErrorPrefixes = [...]*regexp.Regexp{
+		regexp.MustCompile(`(?i)^[[:space:]]*\*{3}[[:space:]]*error:[[:space:]]*`),
+		regexp.MustCompile(`(?i)^[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?[[:space:]]+error:[[:space:]]*`),
+	}
 )
 
 const xcodebuildErrorTailLimit = 64 * 1024
@@ -761,7 +767,43 @@ func runXcodebuildForBuild(ctx context.Context, args []string, logWriter io.Writ
 }
 
 func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) error {
-	return runCommandWithTail(ctx, "xcrun", args, logWriter, "validate", "xcrun altool")
+	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
+	captureWriter := io.Writer(outputTail)
+	if logWriter != nil {
+		captureWriter = io.MultiWriter(logWriter, outputTail)
+	}
+	if err := runCommandWithTail(ctx, "xcrun", args, captureWriter, "validate", "xcrun altool"); err != nil {
+		return err
+	}
+
+	details := parseAltoolValidationErrors(outputTail.String())
+	if len(details) == 0 {
+		return nil
+	}
+	return fmt.Errorf("xcrun altool validate failed: %s", strings.Join(details, "; "))
+}
+
+func parseAltoolValidationErrors(output string) []string {
+	details := make([]string, 0)
+	for _, line := range strings.Split(output, "\n") {
+		markerEnd := -1
+		for _, pattern := range altoolValidationErrorPrefixes {
+			if match := pattern.FindStringIndex(line); match != nil {
+				markerEnd = match[1]
+				break
+			}
+		}
+		if markerEnd < 0 {
+			continue
+		}
+
+		detail := strings.TrimSpace(line[markerEnd:])
+		if detail == "" {
+			detail = "altool reported an unspecified validation error"
+		}
+		details = append(details, detail)
+	}
+	return UniqueDiagnosticDetails(details)
 }
 
 func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer, action string) (string, error) {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -423,6 +423,77 @@ func TestValidateRunsAltoolWithTVOSPlatform(t *testing.T) {
 	}
 }
 
+func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantErr    bool
+		wantDetail string
+	}{
+		{
+			name:       "timestamped server error",
+			output:     "2026-08-10 06:47:56.580 ERROR: [ContentDelivery.Uploader] The bundle version must be higher than the previously uploaded version.\n",
+			wantErr:    true,
+			wantDetail: "The bundle version must be higher than the previously uploaded version.",
+		},
+		{
+			name:       "legacy error",
+			output:     "*** Error: Unable to validate archive './artifacts/Demo.ipa'.\n",
+			wantErr:    true,
+			wantDetail: "Unable to validate archive './artifacts/Demo.ipa'.",
+		},
+		{
+			name:   "benign output containing error text",
+			output: "2026-08-10 06:47:56.580 INFO: Validation completed.\nDiagnostic: no ERROR: records were returned.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			ipaPath := filepath.Join(tempDir, "Demo.ipa")
+			if err := writeTestIPA(ipaPath); err != nil {
+				t.Fatalf("writeTestIPA() error: %v", err)
+			}
+			logPath := filepath.Join(tempDir, "commands.log")
+			t.Setenv("ASC_XCODE_HELPER_VALIDATE_OUTPUT", tt.output)
+
+			restore := overrideTestEnvironment(t)
+			runtimeGOOS = "darwin"
+			lookPathFn = func(file string) (string, error) {
+				switch file {
+				case "xcodebuild":
+					return "/usr/bin/xcodebuild", nil
+				case "xcrun":
+					return "/usr/bin/xcrun", nil
+				default:
+					return "", exec.ErrNotFound
+				}
+			}
+			commandContextFn = helperCommandContext(t, logPath)
+			t.Cleanup(restore)
+
+			result, err := Validate(context.Background(), ValidateOptions{IPAPath: ipaPath})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() error = nil, want server validation failure; result = %+v", result)
+				}
+				if !strings.Contains(err.Error(), tt.wantDetail) {
+					t.Fatalf("Validate() error = %q, want detail %q", err, tt.wantDetail)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Validate() error: %v", err)
+			}
+			if result == nil || !result.Validated {
+				t.Fatalf("Validate() result = %+v, want validated success", result)
+			}
+		})
+	}
+}
+
 func TestValidateRejectsOversizedInfoPlistBeforeAltool(t *testing.T) {
 	tempDir := t.TempDir()
 	ipaPath := writeIPAWithRawInfoPlist(t, buildSizedAppInfoPlist(t, infoplist.MaxBytes+1))
@@ -1333,6 +1404,9 @@ func TestXcodeHelperProcess(t *testing.T) {
 		if _, err := valueAfter(commandArgs[2:], "--file"); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
+		}
+		if output := os.Getenv("ASC_XCODE_HELPER_VALIDATE_OUTPUT"); output != "" {
+			fmt.Fprint(os.Stderr, output)
 		}
 		os.Exit(0)
 	}

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -425,10 +425,12 @@ func TestValidateRunsAltoolWithTVOSPlatform(t *testing.T) {
 
 func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 	tests := []struct {
-		name       string
-		output     string
-		wantErr    bool
-		wantDetail string
+		name           string
+		stdout         string
+		output         string
+		wantErr        bool
+		wantDetail     string
+		maxDetailBytes int
 	}{
 		{
 			name:       "timestamped server error",
@@ -449,6 +451,21 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 			wantDetail: "Early server rejection.",
 		},
 		{
+			name:       "unterminated stdout before timestamped stderr",
+			stdout:     "Upload progress",
+			output:     "2026-08-10 06:47:56.580 ERROR: Server rejected the archive.\n",
+			wantErr:    true,
+			wantDetail: "Server rejected the archive.",
+		},
+		{
+			name:           "aggregate details from both streams stay bounded",
+			stdout:         "2026-08-10 06:47:56.580 ERROR: " + strings.Repeat("a", xcodebuildErrorTailLimit/2) + "\n",
+			output:         "*** Error: " + strings.Repeat("b", xcodebuildErrorTailLimit/2) + "\n",
+			wantErr:        true,
+			wantDetail:     strings.Repeat("a", 32),
+			maxDetailBytes: xcodebuildErrorTailLimit,
+		},
+		{
 			name:   "benign output containing error text",
 			output: "2026-08-10 06:47:56.580 INFO: Validation completed.\nDiagnostic: no ERROR: records were returned.\n",
 		},
@@ -462,6 +479,7 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 				t.Fatalf("writeTestIPA() error: %v", err)
 			}
 			logPath := filepath.Join(tempDir, "commands.log")
+			t.Setenv("ASC_XCODE_HELPER_VALIDATE_STDOUT", tt.stdout)
 			t.Setenv("ASC_XCODE_HELPER_VALIDATE_OUTPUT", tt.output)
 
 			restore := overrideTestEnvironment(t)
@@ -486,6 +504,12 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 				}
 				if !strings.Contains(err.Error(), tt.wantDetail) {
 					t.Fatalf("Validate() error = %q, want detail %q", err, tt.wantDetail)
+				}
+				if tt.maxDetailBytes > 0 {
+					detail := strings.TrimPrefix(err.Error(), "xcrun altool validate failed: ")
+					if len(detail) > tt.maxDetailBytes {
+						t.Fatalf("Validate() detail bytes = %d, want at most %d", len(detail), tt.maxDetailBytes)
+					}
 				}
 				return
 			}
@@ -1410,6 +1434,10 @@ func TestXcodeHelperProcess(t *testing.T) {
 		if _, err := valueAfter(commandArgs[2:], "--file"); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
+		}
+		if output := os.Getenv("ASC_XCODE_HELPER_VALIDATE_STDOUT"); output != "" {
+			fmt.Fprint(os.Stdout, output)
+			time.Sleep(50 * time.Millisecond)
 		}
 		if output := os.Getenv("ASC_XCODE_HELPER_VALIDATE_OUTPUT"); output != "" {
 			fmt.Fprint(os.Stderr, output)

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -443,6 +443,12 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 			wantDetail: "Unable to validate archive './artifacts/Demo.ipa'.",
 		},
 		{
+			name:       "timestamped error before long diagnostics",
+			output:     "2026-08-10 06:47:56.580 ERROR: Early server rejection.\n" + strings.Repeat("x", xcodebuildErrorTailLimit+1) + "\n",
+			wantErr:    true,
+			wantDetail: "Early server rejection.",
+		},
+		{
 			name:   "benign output containing error text",
 			output: "2026-08-10 06:47:56.580 INFO: Validation completed.\nDiagnostic: no ERROR: records were returned.\n",
 		},


### PR DESCRIPTION
## Summary

- inspect validation diagnostics even when the tool exits successfully
- recognize timestamped and legacy server failure records
- keep benign diagnostic text and generic build execution behavior unchanged

## Why

The validation tool can emit a concrete rejection while returning status 0. In that state, the command previously returned `validated: true`, allowing automation to continue with an invalid archive.

## Verification

- RED: helper-backed zero-exit tests returned `validated: true` for both timestamped and legacy failure output before the implementation
- GREEN: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/xcode -run '^(TestValidateClassifiesAltoolOutputWithZeroExit|TestValidateRunsAltoolWithAuthFlags|TestValidateRunsAltoolWithTVOSPlatform)$' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/xcode ./internal/cli/xcode -count=1`
- built `/tmp/asc` and ran a PATH-injected Xcode 26-style helper: server rejection exited 1 with empty stdout; benign output containing `ERROR:` exited 0 with the normal JSON result
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788918087&installation_model_id=10418&pr_number=1920&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1920&signature=94117cad18981de2c89a6687566c8640c21c4b30ca009147a524c0e3eaa4d93a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation reporting for formatted diagnostics, including timestamped and legacy error messages.
  - Validation failures are now surfaced even when the command exits successfully.
  - Multiple identical errors are consolidated, with a fallback message when details are unavailable.
  - Benign output containing incidental `ERROR:` text no longer causes false validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->