### PR TITLE
fix(api): classify HTTP conflict responses

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -431,6 +432,65 @@ func TestGetApps_RetryExhaustedExposesHTTPStatus(t *testing.T) {
 	var statusErr interface{ HTTPStatusCode() int }
 	if !errors.As(err, &statusErr) || statusErr.HTTPStatusCode() != http.StatusServiceUnavailable {
 		t.Fatalf("expected HTTPStatusCode() to report %d, got %v", http.StatusServiceUnavailable, err)
+	}
+}
+
+func TestClientDo_ConflictStatusMatchesSentinelAndPreservesDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps" {
+			t.Fatalf("expected path /v1/apps, got %s", req.URL.Path)
+		}
+		assertAuthorized(t, req)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{
+			"errors": [{
+				"status": "409",
+				"code": "STATE_ERROR.ENTITY_STATE_INVALID",
+				"title": "The resource is not in a valid state",
+				"detail": "Resolve the conflicting state before retrying."
+			}]
+		}`)
+	}))
+	t.Cleanup(server.Close)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	client := &Client{
+		httpClient: server.Client(),
+		keyID:      "KEY123",
+		issuerID:   "ISS456",
+		privateKey: key,
+	}
+
+	_, err = client.do(context.Background(), http.MethodPost, server.URL+"/v1/apps", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	apiErr, ok := errors.AsType[*APIError](err)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusConflict {
+		t.Fatalf("expected status %d, got %d", http.StatusConflict, apiErr.StatusCode)
+	}
+	if apiErr.Code != "STATE_ERROR.ENTITY_STATE_INVALID" {
+		t.Fatalf("expected structured code to be preserved, got %q", apiErr.Code)
+	}
+	if apiErr.Title != "The resource is not in a valid state" {
+		t.Fatalf("expected structured title to be preserved, got %q", apiErr.Title)
+	}
+	if apiErr.Detail != "Resolve the conflicting state before retrying." {
+		t.Fatalf("expected structured detail to be preserved, got %q", apiErr.Detail)
+	}
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected HTTP 409 to match ErrConflict, got %v", err)
 	}
 }
 

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 )
@@ -162,7 +163,7 @@ func (e *APIError) Is(target error) bool {
 	case ErrBadRequest:
 		return strings.EqualFold(e.Code, "BAD_REQUEST")
 	case ErrConflict:
-		return strings.EqualFold(e.Code, "CONFLICT")
+		return strings.EqualFold(e.Code, "CONFLICT") || e.StatusCode == http.StatusConflict
 	default:
 		return false
 	}

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -447,8 +447,10 @@ Examples:
 					err := client.AddBetaTesterToGroups(requestCtx, testerID, groupIDs)
 					cancel()
 					if err != nil {
-						if errors.Is(err, asc.ErrConflict) {
-							// Relationship already exists; treat as idempotent success.
+						alreadySatisfied, verificationErr := betaTesterGroupConflictAlreadySatisfied(ctx, client, testerID, groupIDs, err)
+						if verificationErr != nil {
+							err = fmt.Errorf("%w (failed to verify beta group membership: %w)", err, verificationErr)
+						} else if alreadySatisfied {
 							summary.Updated++
 							continue
 						}
@@ -752,6 +754,57 @@ func fetchExistingTestersByEmail(ctx context.Context, client *asc.Client, appID 
 		byEmail[email] = strings.TrimSpace(tester.ID)
 	}
 	return byEmail, nil
+}
+
+func betaTesterGroupConflictAlreadySatisfied(
+	ctx context.Context,
+	client *asc.Client,
+	testerID string,
+	groupIDs []string,
+	requestErr error,
+) (bool, error) {
+	if !errors.Is(requestErr, asc.ErrConflict) {
+		return false, nil
+	}
+
+	requestedGroupIDs := uniqueSortedStrings(groupIDs)
+	if len(requestedGroupIDs) == 0 {
+		return false, nil
+	}
+
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	first, err := client.GetBetaTesterBetaGroupsRelationships(requestCtx, testerID, asc.WithLinkagesLimit(200))
+	cancel()
+	if err != nil {
+		return false, err
+	}
+
+	all, err := asc.PaginateAll(ctx, first, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		return client.GetBetaTesterBetaGroupsRelationships(requestCtx, testerID, asc.WithLinkagesNextURL(nextURL))
+	})
+	if err != nil {
+		return false, err
+	}
+	resp, ok := all.(*asc.LinkagesResponse)
+	if !ok || resp == nil {
+		return false, fmt.Errorf("unexpected beta tester group relationships response type")
+	}
+
+	presentGroupIDs := make(map[string]struct{}, len(resp.Data))
+	for _, linkage := range resp.Data {
+		groupID := strings.TrimSpace(linkage.ID)
+		if groupID != "" {
+			presentGroupIDs[groupID] = struct{}{}
+		}
+	}
+	for _, groupID := range requestedGroupIDs {
+		if _, ok := presentGroupIDs[groupID]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func fetchTesterGroupMemberships(ctx context.Context, client *asc.Client, resolver *betaGroupResolver) (map[string][]string, error) {

--- a/internal/cli/testflight/beta_testers_csv_conflict_test.go
+++ b/internal/cli/testflight/beta_testers_csv_conflict_test.go
@@ -1,0 +1,150 @@
+package testflight
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type betaTesterCSVConflictTransport func(*http.Request) (*http.Response, error)
+
+func (fn betaTesterCSVConflictTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestBetaTesterGroupConflictAlreadySatisfied(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestErr   error
+		requested    []string
+		memberships  [][]string
+		want         bool
+		wantRequests int
+	}{
+		{
+			name:         "all requested relationships exist",
+			requestErr:   &asc.APIError{Code: "ENTITY_ERROR.RELATIONSHIP.INVALID", StatusCode: http.StatusConflict},
+			requested:    []string{"group-1", "group-2"},
+			memberships:  [][]string{{"group-1"}, {"group-2"}},
+			want:         true,
+			wantRequests: 2,
+		},
+		{
+			name:         "request entity conflict left a relationship missing",
+			requestErr:   &asc.APIError{Code: "ENTITY_ERROR.ATTRIBUTE.INVALID", StatusCode: http.StatusConflict},
+			requested:    []string{"group-1", "group-2"},
+			memberships:  [][]string{{"group-1"}},
+			want:         false,
+			wantRequests: 1,
+		},
+		{
+			name:         "non conflict does not query memberships",
+			requestErr:   errors.New("network failure"),
+			requested:    []string{"group-1"},
+			memberships:  [][]string{{"group-1"}},
+			want:         false,
+			wantRequests: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requests := 0
+			client := newBetaTesterCSVConflictClient(t, func(req *http.Request) (*http.Response, error) {
+				pageIndex := requests
+				requests++
+				if req.Method != http.MethodGet {
+					t.Fatalf("expected GET, got %s", req.Method)
+				}
+				if req.URL.Path != "/v1/betaTesters/tester-1/relationships/betaGroups" {
+					t.Fatalf("unexpected request path %q", req.URL.Path)
+				}
+				if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+					t.Fatalf("expected bearer authorization, got %q", req.Header.Get("Authorization"))
+				}
+
+				if pageIndex >= len(test.memberships) {
+					t.Fatalf("unexpected membership request %d", requests)
+				}
+				data := make([]map[string]string, 0, len(test.memberships[pageIndex]))
+				for _, groupID := range test.memberships[pageIndex] {
+					data = append(data, map[string]string{"type": "betaGroups", "id": groupID})
+				}
+				links := map[string]string{}
+				if pageIndex+1 < len(test.memberships) {
+					links["next"] = fmt.Sprintf(
+						"https://api.appstoreconnect.apple.com/v1/betaTesters/tester-1/relationships/betaGroups?cursor=%d",
+						pageIndex+2,
+					)
+				}
+				body, err := json.Marshal(map[string]any{
+					"data":  data,
+					"links": links,
+				})
+				if err != nil {
+					t.Fatalf("marshal response: %v", err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(string(body))),
+					Request:    req,
+				}, nil
+			})
+
+			got, err := betaTesterGroupConflictAlreadySatisfied(
+				context.Background(),
+				client,
+				"tester-1",
+				test.requested,
+				test.requestErr,
+			)
+			if err != nil {
+				t.Fatalf("betaTesterGroupConflictAlreadySatisfied() error: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("betaTesterGroupConflictAlreadySatisfied() = %t, want %t", got, test.want)
+			}
+			if requests != test.wantRequests {
+				t.Fatalf("membership requests = %d, want %d", requests, test.wantRequests)
+			}
+		})
+	}
+}
+
+func newBetaTesterCSVConflictClient(t *testing.T, transport betaTesterCSVConflictTransport) *asc.Client {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+
+	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
+	}
+	return client
+}

--- a/internal/cli/testflight/beta_testers_csv_conflict_test.go
+++ b/internal/cli/testflight/beta_testers_csv_conflict_test.go
@@ -10,8 +10,9 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,12 +20,6 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
-
-type betaTesterCSVConflictTransport func(*http.Request) (*http.Response, error)
-
-func (fn betaTesterCSVConflictTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return fn(req)
-}
 
 func TestBetaTesterGroupConflictAlreadySatisfied(t *testing.T) {
 	tests := []struct {
@@ -64,7 +59,7 @@ func TestBetaTesterGroupConflictAlreadySatisfied(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			requests := 0
-			client := newBetaTesterCSVConflictClient(t, func(req *http.Request) (*http.Response, error) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				pageIndex := requests
 				requests++
 				if req.Method != http.MethodGet {
@@ -75,6 +70,12 @@ func TestBetaTesterGroupConflictAlreadySatisfied(t *testing.T) {
 				}
 				if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
 					t.Fatalf("expected bearer authorization, got %q", req.Header.Get("Authorization"))
+				}
+				if pageIndex == 0 && req.URL.Query().Get("limit") != "200" {
+					t.Fatalf("first page limit = %q, want 200", req.URL.Query().Get("limit"))
+				}
+				if pageIndex > 0 && req.URL.Query().Get("cursor") != fmt.Sprint(pageIndex+1) {
+					t.Fatalf("page %d cursor = %q, want %d", pageIndex+1, req.URL.Query().Get("cursor"), pageIndex+1)
 				}
 
 				if pageIndex >= len(test.memberships) {
@@ -91,20 +92,16 @@ func TestBetaTesterGroupConflictAlreadySatisfied(t *testing.T) {
 						pageIndex+2,
 					)
 				}
-				body, err := json.Marshal(map[string]any{
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]any{
 					"data":  data,
 					"links": links,
-				})
-				if err != nil {
+				}); err != nil {
 					t.Fatalf("marshal response: %v", err)
 				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(string(body))),
-					Request:    req,
-				}, nil
-			})
+			}))
+			t.Cleanup(server.Close)
+			client := newBetaTesterCSVConflictClient(t, server)
 
 			got, err := betaTesterGroupConflictAlreadySatisfied(
 				context.Background(),
@@ -126,7 +123,7 @@ func TestBetaTesterGroupConflictAlreadySatisfied(t *testing.T) {
 	}
 }
 
-func newBetaTesterCSVConflictClient(t *testing.T, transport betaTesterCSVConflictTransport) *asc.Client {
+func newBetaTesterCSVConflictClient(t *testing.T, server *httptest.Server) *asc.Client {
 	t.Helper()
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -140,6 +137,17 @@ func newBetaTesterCSVConflictClient(t *testing.T, transport betaTesterCSVConflic
 	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
 	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
 		t.Fatalf("write private key: %v", err)
+	}
+
+	transport, ok := server.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("test server transport type = %T, want *http.Transport", server.Client().Transport)
+	}
+	transport = transport.Clone()
+	transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	transport.TLSClientConfig.ServerName = "example.com"
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
 	}
 
 	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, &http.Client{Transport: transport})


### PR DESCRIPTION
## Summary

- classify HTTP 409 responses as `ErrConflict` even when the structured API code is resource-specific
- preserve the original code, title, detail, and status for diagnostics
- verify current TestFlight group membership before accepting a 409 as an already-satisfied CSV update
- cover both the signed client response path and the paginated membership verification path

## Why

The API can return several structured error codes for a conflict response. Callers that rely on `errors.Is` need one stable classification without losing the response details that explain the conflict.

The classification is status-wide, while idempotent relationship handling remains state-based: the CSV importer only accepts a conflict when every requested group linkage is present.

## Testing

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run ^TestClientDo_ConflictStatusMatchesSentinelAndPreservesDetails$ -count=1 -v`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/testflight -run ^TestBetaTesterGroupConflictAlreadySatisfied$ -count=1 -v`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/testflight -count=1`
- `go build -o /tmp/asc .`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP conflict responses by consistently recognizing status 409 as a conflict error.
  * Preserved error details—including status, code, title, and message—when conflict responses are returned.
  * Improved beta tester group updates so conflicts are treated as successful only when all requested groups are already assigned.
  * Added clearer reporting when group membership cannot be fully verified or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->