### PR TITLE
fix(screenshots): canonicalize reviewed upload targets

### DIFF
--- a/internal/asc/screenshot_sizes_test.go
+++ b/internal/asc/screenshot_sizes_test.go
@@ -193,6 +193,17 @@ func TestScreenshotDisplayTypesMatchOpenAPI(t *testing.T) {
 	if len(unexpectedExtras) > 0 {
 		t.Fatalf("unexpected screenshot display types not in OpenAPI: %v", unexpectedExtras)
 	}
+
+	specSet := make(map[string]struct{}, len(specTypes))
+	for _, displayType := range specTypes {
+		specSet[displayType] = struct{}{}
+	}
+	for _, displayType := range codeTypes {
+		canonical := CanonicalScreenshotDisplayTypeForAPI(displayType)
+		if _, ok := specSet[canonical]; !ok {
+			t.Fatalf("canonical display type %q for %q is not in OpenAPI", canonical, displayType)
+		}
+	}
 }
 
 func TestCanonicalScreenshotDisplayTypeForAPI(t *testing.T) {

--- a/internal/cli/assets/assets_screenshots_review_plan.go
+++ b/internal/cli/assets/assets_screenshots_review_plan.go
@@ -326,15 +326,22 @@ func executeScreenshotReviewPlan(ctx context.Context, opts screenshotReviewPlanO
 			continue
 		}
 
-		result.ApprovedReadyEntries++
-		if coverageByLocale[locale] == nil {
-			coverageByLocale[locale] = make(map[string]bool)
-		}
-
+		canonicalDisplayTypes := make([]string, 0, len(entry.DisplayTypes))
 		seenDisplayTypes := make(map[string]struct{}, len(entry.DisplayTypes))
+		displayTypesValid := true
 		for _, displayType := range entry.DisplayTypes {
 			rawDisplayType := strings.TrimSpace(displayType)
 			if rawDisplayType == "" {
+				appendScreenshotReviewIssue(
+					result,
+					"error",
+					entry.Key,
+					locale,
+					displayType,
+					"approved review entry contains an empty screenshot display type",
+					"Regenerate the review manifest with a supported App Store screenshot size.",
+				)
+				displayTypesValid = false
 				continue
 			}
 			displayValue := asc.CanonicalScreenshotDisplayTypeForAPI(rawDisplayType)
@@ -348,12 +355,24 @@ func executeScreenshotReviewPlan(ctx context.Context, opts screenshotReviewPlanO
 					fmt.Sprintf("approved review entry contains unsupported screenshot display type %q", rawDisplayType),
 					"Regenerate the review manifest with a supported App Store screenshot size.",
 				)
+				displayTypesValid = false
 				continue
 			}
 			if _, exists := seenDisplayTypes[displayValue]; exists {
 				continue
 			}
 			seenDisplayTypes[displayValue] = struct{}{}
+			canonicalDisplayTypes = append(canonicalDisplayTypes, displayValue)
+		}
+		if !displayTypesValid || len(canonicalDisplayTypes) == 0 {
+			continue
+		}
+
+		result.ApprovedReadyEntries++
+		if coverageByLocale[locale] == nil {
+			coverageByLocale[locale] = make(map[string]bool)
+		}
+		for _, displayValue := range canonicalDisplayTypes {
 			groupKey := screenshotGroupKey{
 				locale:         locale,
 				localizationID: localizationID,

--- a/internal/cli/assets/assets_screenshots_review_plan.go
+++ b/internal/cli/assets/assets_screenshots_review_plan.go
@@ -331,11 +331,29 @@ func executeScreenshotReviewPlan(ctx context.Context, opts screenshotReviewPlanO
 			coverageByLocale[locale] = make(map[string]bool)
 		}
 
+		seenDisplayTypes := make(map[string]struct{}, len(entry.DisplayTypes))
 		for _, displayType := range entry.DisplayTypes {
-			displayValue := strings.TrimSpace(displayType)
-			if displayValue == "" {
+			rawDisplayType := strings.TrimSpace(displayType)
+			if rawDisplayType == "" {
 				continue
 			}
+			displayValue := asc.CanonicalScreenshotDisplayTypeForAPI(rawDisplayType)
+			if !asc.IsValidScreenshotDisplayType(displayValue) {
+				appendScreenshotReviewIssue(
+					result,
+					"error",
+					entry.Key,
+					locale,
+					rawDisplayType,
+					fmt.Sprintf("approved review entry contains unsupported screenshot display type %q", rawDisplayType),
+					"Regenerate the review manifest with a supported App Store screenshot size.",
+				)
+				continue
+			}
+			if _, exists := seenDisplayTypes[displayValue]; exists {
+				continue
+			}
+			seenDisplayTypes[displayValue] = struct{}{}
 			groupKey := screenshotGroupKey{
 				locale:         locale,
 				localizationID: localizationID,

--- a/internal/cli/cmdtest/screenshots_plan_apply_test.go
+++ b/internal/cli/cmdtest/screenshots_plan_apply_test.go
@@ -315,6 +315,123 @@ func TestScreenshotsApplyUploadsApprovedArtifacts(t *testing.T) {
 	}
 }
 
+func TestScreenshotsApplyCanonicalizesLegacyReviewDisplayAliases(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	reviewDir, imagePath := writeScreenshotReviewArtifactsWithPlannedDisplayType(
+		t,
+		1260,
+		2736,
+		1260,
+		2736,
+		[]string{"APP_IPHONE_67", "APP_IPHONE_69"},
+	)
+	fileInfo, err := os.Stat(imagePath)
+	if err != nil {
+		t.Fatalf("stat review artifact: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	setListCalls := 0
+	screenshotCreates := 0
+	uploads := 0
+	invalidSetCreates := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789/appStoreVersions":
+			return statusJSONResponse(`{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return statusJSONResponse(`{"data":[{"type":"appStoreVersionLocalizations","id":"LOC_123","attributes":{"locale":"en-US"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/LOC_123/appScreenshotSets":
+			setListCalls++
+			return statusJSONResponse(`{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_67"}}],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshotSets":
+			invalidSetCreates++
+			body, readErr := io.ReadAll(req.Body)
+			if readErr != nil {
+				t.Fatalf("read screenshot set request: %v", readErr)
+			}
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, fmt.Sprintf(`{"errors":[{"status":"422","detail":"unexpected screenshot set request: %s"}]}`, body)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return statusJSONResponse(`{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return statusJSONResponse(`{"data":[],"links":{}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appScreenshots":
+			screenshotCreates++
+			body := fmt.Sprintf(`{"data":{"type":"appScreenshots","id":"new-1","attributes":{"uploadOperations":[{"method":"PUT","url":"https://upload.example/new-1","length":%d,"offset":0}]}}}`, fileInfo.Size())
+			return statusJSONResponse(body), nil
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
+			uploads++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     http.Header{},
+			}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshots/new-1":
+			return statusJSONResponse(`{"data":{"type":"appScreenshots","id":"new-1","attributes":{"uploaded":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshots/new-1":
+			return statusJSONResponse(`{"data":{"type":"appScreenshots","id":"new-1","attributes":{"assetDeliveryState":{"state":"COMPLETE"}}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return statusJSONResponse(`{}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"screenshots", "apply",
+			"--app", "123456789",
+			"--version", "1.2.3",
+			"--review-output-dir", reviewDir,
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	if payload["plannedGroups"] != float64(1) {
+		t.Fatalf("expected plannedGroups=1, got %v", payload["plannedGroups"])
+	}
+	groups, ok := payload["groups"].([]any)
+	if !ok || len(groups) != 1 {
+		t.Fatalf("expected one canonical group, got %T %v", payload["groups"], payload["groups"])
+	}
+	if displayType := groups[0].(map[string]any)["displayType"]; displayType != "APP_IPHONE_67" {
+		t.Fatalf("expected displayType APP_IPHONE_67, got %v", displayType)
+	}
+	if setListCalls != 1 || screenshotCreates != 1 || uploads != 1 || invalidSetCreates != 0 {
+		t.Fatalf(
+			"expected one canonical mutation sequence, got set lists=%d screenshot creates=%d uploads=%d invalid set creates=%d",
+			setListCalls,
+			screenshotCreates,
+			uploads,
+			invalidSetCreates,
+		)
+	}
+}
+
 func TestScreenshotsPlanRejectsVersionIDFromDifferentApp(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/screenshots_plan_apply_test.go
+++ b/internal/cli/cmdtest/screenshots_plan_apply_test.go
@@ -568,6 +568,86 @@ func TestScreenshotsPlanRejectsActualImageDimensionsThatDoNotMatchPlannedDisplay
 	}
 }
 
+func TestScreenshotsPlanRejectsEmptyReviewDisplayType(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	reviewDir, _ := writeScreenshotReviewArtifactsWithPlannedDisplayType(t, 1260, 2736, 1260, 2736, []string{"APP_IPHONE_67", "   "})
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/123456789/appStoreVersions":
+			return statusJSONResponse(`{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			return statusJSONResponse(`{"data":[{"type":"appStoreVersionLocalizations","id":"LOC_123","attributes":{"locale":"en-US"}}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"screenshots", "plan",
+			"--app", "123456789",
+			"--version", "1.2.3",
+			"--review-output-dir", reviewDir,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected empty display type validation error")
+	}
+	if stdout == "" {
+		t.Fatal("expected structured output describing the blocking issue")
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%s", err, stdout)
+	}
+	if payload["approvedReadyEntries"] != float64(0) {
+		t.Fatalf("expected approvedReadyEntries=0, got %v", payload["approvedReadyEntries"])
+	}
+	if payload["plannedGroups"] != float64(0) {
+		t.Fatalf("expected plannedGroups=0, got %v", payload["plannedGroups"])
+	}
+	if payload["errorCount"].(float64) < 1 {
+		t.Fatalf("expected at least one blocking error, got %v", payload["errorCount"])
+	}
+	issues, ok := payload["issues"].([]any)
+	if !ok || len(issues) == 0 {
+		t.Fatalf("expected issues slice, got %T %v", payload["issues"], payload["issues"])
+	}
+	found := false
+	for _, rawIssue := range issues {
+		message := fmt.Sprint(rawIssue.(map[string]any)["message"])
+		if strings.Contains(message, "empty screenshot display type") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected empty display type issue, got %v", issues)
+	}
+}
+
 func writeScreenshotReviewArtifacts(t *testing.T) (string, string) {
 	return writeScreenshotReviewArtifactsWithSize(t, 1284, 2778)
 }

--- a/internal/screenshots/review.go
+++ b/internal/screenshots/review.go
@@ -411,6 +411,7 @@ func rawIndexScreenshotKey(screenshotID string) string {
 
 func matchingAppDisplayTypes(width, height int) []string {
 	matches := make([]string, 0)
+	seen := make(map[string]struct{})
 	for _, displayType := range asc.ScreenshotDisplayTypes() {
 		if !strings.HasPrefix(displayType, "APP_") {
 			continue
@@ -421,7 +422,11 @@ func matchingAppDisplayTypes(width, height int) []string {
 		}
 		for _, dimension := range dimensions {
 			if dimension.Width == width && dimension.Height == height {
-				matches = append(matches, displayType)
+				canonical := asc.CanonicalScreenshotDisplayTypeForAPI(displayType)
+				if _, exists := seen[canonical]; !exists {
+					seen[canonical] = struct{}{}
+					matches = append(matches, canonical)
+				}
 				break
 			}
 		}

--- a/internal/screenshots/review_test.go
+++ b/internal/screenshots/review_test.go
@@ -112,6 +112,20 @@ func TestGenerateReview_WritesManifestAndHTML(t *testing.T) {
 	}
 }
 
+func TestMatchingAppDisplayTypesCanonicalizesAPIAliases(t *testing.T) {
+	got := strings.Join(matchingAppDisplayTypes(1260, 2736), ",")
+	if want := "APP_IPHONE_67"; got != want {
+		t.Fatalf("matchingAppDisplayTypes() = %q, want %q", got, want)
+	}
+}
+
+func TestMatchingAppDisplayTypesPreservesDistinctCanonicalSlots(t *testing.T) {
+	got := strings.Join(matchingAppDisplayTypes(2048, 2732), ",")
+	if want := "APP_IPAD_PRO_129,APP_IPAD_PRO_3GEN_129"; got != want {
+		t.Fatalf("matchingAppDisplayTypes() = %q, want %q", got, want)
+	}
+}
+
 func TestGenerateReview_RequiresFramedDirectory(t *testing.T) {
 	_, err := GenerateReview(context.Background(), ReviewRequest{
 		FramedDir: filepath.Join(t.TempDir(), "missing"),


### PR DESCRIPTION
## Summary

- canonicalize catalog aliases when generating screenshot review manifests
- normalize and deduplicate display types from existing review artifacts before planning or applying uploads
- verify every catalog target maps to the current API enum while preserving distinct valid screenshot slots

## Validation

- focused review-generation, legacy plan/apply, and OpenAPI parity tests
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- built /tmp/asc, generated and approved a 1260x2736 review artifact, and confirmed one canonical display target
- ran a read-only screenshot plan against the disposable app and confirmed one upload group with zero errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot display type handling by trimming, validating, and deduplicating values.
  * Added support for legacy display type aliases by converting them to canonical API values.
  * Unsupported or empty display types are now flagged and excluded from uploads.
  * Preserved distinct iPhone and iPad screenshot display slots.

* **Tests**
  * Added coverage for alias conversion, validation, deduplication, and screenshot upload planning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->