### PR TITLE
Validate App Preview files before upload

### DIFF
--- a/internal/cli/assets/assets_previews.go
+++ b/internal/cli/assets/assets_previews.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"mime"
 	"os"
 	"path/filepath"
 	"sort"
@@ -79,8 +78,22 @@ Examples:
 	}
 }
 
+type previewUploadDependencies struct {
+	GetClient func() (*asc.Client, error)
+}
+
 // AssetsPreviewsUploadCommand returns the previews upload subcommand.
 func AssetsPreviewsUploadCommand() *ffcli.Command {
+	return assetsPreviewsUploadCommandWithDependencies(previewUploadDependencies{
+		GetClient: shared.GetASCClient,
+	})
+}
+
+func assetsPreviewsUploadCommandWithDependencies(deps previewUploadDependencies) *ffcli.Command {
+	if deps.GetClient == nil {
+		deps.GetClient = shared.GetASCClient
+	}
+
 	fs := flag.NewFlagSet("upload", flag.ExitOnError)
 
 	localizationID := fs.String("version-localization", "", "App Store version localization ID")
@@ -140,8 +153,11 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("video-previews upload: %w", err)
 			}
+			if err := validatePreviewFiles(files); err != nil {
+				return fmt.Errorf("video-previews upload: %w", err)
+			}
 
-			client, err := shared.GetASCClient()
+			client, err := deps.GetClient()
 			if err != nil {
 				return fmt.Errorf("video-previews upload: %w", err)
 			}
@@ -773,19 +789,36 @@ func detectPreviewMimeType(path string) (string, error) {
 	if ext == "" {
 		return "", fmt.Errorf("preview file %q is missing an extension", path)
 	}
-	mimeType := mime.TypeByExtension(ext)
-	if mimeType == "" {
-		return "", fmt.Errorf("unsupported preview file extension %q", ext)
+	switch ext {
+	case ".mov":
+		return "video/quicktime", nil
+	case ".m4v":
+		return "video/x-m4v", nil
+	case ".mp4":
+		return "video/mp4", nil
+	default:
+		return "", fmt.Errorf("unsupported preview file extension %q; supported extensions are .mov, .m4v, and .mp4", ext)
 	}
-	if idx := strings.Index(mimeType, ";"); idx > 0 {
-		mimeType = mimeType[:idx]
+}
+
+func validatePreviewFiles(files []string) error {
+	for _, filePath := range files {
+		if err := asc.ValidateImageFile(filePath); err != nil {
+			return err
+		}
+		if _, err := detectPreviewMimeType(filePath); err != nil {
+			return err
+		}
 	}
-	return mimeType, nil
+	return nil
 }
 
 func uploadPreviews(ctx context.Context, client *asc.Client, localizationID, previewType string, files []string, skipExisting, replace, dryRun bool) (asc.AppPreviewUploadResult, error) {
 	if client == nil {
 		return asc.AppPreviewUploadResult{}, fmt.Errorf("client is required")
+	}
+	if err := validatePreviewFiles(files); err != nil {
+		return asc.AppPreviewUploadResult{}, err
 	}
 
 	requestCtx, reqCancel := shared.ContextWithTimeout(ctx)

--- a/internal/cli/assets/assets_previews_test.go
+++ b/internal/cli/assets/assets_previews_test.go
@@ -5,8 +5,13 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestAssetsPreviewsUploadCommandRejectsSkipExistingWithReplace(t *testing.T) {
@@ -35,6 +40,136 @@ func TestAssetsPreviewsUploadCommandRejectsSkipExistingWithReplace(t *testing.T)
 	}
 	if !strings.Contains(stderr, "--skip-existing and --replace are mutually exclusive") {
 		t.Fatalf("expected mutually exclusive error in stderr, got %q", stderr)
+	}
+}
+
+func TestAssetsPreviewsUploadCommandRejectsUnsupportedFileBeforeAuth(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a-preview.mov", "b-poster.png"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("not-empty"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	clientCalled := false
+	cmd := assetsPreviewsUploadCommandWithDependencies(previewUploadDependencies{
+		GetClient: func() (*asc.Client, error) {
+			clientCalled = true
+			return &asc.Client{}, nil
+		},
+	})
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--version-localization", "LOC_ID",
+		"--path", dir,
+		"--device-type", "IPHONE_65",
+		"--replace",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), cmd.FlagSet.Args())
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if runErr == nil {
+		t.Fatal("expected unsupported preview file error")
+	}
+	if !strings.Contains(runErr.Error(), `unsupported preview file extension ".png"`) {
+		t.Fatalf("expected local file-type error before auth, got %v", runErr)
+	}
+	if clientCalled {
+		t.Fatal("expected preview file validation before auth/client creation")
+	}
+}
+
+func TestDetectPreviewMimeTypeRejectsRegisteredNonVideoMIME(t *testing.T) {
+	_, err := detectPreviewMimeType("poster.png")
+	if err == nil {
+		t.Fatal("expected unsupported preview file error")
+	}
+	if !strings.Contains(err.Error(), `unsupported preview file extension ".png"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDetectPreviewMimeTypeUsesSupportedVideoMapping(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "preview.mov", want: "video/quicktime"},
+		{path: "preview.m4v", want: "video/x-m4v"},
+		{path: "preview.MP4", want: "video/mp4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got, err := detectPreviewMimeType(tt.path)
+			if err != nil {
+				t.Fatalf("detectPreviewMimeType(%q) error: %v", tt.path, err)
+			}
+			if got != tt.want {
+				t.Fatalf("detectPreviewMimeType(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUploadPreviewsRejectsUnsupportedFileBeforeRequests(t *testing.T) {
+	tests := []struct {
+		name    string
+		replace bool
+		dryRun  bool
+	}{
+		{name: "replace", replace: true},
+		{name: "dry run", dryRun: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "poster.png")
+			if err := os.WriteFile(filePath, []byte("not-empty"), 0o600); err != nil {
+				t.Fatalf("write invalid preview: %v", err)
+			}
+
+			requests := 0
+			deleteRequests := 0
+			client := newAssetsUploadTestServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if r.Method == http.MethodDelete {
+					deleteRequests++
+				}
+				writeAssetsTestJSON(w, http.StatusInternalServerError, `{"errors":[{"status":"500","detail":"unexpected request"}]}`)
+			}))
+
+			_, err := uploadPreviews(
+				context.Background(),
+				client,
+				"LOC_ID",
+				"IPHONE_65",
+				[]string{filePath},
+				false,
+				tt.replace,
+				tt.dryRun,
+			)
+			if err == nil {
+				t.Fatal("expected unsupported preview file error")
+			}
+			if !strings.Contains(err.Error(), `unsupported preview file extension ".png"`) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if requests != 0 {
+				t.Fatalf("requests = %d, want 0", requests)
+			}
+			if deleteRequests != 0 {
+				t.Fatalf("DELETE requests = %d, want 0", deleteRequests)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- restrict App Preview uploads to the supported .mov, .m4v, and .mp4 extensions with deterministic MIME values
- validate every collected file before authentication or App Store Connect requests
- reject invalid files in replace and dry-run modes before any lookup, creation, deletion, or upload

## Behavior

Valid App Preview files keep the existing command, flags, output shape, and upload flow. A missing or unsupported extension now fails locally with the supported extensions in the error. The extension check is case-insensitive.

This follows Apple's current App Preview specification: https://developer.apple.com/help/app-store-connect/reference/app-information/app-preview-specifications

## Verification

- focused RED-to-GREEN tests for the MIME mapping and registered non-video types
- command coverage proving all directory inputs are checked before client construction
- HTTP coverage proving replace and dry-run perform zero requests and zero deletes for invalid files
- built-binary checks: exit 1, empty stdout, local error on stderr without credentials
- read-only preview listing against the disposable app; no Apple state changed
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788923379&installation_model_id=10418&pr_number=1929&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1929&signature=9c96e90ecf0831d5c73efadc926a64b51d60a4cc1279748754430471932196d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview uploads now recognize `.mov`, `.m4v`, and `.mp4` video files.
  * Unsupported file types are rejected before upload activity begins.
  * Upload validation is consistently applied to all selected files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->