### PR TITLE
fix(notarization): detect failed multipart completions

### DIFF
--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -613,30 +613,50 @@ func completeMultipartUploadWithClient(ctx context.Context, httpClient *http.Cli
 
 	decoder := xml.NewDecoder(bytes.NewReader(respBody))
 	rootSeen := false
+	rootClosed := false
+	rootDepth := 0
 	for {
 		token, decodeErr := decoder.Token()
 		if errors.Is(decodeErr, io.EOF) {
 			if !rootSeen {
 				return errors.New("parse complete multipart upload response: missing root element")
 			}
+			if !rootClosed {
+				return errors.New("parse complete multipart upload response: incomplete root element")
+			}
 			break
 		}
 		if decodeErr != nil {
 			return fmt.Errorf("parse complete multipart upload response: %w", decodeErr)
 		}
-		start, ok := token.(xml.StartElement)
-		if !ok || rootSeen {
-			continue
-		}
-		rootSeen = true
-		switch start.Name.Local {
-		case "Error":
-			return fmt.Errorf("complete multipart upload failed: %s", sanitizeErrorBody(respBody))
-		case "CompleteMultipartUploadResult":
-			// Consume the complete document so truncated or malformed success
-			// responses cannot be mistaken for a completed upload.
-		default:
-			return fmt.Errorf("unexpected complete multipart upload response: %s", sanitizeErrorBody(respBody))
+
+		switch value := token.(type) {
+		case xml.StartElement:
+			if rootClosed {
+				return errors.New("parse complete multipart upload response: multiple root elements")
+			}
+			if !rootSeen {
+				rootSeen = true
+				switch value.Name.Local {
+				case "Error":
+					return fmt.Errorf("complete multipart upload failed: %s", sanitizeErrorBody(respBody))
+				case "CompleteMultipartUploadResult":
+					// Consume the complete document so malformed success responses
+					// cannot be mistaken for a completed upload.
+				default:
+					return fmt.Errorf("unexpected complete multipart upload response: %s", sanitizeErrorBody(respBody))
+				}
+			}
+			rootDepth++
+		case xml.EndElement:
+			rootDepth--
+			if rootDepth == 0 {
+				rootClosed = true
+			}
+		case xml.CharData:
+			if (!rootSeen || rootClosed) && len(bytes.TrimSpace(value)) != 0 {
+				return errors.New("parse complete multipart upload response: character data outside root element")
+			}
 		}
 	}
 	return nil

--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -555,6 +555,10 @@ func uploadMultipartPart(ctx context.Context, host, encodedPath string, creds S3
 }
 
 func completeMultipartUpload(ctx context.Context, host, encodedPath string, creds S3Credentials, uploadID string, parts []s3CompletedPart) error {
+	return completeMultipartUploadWithClient(ctx, http.DefaultClient, host, encodedPath, creds, uploadID, parts)
+}
+
+func completeMultipartUploadWithClient(ctx context.Context, httpClient *http.Client, host, encodedPath string, creds S3Credentials, uploadID string, parts []s3CompletedPart) error {
 	query := url.Values{}
 	query.Set("uploadId", uploadID)
 	rawQuery := encodeS3Query(query)
@@ -594,17 +598,17 @@ func completeMultipartUpload(ctx context.Context, host, encodedPath string, cred
 	}
 	signS3Request(req, creds, payloadHash, now)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("complete multipart upload failed: %w", err)
 	}
 	defer resp.Body.Close()
 	respBody, err := io.ReadAll(resp.Body)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("complete multipart upload failed with status %d: %s", resp.StatusCode, sanitizeErrorBody(respBody))
-	}
 	if err != nil {
 		return fmt.Errorf("read complete multipart upload response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("complete multipart upload failed with status %d: %s", resp.StatusCode, sanitizeErrorBody(respBody))
 	}
 
 	decoder := xml.NewDecoder(bytes.NewReader(respBody))

--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -612,22 +612,32 @@ func completeMultipartUploadWithClient(ctx context.Context, httpClient *http.Cli
 	}
 
 	decoder := xml.NewDecoder(bytes.NewReader(respBody))
+	rootSeen := false
 	for {
 		token, decodeErr := decoder.Token()
 		if errors.Is(decodeErr, io.EOF) {
+			if !rootSeen {
+				return errors.New("parse complete multipart upload response: missing root element")
+			}
 			break
 		}
 		if decodeErr != nil {
 			return fmt.Errorf("parse complete multipart upload response: %w", decodeErr)
 		}
 		start, ok := token.(xml.StartElement)
-		if !ok {
+		if !ok || rootSeen {
 			continue
 		}
-		if start.Name.Local == "Error" {
+		rootSeen = true
+		switch start.Name.Local {
+		case "Error":
 			return fmt.Errorf("complete multipart upload failed: %s", sanitizeErrorBody(respBody))
+		case "CompleteMultipartUploadResult":
+			// Consume the complete document so truncated or malformed success
+			// responses cannot be mistaken for a completed upload.
+		default:
+			return fmt.Errorf("unexpected complete multipart upload response: %s", sanitizeErrorBody(respBody))
 		}
-		break
 	}
 	return nil
 }

--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -598,9 +599,31 @@ func completeMultipartUpload(ctx context.Context, host, encodedPath string, cred
 		return fmt.Errorf("complete multipart upload failed: %w", err)
 	}
 	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("complete multipart upload failed with status %d: %s", resp.StatusCode, sanitizeErrorBody(respBody))
+	}
+	if err != nil {
+		return fmt.Errorf("read complete multipart upload response: %w", err)
+	}
+
+	decoder := xml.NewDecoder(bytes.NewReader(respBody))
+	for {
+		token, decodeErr := decoder.Token()
+		if errors.Is(decodeErr, io.EOF) {
+			break
+		}
+		if decodeErr != nil {
+			return fmt.Errorf("parse complete multipart upload response: %w", decodeErr)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if start.Name.Local == "Error" {
+			return fmt.Errorf("complete multipart upload failed: %s", sanitizeErrorBody(respBody))
+		}
+		break
 	}
 	return nil
 }

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -552,6 +552,92 @@ func TestUploadToS3_Validation(t *testing.T) {
 	}
 }
 
+func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
+	const diagnosticLimit = 200
+	const omittedMarker = "OMITTED-DIAGNOSTIC-MARKER"
+
+	tests := []struct {
+		name      string
+		body      string
+		wantError bool
+	}{
+		{
+			name: "embedded error after keepalive whitespace and prolog",
+			body: " \r\n\t<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<Error><Code>InternalError</Code><Message>retry the upload</Message></Error>" +
+				"\x1b" + strings.Repeat("x", diagnosticLimit) + omittedMarker,
+			wantError: true,
+		},
+		{
+			name: "normal completion result",
+			body: "\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+				"<Bucket>example</Bucket><Key>archive.zip</Key><ETag>\"etag\"</ETag>" +
+				"</CompleteMultipartUploadResult>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalClient := http.DefaultClient
+			http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodPost {
+					t.Fatalf("method = %s, want POST", req.Method)
+				}
+				if req.URL.Path != "/archive.zip" {
+					t.Fatalf("path = %q, want /archive.zip", req.URL.Path)
+				}
+				if req.URL.Query().Get("uploadId") != "upload-123" {
+					t.Fatalf("uploadId = %q, want upload-123", req.URL.Query().Get("uploadId"))
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(tt.body)),
+					Request:    req,
+				}, nil
+			})}
+			t.Cleanup(func() { http.DefaultClient = originalClient })
+
+			err := completeMultipartUpload(
+				context.Background(),
+				"example.s3.us-west-2.amazonaws.com",
+				"/archive.zip",
+				S3Credentials{AccessKeyID: "key", SecretAccessKey: "secret"},
+				"upload-123",
+				[]s3CompletedPart{{PartNumber: 1, ETag: "\"etag\""}},
+			)
+			if !tt.wantError {
+				if err != nil {
+					t.Fatalf("completeMultipartUpload() error = %v, want nil", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("completeMultipartUpload() error = nil, want embedded S3 error")
+			}
+			const errorPrefix = "complete multipart upload failed: "
+			if !strings.HasPrefix(err.Error(), errorPrefix) {
+				t.Fatalf("error = %q, want prefix %q", err, errorPrefix)
+			}
+			diagnostic := strings.TrimPrefix(err.Error(), errorPrefix)
+			if !strings.Contains(diagnostic, "<Code>InternalError</Code>") || !strings.Contains(diagnostic, "<Message>retry the upload</Message>") {
+				t.Fatalf("diagnostic = %q, want S3 code and message", diagnostic)
+			}
+			if strings.Contains(diagnostic, "\x1b") {
+				t.Fatalf("diagnostic contains control character: %q", diagnostic)
+			}
+			if strings.Contains(diagnostic, omittedMarker) {
+				t.Fatalf("diagnostic contains content beyond limit: %q", diagnostic)
+			}
+			if len(diagnostic) > diagnosticLimit {
+				t.Fatalf("diagnostic length = %d, want <= %d", len(diagnostic), diagnosticLimit)
+			}
+		})
+	}
+}
+
 func TestEncodeS3Query(t *testing.T) {
 	values := url.Values{}
 	values.Set("uploads", "")

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -575,7 +575,7 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 			body: "\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 				"<CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
 				"<Bucket>example</Bucket><Key>archive.zip</Key><ETag>\"etag\"</ETag>" +
-				"</CompleteMultipartUploadResult>",
+				"</CompleteMultipartUploadResult>\n<!-- completed -->\n ",
 		},
 		{
 			name:            "unexpected response root",
@@ -586,6 +586,18 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 			name: "truncated completion result",
 			body: "<?xml version=\"1.0\"?>" +
 				"<CompleteMultipartUploadResult><Bucket>example</Bucket>",
+			wantErrorPrefix: "parse complete multipart upload response: ",
+		},
+		{
+			name: "second root after completion result",
+			body: "<CompleteMultipartUploadResult></CompleteMultipartUploadResult>" +
+				"<Error><Code>InternalError</Code></Error>",
+			wantErrorPrefix: "parse complete multipart upload response: ",
+		},
+		{
+			name: "non-whitespace data after completion result",
+			body: "<CompleteMultipartUploadResult></CompleteMultipartUploadResult>" +
+				"unexpected trailing data",
 			wantErrorPrefix: "parse complete multipart upload response: ",
 		},
 	}

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -579,8 +579,7 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			originalClient := http.DefaultClient
-			http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if req.Method != http.MethodPost {
 					t.Fatalf("method = %s, want POST", req.Method)
 				}
@@ -590,18 +589,18 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 				if req.URL.Query().Get("uploadId") != "upload-123" {
 					t.Fatalf("uploadId = %q, want upload-123", req.URL.Query().Get("uploadId"))
 				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Header:     make(http.Header),
-					Body:       io.NopCloser(strings.NewReader(tt.body)),
-					Request:    req,
-				}, nil
-			})}
-			t.Cleanup(func() { http.DefaultClient = originalClient })
+				mustWriteBody(t, w, tt.body)
+			}))
+			t.Cleanup(server.Close)
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("parse test server URL: %v", err)
+			}
 
-			err := completeMultipartUpload(
+			err = completeMultipartUploadWithClient(
 				context.Background(),
-				"example.s3.us-west-2.amazonaws.com",
+				server.Client(),
+				serverURL.Host,
 				"/archive.zip",
 				S3Credentials{AccessKeyID: "key", SecretAccessKey: "secret"},
 				"upload-123",
@@ -635,6 +634,32 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 				t.Fatalf("diagnostic length = %d, want <= %d", len(diagnostic), diagnosticLimit)
 			}
 		})
+	}
+}
+
+func TestCompleteMultipartUploadReportsPartialBodyReadError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "128")
+		w.WriteHeader(http.StatusBadGateway)
+		mustWriteBody(t, w, "<Error><Code>InternalError</Code>")
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+
+	err = completeMultipartUploadWithClient(
+		context.Background(),
+		server.Client(),
+		serverURL.Host,
+		"/archive.zip",
+		S3Credentials{AccessKeyID: "key", SecretAccessKey: "secret"},
+		"upload-123",
+		[]s3CompletedPart{{PartNumber: 1, ETag: "\"etag\""}},
+	)
+	if err == nil || !strings.Contains(err.Error(), "read complete multipart upload response") {
+		t.Fatalf("completeMultipartUpload() error = %v, want response read error", err)
 	}
 }
 

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -557,16 +557,18 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 	const omittedMarker = "OMITTED-DIAGNOSTIC-MARKER"
 
 	tests := []struct {
-		name      string
-		body      string
-		wantError bool
+		name            string
+		body            string
+		wantErrorPrefix string
+		checkDiagnostic bool
 	}{
 		{
 			name: "embedded error after keepalive whitespace and prolog",
 			body: " \r\n\t<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 				"<Error><Code>InternalError</Code><Message>retry the upload</Message></Error>" +
 				"\x1b" + strings.Repeat("x", diagnosticLimit) + omittedMarker,
-			wantError: true,
+			wantErrorPrefix: "complete multipart upload failed: ",
+			checkDiagnostic: true,
 		},
 		{
 			name: "normal completion result",
@@ -574,6 +576,17 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 				"<CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
 				"<Bucket>example</Bucket><Key>archive.zip</Key><ETag>\"etag\"</ETag>" +
 				"</CompleteMultipartUploadResult>",
+		},
+		{
+			name:            "unexpected response root",
+			body:            "<?xml version=\"1.0\"?><UnexpectedResult><Message>unknown</Message></UnexpectedResult>",
+			wantErrorPrefix: "unexpected complete multipart upload response: ",
+		},
+		{
+			name: "truncated completion result",
+			body: "<?xml version=\"1.0\"?>" +
+				"<CompleteMultipartUploadResult><Bucket>example</Bucket>",
+			wantErrorPrefix: "parse complete multipart upload response: ",
 		},
 	}
 
@@ -606,7 +619,7 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 				"upload-123",
 				[]s3CompletedPart{{PartNumber: 1, ETag: "\"etag\""}},
 			)
-			if !tt.wantError {
+			if tt.wantErrorPrefix == "" {
 				if err != nil {
 					t.Fatalf("completeMultipartUpload() error = %v, want nil", err)
 				}
@@ -614,12 +627,16 @@ func TestCompleteMultipartUploadClassifiesResponseBody(t *testing.T) {
 			}
 
 			if err == nil {
-				t.Fatal("completeMultipartUpload() error = nil, want embedded S3 error")
+				t.Fatal("completeMultipartUpload() error = nil, want response classification error")
 			}
+			if !strings.HasPrefix(err.Error(), tt.wantErrorPrefix) {
+				t.Fatalf("error = %q, want prefix %q", err, tt.wantErrorPrefix)
+			}
+			if !tt.checkDiagnostic {
+				return
+			}
+
 			const errorPrefix = "complete multipart upload failed: "
-			if !strings.HasPrefix(err.Error(), errorPrefix) {
-				t.Fatalf("error = %q, want prefix %q", err, errorPrefix)
-			}
 			diagnostic := strings.TrimPrefix(err.Error(), errorPrefix)
 			if !strings.Contains(diagnostic, "<Code>InternalError</Code>") || !strings.Contains(diagnostic, "<Message>retry the upload</Message>") {
 				t.Fatalf("diagnostic = %q, want S3 code and message", diagnostic)


### PR DESCRIPTION
## Summary

- inspect the XML body returned after multipart upload completion
- classify an Error document as failure even when the HTTP status is successful
- keep normal completion documents successful and bound diagnostics through the existing sanitizer

## Verification

- reproduced the false success with leading keepalive whitespace and an XML prolog
- covered the normal completion response as a control
- verified the request method, object path, upload ID, diagnostic sanitization, and diagnostic bound
- built the CLI at /tmp/asc and verified unchanged notarization submit help plus safe local validation
- passed focused ASC and notarization tests
- passed make format, make check-docs, make lint, and the full test suite

## Compatibility

No command, flag, help, output schema, or generic HTTP behavior changes. The existing false-success path now returns an error.

## Live verification

No live notarization or storage mutation was performed. The response behavior is covered deterministically with a local HTTP transport.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788921408&installation_model_id=10418&pr_number=1927&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1927&signature=249a33859c17686c7aed6c923a742f1174a7967931b957ccab2abadf778cade0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart upload completion error handling.
  * Detects service errors embedded in otherwise successful responses.
  * Validates response formats and reports malformed or unexpected responses.
  * Identifies incomplete, truncated, or extra response content.
  * Preserves useful diagnostic details while removing control characters and limiting message length.
  * Reports failures when response data cannot be read.
  * Provides more reliable feedback when uploads fail during completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->