### PR TITLE
Reject conflicting accessibility pagination options

### DIFF
--- a/internal/cli/accessibility/accessibility.go
+++ b/internal/cli/accessibility/accessibility.go
@@ -72,14 +72,14 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("accessibility list: --limit must be between 1 and 200")
-			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("accessibility list: %w", err)
 			}
 			if err := rejectAccessibilityNextFlagConflicts(fs, *next, "app", "device-family", "state", "fields", "limit"); err != nil {
 				return err
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return fmt.Errorf("accessibility list: --limit must be between 1 and 200")
 			}
 
 			deviceFamilies, err := normalizeAccessibilityDeviceFamilies(shared.SplitCSVUpper(*deviceFamily))

--- a/internal/cli/accessibility/accessibility.go
+++ b/internal/cli/accessibility/accessibility.go
@@ -78,6 +78,9 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("accessibility list: %w", err)
 			}
+			if err := rejectAccessibilityNextFlagConflicts(fs, *next, "app", "device-family", "state", "fields", "limit"); err != nil {
+				return err
+			}
 
 			deviceFamilies, err := normalizeAccessibilityDeviceFamilies(shared.SplitCSVUpper(*deviceFamily))
 			if err != nil {
@@ -141,6 +144,22 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func rejectAccessibilityNextFlagConflicts(fs *flag.FlagSet, next string, names ...string) error {
+	if strings.TrimSpace(next) == "" {
+		return nil
+	}
+	provided := make(map[string]struct{}, len(names))
+	fs.Visit(func(f *flag.Flag) {
+		provided[f.Name] = struct{}{}
+	})
+	for _, name := range names {
+		if _, ok := provided[name]; ok {
+			return shared.UsageErrorf("accessibility list: --next cannot be combined with --%s", name)
+		}
+	}
+	return nil
 }
 
 // AccessibilityGetCommand returns the accessibility view subcommand.

--- a/internal/cli/cmdtest/accessibility_next_conflicts_test.go
+++ b/internal/cli/cmdtest/accessibility_next_conflicts_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
@@ -55,6 +56,11 @@ func TestAccessibilityListRejectsNextQueryFlagsBeforeAuth(t *testing.T) {
 			args:    []string{"accessibility", "list", "--limit", "0", "--next", nextURL},
 			wantErr: "accessibility list: --next cannot be combined with --limit",
 		},
+		{
+			name:    "out of range limit after next",
+			args:    []string{"accessibility", "list", "--next", nextURL, "--limit", "201"},
+			wantErr: "accessibility list: --next cannot be combined with --limit",
+		},
 	}
 
 	for _, test := range tests {
@@ -71,6 +77,28 @@ func TestAccessibilityListRejectsNextQueryFlagsBeforeAuth(t *testing.T) {
 				t.Fatal("client factory ran before --next conflict validation")
 			}
 		})
+	}
+}
+
+func TestAccessibilityListInvalidNextPrecedesLimitConflict(t *testing.T) {
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{
+			"accessibility", "list",
+			"--next", "http://api.appstoreconnect.apple.com/v1/apps/app-1/accessibilityDeclarations?cursor=next",
+			"--limit", "201",
+		}, "1.2.3")
+		if code != rootcmd.ExitError {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitError)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "accessibility list: --next must be an App Store Connect URL") {
+		t.Fatalf("stderr = %q, want invalid --next error", stderr)
+	}
+	if strings.Contains(stderr, "--limit") {
+		t.Fatalf("stderr = %q, want --next validation to take precedence", stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/accessibility_next_conflicts_test.go
+++ b/internal/cli/cmdtest/accessibility_next_conflicts_test.go
@@ -1,0 +1,171 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestAccessibilityListRejectsNextQueryFlagsBeforeAuth(t *testing.T) {
+	t.Cleanup(func() { shared.SetSelectedProfile("") })
+	t.Setenv("ASC_APP_ID", "")
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/accessibilityDeclarations?cursor=next"
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "app before next",
+			args:    []string{"accessibility", "list", "--app", "app-2", "--next", nextURL},
+			wantErr: "accessibility list: --next cannot be combined with --app",
+		},
+		{
+			name:    "explicit empty app after next",
+			args:    []string{"accessibility", "list", "--next", nextURL, "--app", ""},
+			wantErr: "accessibility list: --next cannot be combined with --app",
+		},
+		{
+			name:    "device family after next",
+			args:    []string{"accessibility", "list", "--next", nextURL, "--device-family", "IPHONE"},
+			wantErr: "accessibility list: --next cannot be combined with --device-family",
+		},
+		{
+			name:    "state before next",
+			args:    []string{"accessibility", "list", "--state", "PUBLISHED", "--next", nextURL},
+			wantErr: "accessibility list: --next cannot be combined with --state",
+		},
+		{
+			name:    "explicit empty fields after next",
+			args:    []string{"accessibility", "list", "--next", nextURL, "--fields", ""},
+			wantErr: "accessibility list: --next cannot be combined with --fields",
+		},
+		{
+			name:    "explicit zero limit before next",
+			args:    []string{"accessibility", "list", "--limit", "0", "--next", nextURL},
+			wantErr: "accessibility list: --next cannot be combined with --limit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during validation")
+			})
+			defer restore()
+
+			assertUsageExit(t, test.args, test.wantErr)
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before --next conflict validation")
+			}
+		})
+	}
+}
+
+func TestAccessibilityListNextOnlyUsesCursorURL(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "env-app")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/accessibilityDeclarations?cursor=page-2&filter%5Bstate%5D=PUBLISHED&limit=5"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/accessibilityDeclarations" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		query := req.URL.Query()
+		if got := query.Get("cursor"); got != "page-2" {
+			t.Errorf("cursor = %q, want page-2", got)
+		}
+		if got := query.Get("filter[state]"); got != "PUBLISHED" {
+			t.Errorf("filter[state] = %q, want PUBLISHED", got)
+		}
+		if got := query.Get("limit"); got != "5" {
+			t.Errorf("limit = %q, want 5", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"accessibilityDeclarations","id":"decl-next"}],"links":{"next":""}}`)
+	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"accessibility", "list", "--next", nextURL, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"decl-next"`) {
+		t.Fatalf("stdout = %q, want cursor response", stdout)
+	}
+}
+
+func TestAccessibilityListFilterOnlyBuildsDocumentedQuery(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/accessibilityDeclarations" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		want := url.Values{
+			"fields[accessibilityDeclarations]": {"deviceFamily,state"},
+			"filter[deviceFamily]":              {"IPHONE,IPAD"},
+			"filter[state]":                     {"DRAFT"},
+			"limit":                             {"25"},
+		}
+		if got := req.URL.Query(); got.Encode() != want.Encode() {
+			t.Errorf("query = %q, want %q", got.Encode(), want.Encode())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"accessibilityDeclarations","id":"decl-filtered"}],"links":{"next":""}}`)
+	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		args := []string{
+			"accessibility", "list",
+			"--app", "app-1",
+			"--device-family", "iphone,ipad",
+			"--state", "draft",
+			"--fields", "deviceFamily,state",
+			"--limit", "25",
+			"--output", "json",
+		}
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"decl-filtered"`) {
+		t.Fatalf("stdout = %q, want filtered response", stdout)
+	}
+}


### PR DESCRIPTION
## Summary

- Reject explicit server-side selectors and query options when `--next` supplies the complete accessibility continuation URL.
- Keep next-only pagination, implicit `ASC_APP_ID`, `--paginate`, and output controls unchanged.
- Cover usage exits before authentication and both continuation-only and filter-only HTTP requests.

## Compatibility

`accessibility list` now exits with usage status 2 when `--next` is combined with an explicitly supplied `--app`, `--device-family`, `--state`, `--fields`, or `--limit`. These combinations previously appeared successful even though the continuation URL took precedence and the explicit option had no effect.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built `/tmp/asc` command-level exit checks
- Local mock verification for the exact next-only and filter-only request queries

Command help is unchanged, so no generated documentation update is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788921143&installation_model_id=10418&pr_number=1926&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1926&signature=d670c1ac2cdc39fa4823047c50918c00ee25c7f98fc54d6046af97eb5998d2e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for accessibility list commands by rejecting incompatible combinations of `--next` with other query options.
  * Preserved query parameters supplied in cursor URLs.
  * Continued to accept blank `--next` values.
* **Tests**
  * Added coverage for flag conflicts, cursor handling, authentication flow, and query parameter construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->