### PR TITLE
fix(analytics): accept instance and segment resource IDs

### DIFF
--- a/internal/asc/analytics.go
+++ b/internal/asc/analytics.go
@@ -611,7 +611,10 @@ func (c *Client) GetAnalyticsReportInstances(ctx context.Context, reportID strin
 
 // GetAnalyticsReportInstance retrieves a specific report instance by ID.
 func (c *Client) GetAnalyticsReportInstance(ctx context.Context, instanceID string) (*AnalyticsReportInstanceResponse, error) {
-	path := fmt.Sprintf("/v1/analyticsReportInstances/%s", strings.TrimSpace(instanceID))
+	path, err := resourcePath("/v1/analyticsReportInstances/%s", instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("analytics report instance: %w", err)
+	}
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
@@ -626,6 +629,13 @@ func (c *Client) GetAnalyticsReportInstance(ctx context.Context, instanceID stri
 
 // GetAnalyticsReportInstanceSegmentsRelationships retrieves segment linkages for a report instance.
 func (c *Client) GetAnalyticsReportInstanceSegmentsRelationships(ctx context.Context, instanceID string, opts ...LinkagesOption) (*AnalyticsReportInstanceSegmentsLinkagesResponse, error) {
+	if strings.TrimSpace(instanceID) != "" {
+		var err error
+		instanceID, err = validateResourcePathSegment(instanceID)
+		if err != nil {
+			return nil, fmt.Errorf("analytics report instance segments relationship: %w", err)
+		}
+	}
 	return getTypedResourceLinkages[AnalyticsReportInstanceSegmentsLinkagesResponse](
 		c,
 		ctx,
@@ -645,15 +655,22 @@ func (c *Client) GetAnalyticsReportSegments(ctx context.Context, instanceID stri
 		opt(query)
 	}
 
-	path := fmt.Sprintf("/v1/analyticsReportInstances/%s/segments", strings.TrimSpace(instanceID))
+	var path string
 	if query.nextURL != "" {
 		// Validate nextURL to prevent credential exfiltration
 		if err := validateNextURL(query.nextURL); err != nil {
 			return nil, fmt.Errorf("analyticsReportSegments: %w", err)
 		}
 		path = query.nextURL
-	} else if queryString := buildAnalyticsReportSegmentsQuery(query); queryString != "" {
-		path += "?" + queryString
+	} else {
+		var err error
+		path, err = resourcePath("/v1/analyticsReportInstances/%s/segments", instanceID)
+		if err != nil {
+			return nil, fmt.Errorf("analytics report segments: %w", err)
+		}
+		if queryString := buildAnalyticsReportSegmentsQuery(query); queryString != "" {
+			path += "?" + queryString
+		}
 	}
 
 	data, err := c.do(ctx, "GET", path, nil)

--- a/internal/asc/analytics.go
+++ b/internal/asc/analytics.go
@@ -631,7 +631,7 @@ func (c *Client) GetAnalyticsReportInstance(ctx context.Context, instanceID stri
 func (c *Client) GetAnalyticsReportInstanceSegmentsRelationships(ctx context.Context, instanceID string, opts ...LinkagesOption) (*AnalyticsReportInstanceSegmentsLinkagesResponse, error) {
 	if strings.TrimSpace(instanceID) != "" {
 		var err error
-		instanceID, err = validateResourcePathSegment(instanceID)
+		instanceID, err = ValidateResourcePathSegment(instanceID)
 		if err != nil {
 			return nil, fmt.Errorf("analytics report instance segments relationship: %w", err)
 		}
@@ -687,7 +687,10 @@ func (c *Client) GetAnalyticsReportSegments(ctx context.Context, instanceID stri
 
 // GetAnalyticsReportSegment retrieves a specific report segment by ID.
 func (c *Client) GetAnalyticsReportSegment(ctx context.Context, segmentID string) (*AnalyticsReportSegmentResponse, error) {
-	path := fmt.Sprintf("/v1/analyticsReportSegments/%s", strings.TrimSpace(segmentID))
+	path, err := resourcePath("/v1/analyticsReportSegments/%s", segmentID)
+	if err != nil {
+		return nil, fmt.Errorf("analytics report segment: %w", err)
+	}
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/analytics_test.go
+++ b/internal/asc/analytics_test.go
@@ -465,7 +465,7 @@ func TestGetAnalyticsReportInstance_SendsRequest(t *testing.T) {
 	}
 }
 
-func TestAnalyticsInstanceEndpointsRejectIDsThatEscapePathSegment(t *testing.T) {
+func TestAnalyticsResourceEndpointsRejectIDsThatEscapePathSegment(t *testing.T) {
 	tests := []struct {
 		name string
 		call func(*Client) error
@@ -488,6 +488,13 @@ func TestAnalyticsInstanceEndpointsRejectIDsThatEscapePathSegment(t *testing.T) 
 			name: "GetAnalyticsReportSegments",
 			call: func(client *Client) error {
 				_, err := client.GetAnalyticsReportSegments(context.Background(), "inst-1/relationships/reports")
+				return err
+			},
+		},
+		{
+			name: "GetAnalyticsReportSegment",
+			call: func(client *Client) error {
+				_, err := client.GetAnalyticsReportSegment(context.Background(), "seg-1/relationships/report")
 				return err
 			},
 		},

--- a/internal/asc/analytics_test.go
+++ b/internal/asc/analytics_test.go
@@ -465,6 +465,52 @@ func TestGetAnalyticsReportInstance_SendsRequest(t *testing.T) {
 	}
 }
 
+func TestAnalyticsInstanceEndpointsRejectIDsThatEscapePathSegment(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*Client) error
+	}{
+		{
+			name: "GetAnalyticsReportInstance",
+			call: func(client *Client) error {
+				_, err := client.GetAnalyticsReportInstance(context.Background(), "inst-1/relationships/reports")
+				return err
+			},
+		},
+		{
+			name: "GetAnalyticsReportInstanceSegmentsRelationships",
+			call: func(client *Client) error {
+				_, err := client.GetAnalyticsReportInstanceSegmentsRelationships(context.Background(), "inst-1/relationships/reports")
+				return err
+			},
+		},
+		{
+			name: "GetAnalyticsReportSegments",
+			call: func(client *Client) error {
+				_, err := client.GetAnalyticsReportSegments(context.Background(), "inst-1/relationships/reports")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			client := newTestClient(t, func(_ *http.Request) {
+				requestCount++
+			}, jsonResponse(http.StatusOK, `{}`))
+
+			err := tt.call(client)
+			if err == nil || !strings.Contains(err.Error(), "single path segment") {
+				t.Fatalf("error = %v, want path-segment rejection", err)
+			}
+			if requestCount != 0 {
+				t.Fatalf("request count = %d, want 0", requestCount)
+			}
+		})
+	}
+}
+
 func TestGetAnalyticsReportSegment_SendsRequest(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":{"type":"analyticsReportSegments","id":"seg-1"}}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/resource_path.go
+++ b/internal/asc/resource_path.go
@@ -13,13 +13,13 @@ import (
 // pre-encoded sequence, and "\" is normalized inconsistently across platforms.
 const reservedPathSegmentCharacters = `/?#%\`
 
-// validateResourcePathSegment trims an identifier and confirms it occupies
+// ValidateResourcePathSegment trims an identifier and confirms it occupies
 // exactly one path segment.
 //
 // Reserved delimiters are rejected rather than percent-encoded. Encoding would
 // silently turn an operator mistake into a request for a resource that does not
 // exist, and validateAPIPath rejects "%" in outbound paths anyway.
-func validateResourcePathSegment(id string) (string, error) {
+func ValidateResourcePathSegment(id string) (string, error) {
 	segment := strings.TrimSpace(id)
 	if segment == "" {
 		return "", errors.New("resource identifier is required")
@@ -48,7 +48,7 @@ func resourcePath(template string, ids ...string) (string, error) {
 	}
 	args := make([]any, 0, len(ids))
 	for _, id := range ids {
-		segment, err := validateResourcePathSegment(id)
+		segment, err := ValidateResourcePathSegment(id)
 		if err != nil {
 			return "", err
 		}

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -174,12 +174,12 @@ func normalizeAnalyticsAccessType(value string) (asc.AnalyticsAccessType, error)
 	}
 }
 
-func validateUUIDFlag(flagName, value string) error {
+func validateAnalyticsRequestID(value string) error {
 	if strings.TrimSpace(value) == "" {
-		return fmt.Errorf("%s is required", flagName)
+		return fmt.Errorf("--request-id is required")
 	}
 	if !uuidPattern.MatchString(strings.TrimSpace(value)) {
-		return fmt.Errorf("%s must be a valid UUID", flagName)
+		return fmt.Errorf("--request-id must be a valid UUID")
 	}
 	return nil
 }

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -184,6 +184,32 @@ func validateAnalyticsRequestID(value string) error {
 	return nil
 }
 
+func analyticsDownloadDefaultOutput(requestID, instanceID string) string {
+	return fmt.Sprintf("analytics_report_%s_%s.csv.gz", strings.TrimSpace(requestID), sanitizeAnalyticsFilenameComponent(instanceID))
+}
+
+func sanitizeAnalyticsFilenameComponent(value string) string {
+	trimmed := strings.TrimSpace(value)
+	var sanitized strings.Builder
+	sanitized.Grow(len(trimmed))
+	for _, r := range trimmed {
+		isASCIIAlpha := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		switch {
+		case isASCIIAlpha || isDigit || r == '.' || r == '-' || r == '_':
+			sanitized.WriteRune(r)
+		default:
+			sanitized.WriteByte('_')
+		}
+	}
+
+	result := strings.Trim(sanitized.String(), "._-")
+	if result == "" {
+		return "instance"
+	}
+	return result
+}
+
 func normalizeReportDate(value string, frequency asc.SalesReportFrequency) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {

--- a/internal/cli/analytics/analytics_helpers_test.go
+++ b/internal/cli/analytics/analytics_helpers_test.go
@@ -5,11 +5,49 @@ import (
 	"compress/gzip"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+func TestAnalyticsDownloadDefaultOutputSanitizesInstanceID(t *testing.T) {
+	const requestID = "11111111-1111-1111-1111-111111111111"
+	tests := []struct {
+		name       string
+		instanceID string
+		want       string
+	}{
+		{
+			name:       "preserves prefixed ID",
+			instanceID: "r39-example-instance",
+			want:       "analytics_report_11111111-1111-1111-1111-111111111111_r39-example-instance.csv.gz",
+		},
+		{
+			name:       "removes path syntax",
+			instanceID: `r39/../../target\segment:part`,
+			want:       "analytics_report_11111111-1111-1111-1111-111111111111_r39_.._.._target_segment_part.csv.gz",
+		},
+		{
+			name:       "uses fallback for only path syntax",
+			instanceID: `../\:`,
+			want:       "analytics_report_11111111-1111-1111-1111-111111111111_instance.csv.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := analyticsDownloadDefaultOutput(requestID, tt.instanceID)
+			if got != tt.want {
+				t.Fatalf("analyticsDownloadDefaultOutput() = %q, want %q", got, tt.want)
+			}
+			if filepath.Base(got) != got || strings.ContainsAny(got, `/\`) {
+				t.Fatalf("analyticsDownloadDefaultOutput() returned path syntax: %q", got)
+			}
+		})
+	}
+}
 
 func TestResolveReportOutputPaths_Decompress(t *testing.T) {
 	compressed, decompressed := shared.ResolveReportOutputPaths("report.tsv.gz", "default.tsv.gz", ".tsv", true)

--- a/internal/cli/analytics/analytics_instances.go
+++ b/internal/cli/analytics/analytics_instances.go
@@ -57,9 +57,15 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			if strings.TrimSpace(*instanceID) == "" {
+			id := strings.TrimSpace(*instanceID)
+			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --instance-id is required")
 				return shared.MissingRequiredUsageError()
+			}
+			var err error
+			id, err = asc.ValidateResourcePathSegment(id)
+			if err != nil {
+				return fmt.Errorf("analytics instances view: --instance-id: %w", err)
 			}
 
 			client, err := shared.GetASCClient()
@@ -70,7 +76,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetAnalyticsReportInstance(requestCtx, strings.TrimSpace(*instanceID))
+			resp, err := client.GetAnalyticsReportInstance(requestCtx, id)
 			if err != nil {
 				return fmt.Errorf("analytics instances view: failed to fetch: %w", err)
 			}
@@ -113,6 +119,13 @@ Examples:
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --instance-id is required")
 				return shared.MissingRequiredUsageError()
+			}
+			if id != "" {
+				var err error
+				id, err = asc.ValidateResourcePathSegment(id)
+				if err != nil {
+					return fmt.Errorf("analytics instances links: --instance-id: %w", err)
+				}
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/analytics/analytics_instances.go
+++ b/internal/cli/analytics/analytics_instances.go
@@ -110,11 +110,6 @@ Examples:
 			}
 
 			id := strings.TrimSpace(*instanceID)
-			if id != "" {
-				if err := validateUUIDFlag("--instance-id", id); err != nil {
-					return fmt.Errorf("analytics instances links: %w", err)
-				}
-			}
 			if id == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --instance-id is required")
 				return shared.MissingRequiredUsageError()

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -609,7 +609,7 @@ Examples:
 				return fmt.Errorf("analytics download: %w", err)
 			}
 
-			defaultOutput := fmt.Sprintf("analytics_report_%s_%s.csv.gz", strings.TrimSpace(*requestID), strings.TrimSpace(*instanceID))
+			defaultOutput := analyticsDownloadDefaultOutput(*requestID, *instanceID)
 			compressedPath, decompressedPath := shared.ResolveReportOutputPaths(*output, defaultOutput, ".csv", *decompress)
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -139,7 +139,7 @@ Examples:
 				return fmt.Errorf("analytics requests: %w", err)
 			}
 			if strings.TrimSpace(*requestID) != "" {
-				if err := validateUUIDFlag("--request-id", *requestID); err != nil {
+				if err := validateAnalyticsRequestID(*requestID); err != nil {
 					return fmt.Errorf("analytics requests: %w", err)
 				}
 			}
@@ -336,7 +336,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --request-id is required")
 				return shared.MissingRequiredUsageError()
 			}
-			if err := validateUUIDFlag("--request-id", id); err != nil {
+			if err := validateAnalyticsRequestID(id); err != nil {
 				return fmt.Errorf("analytics requests delete: %w", err)
 			}
 			if !*confirm {
@@ -424,12 +424,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 			if strings.TrimSpace(*requestID) != "" {
-				if err := validateUUIDFlag("--request-id", *requestID); err != nil {
-					return fmt.Errorf("analytics view: %w", err)
-				}
-			}
-			if strings.TrimSpace(*instanceID) != "" {
-				if err := validateUUIDFlag("--instance-id", *instanceID); err != nil {
+				if err := validateAnalyticsRequestID(*requestID); err != nil {
 					return fmt.Errorf("analytics view: %w", err)
 				}
 			}
@@ -610,16 +605,8 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --instance-id is required")
 				return shared.MissingRequiredUsageError()
 			}
-			if err := validateUUIDFlag("--request-id", *requestID); err != nil {
+			if err := validateAnalyticsRequestID(*requestID); err != nil {
 				return fmt.Errorf("analytics download: %w", err)
-			}
-			if err := validateUUIDFlag("--instance-id", *instanceID); err != nil {
-				return fmt.Errorf("analytics download: %w", err)
-			}
-			if strings.TrimSpace(*segmentID) != "" {
-				if err := validateUUIDFlag("--segment-id", *segmentID); err != nil {
-					return fmt.Errorf("analytics download: %w", err)
-				}
 			}
 
 			defaultOutput := fmt.Sprintf("analytics_report_%s_%s.csv.gz", strings.TrimSpace(*requestID), strings.TrimSpace(*instanceID))

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -428,6 +428,11 @@ Examples:
 					return fmt.Errorf("analytics view: %w", err)
 				}
 			}
+			if strings.TrimSpace(*instanceID) != "" {
+				if _, err := asc.ValidateResourcePathSegment(*instanceID); err != nil {
+					return fmt.Errorf("analytics view: --instance-id: %w", err)
+				}
+			}
 			if *limit != 0 && (*limit < 1 || *limit > analyticsMaxLimit) {
 				return fmt.Errorf("analytics view: --limit must be between 1 and 200")
 			}
@@ -607,6 +612,14 @@ Examples:
 			}
 			if err := validateAnalyticsRequestID(*requestID); err != nil {
 				return fmt.Errorf("analytics download: %w", err)
+			}
+			if _, err := asc.ValidateResourcePathSegment(*instanceID); err != nil {
+				return fmt.Errorf("analytics download: --instance-id: %w", err)
+			}
+			if strings.TrimSpace(*segmentID) != "" {
+				if _, err := asc.ValidateResourcePathSegment(*segmentID); err != nil {
+					return fmt.Errorf("analytics download: --segment-id: %w", err)
+				}
 			}
 
 			defaultOutput := analyticsDownloadDefaultOutput(*requestID, *instanceID)

--- a/internal/cli/analytics/analytics_segments.go
+++ b/internal/cli/analytics/analytics_segments.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -52,9 +54,15 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			if strings.TrimSpace(*segmentID) == "" {
+			id := strings.TrimSpace(*segmentID)
+			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --segment-id is required")
 				return shared.MissingRequiredUsageError()
+			}
+			var err error
+			id, err = asc.ValidateResourcePathSegment(id)
+			if err != nil {
+				return fmt.Errorf("analytics segments view: --segment-id: %w", err)
 			}
 
 			client, err := shared.GetASCClient()
@@ -65,7 +73,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.GetAnalyticsReportSegment(requestCtx, strings.TrimSpace(*segmentID))
+			resp, err := client.GetAnalyticsReportSegment(requestCtx, id)
 			if err != nil {
 				return fmt.Errorf("analytics segments view: failed to fetch: %w", err)
 			}

--- a/internal/cli/cmdtest/analytics_resource_ids_test.go
+++ b/internal/cli/cmdtest/analytics_resource_ids_test.go
@@ -121,6 +121,83 @@ func TestAnalyticsRequestIDValidationRemainsBeforeClientConstruction(t *testing.
 	}
 }
 
+func TestAnalyticsResourcePathValidationRemainsBeforeClientConstruction(t *testing.T) {
+	setupAnalyticsResourceIDAuth(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "instances view",
+			args: []string{
+				"analytics", "instances", "view",
+				"--instance-id", "r39/escaped-instance",
+			},
+		},
+		{
+			name: "instances links",
+			args: []string{
+				"analytics", "instances", "links",
+				"--instance-id", "r39/escaped-instance",
+			},
+		},
+		{
+			name: "view filter",
+			args: []string{
+				"analytics", "view",
+				"--request-id", analyticsViewRequestID,
+				"--instance-id", "r39/escaped-instance",
+			},
+		},
+		{
+			name: "segments view",
+			args: []string{
+				"analytics", "segments", "view",
+				"--segment-id", "s39/escaped-segment",
+			},
+		},
+		{
+			name: "download",
+			args: []string{
+				"analytics", "download",
+				"--request-id", analyticsViewRequestID,
+				"--instance-id", "r39/escaped-instance",
+			},
+		},
+		{
+			name: "download segment",
+			args: []string{
+				"analytics", "download",
+				"--request-id", analyticsViewRequestID,
+				"--instance-id", "r39-example-instance",
+				"--segment-id", "s39/escaped-segment",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return nil, errors.New("client construction should not be attempted")
+			}))
+
+			stdout, stderr, runErr := runCommand(t, test.args)
+			if runErr == nil || !strings.Contains(runErr.Error(), "single path segment") {
+				t.Fatalf("run error = %v, want resource path-segment validation", runErr)
+			}
+			if stdout != "" || stderr != "" {
+				t.Fatalf("expected empty output, got stdout=%q stderr=%q", stdout, stderr)
+			}
+			if clientFactoryCalls != 0 {
+				t.Fatalf("client factory calls = %d, want 0", clientFactoryCalls)
+			}
+		})
+	}
+}
+
 func runAnalyticsDownloadIDCase(t *testing.T, instanceID, segmentID string) {
 	t.Helper()
 	setupAnalyticsResourceIDAuth(t)

--- a/internal/cli/cmdtest/analytics_resource_ids_test.go
+++ b/internal/cli/cmdtest/analytics_resource_ids_test.go
@@ -1,0 +1,218 @@
+package cmdtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestAnalyticsInstancesLinksAcceptsPrefixedInstanceID(t *testing.T) {
+	setupAnalyticsResourceIDAuth(t)
+
+	const (
+		instanceID = "r39-example-instance"
+		segmentID  = "s39-example-segment"
+	)
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/analyticsReportInstances/"+instanceID+"/relationships/segments" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if req.URL.RawQuery != "" {
+			t.Fatalf("unexpected query: %q", req.URL.RawQuery)
+		}
+		if req.Header.Get("Authorization") == "" {
+			t.Fatal("expected Authorization header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"analyticsReportSegments","id":"`+segmentID+`"}],"links":{}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := newReviewTestServerClient(t, server)
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) { return client, nil }))
+
+	stdout, stderr, runErr := runCommand(t, []string{
+		"analytics", "instances", "links",
+		"--instance-id", instanceID,
+		"--output", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+	var response struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s", err, stdout)
+	}
+	if len(response.Data) != 1 || response.Data[0].ID != segmentID {
+		t.Fatalf("unexpected output: %s", stdout)
+	}
+}
+
+func TestAnalyticsDownloadAcceptsPrefixedInstanceID(t *testing.T) {
+	runAnalyticsDownloadIDCase(t, "r39-example-instance", "33333333-3333-3333-3333-333333333333")
+}
+
+func TestAnalyticsDownloadAcceptsPrefixedSegmentID(t *testing.T) {
+	runAnalyticsDownloadIDCase(t, "22222222-2222-2222-2222-222222222222", "s39-example-segment")
+}
+
+func TestAnalyticsRequestIDValidationRemainsBeforeClientConstruction(t *testing.T) {
+	setupAnalyticsResourceIDAuth(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "view",
+			args: []string{"analytics", "view", "--request-id", "r39-not-a-request-uuid"},
+		},
+		{
+			name: "download",
+			args: []string{
+				"analytics", "download",
+				"--request-id", "r39-not-a-request-uuid",
+				"--instance-id", "r39-example-instance",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return nil, errors.New("client construction should not be attempted")
+			}))
+
+			stdout, stderr, runErr := runCommand(t, test.args)
+			if runErr == nil || !strings.Contains(runErr.Error(), "--request-id must be a valid UUID") {
+				t.Fatalf("run error = %v, want request UUID validation", runErr)
+			}
+			if stdout != "" || stderr != "" {
+				t.Fatalf("expected empty output, got stdout=%q stderr=%q", stdout, stderr)
+			}
+			if clientFactoryCalls != 0 {
+				t.Fatalf("client factory calls = %d, want 0", clientFactoryCalls)
+			}
+		})
+	}
+}
+
+func runAnalyticsDownloadIDCase(t *testing.T, instanceID, segmentID string) {
+	t.Helper()
+	setupAnalyticsResourceIDAuth(t)
+
+	const reportPayload = "analytics-report-data"
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			assertAnalyticsResourceIDRequest(t, req, "/v1/analyticsReportRequests/"+analyticsViewRequestID+"/reports", "limit=200", true)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":[{"type":"analyticsReports","id":"r39-example-report"}],"links":{}}`)
+		case 2:
+			assertAnalyticsResourceIDRequest(t, req, "/v1/analyticsReports/r39-example-report/instances", "limit=200", true)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":[{"type":"analyticsReportInstances","id":"`+instanceID+`"}],"links":{}}`)
+		case 3:
+			assertAnalyticsResourceIDRequest(t, req, "/v1/analyticsReportInstances/"+instanceID+"/segments", "limit=200", true)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":[{"type":"analyticsReportSegments","id":"`+segmentID+`","attributes":{"url":"https://mzstatic.com/report.gz"}}],"links":{}}`)
+		case 4:
+			assertAnalyticsResourceIDRequest(t, req, "/report.gz", "", false)
+			w.Header().Set("Content-Type", "application/a-gzip")
+			_, _ = io.WriteString(w, reportPayload)
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := newReviewTestServerClient(t, server)
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) { return client, nil }))
+
+	outputPath := filepath.Join(t.TempDir(), "analytics-report.csv.gz")
+	stdout, stderr, runErr := runCommand(t, []string{
+		"analytics", "download",
+		"--request-id", analyticsViewRequestID,
+		"--instance-id", instanceID,
+		"--segment-id", segmentID,
+		"--output", outputPath,
+		"--output-format", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 4 {
+		t.Fatalf("request count = %d, want 4", requestCount)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !bytes.Equal(data, []byte(reportPayload)) {
+		t.Fatalf("report data = %q, want %q", data, reportPayload)
+	}
+	var result struct {
+		RequestID  string `json:"requestId"`
+		InstanceID string `json:"instanceId"`
+		SegmentID  string `json:"segmentId"`
+		FilePath   string `json:"filePath"`
+		FileSize   int64  `json:"fileSize"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s", err, stdout)
+	}
+	if result.RequestID != analyticsViewRequestID || result.InstanceID != instanceID || result.SegmentID != segmentID || result.FilePath != outputPath || result.FileSize != int64(len(reportPayload)) {
+		t.Fatalf("unexpected output: %+v", result)
+	}
+}
+
+func setupAnalyticsResourceIDAuth(t *testing.T) {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+}
+
+func assertAnalyticsResourceIDRequest(t *testing.T, req *http.Request, wantPath, wantQuery string, wantAuth bool) {
+	t.Helper()
+	if req.Method != http.MethodGet || req.URL.Path != wantPath {
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+	}
+	if req.URL.RawQuery != wantQuery {
+		t.Fatalf("query = %q, want %q", req.URL.RawQuery, wantQuery)
+	}
+	if got := req.Header.Get("Authorization"); wantAuth && got == "" {
+		t.Fatal("expected Authorization header")
+	} else if !wantAuth && got != "" {
+		t.Fatalf("unexpected Authorization header on report download: %q", got)
+	}
+}

--- a/internal/cli/cmdtest/analytics_view_filters_test.go
+++ b/internal/cli/cmdtest/analytics_view_filters_test.go
@@ -301,17 +301,19 @@ func TestAnalyticsViewDeprecatedDateConflictsWithProcessingDate(t *testing.T) {
 	}
 }
 
-func TestAnalyticsViewNoFiltersPreservesInstanceAndSegmentBehavior(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+func TestAnalyticsViewAcceptsPrefixedInstanceAndPreservesSegmentBehavior(t *testing.T) {
+	setupAnalyticsResourceIDAuth(t)
 
-	const instanceID = "22222222-2222-2222-2222-222222222222"
+	const instanceID = "r39-example-instance"
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
 	requestCount := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		requestCount++
+		if req.Header.Get("Authorization") == "" {
+			t.Fatal("expected Authorization header")
+		}
 		switch requestCount {
 		case 1:
 			if req.URL.Path != "/v1/analyticsReportRequests/"+analyticsViewRequestID+"/reports" || req.URL.RawQuery != "limit=200" {
@@ -363,7 +365,7 @@ func TestAnalyticsViewNoFiltersPreservesInstanceAndSegmentBehavior(t *testing.T)
 			"name":"App Sessions",
 			"granularity":"DAILY",
 			"instances":[{
-				"id":"22222222-2222-2222-2222-222222222222",
+				"id":"r39-example-instance",
 				"reportDate":"2024-01-19",
 				"processingDate":"2024-01-20",
 				"granularity":"DAILY",


### PR DESCRIPTION
## Summary

- accept string resource IDs returned for analytics report instances and segments across view, relationship listing, and download flows
- retain UUID validation for analytics request IDs and preserve required-ID errors
- add command-level HTTP coverage for exact paths, query parameters, authentication, output, and downloaded bytes

## Validation

- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- built /tmp/asc and verified prefixed instance and segment IDs pass local validation
- exercised the built CLI against a local mock through the authenticated relationship, report, instance, and segment paths

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788918331&installation_model_id=10418&pr_number=1921&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1921&signature=c15c13f2f3623dc4fbde21236295c600a8411a1dfd4795bfc1b4c9b413e964fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Analytics commands now accept prefixed instance and segment identifiers.
- Request IDs receive clearer validation errors before processing begins.
- Analytics links and downloads support non-UUID resource identifiers.
- Invalid path-based identifiers are rejected before requests are sent.
- Downloaded reports use safer, sanitized default filenames.

## Tests
- Expanded coverage for prefixed identifiers, downloads, responses, validation order, path safety, and filename generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->