### PR TITLE
Recognize unified certificates for Mac signing

### DIFF
--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -439,15 +439,15 @@ func inferCertificateType(profileType string) (string, error) {
 		strings.Contains(normalized, "TVOS_APP_INHOUSE"):
 		return "IOS_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_DEVELOPMENT"):
-		return "IOS_DEVELOPMENT", nil
+		return "IOS_DEVELOPMENT,DEVELOPMENT", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_STORE"):
-		return "MAC_APP_DISTRIBUTION", nil
+		return "MAC_APP_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_DIRECT"):
 		return "DEVELOPER_ID_APPLICATION", nil
 	case strings.Contains(normalized, "MAC_APP_DEVELOPMENT"):
-		return "MAC_APP_DEVELOPMENT", nil
+		return "MAC_APP_DEVELOPMENT,DEVELOPMENT", nil
 	case strings.Contains(normalized, "MAC_APP_STORE"):
-		return "MAC_APP_DISTRIBUTION", nil
+		return "MAC_APP_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_APP_DIRECT"):
 		return "DEVELOPER_ID_APPLICATION", nil
 	default:

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -439,7 +439,7 @@ func inferCertificateType(profileType string) (string, error) {
 		strings.Contains(normalized, "TVOS_APP_INHOUSE"):
 		return "IOS_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_DEVELOPMENT"):
-		return "IOS_DEVELOPMENT,DEVELOPMENT", nil
+		return "MAC_APP_DEVELOPMENT,DEVELOPMENT", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_STORE"):
 		return "MAC_APP_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_DIRECT"):

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -422,7 +422,7 @@ func TestResolveSigningCertificateTypesIncludesCompatibleCertificatesForMacProfi
 		want        string
 	}{
 		{profileType: "MAC_APP_DEVELOPMENT", want: "MAC_APP_DEVELOPMENT,DEVELOPMENT"},
-		{profileType: "MAC_CATALYST_APP_DEVELOPMENT", want: "IOS_DEVELOPMENT,DEVELOPMENT"},
+		{profileType: "MAC_CATALYST_APP_DEVELOPMENT", want: "MAC_APP_DEVELOPMENT,DEVELOPMENT"},
 		{profileType: "MAC_APP_STORE", want: "MAC_APP_DISTRIBUTION,DISTRIBUTION"},
 		{profileType: "MAC_CATALYST_APP_STORE", want: "MAC_APP_DISTRIBUTION,DISTRIBUTION"},
 	}

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -416,6 +416,40 @@ func TestResolveSigningCertificateTypesIncludesCompatibleCertificatesForIOSAndTV
 	}
 }
 
+func TestResolveSigningCertificateTypesIncludesCompatibleCertificatesForMacProfiles(t *testing.T) {
+	tests := []struct {
+		profileType string
+		want        string
+	}{
+		{profileType: "MAC_APP_DEVELOPMENT", want: "MAC_APP_DEVELOPMENT,DEVELOPMENT"},
+		{profileType: "MAC_CATALYST_APP_DEVELOPMENT", want: "IOS_DEVELOPMENT,DEVELOPMENT"},
+		{profileType: "MAC_APP_STORE", want: "MAC_APP_DISTRIBUTION,DISTRIBUTION"},
+		{profileType: "MAC_CATALYST_APP_STORE", want: "MAC_APP_DISTRIBUTION,DISTRIBUTION"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profileType, func(t *testing.T) {
+			got, err := resolveSigningCertificateTypes(tt.profileType, "")
+			if err != nil {
+				t.Fatalf("resolveSigningCertificateTypes() error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveSigningCertificateTypes() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveSigningCertificateTypesPreservesExplicitSelection(t *testing.T) {
+	got, err := resolveSigningCertificateTypes("MAC_APP_STORE", "mac_app_distribution")
+	if err != nil {
+		t.Fatalf("resolveSigningCertificateTypes() error: %v", err)
+	}
+	if got != "MAC_APP_DISTRIBUTION" {
+		t.Fatalf("resolveSigningCertificateTypes() = %q, want %q", got, "MAC_APP_DISTRIBUTION")
+	}
+}
+
 func TestResolveSigningAssetsChecksEveryActiveProfileForInferredCertificateType(t *testing.T) {
 	requestPaths := []string{}
 	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {


### PR DESCRIPTION
## Summary

- include unified Apple development certificates when inferring Mac and Mac Catalyst development signing
- include unified Apple distribution certificates when inferring Mac and Mac Catalyst App Store signing
- preserve legacy certificate compatibility and explicit `--certificate-type` selection

## Contract evidence

Apple documents Apple Development and Apple Distribution certificates as unified across iOS, macOS, tvOS, and watchOS for Xcode 11 and later:

https://developer.apple.com/help/account/certificates/certificates-overview

The repository OpenAPI snapshot exposes `DEVELOPMENT`, `DISTRIBUTION`, `MAC_APP_DEVELOPMENT`, and `MAC_APP_DISTRIBUTION` in the certificate filter enum, alongside the affected Mac and Mac Catalyst profile types.

## Verification

- RED confirmed all four affected inferred filters omitted their compatible unified certificate type
- `go test ./internal/cli/signing -run 'TestResolveSigningCertificateTypes(IncludesCompatibleCertificatesForIOSAndTVOSProfiles|IncludesCompatibleCertificatesForMacProfiles|PreservesExplicitSelection)$' -count=1`
- `go test ./internal/cli/signing -count=1`
- `go test ./internal/asc -run 'Test(GetCertificates|GetProfileCertificates|CreateProfile)' -count=1`
- built `/tmp/asc` and verified current `signing fetch --help`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Live verification

Read-only authentication and app lookup succeeded against disposable app `6759231657`. Mac development and Mac App Store fetches were attempted without `--create-missing`; the app has no active profiles of either type, so both stopped without mutation before certificate compatibility could be observed live.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788918882&installation_model_id=10418&pr_number=1924&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1924&signature=e4a7058a00d52a42e861f55280f66758ffb84f70c199b5c849ba4437e9426330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signing certificate selection for iOS development, macOS development, macOS Catalyst, and macOS distribution profiles.
  * Added compatible fallback certificate types to improve profile matching.
  * Explicitly selected certificate types are now normalized and preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->