### PR TITLE
Validate migration localizations before network requests

### DIFF
--- a/internal/cli/cmdtest/localizations_update_test.go
+++ b/internal/cli/cmdtest/localizations_update_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 type locUpdateRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -225,6 +227,54 @@ func TestLocalizationsUpdate_RejectsRawKeywordCharactersIncludingTrailingSpaceBe
 	}
 	if requestCount != 0 {
 		t.Fatalf("expected no HTTP requests, got %d", requestCount)
+	}
+}
+
+func TestLocalizationsUpdate_RejectsInvalidVersionFieldsBeforeClientCreation(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		value   string
+		wantErr string
+	}{
+		{name: "description", flag: "--description", value: strings.Repeat("d", 4001), wantErr: "description exceeds 4000 characters"},
+		{name: "keywords", flag: "--keywords", value: strings.Repeat("k", 101), wantErr: "keywords exceed 100 characters"},
+		{name: "whats new", flag: "--whats-new", value: strings.Repeat("w", 4001), wantErr: "whatsNew exceeds 4000 characters"},
+		{name: "promotional text", flag: "--promotional-text", value: strings.Repeat("p", 171), wantErr: "promotionalText exceeds 170 characters"},
+		{name: "support URL", flag: "--support-url", value: "relative/support", wantErr: "supportUrl must be a valid URI"},
+		{name: "marketing URL", flag: "--marketing-url", value: "relative/marketing", wantErr: "marketingUrl must be a valid URI"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientCalls++
+				return nil, errors.New("client should not be created")
+			}))
+
+			stdout, stderr := captureOutput(t, func() {
+				code := cmd.Run([]string{
+					"localizations", "update",
+					"--version", "ver-1",
+					"--locale", "en-US",
+					test.flag, test.value,
+				}, "1.2.3")
+				if code != cmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+			if clientCalls != 0 {
+				t.Fatalf("expected no client creation, got %d", clientCalls)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -361,6 +361,25 @@ func TestMigrateImportPreflightsWouldCreateAppInfoLocalesBeforeMutations(t *test
 	api.assertComplete(t, 0)
 }
 
+func TestMigrateImportPreflightsWouldCreateScreenshotLocalesBeforeMutations(t *testing.T) {
+	root := writeMigrateImportMetadata(t, map[string]map[string]string{
+		"en-US": {"description.txt": "English description"},
+	})
+	screenshotsDir := filepath.Join(root, "screenshots", "nl")
+	if err := os.MkdirAll(screenshotsDir, 0o755); err != nil {
+		t.Fatalf("mkdir screenshots: %v", err)
+	}
+	writePNGForMigrate(t, filepath.Join(screenshotsDir, "iphone_65_screen.png"), 1242, 2688)
+
+	planning := migrateImportPlanningExpectations(`{"data":[]}`)
+	api := newMigrateImportAPI(t, planning[:2]...)
+
+	stdout, stderr, runErr := runMigrateImportWithOptions(t, root)
+	const wantError = `migrate import: locale "nl": unsupported locale "nl"; did you mean: nl-NL`
+	assertMigrateImportError(t, stdout, stderr, runErr, wantError)
+	api.assertComplete(t, 0)
+}
+
 func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T) {
 	root := writeMigrateImportMetadata(t, validMigrateAppInfoMetadata())
 	expectations := append(migrateImportPlanningExpectations(
@@ -549,19 +568,26 @@ func writeMigrateImportMetadata(t *testing.T, localeFiles map[string]map[string]
 
 func runMigrateImport(t *testing.T, root string) (string, string, error) {
 	t.Helper()
+	return runMigrateImportWithOptions(t, root, "--skip-screenshots")
+}
+
+func runMigrateImportWithOptions(t *testing.T, root string, options ...string) (string, string, error) {
+	t.Helper()
 	rootCmd := RootCommand("1.2.3")
 	rootCmd.FlagSet.SetOutput(io.Discard)
 
+	args := []string{
+		"migrate", "import",
+		"--app", "APP_ID",
+		"--version-id", "VERSION_ID",
+		"--fastlane-dir", root,
+		"--confirm",
+	}
+	args = append(args, options...)
+
 	var runErr error
 	stdout, stderr := captureOutput(t, func() {
-		if err := rootCmd.Parse([]string{
-			"migrate", "import",
-			"--app", "APP_ID",
-			"--version-id", "VERSION_ID",
-			"--fastlane-dir", root,
-			"--confirm",
-			"--skip-screenshots",
-		}); err != nil {
+		if err := rootCmd.Parse(args); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		runErr = rootCmd.Run(context.Background())

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -380,6 +380,68 @@ func TestMigrateImportPreflightsWouldCreateScreenshotLocalesBeforeMutations(t *t
 	api.assertComplete(t, 0)
 }
 
+func TestMigrateImportAllowsVersionLocalizationUpdatesFromLaterPages(t *testing.T) {
+	root := writeMigrateImportMetadata(t, map[string]map[string]string{
+		"en-US": {"description.txt": "English description"},
+		"ja": {
+			"description.txt":   "Japanese description",
+			"release_notes.txt": "Japanese release notes",
+		},
+	})
+	expectations := []migrateImportExpectation{
+		{
+			method:   http.MethodGet,
+			path:     "/v1/appStoreVersions/VERSION_ID",
+			response: `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`,
+		},
+		{
+			method:   http.MethodGet,
+			path:     "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations",
+			response: `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations?cursor=page-2&limit=200"}}`,
+		},
+		{
+			method:               http.MethodGet,
+			path:                 "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations",
+			rawQuery:             "cursor=page-2&limit=200",
+			requireAuthorization: true,
+			response:             `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}],"links":{"next":""}}`,
+		},
+		{
+			method:   http.MethodPatch,
+			path:     "/v1/appStoreVersionLocalizations/loc-en",
+			body:     `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"description":"English description"}}}`,
+			response: `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}}}`,
+		},
+		{
+			method: http.MethodPatch,
+			path:   "/v1/appStoreVersionLocalizations/loc-ja",
+			body: `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{` +
+				`"description":"Japanese description","whatsNew":"Japanese release notes"}}}`,
+			response: `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}}`,
+		},
+	}
+	api := newMigrateImportAPI(t, expectations...)
+
+	stdout, stderr, runErr := runMigrateImport(t, root)
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result migrate.MigrateImportResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Uploaded) != 2 || result.Uploaded[1].Action != "update" || result.Uploaded[1].LocalizationID != "loc-ja" {
+		t.Fatalf("unexpected version localization uploads: %#v", result.Uploaded)
+	}
+	if got := api.queries[1]; got != "limit=200" {
+		t.Fatalf("first version localization query = %q, want %q", got, "limit=200")
+	}
+	api.assertComplete(t, 2)
+}
+
 func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesFromLaterPages(t *testing.T) {
 	root := writeMigrateImportMetadata(t, validMigrateAppInfoMetadata())
 	expectations := append(migrateImportPlanningExpectations(

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -3,12 +3,15 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"image/png"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -17,6 +20,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/migrate"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
@@ -232,7 +236,7 @@ func TestMigrateImportDryRunSupportsIPhone69AliasAsAppIPhone67(t *testing.T) {
 	}
 }
 
-func TestMigrateImportValidatesEveryLocalizationBeforeRequests(t *testing.T) {
+func TestMigrateImportRejectsLocalValidationBeforeClientCreation(t *testing.T) {
 	tests := []struct {
 		name      string
 		file      string
@@ -275,332 +279,80 @@ func TestMigrateImportValidatesEveryLocalizationBeforeRequests(t *testing.T) {
 			value:     "://invalid",
 			wantError: `migrate import: locale "ja": supportUrl must be a valid URI`,
 		},
+		{
+			name:      "app name length",
+			file:      "name.txt",
+			value:     strings.Repeat("n", validation.LimitName+1),
+			wantError: `migrate import: locale "ja": name exceeds 30 characters`,
+		},
+		{
+			name:      "app subtitle length",
+			file:      "subtitle.txt",
+			value:     strings.Repeat("s", validation.LimitSubtitle+1),
+			wantError: `migrate import: locale "ja": subtitle exceeds 30 characters`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			setupAuth(t)
-			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-
-			root := t.TempDir()
-			metadataDir := filepath.Join(root, "metadata")
-			for _, locale := range []string{"en-US", "ja"} {
-				if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
-					t.Fatalf("mkdir metadata locale %s: %v", locale, err)
-				}
-			}
-			writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
-			writeFile(t, filepath.Join(metadataDir, "ja", test.file), test.value)
-
-			originalTransport := http.DefaultTransport
-			t.Cleanup(func() {
-				http.DefaultTransport = originalTransport
+			root := writeMigrateImportMetadata(t, map[string]map[string]string{
+				"en-US": {"description.txt": "English description"},
+				"ja":    {test.file: test.value},
 			})
 
-			requestCount := 0
-			mutationCount := 0
-			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				requestCount++
-				if req.Method == http.MethodPost || req.Method == http.MethodPatch || req.Method == http.MethodDelete {
-					mutationCount++
-				}
-				switch {
-				case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
-					return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
-				case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
-					return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
-				case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-en":
-					return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US","description":"English description"}}}`), nil
-				default:
-					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-				}
+			factoryCalls := 0
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				factoryCalls++
+				return nil, errors.New("client factory must not run before local validation")
 			})
+			t.Cleanup(restore)
 
-			rootCmd := RootCommand("1.2.3")
-			rootCmd.FlagSet.SetOutput(io.Discard)
-
-			var runErr error
-			stdout, stderr := captureOutput(t, func() {
-				if err := rootCmd.Parse([]string{
-					"migrate", "import",
-					"--app", "APP_ID",
-					"--version-id", "VERSION_ID",
-					"--fastlane-dir", root,
-					"--confirm",
-					"--skip-screenshots",
-				}); err != nil {
-					t.Fatalf("parse error: %v", err)
-				}
-				runErr = rootCmd.Run(context.Background())
-			})
-
-			if runErr == nil {
-				t.Fatal("expected localization validation error")
-			}
-			if runErr.Error() != test.wantError {
-				t.Fatalf("run error = %q, want %q", runErr, test.wantError)
-			}
-			if stdout != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout)
-			}
-			if stderr != "" {
-				t.Fatalf("expected empty stderr, got %q", stderr)
-			}
-			if requestCount != 0 {
-				t.Fatalf("expected no HTTP requests, got %d", requestCount)
-			}
-			if mutationCount != 0 {
-				t.Fatalf("expected no localization mutations, got %d", mutationCount)
+			stdout, stderr, runErr := runMigrateImport(t, root)
+			assertMigrateImportError(t, stdout, stderr, runErr, test.wantError)
+			if factoryCalls != 0 {
+				t.Fatalf("client factory calls = %d, want zero", factoryCalls)
 			}
 		})
 	}
 }
 
 func TestMigrateImportPreflightsAppInfoCreatesBeforeMutations(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	root := writeMigrateImportMetadata(t, validMigrateAppInfoMetadata())
+	api := newMigrateImportAPI(t, migrateImportPlanningExpectations(`{"data":[]}`)...)
 
-	root := t.TempDir()
-	metadataDir := filepath.Join(root, "metadata")
-	for _, locale := range []string{"en-US", "ja"} {
-		if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
-			t.Fatalf("mkdir metadata locale %s: %v", locale, err)
-		}
-	}
-	writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
-	writeFile(t, filepath.Join(metadataDir, "ja", "description.txt"), "Japanese description")
-	writeFile(t, filepath.Join(metadataDir, "ja", "subtitle.txt"), "Japanese subtitle")
-
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	var requests []string
-	mutationCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.Path)
-		if req.Method == http.MethodPost || req.Method == http.MethodPatch || req.Method == http.MethodDelete {
-			mutationCount++
-		}
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
-			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
-			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_ID/appInfos":
-			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
-			return migrateJSONResponse(http.StatusOK, `{"data":[]}`), nil
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-		}
-	})
-
-	rootCmd := RootCommand("1.2.3")
-	rootCmd.FlagSet.SetOutput(io.Discard)
-
-	var runErr error
-	stdout, stderr := captureOutput(t, func() {
-		if err := rootCmd.Parse([]string{
-			"migrate", "import",
-			"--app", "APP_ID",
-			"--version-id", "VERSION_ID",
-			"--fastlane-dir", root,
-			"--confirm",
-			"--skip-screenshots",
-		}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		runErr = rootCmd.Run(context.Background())
-	})
-
-	if runErr == nil {
-		t.Fatal("expected app info localization validation error")
-	}
+	stdout, stderr, runErr := runMigrateImport(t, root)
 	const wantError = `migrate import: locale "ja": name is required when creating app info localization`
-	if runErr.Error() != wantError {
-		t.Fatalf("run error = %q, want %q", runErr, wantError)
-	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
-	}
-	if mutationCount != 0 {
-		t.Fatalf("expected no mutations, got %d (%v)", mutationCount, requests)
-	}
-	wantRequests := []string{
-		"GET /v1/appStoreVersions/VERSION_ID",
-		"GET /v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations",
-		"GET /v1/apps/APP_ID/appInfos",
-		"GET /v1/appInfos/appinfo-1/appInfoLocalizations",
-	}
-	if !slices.Equal(requests, wantRequests) {
-		t.Fatalf("requests = %v, want %v", requests, wantRequests)
-	}
-}
-
-func TestMigrateImportPreflightsAppInfoLengthsBeforeMutations(t *testing.T) {
-	tests := []struct {
-		name      string
-		fileName  string
-		value     string
-		wantError string
-	}{
-		{
-			name:      "name",
-			fileName:  "name.txt",
-			value:     strings.Repeat("n", validation.LimitName+1),
-			wantError: `migrate import: locale "ja": name exceeds 30 characters`,
-		},
-		{
-			name:      "subtitle",
-			fileName:  "subtitle.txt",
-			value:     strings.Repeat("s", validation.LimitSubtitle+1),
-			wantError: `migrate import: locale "ja": subtitle exceeds 30 characters`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setupAuth(t)
-			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-
-			root := t.TempDir()
-			metadataDir := filepath.Join(root, "metadata")
-			for _, locale := range []string{"en-US", "ja"} {
-				if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
-					t.Fatalf("mkdir metadata locale %s: %v", locale, err)
-				}
-			}
-			writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
-			writeFile(t, filepath.Join(metadataDir, "ja", "description.txt"), "Japanese description")
-			writeFile(t, filepath.Join(metadataDir, "ja", tt.fileName), tt.value)
-
-			originalTransport := http.DefaultTransport
-			t.Cleanup(func() {
-				http.DefaultTransport = originalTransport
-			})
-
-			var requests []string
-			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				requests = append(requests, req.Method+" "+req.URL.Path)
-				return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-			})
-
-			rootCmd := RootCommand("1.2.3")
-			rootCmd.FlagSet.SetOutput(io.Discard)
-
-			var runErr error
-			stdout, stderr := captureOutput(t, func() {
-				if err := rootCmd.Parse([]string{
-					"migrate", "import",
-					"--app", "APP_ID",
-					"--version-id", "VERSION_ID",
-					"--fastlane-dir", root,
-					"--confirm",
-					"--skip-screenshots",
-				}); err != nil {
-					t.Fatalf("parse error: %v", err)
-				}
-				runErr = rootCmd.Run(context.Background())
-			})
-
-			if runErr == nil {
-				t.Fatal("expected app info localization validation error")
-			}
-			if runErr.Error() != tt.wantError {
-				t.Fatalf("run error = %q, want %q", runErr, tt.wantError)
-			}
-			if stdout != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout)
-			}
-			if stderr != "" {
-				t.Fatalf("expected empty stderr, got %q", stderr)
-			}
-			if len(requests) != 0 {
-				t.Fatalf("expected no HTTP requests, got %v", requests)
-			}
-		})
-	}
+	assertMigrateImportError(t, stdout, stderr, runErr, wantError)
+	api.assertComplete(t, 0)
 }
 
 func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	root := writeMigrateImportMetadata(t, validMigrateAppInfoMetadata())
+	expectations := append(migrateImportPlanningExpectations(
+		`{"data":[{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja"}}]}`,
+	), []migrateImportExpectation{
+		{
+			method:   http.MethodPatch,
+			path:     "/v1/appStoreVersionLocalizations/loc-en",
+			body:     `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"description":"English description"}}}`,
+			response: `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}}}`,
+		},
+		{
+			method:   http.MethodPatch,
+			path:     "/v1/appStoreVersionLocalizations/loc-ja",
+			body:     `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"description":"Japanese description"}}}`,
+			response: `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}}`,
+		},
+		{
+			method:   http.MethodPatch,
+			path:     "/v1/appInfoLocalizations/appinfo-loc-ja",
+			body:     `{"data":{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"subtitle":"Japanese subtitle"}}}`,
+			response: `{"data":{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja","subtitle":"Japanese subtitle"}}}`,
+		},
+	}...)
+	api := newMigrateImportAPI(t, expectations...)
 
-	root := t.TempDir()
-	metadataDir := filepath.Join(root, "metadata")
-	for _, locale := range []string{"en-US", "ja"} {
-		if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
-			t.Fatalf("mkdir metadata locale %s: %v", locale, err)
-		}
-	}
-	writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
-	writeFile(t, filepath.Join(metadataDir, "ja", "description.txt"), "Japanese description")
-	writeFile(t, filepath.Join(metadataDir, "ja", "subtitle.txt"), "Japanese subtitle")
-
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	var requests []string
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.Path)
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
-			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
-			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_ID/appInfos":
-			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
-			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja"}}]}`), nil
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-en":
-			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}}}`), nil
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-ja":
-			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}}`), nil
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/appinfo-loc-ja":
-			body, err := io.ReadAll(req.Body)
-			if err != nil {
-				t.Fatalf("read app info update body: %v", err)
-			}
-			var payload asc.AppInfoLocalizationUpdateRequest
-			if err := json.Unmarshal(body, &payload); err != nil {
-				t.Fatalf("unmarshal app info update body: %v", err)
-			}
-			if payload.Data.Attributes.Subtitle != "Japanese subtitle" {
-				t.Fatalf("subtitle = %q, want Japanese subtitle", payload.Data.Attributes.Subtitle)
-			}
-			if payload.Data.Attributes.Name != "" || payload.Data.Attributes.Locale != "" {
-				t.Fatalf("unexpected name/locale in update: %#v", payload.Data.Attributes)
-			}
-			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja","subtitle":"Japanese subtitle"}}}`), nil
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-		}
-	})
-
-	rootCmd := RootCommand("1.2.3")
-	rootCmd.FlagSet.SetOutput(io.Discard)
-
-	var runErr error
-	stdout, stderr := captureOutput(t, func() {
-		if err := rootCmd.Parse([]string{
-			"migrate", "import",
-			"--app", "APP_ID",
-			"--version-id", "VERSION_ID",
-			"--fastlane-dir", root,
-			"--confirm",
-			"--skip-screenshots",
-		}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		runErr = rootCmd.Run(context.Background())
-	})
+	stdout, stderr, runErr := runMigrateImport(t, root)
 	if runErr != nil {
 		t.Fatalf("run error: %v", runErr)
 	}
@@ -615,18 +367,186 @@ func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T
 	if len(result.AppInfoUploaded) != 1 || result.AppInfoUploaded[0].Action != "update" || result.AppInfoUploaded[0].LocalizationID != "appinfo-loc-ja" {
 		t.Fatalf("unexpected app info upload result: %#v", result.AppInfoUploaded)
 	}
+	api.assertComplete(t, 3)
+}
 
-	wantRequests := []string{
-		"GET /v1/appStoreVersions/VERSION_ID",
-		"GET /v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations",
-		"GET /v1/apps/APP_ID/appInfos",
-		"GET /v1/appInfos/appinfo-1/appInfoLocalizations",
-		"PATCH /v1/appStoreVersionLocalizations/loc-en",
-		"PATCH /v1/appStoreVersionLocalizations/loc-ja",
-		"PATCH /v1/appInfoLocalizations/appinfo-loc-ja",
+type migrateImportExpectation struct {
+	method   string
+	path     string
+	body     string
+	response string
+}
+
+type migrateImportAPI struct {
+	expectations []migrateImportExpectation
+	requests     []string
+	mutations    int
+	factoryCalls int
+}
+
+func newMigrateImportAPI(t *testing.T, expectations ...migrateImportExpectation) *migrateImportAPI {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	api := &migrateImportAPI{expectations: expectations}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestLabel := req.Method + " " + req.URL.Path
+		api.requests = append(api.requests, requestLabel)
+		if req.Method == http.MethodPost || req.Method == http.MethodPatch || req.Method == http.MethodDelete {
+			api.mutations++
+		}
+
+		index := len(api.requests) - 1
+		if index >= len(api.expectations) {
+			t.Errorf("unexpected request %d: %s", index+1, requestLabel)
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		expected := api.expectations[index]
+		if req.Method != expected.method || req.URL.Path != expected.path {
+			t.Errorf("request %d = %s, want %s %s", index+1, requestLabel, expected.method, expected.path)
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		if expected.body != "" {
+			assertJSONDocument(t, req.Body, expected.body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, expected.response)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse migrate import test server URL: %v", err)
 	}
-	if !slices.Equal(requests, wantRequests) {
-		t.Fatalf("requests = %v, want %v", requests, wantRequests)
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create migrate import test client: %v", err)
+	}
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		api.factoryCalls++
+		return client, nil
+	})
+	t.Cleanup(restore)
+	return api
+}
+
+func (api *migrateImportAPI) assertComplete(t *testing.T, wantMutations int) {
+	t.Helper()
+	wantRequests := make([]string, 0, len(api.expectations))
+	for _, expected := range api.expectations {
+		wantRequests = append(wantRequests, expected.method+" "+expected.path)
+	}
+	if !slices.Equal(api.requests, wantRequests) {
+		t.Fatalf("requests = %v, want %v", api.requests, wantRequests)
+	}
+	if api.mutations != wantMutations {
+		t.Fatalf("mutations = %d, want %d", api.mutations, wantMutations)
+	}
+	if api.factoryCalls != 1 {
+		t.Fatalf("client factory calls = %d, want 1", api.factoryCalls)
+	}
+}
+
+func migrateImportPlanningExpectations(appInfoLocalizations string) []migrateImportExpectation {
+	return []migrateImportExpectation{
+		{
+			method:   http.MethodGet,
+			path:     "/v1/appStoreVersions/VERSION_ID",
+			response: `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`,
+		},
+		{
+			method:   http.MethodGet,
+			path:     "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations",
+			response: `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`,
+		},
+		{
+			method:   http.MethodGet,
+			path:     "/v1/apps/APP_ID/appInfos",
+			response: `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`,
+		},
+		{
+			method:   http.MethodGet,
+			path:     "/v1/appInfos/appinfo-1/appInfoLocalizations",
+			response: appInfoLocalizations,
+		},
+	}
+}
+
+func validMigrateAppInfoMetadata() map[string]map[string]string {
+	return map[string]map[string]string{
+		"en-US": {"description.txt": "English description"},
+		"ja": {
+			"description.txt": "Japanese description",
+			"subtitle.txt":    "Japanese subtitle",
+		},
+	}
+}
+
+func writeMigrateImportMetadata(t *testing.T, localeFiles map[string]map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for locale, files := range localeFiles {
+		localeDir := filepath.Join(root, "metadata", locale)
+		if err := os.MkdirAll(localeDir, 0o755); err != nil {
+			t.Fatalf("mkdir metadata locale %s: %v", locale, err)
+		}
+		for file, value := range files {
+			writeFile(t, filepath.Join(localeDir, file), value)
+		}
+	}
+	return root
+}
+
+func runMigrateImport(t *testing.T, root string) (string, string, error) {
+	t.Helper()
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", root,
+			"--confirm",
+			"--skip-screenshots",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = rootCmd.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func assertMigrateImportError(t *testing.T, stdout, stderr string, runErr error, wantError string) {
+	t.Helper()
+	if runErr == nil {
+		t.Fatal("expected migrate import error")
+	}
+	if runErr.Error() != wantError {
+		t.Fatalf("run error = %q, want %q", runErr, wantError)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -230,6 +230,81 @@ func TestMigrateImportDryRunSupportsIPhone69AliasAsAppIPhone67(t *testing.T) {
 	}
 }
 
+func TestMigrateImportValidatesEveryLocalizationBeforeRequests(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	root := t.TempDir()
+	metadataDir := filepath.Join(root, "metadata")
+	for _, locale := range []string{"en-US", "ja"} {
+		if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
+			t.Fatalf("mkdir metadata locale %s: %v", locale, err)
+		}
+	}
+	writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
+	writeFile(t, filepath.Join(metadataDir, "ja", "keywords.txt"), strings.Repeat("語", 101))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requestCount := 0
+	mutationCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-en":
+			mutationCount++
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US","description":"English description"}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", root,
+			"--confirm",
+			"--skip-screenshots",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = rootCmd.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected localization validation error")
+	}
+	const wantError = `migrate import: locale "ja": keywords exceed 100 characters`
+	if runErr.Error() != wantError {
+		t.Fatalf("run error = %q, want %q", runErr, wantError)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 0 {
+		t.Fatalf("expected no HTTP requests, got %d", requestCount)
+	}
+	if mutationCount != 0 {
+		t.Fatalf("expected no localization mutations, got %d", mutationCount)
+	}
+}
+
 func TestMigrateImportUploadsAndSkipsExistingScreenshots(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/migrate"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 func TestMigrateImportDryRunPlan(t *testing.T) {
@@ -231,77 +232,126 @@ func TestMigrateImportDryRunSupportsIPhone69AliasAsAppIPhone67(t *testing.T) {
 }
 
 func TestMigrateImportValidatesEveryLocalizationBeforeRequests(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-
-	root := t.TempDir()
-	metadataDir := filepath.Join(root, "metadata")
-	for _, locale := range []string{"en-US", "ja"} {
-		if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
-			t.Fatalf("mkdir metadata locale %s: %v", locale, err)
-		}
+	tests := []struct {
+		name      string
+		file      string
+		value     string
+		wantError string
+	}{
+		{
+			name:      "description length",
+			file:      "description.txt",
+			value:     strings.Repeat("d", validation.LimitDescription+1),
+			wantError: `migrate import: locale "ja": description exceeds 4000 characters`,
+		},
+		{
+			name:      "keyword length",
+			file:      "keywords.txt",
+			value:     strings.Repeat("語", validation.LimitKeywords+1),
+			wantError: `migrate import: locale "ja": keywords exceed 100 characters`,
+		},
+		{
+			name:      "whats new length",
+			file:      "release_notes.txt",
+			value:     strings.Repeat("n", validation.LimitWhatsNew+1),
+			wantError: `migrate import: locale "ja": whatsNew exceeds 4000 characters`,
+		},
+		{
+			name:      "promotional text length",
+			file:      "promotional_text.txt",
+			value:     strings.Repeat("p", validation.LimitPromotionalText+1),
+			wantError: `migrate import: locale "ja": promotionalText exceeds 170 characters`,
+		},
+		{
+			name:      "marketing URI",
+			file:      "marketing_url.txt",
+			value:     "://invalid",
+			wantError: `migrate import: locale "ja": marketingUrl must be a valid URI`,
+		},
+		{
+			name:      "support URI",
+			file:      "support_url.txt",
+			value:     "://invalid",
+			wantError: `migrate import: locale "ja": supportUrl must be a valid URI`,
+		},
 	}
-	writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
-	writeFile(t, filepath.Join(metadataDir, "ja", "keywords.txt"), strings.Repeat("語", 101))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	requestCount := 0
-	mutationCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requestCount++
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
-			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
-			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-en":
-			mutationCount++
-			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US","description":"English description"}}}`), nil
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-		}
-	})
+			root := t.TempDir()
+			metadataDir := filepath.Join(root, "metadata")
+			for _, locale := range []string{"en-US", "ja"} {
+				if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
+					t.Fatalf("mkdir metadata locale %s: %v", locale, err)
+				}
+			}
+			writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
+			writeFile(t, filepath.Join(metadataDir, "ja", test.file), test.value)
 
-	rootCmd := RootCommand("1.2.3")
-	rootCmd.FlagSet.SetOutput(io.Discard)
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() {
+				http.DefaultTransport = originalTransport
+			})
 
-	var runErr error
-	stdout, stderr := captureOutput(t, func() {
-		if err := rootCmd.Parse([]string{
-			"migrate", "import",
-			"--app", "APP_ID",
-			"--version-id", "VERSION_ID",
-			"--fastlane-dir", root,
-			"--confirm",
-			"--skip-screenshots",
-		}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		runErr = rootCmd.Run(context.Background())
-	})
+			requestCount := 0
+			mutationCount := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requestCount++
+				if req.Method == http.MethodPost || req.Method == http.MethodPatch || req.Method == http.MethodDelete {
+					mutationCount++
+				}
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
+					return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
+					return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
+				case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-en":
+					return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US","description":"English description"}}}`), nil
+				default:
+					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+			})
 
-	if runErr == nil {
-		t.Fatal("expected localization validation error")
-	}
-	const wantError = `migrate import: locale "ja": keywords exceed 100 characters`
-	if runErr.Error() != wantError {
-		t.Fatalf("run error = %q, want %q", runErr, wantError)
-	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
-	}
-	if requestCount != 0 {
-		t.Fatalf("expected no HTTP requests, got %d", requestCount)
-	}
-	if mutationCount != 0 {
-		t.Fatalf("expected no localization mutations, got %d", mutationCount)
+			rootCmd := RootCommand("1.2.3")
+			rootCmd.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := rootCmd.Parse([]string{
+					"migrate", "import",
+					"--app", "APP_ID",
+					"--version-id", "VERSION_ID",
+					"--fastlane-dir", root,
+					"--confirm",
+					"--skip-screenshots",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = rootCmd.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected localization validation error")
+			}
+			if runErr.Error() != test.wantError {
+				t.Fatalf("run error = %q, want %q", runErr, test.wantError)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if requestCount != 0 {
+				t.Fatalf("expected no HTTP requests, got %d", requestCount)
+			}
+			if mutationCount != 0 {
+				t.Fatalf("expected no localization mutations, got %d", mutationCount)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -380,11 +380,18 @@ func TestMigrateImportPreflightsWouldCreateScreenshotLocalesBeforeMutations(t *t
 	api.assertComplete(t, 0)
 }
 
-func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T) {
+func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesFromLaterPages(t *testing.T) {
 	root := writeMigrateImportMetadata(t, validMigrateAppInfoMetadata())
 	expectations := append(migrateImportPlanningExpectations(
-		`{"data":[{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja"}}]}`,
+		`{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/appInfos/appinfo-1/appInfoLocalizations?cursor=page-2&limit=200"}}`,
 	), []migrateImportExpectation{
+		{
+			method:               http.MethodGet,
+			path:                 "/v1/appInfos/appinfo-1/appInfoLocalizations",
+			rawQuery:             "cursor=page-2&limit=200",
+			requireAuthorization: true,
+			response:             `{"data":[{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja"}}],"links":{"next":""}}`,
+		},
 		{
 			method:   http.MethodPatch,
 			path:     "/v1/appStoreVersionLocalizations/loc-en",
@@ -421,19 +428,58 @@ func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T
 	if len(result.AppInfoUploaded) != 1 || result.AppInfoUploaded[0].Action != "update" || result.AppInfoUploaded[0].LocalizationID != "appinfo-loc-ja" {
 		t.Fatalf("unexpected app info upload result: %#v", result.AppInfoUploaded)
 	}
+	if got := api.queries[3]; got != "limit=200" {
+		t.Fatalf("first app info localization query = %q, want %q", got, "limit=200")
+	}
 	api.assertComplete(t, 3)
 }
 
+func TestMigrateImportStopsOnAppInfoPaginationErrorBeforeMutations(t *testing.T) {
+	root := writeMigrateImportMetadata(t, validMigrateAppInfoMetadata())
+	expectations := append(migrateImportPlanningExpectations(
+		`{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/appInfos/appinfo-1/appInfoLocalizations?cursor=page-2&limit=200"}}`,
+	), migrateImportExpectation{
+		method:               http.MethodGet,
+		path:                 "/v1/appInfos/appinfo-1/appInfoLocalizations",
+		rawQuery:             "cursor=page-2&limit=200",
+		requireAuthorization: true,
+		status:               http.StatusInternalServerError,
+		response:             `{"errors":[{"status":"500","code":"UNEXPECTED_ERROR","title":"Request failed","detail":"pagination unavailable"}]}`,
+	})
+	api := newMigrateImportAPI(t, expectations...)
+
+	stdout, stderr, runErr := runMigrateImport(t, root)
+	if runErr == nil {
+		t.Fatal("expected pagination error")
+	}
+	for _, want := range []string{"migrate import: failed to fetch app info localizations: page 2:", "pagination unavailable"} {
+		if !strings.Contains(runErr.Error(), want) {
+			t.Fatalf("run error = %q, want it to contain %q", runErr, want)
+		}
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected empty output, got stdout %q stderr %q", stdout, stderr)
+	}
+	if got := api.queries[3]; got != "limit=200" {
+		t.Fatalf("first app info localization query = %q, want %q", got, "limit=200")
+	}
+	api.assertComplete(t, 0)
+}
+
 type migrateImportExpectation struct {
-	method   string
-	path     string
-	body     string
-	response string
+	method               string
+	path                 string
+	rawQuery             string
+	requireAuthorization bool
+	status               int
+	body                 string
+	response             string
 }
 
 type migrateImportAPI struct {
 	expectations []migrateImportExpectation
 	requests     []string
+	queries      []string
 	mutations    int
 	factoryCalls int
 }
@@ -447,6 +493,7 @@ func newMigrateImportAPI(t *testing.T, expectations ...migrateImportExpectation)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestLabel := req.Method + " " + req.URL.Path
 		api.requests = append(api.requests, requestLabel)
+		api.queries = append(api.queries, req.URL.RawQuery)
 		if req.Method == http.MethodPost || req.Method == http.MethodPatch || req.Method == http.MethodDelete {
 			api.mutations++
 		}
@@ -463,11 +510,24 @@ func newMigrateImportAPI(t *testing.T, expectations ...migrateImportExpectation)
 			http.Error(w, "unexpected request", http.StatusInternalServerError)
 			return
 		}
+		if expected.rawQuery != "" && req.URL.RawQuery != expected.rawQuery {
+			t.Errorf("request %d query = %q, want %q", index+1, req.URL.RawQuery, expected.rawQuery)
+			http.Error(w, "unexpected query", http.StatusInternalServerError)
+			return
+		}
+		if expected.requireAuthorization && !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("request %d Authorization header = %q, want bearer token", index+1, req.Header.Get("Authorization"))
+			http.Error(w, "missing authorization", http.StatusInternalServerError)
+			return
+		}
 		if expected.body != "" {
 			assertJSONDocument(t, req.Body, expected.body)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		if expected.status != 0 {
+			w.WriteHeader(expected.status)
+		}
 		_, _ = io.WriteString(w, expected.response)
 	}))
 	t.Cleanup(server.Close)

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -352,6 +353,195 @@ func TestMigrateImportValidatesEveryLocalizationBeforeRequests(t *testing.T) {
 				t.Fatalf("expected no localization mutations, got %d", mutationCount)
 			}
 		})
+	}
+}
+
+func TestMigrateImportPreflightsAppInfoCreatesBeforeMutations(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	root := t.TempDir()
+	metadataDir := filepath.Join(root, "metadata")
+	for _, locale := range []string{"en-US", "ja"} {
+		if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
+			t.Fatalf("mkdir metadata locale %s: %v", locale, err)
+		}
+	}
+	writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
+	writeFile(t, filepath.Join(metadataDir, "ja", "description.txt"), "Japanese description")
+	writeFile(t, filepath.Join(metadataDir, "ja", "subtitle.txt"), "Japanese subtitle")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var requests []string
+	mutationCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		if req.Method == http.MethodPost || req.Method == http.MethodPatch || req.Method == http.MethodDelete {
+			mutationCount++
+		}
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_ID/appInfos":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return migrateJSONResponse(http.StatusOK, `{"data":[]}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", root,
+			"--confirm",
+			"--skip-screenshots",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = rootCmd.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected app info localization validation error")
+	}
+	const wantError = `migrate import: locale "ja": name is required when creating app info localization`
+	if runErr.Error() != wantError {
+		t.Fatalf("run error = %q, want %q", runErr, wantError)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if mutationCount != 0 {
+		t.Fatalf("expected no mutations, got %d (%v)", mutationCount, requests)
+	}
+	wantRequests := []string{
+		"GET /v1/appStoreVersions/VERSION_ID",
+		"GET /v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations",
+		"GET /v1/apps/APP_ID/appInfos",
+		"GET /v1/appInfos/appinfo-1/appInfoLocalizations",
+	}
+	if !slices.Equal(requests, wantRequests) {
+		t.Fatalf("requests = %v, want %v", requests, wantRequests)
+	}
+}
+
+func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	root := t.TempDir()
+	metadataDir := filepath.Join(root, "metadata")
+	for _, locale := range []string{"en-US", "ja"} {
+		if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
+			t.Fatalf("mkdir metadata locale %s: %v", locale, err)
+		}
+	}
+	writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
+	writeFile(t, filepath.Join(metadataDir, "ja", "description.txt"), "Japanese description")
+	writeFile(t, filepath.Join(metadataDir, "ja", "subtitle.txt"), "Japanese subtitle")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var requests []string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_ID/appInfos":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/appinfo-1/appInfoLocalizations":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja"}}]}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-en":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-ja":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja"}}}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appInfoLocalizations/appinfo-loc-ja":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read app info update body: %v", err)
+			}
+			var payload asc.AppInfoLocalizationUpdateRequest
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("unmarshal app info update body: %v", err)
+			}
+			if payload.Data.Attributes.Subtitle != "Japanese subtitle" {
+				t.Fatalf("subtitle = %q, want Japanese subtitle", payload.Data.Attributes.Subtitle)
+			}
+			if payload.Data.Attributes.Name != "" || payload.Data.Attributes.Locale != "" {
+				t.Fatalf("unexpected name/locale in update: %#v", payload.Data.Attributes)
+			}
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appInfoLocalizations","id":"appinfo-loc-ja","attributes":{"locale":"ja","subtitle":"Japanese subtitle"}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", root,
+			"--confirm",
+			"--skip-screenshots",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = rootCmd.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result migrate.MigrateImportResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.AppInfoUploaded) != 1 || result.AppInfoUploaded[0].Action != "update" || result.AppInfoUploaded[0].LocalizationID != "appinfo-loc-ja" {
+		t.Fatalf("unexpected app info upload result: %#v", result.AppInfoUploaded)
+	}
+
+	wantRequests := []string{
+		"GET /v1/appStoreVersions/VERSION_ID",
+		"GET /v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations",
+		"GET /v1/apps/APP_ID/appInfos",
+		"GET /v1/appInfos/appinfo-1/appInfoLocalizations",
+		"PATCH /v1/appStoreVersionLocalizations/loc-en",
+		"PATCH /v1/appStoreVersionLocalizations/loc-ja",
+		"PATCH /v1/appInfoLocalizations/appinfo-loc-ja",
+	}
+	if !slices.Equal(requests, wantRequests) {
+		t.Fatalf("requests = %v, want %v", requests, wantRequests)
 	}
 }
 

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -326,6 +326,41 @@ func TestMigrateImportPreflightsAppInfoCreatesBeforeMutations(t *testing.T) {
 	api.assertComplete(t, 0)
 }
 
+func TestMigrateImportPreflightsWouldCreateVersionLocalesBeforeMutations(t *testing.T) {
+	root := writeMigrateImportMetadata(t, map[string]map[string]string{
+		"en-US": {"description.txt": "English description"},
+		"nl": {
+			"description.txt": "Dutch description",
+			"name.txt":        "Dutch name",
+		},
+	})
+	planning := migrateImportPlanningExpectations(`{"data":[]}`)
+	api := newMigrateImportAPI(t, planning[:2]...)
+
+	stdout, stderr, runErr := runMigrateImport(t, root)
+	const wantError = `migrate import: locale "nl": unsupported locale "nl"; did you mean: nl-NL`
+	assertMigrateImportError(t, stdout, stderr, runErr, wantError)
+	api.assertComplete(t, 0)
+}
+
+func TestMigrateImportPreflightsWouldCreateAppInfoLocalesBeforeMutations(t *testing.T) {
+	root := writeMigrateImportMetadata(t, map[string]map[string]string{
+		"en-US": {"description.txt": "English description"},
+		"nl": {
+			"description.txt": "Dutch description",
+			"name.txt":        "Dutch name",
+		},
+	})
+	planning := migrateImportPlanningExpectations(`{"data":[]}`)
+	planning[1].response = `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-en","attributes":{"locale":"en-US"}},{"type":"appStoreVersionLocalizations","id":"loc-nl","attributes":{"locale":"nl"}}]}`
+	api := newMigrateImportAPI(t, planning...)
+
+	stdout, stderr, runErr := runMigrateImport(t, root)
+	const wantError = `migrate import: locale "nl": unsupported locale "nl"; did you mean: nl-NL`
+	assertMigrateImportError(t, stdout, stderr, runErr, wantError)
+	api.assertComplete(t, 0)
+}
+
 func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T) {
 	root := writeMigrateImportMetadata(t, validMigrateAppInfoMetadata())
 	expectations := append(migrateImportPlanningExpectations(

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -442,6 +442,91 @@ func TestMigrateImportPreflightsAppInfoCreatesBeforeMutations(t *testing.T) {
 	}
 }
 
+func TestMigrateImportPreflightsAppInfoLengthsBeforeMutations(t *testing.T) {
+	tests := []struct {
+		name      string
+		fileName  string
+		value     string
+		wantError string
+	}{
+		{
+			name:      "name",
+			fileName:  "name.txt",
+			value:     strings.Repeat("n", validation.LimitName+1),
+			wantError: `migrate import: locale "ja": name exceeds 30 characters`,
+		},
+		{
+			name:      "subtitle",
+			fileName:  "subtitle.txt",
+			value:     strings.Repeat("s", validation.LimitSubtitle+1),
+			wantError: `migrate import: locale "ja": subtitle exceeds 30 characters`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			root := t.TempDir()
+			metadataDir := filepath.Join(root, "metadata")
+			for _, locale := range []string{"en-US", "ja"} {
+				if err := os.MkdirAll(filepath.Join(metadataDir, locale), 0o755); err != nil {
+					t.Fatalf("mkdir metadata locale %s: %v", locale, err)
+				}
+			}
+			writeFile(t, filepath.Join(metadataDir, "en-US", "description.txt"), "English description")
+			writeFile(t, filepath.Join(metadataDir, "ja", "description.txt"), "Japanese description")
+			writeFile(t, filepath.Join(metadataDir, "ja", tt.fileName), tt.value)
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() {
+				http.DefaultTransport = originalTransport
+			})
+
+			var requests []string
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests = append(requests, req.Method+" "+req.URL.Path)
+				return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			})
+
+			rootCmd := RootCommand("1.2.3")
+			rootCmd.FlagSet.SetOutput(io.Discard)
+
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := rootCmd.Parse([]string{
+					"migrate", "import",
+					"--app", "APP_ID",
+					"--version-id", "VERSION_ID",
+					"--fastlane-dir", root,
+					"--confirm",
+					"--skip-screenshots",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = rootCmd.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected app info localization validation error")
+			}
+			if runErr.Error() != tt.wantError {
+				t.Fatalf("run error = %q, want %q", runErr, tt.wantError)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if len(requests) != 0 {
+				t.Fatalf("expected no HTTP requests, got %v", requests)
+			}
+		})
+	}
+}
+
 func TestMigrateImportAllowsSubtitleOnlyAppInfoUpdatesAfterPlanning(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/localizations/update.go
+++ b/internal/cli/localizations/update.go
@@ -214,7 +214,15 @@ func updateVersionLocalization(ctx context.Context, p updateVersionParams) error
 		fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
 		return shared.MissingRequiredUsageError()
 	}
-	if err := shared.ValidateVersionLocalizationAttributes(asc.AppStoreVersionLocalizationAttributes{Keywords: p.keywords}); err != nil {
+	attrs := asc.AppStoreVersionLocalizationAttributes{
+		Description:     p.description,
+		Keywords:        p.keywords,
+		WhatsNew:        p.whatsNew,
+		PromotionalText: p.promotionalText,
+		SupportURL:      p.supportURL,
+		MarketingURL:    p.marketingURL,
+	}
+	if err := shared.ValidateVersionLocalizationAttributes(attrs); err != nil {
 		return shared.UsageError(err.Error())
 	}
 
@@ -241,15 +249,6 @@ func updateVersionLocalization(ctx context.Context, p updateVersionParams) error
 	}
 	if localizationID == "" {
 		return fmt.Errorf("localizations update: no existing localization found for locale %q", p.locale)
-	}
-
-	attrs := asc.AppStoreVersionLocalizationAttributes{
-		Description:     p.description,
-		Keywords:        p.keywords,
-		WhatsNew:        p.whatsNew,
-		PromotionalText: p.promotionalText,
-		SupportURL:      p.supportURL,
-		MarketingURL:    p.marketingURL,
 	}
 
 	resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, localizationID, attrs)

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -357,6 +357,35 @@ func fetchAppInfoLocalizationsForPlan(ctx context.Context, client *asc.Client, a
 	return allPages.Data, nil
 }
 
+func fetchVersionLocalizationsForPlan(ctx context.Context, client *asc.Client, versionID string) ([]asc.Resource[asc.AppStoreVersionLocalizationAttributes], error) {
+	firstPage, err := client.GetAppStoreVersionLocalizations(ctx, versionID, asc.WithAppStoreVersionLocalizationsLimit(200))
+	if err != nil {
+		return nil, err
+	}
+	if firstPage == nil {
+		return nil, fmt.Errorf("empty version localizations response")
+	}
+
+	paginated, err := asc.PaginateAll(ctx, firstPage, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		nextPage, err := client.GetAppStoreVersionLocalizations(pageCtx, versionID, asc.WithAppStoreVersionLocalizationsNextURL(nextURL))
+		if err != nil {
+			return nil, err
+		}
+		if nextPage == nil {
+			return nil, fmt.Errorf("empty version localizations response")
+		}
+		return nextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	allPages, ok := paginated.(*asc.AppStoreVersionLocalizationsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected version localization pagination response type")
+	}
+	return allPages.Data, nil
+}
+
 func uploadAppInfoLocalizations(ctx context.Context, client *asc.Client, plan appInfoLocalizationPlan) ([]LocalizationUploadItem, error) {
 	results := make([]LocalizationUploadItem, 0, len(plan.localizations))
 	for _, prepared := range plan.localizations {

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -158,6 +158,17 @@ type preparedVersionLocalization struct {
 	attributes   asc.AppStoreVersionLocalizationAttributes
 }
 
+type preparedAppInfoLocalization struct {
+	localization   AppInfoFastlaneLocalization
+	attributes     asc.AppInfoLocalizationAttributes
+	localizationID string
+}
+
+type appInfoLocalizationPlan struct {
+	appInfoID     string
+	localizations []preparedAppInfoLocalization
+}
+
 func prepareVersionLocalizations(localizations []FastlaneLocalization) ([]preparedVersionLocalization, error) {
 	prepared := make([]preparedVersionLocalization, 0, len(localizations))
 	for _, loc := range localizations {
@@ -217,32 +228,35 @@ func uploadVersionLocalizations(ctx context.Context, client *asc.Client, version
 	return results, shared.NormalizeSubmitReadinessCreateWarnings(warnings), nil
 }
 
-func uploadAppInfoLocalizations(ctx context.Context, client *asc.Client, appID string, appInfoLocs []AppInfoFastlaneLocalization) ([]LocalizationUploadItem, error) {
+func prepareAppInfoLocalizations(ctx context.Context, client *asc.Client, appID string, appInfoLocs []AppInfoFastlaneLocalization) (appInfoLocalizationPlan, error) {
 	if len(appInfoLocs) == 0 {
-		return nil, nil
+		return appInfoLocalizationPlan{}, nil
 	}
 	appInfos, err := client.GetAppInfos(ctx, appID)
 	if err != nil {
-		return nil, fmt.Errorf("migrate import: failed to get app info: %w", err)
+		return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: failed to get app info: %w", err)
 	}
 	if len(appInfos.Data) == 0 {
-		return nil, fmt.Errorf("migrate import: no app info found for app")
+		return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: no app info found for app")
 	}
 	appInfoID := shared.SelectBestAppInfoID(appInfos)
 	if strings.TrimSpace(appInfoID) == "" {
-		return nil, fmt.Errorf("migrate import: failed to select app info for app")
+		return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: failed to select app info for app")
 	}
 
 	existingAppInfoLocs, err := client.GetAppInfoLocalizations(ctx, appInfoID)
 	if err != nil {
-		return nil, fmt.Errorf("migrate import: failed to fetch app info localizations: %w", err)
+		return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: failed to fetch app info localizations: %w", err)
 	}
 	appInfoLocaleToID := make(map[string]string)
 	for _, loc := range existingAppInfoLocs.Data {
 		appInfoLocaleToID[loc.Attributes.Locale] = loc.ID
 	}
 
-	results := make([]LocalizationUploadItem, 0, len(appInfoLocs))
+	plan := appInfoLocalizationPlan{
+		appInfoID:     appInfoID,
+		localizations: make([]preparedAppInfoLocalization, 0, len(appInfoLocs)),
+	}
 	for _, loc := range appInfoLocs {
 		attrs := asc.AppInfoLocalizationAttributes{
 			Locale:           loc.Locale,
@@ -250,16 +264,32 @@ func uploadAppInfoLocalizations(ctx context.Context, client *asc.Client, appID s
 			Subtitle:         loc.Subtitle,
 			PrivacyPolicyURL: loc.PrivacyURL,
 		}
-
-		action := "create"
 		localizationID := appInfoLocaleToID[loc.Locale]
+		if localizationID == "" && strings.TrimSpace(attrs.Name) == "" {
+			return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: locale %q: name is required when creating app info localization", loc.Locale)
+		}
+		plan.localizations = append(plan.localizations, preparedAppInfoLocalization{
+			localization:   loc,
+			attributes:     attrs,
+			localizationID: localizationID,
+		})
+	}
+	return plan, nil
+}
+
+func uploadAppInfoLocalizations(ctx context.Context, client *asc.Client, plan appInfoLocalizationPlan) ([]LocalizationUploadItem, error) {
+	results := make([]LocalizationUploadItem, 0, len(plan.localizations))
+	for _, prepared := range plan.localizations {
+		loc := prepared.localization
+		action := "create"
+		localizationID := prepared.localizationID
 		if localizationID != "" {
 			action = "update"
-			if _, err := client.UpdateAppInfoLocalization(ctx, localizationID, attrs); err != nil {
+			if _, err := client.UpdateAppInfoLocalization(ctx, localizationID, prepared.attributes); err != nil {
 				return nil, fmt.Errorf("migrate import: failed to update app info %s: %w", loc.Locale, err)
 			}
 		} else {
-			resp, err := client.CreateAppInfoLocalization(ctx, appInfoID, attrs)
+			resp, err := client.CreateAppInfoLocalization(ctx, plan.appInfoID, prepared.attributes)
 			if err != nil {
 				return nil, fmt.Errorf("migrate import: failed to create app info %s: %w", loc.Locale, err)
 			}

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -153,9 +153,13 @@ func buildAppInfoFilePlans(localizations []AppInfoFastlaneLocalization) []Locali
 	return plans
 }
 
-func uploadVersionLocalizations(ctx context.Context, client *asc.Client, versionID string, localizations []FastlaneLocalization, localeToID map[string]string, submitOpts shared.SubmitReadinessOptions) ([]LocalizationUploadItem, []shared.SubmitReadinessCreateWarning, error) {
-	results := make([]LocalizationUploadItem, 0, len(localizations))
-	warnings := make([]shared.SubmitReadinessCreateWarning, 0, len(localizations))
+type preparedVersionLocalization struct {
+	localization FastlaneLocalization
+	attributes   asc.AppStoreVersionLocalizationAttributes
+}
+
+func prepareVersionLocalizations(localizations []FastlaneLocalization) ([]preparedVersionLocalization, error) {
+	prepared := make([]preparedVersionLocalization, 0, len(localizations))
 	for _, loc := range localizations {
 		attrs := asc.AppStoreVersionLocalizationAttributes{
 			Locale:          loc.Locale,
@@ -167,8 +171,22 @@ func uploadVersionLocalizations(ctx context.Context, client *asc.Client, version
 			MarketingURL:    loc.MarketingURL,
 		}
 		if err := shared.ValidateVersionLocalizationAttributes(attrs); err != nil {
-			return nil, nil, fmt.Errorf("migrate import: locale %q: %w", loc.Locale, err)
+			return nil, fmt.Errorf("migrate import: locale %q: %w", loc.Locale, err)
 		}
+		prepared = append(prepared, preparedVersionLocalization{
+			localization: loc,
+			attributes:   attrs,
+		})
+	}
+	return prepared, nil
+}
+
+func uploadVersionLocalizations(ctx context.Context, client *asc.Client, versionID string, localizations []preparedVersionLocalization, localeToID map[string]string, submitOpts shared.SubmitReadinessOptions) ([]LocalizationUploadItem, []shared.SubmitReadinessCreateWarning, error) {
+	results := make([]LocalizationUploadItem, 0, len(localizations))
+	warnings := make([]shared.SubmitReadinessCreateWarning, 0, len(localizations))
+	for _, prepared := range localizations {
+		loc := prepared.localization
+		attrs := prepared.attributes
 		action := "create"
 		localizationID := localeToID[loc.Locale]
 		if localizationID != "" {

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -193,6 +193,26 @@ func prepareVersionLocalizations(localizations []FastlaneLocalization) ([]prepar
 	return prepared, nil
 }
 
+func validateVersionLocalizationCreateLocales(localizations []preparedVersionLocalization, localeToID map[string]string) error {
+	for _, prepared := range localizations {
+		locale := prepared.localization.Locale
+		if err := validateLocalizationCreateTarget(locale, localeToID[locale]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateLocalizationCreateTarget(locale, localizationID string) error {
+	if localizationID != "" {
+		return nil
+	}
+	if _, err := shared.CanonicalizeAppStoreLocalizationLocale(locale); err != nil {
+		return fmt.Errorf("migrate import: locale %q: %w", locale, err)
+	}
+	return nil
+}
+
 func prepareAppInfoLocalizationAttributes(localizations []AppInfoFastlaneLocalization) ([]preparedAppInfoLocalization, error) {
 	prepared := make([]preparedAppInfoLocalization, 0, len(localizations))
 	for _, loc := range localizations {
@@ -285,8 +305,13 @@ func prepareAppInfoLocalizations(ctx context.Context, client *asc.Client, appID 
 		loc := prepared.localization
 		attrs := prepared.attributes
 		localizationID := appInfoLocaleToID[loc.Locale]
-		if localizationID == "" && strings.TrimSpace(attrs.Name) == "" {
-			return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: locale %q: name is required when creating app info localization", loc.Locale)
+		if err := validateLocalizationCreateTarget(loc.Locale, localizationID); err != nil {
+			return appInfoLocalizationPlan{}, err
+		}
+		if localizationID == "" {
+			if strings.TrimSpace(attrs.Name) == "" {
+				return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: locale %q: name is required when creating app info localization", loc.Locale)
+			}
 		}
 		prepared.localizationID = localizationID
 		plan.localizations = append(plan.localizations, prepared)

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/assets"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 func resolveAppID(ctx context.Context, client *asc.Client, appFlag string, config DeliverfileConfig) (string, error) {
@@ -192,6 +193,29 @@ func prepareVersionLocalizations(localizations []FastlaneLocalization) ([]prepar
 	return prepared, nil
 }
 
+func prepareAppInfoLocalizationAttributes(localizations []AppInfoFastlaneLocalization) ([]preparedAppInfoLocalization, error) {
+	prepared := make([]preparedAppInfoLocalization, 0, len(localizations))
+	for _, loc := range localizations {
+		attrs := asc.AppInfoLocalizationAttributes{
+			Locale:           loc.Locale,
+			Name:             loc.Name,
+			Subtitle:         loc.Subtitle,
+			PrivacyPolicyURL: loc.PrivacyURL,
+		}
+		for _, issue := range validation.AppInfoLocalizationLengthIssues(validation.AppInfoLocalization{
+			Name:     attrs.Name,
+			Subtitle: attrs.Subtitle,
+		}) {
+			return nil, fmt.Errorf("migrate import: locale %q: %s exceeds %d %s", loc.Locale, issue.Field, issue.Limit, issue.Unit)
+		}
+		prepared = append(prepared, preparedAppInfoLocalization{
+			localization: loc,
+			attributes:   attrs,
+		})
+	}
+	return prepared, nil
+}
+
 func uploadVersionLocalizations(ctx context.Context, client *asc.Client, versionID string, localizations []preparedVersionLocalization, localeToID map[string]string, submitOpts shared.SubmitReadinessOptions) ([]LocalizationUploadItem, []shared.SubmitReadinessCreateWarning, error) {
 	results := make([]LocalizationUploadItem, 0, len(localizations))
 	warnings := make([]shared.SubmitReadinessCreateWarning, 0, len(localizations))
@@ -228,8 +252,8 @@ func uploadVersionLocalizations(ctx context.Context, client *asc.Client, version
 	return results, shared.NormalizeSubmitReadinessCreateWarnings(warnings), nil
 }
 
-func prepareAppInfoLocalizations(ctx context.Context, client *asc.Client, appID string, appInfoLocs []AppInfoFastlaneLocalization) (appInfoLocalizationPlan, error) {
-	if len(appInfoLocs) == 0 {
+func prepareAppInfoLocalizations(ctx context.Context, client *asc.Client, appID string, localizations []preparedAppInfoLocalization) (appInfoLocalizationPlan, error) {
+	if len(localizations) == 0 {
 		return appInfoLocalizationPlan{}, nil
 	}
 	appInfos, err := client.GetAppInfos(ctx, appID)
@@ -255,24 +279,17 @@ func prepareAppInfoLocalizations(ctx context.Context, client *asc.Client, appID 
 
 	plan := appInfoLocalizationPlan{
 		appInfoID:     appInfoID,
-		localizations: make([]preparedAppInfoLocalization, 0, len(appInfoLocs)),
+		localizations: make([]preparedAppInfoLocalization, 0, len(localizations)),
 	}
-	for _, loc := range appInfoLocs {
-		attrs := asc.AppInfoLocalizationAttributes{
-			Locale:           loc.Locale,
-			Name:             loc.Name,
-			Subtitle:         loc.Subtitle,
-			PrivacyPolicyURL: loc.PrivacyURL,
-		}
+	for _, prepared := range localizations {
+		loc := prepared.localization
+		attrs := prepared.attributes
 		localizationID := appInfoLocaleToID[loc.Locale]
 		if localizationID == "" && strings.TrimSpace(attrs.Name) == "" {
 			return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: locale %q: name is required when creating app info localization", loc.Locale)
 		}
-		plan.localizations = append(plan.localizations, preparedAppInfoLocalization{
-			localization:   loc,
-			attributes:     attrs,
-			localizationID: localizationID,
-		})
+		prepared.localizationID = localizationID
+		plan.localizations = append(plan.localizations, prepared)
 	}
 	return plan, nil
 }

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -297,12 +297,12 @@ func prepareAppInfoLocalizations(ctx context.Context, client *asc.Client, appID 
 		return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: failed to select app info for app")
 	}
 
-	existingAppInfoLocs, err := client.GetAppInfoLocalizations(ctx, appInfoID)
+	existingAppInfoLocs, err := fetchAppInfoLocalizationsForPlan(ctx, client, appInfoID)
 	if err != nil {
 		return appInfoLocalizationPlan{}, fmt.Errorf("migrate import: failed to fetch app info localizations: %w", err)
 	}
 	appInfoLocaleToID := make(map[string]string)
-	for _, loc := range existingAppInfoLocs.Data {
+	for _, loc := range existingAppInfoLocs {
 		appInfoLocaleToID[loc.Attributes.Locale] = loc.ID
 	}
 
@@ -326,6 +326,35 @@ func prepareAppInfoLocalizations(ctx context.Context, client *asc.Client, appID 
 		plan.localizations = append(plan.localizations, prepared)
 	}
 	return plan, nil
+}
+
+func fetchAppInfoLocalizationsForPlan(ctx context.Context, client *asc.Client, appInfoID string) ([]asc.Resource[asc.AppInfoLocalizationAttributes], error) {
+	firstPage, err := client.GetAppInfoLocalizations(ctx, appInfoID, asc.WithAppInfoLocalizationsLimit(200))
+	if err != nil {
+		return nil, err
+	}
+	if firstPage == nil {
+		return nil, fmt.Errorf("empty app info localizations response")
+	}
+
+	paginated, err := asc.PaginateAll(ctx, firstPage, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		nextPage, err := client.GetAppInfoLocalizations(pageCtx, appInfoID, asc.WithAppInfoLocalizationsNextURL(nextURL))
+		if err != nil {
+			return nil, err
+		}
+		if nextPage == nil {
+			return nil, fmt.Errorf("empty app info localizations response")
+		}
+		return nextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	allPages, ok := paginated.(*asc.AppInfoLocalizationsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected app info localization pagination response type")
+	}
+	return allPages.Data, nil
 }
 
 func uploadAppInfoLocalizations(ctx context.Context, client *asc.Client, plan appInfoLocalizationPlan) ([]LocalizationUploadItem, error) {

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -203,6 +203,15 @@ func validateVersionLocalizationCreateLocales(localizations []preparedVersionLoc
 	return nil
 }
 
+func validateScreenshotLocalizationCreateLocales(screenshots []ScreenshotPlan, localeToID map[string]string) error {
+	for _, screenshot := range screenshots {
+		if err := validateLocalizationCreateTarget(screenshot.Locale, localeToID[screenshot.Locale]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func validateLocalizationCreateTarget(locale, localizationID string) error {
 	if localizationID != "" {
 		return nil

--- a/internal/cli/migrate/import_helpers_test.go
+++ b/internal/cli/migrate/import_helpers_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 type migrateUploadRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -112,38 +111,46 @@ func TestUploadScreenshots_ReordersPlannedFilesBeforeUntouchedRemoteExtras(t *te
 	}
 }
 
-func TestUploadVersionLocalizations_RejectsOverLimitKeywordBytesBeforeRequests(t *testing.T) {
-	origTransport := http.DefaultTransport
-	requestCount := 0
-	http.DefaultTransport = migrateUploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requestCount++
-		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-		return nil, nil
-	})
-	t.Cleanup(func() {
-		http.DefaultTransport = origTransport
-	})
-
-	client := newMigrateUploadTestClient(t)
-	_, _, err := uploadVersionLocalizations(
-		context.Background(),
-		client,
-		"version-1",
-		[]FastlaneLocalization{{
-			Locale:   "ja",
-			Keywords: strings.Repeat("語", 101),
-		}},
-		map[string]string{},
-		shared.SubmitReadinessOptions{},
-	)
+func TestPrepareVersionLocalizationsRejectsOverLimitKeywords(t *testing.T) {
+	_, err := prepareVersionLocalizations([]FastlaneLocalization{{
+		Locale:   "ja",
+		Keywords: strings.Repeat("語", 101),
+	}})
 	if err == nil {
-		t.Fatal("expected upload validation error")
+		t.Fatal("expected localization validation error")
 	}
-	if !strings.Contains(err.Error(), "keywords exceed 100 characters") {
-		t.Fatalf("expected keyword character-limit error, got %v", err)
+	const wantError = `migrate import: locale "ja": keywords exceed 100 characters`
+	if err.Error() != wantError {
+		t.Fatalf("prepareVersionLocalizations() error = %q, want %q", err, wantError)
 	}
-	if requestCount != 0 {
-		t.Fatalf("expected no HTTP requests, got %d", requestCount)
+}
+
+func TestPrepareVersionLocalizationsPreservesOrderAndDuplicates(t *testing.T) {
+	localizations := []FastlaneLocalization{
+		{Locale: "en-US", Description: "first"},
+		{Locale: "en-US", Description: "second"},
+		{Locale: "fr-FR", Description: "third"},
+	}
+
+	prepared, err := prepareVersionLocalizations(localizations)
+	if err != nil {
+		t.Fatalf("prepareVersionLocalizations() error: %v", err)
+	}
+	if len(prepared) != len(localizations) {
+		t.Fatalf("prepared localization count = %d, want %d", len(prepared), len(localizations))
+	}
+
+	gotLocales := make([]string, 0, len(prepared))
+	gotDescriptions := make([]string, 0, len(prepared))
+	for _, item := range prepared {
+		gotLocales = append(gotLocales, item.localization.Locale)
+		gotDescriptions = append(gotDescriptions, item.attributes.Description)
+	}
+	if want := []string{"en-US", "en-US", "fr-FR"}; !reflect.DeepEqual(gotLocales, want) {
+		t.Fatalf("prepared locales = %v, want %v", gotLocales, want)
+	}
+	if want := []string{"first", "second", "third"}; !reflect.DeepEqual(gotDescriptions, want) {
+		t.Fatalf("prepared descriptions = %v, want %v", gotDescriptions, want)
 	}
 }
 

--- a/internal/cli/migrate/import_helpers_test.go
+++ b/internal/cli/migrate/import_helpers_test.go
@@ -154,6 +154,20 @@ func TestPrepareVersionLocalizationsPreservesOrderAndDuplicates(t *testing.T) {
 	}
 }
 
+func TestValidateLocalizationCreateTargetAllowsExistingUnsupportedRoot(t *testing.T) {
+	if err := validateLocalizationCreateTarget("nl", "existing-loc"); err != nil {
+		t.Fatalf("validateLocalizationCreateTarget() error = %v, want nil for update", err)
+	}
+}
+
+func TestValidateLocalizationCreateTargetRejectsUnsupportedRootCreate(t *testing.T) {
+	err := validateLocalizationCreateTarget("nl", "")
+	const wantError = `migrate import: locale "nl": unsupported locale "nl"; did you mean: nl-NL`
+	if err == nil || err.Error() != wantError {
+		t.Fatalf("validateLocalizationCreateTarget() error = %q, want %q", err, wantError)
+	}
+}
+
 func newMigrateUploadTestClient(t *testing.T) *asc.Client {
 	t.Helper()
 

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -202,6 +202,10 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID or Deliverfile app_identifier)")
 				return shared.MissingRequiredUsageError()
 			}
+			preparedLocalizations, err := prepareVersionLocalizations(localizations)
+			if err != nil {
+				return err
+			}
 
 			var client *asc.Client
 			var requestCtx context.Context
@@ -281,7 +285,7 @@ Examples:
 			if migrateVersionLocalizationsNeedUpdateContext(localizations, localeToID) {
 				submitOpts = shared.ResolveSubmitReadinessOptionsForVersionBestEffort(requestCtx, client, resolvedVersionID, resolvedAppID, "")
 			}
-			uploaded, warnings, err := uploadVersionLocalizations(requestCtx, client, resolvedVersionID, localizations, localeToID, submitOpts)
+			uploaded, warnings, err := uploadVersionLocalizations(requestCtx, client, resolvedVersionID, preparedLocalizations, localeToID, submitOpts)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -280,6 +280,10 @@ Examples:
 					localeToID[loc.Attributes.Locale] = loc.ID
 				}
 			}
+			appInfoPlan, err := prepareAppInfoLocalizations(requestCtx, client, resolvedAppID, appInfoLocs)
+			if err != nil {
+				return err
+			}
 
 			submitOpts := shared.SubmitReadinessOptions{}
 			if migrateVersionLocalizationsNeedUpdateContext(localizations, localeToID) {
@@ -289,7 +293,7 @@ Examples:
 			if err != nil {
 				return err
 			}
-			appInfoUploaded, err := uploadAppInfoLocalizations(requestCtx, client, resolvedAppID, appInfoLocs)
+			appInfoUploaded, err := uploadAppInfoLocalizations(requestCtx, client, appInfoPlan)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -284,6 +284,9 @@ Examples:
 					localeToID[loc.Attributes.Locale] = loc.ID
 				}
 			}
+			if err := validateVersionLocalizationCreateLocales(preparedLocalizations, localeToID); err != nil {
+				return err
+			}
 			appInfoPlan, err := prepareAppInfoLocalizations(requestCtx, client, resolvedAppID, preparedAppInfoLocalizations)
 			if err != nil {
 				return err

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -276,11 +276,11 @@ Examples:
 
 			localeToID := make(map[string]string)
 			if len(localizations) > 0 || len(screenshotPlan) > 0 {
-				existingLocs, err := client.GetAppStoreVersionLocalizations(requestCtx, strings.TrimSpace(resolvedVersionID), asc.WithAppStoreVersionLocalizationsLimit(200))
+				existingLocs, err := fetchVersionLocalizationsForPlan(requestCtx, client, strings.TrimSpace(resolvedVersionID))
 				if err != nil {
 					return fmt.Errorf("migrate import: failed to fetch existing localizations: %w", err)
 				}
-				for _, loc := range existingLocs.Data {
+				for _, loc := range existingLocs {
 					localeToID[loc.Attributes.Locale] = loc.ID
 				}
 			}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -287,6 +287,9 @@ Examples:
 			if err := validateVersionLocalizationCreateLocales(preparedLocalizations, localeToID); err != nil {
 				return err
 			}
+			if err := validateScreenshotLocalizationCreateLocales(screenshotPlan, localeToID); err != nil {
+				return err
+			}
 			appInfoPlan, err := prepareAppInfoLocalizations(requestCtx, client, resolvedAppID, preparedAppInfoLocalizations)
 			if err != nil {
 				return err

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -206,6 +206,10 @@ Examples:
 			if err != nil {
 				return err
 			}
+			preparedAppInfoLocalizations, err := prepareAppInfoLocalizationAttributes(appInfoLocs)
+			if err != nil {
+				return err
+			}
 
 			var client *asc.Client
 			var requestCtx context.Context
@@ -280,7 +284,7 @@ Examples:
 					localeToID[loc.Attributes.Locale] = loc.ID
 				}
 			}
-			appInfoPlan, err := prepareAppInfoLocalizations(requestCtx, client, resolvedAppID, appInfoLocs)
+			appInfoPlan, err := prepareAppInfoLocalizations(requestCtx, client, resolvedAppID, preparedAppInfoLocalizations)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/shared/localizations.go
+++ b/internal/cli/shared/localizations.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -76,9 +77,41 @@ func ValidateVersionLocalizationKeys(locale string, values map[string]string) er
 	return validateLocalizationKeys(locale, values, versionLocalizationAllowedKeys)
 }
 
-// ValidateVersionLocalizationAttributes validates version localization field limits.
+// ValidateVersionLocalizationAttributes validates version localization attributes
+// that the App Store Connect request contract makes locally knowable.
 func ValidateVersionLocalizationAttributes(attrs asc.AppStoreVersionLocalizationAttributes) error {
-	return validation.ValidateKeywordField(attrs.Keywords)
+	issues := validation.VersionLocalizationLengthIssues(validation.VersionLocalization{
+		Description:     attrs.Description,
+		Keywords:        attrs.Keywords,
+		WhatsNew:        attrs.WhatsNew,
+		PromotionalText: attrs.PromotionalText,
+	})
+	if len(issues) > 0 {
+		issue := issues[0]
+		if issue.Field == "keywords" {
+			return fmt.Errorf("keywords exceed %d %s", issue.Limit, issue.Unit)
+		}
+		return fmt.Errorf("%s exceeds %d %s", issue.Field, issue.Limit, issue.Unit)
+	}
+
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "marketingUrl", value: attrs.MarketingURL},
+		{name: "supportUrl", value: attrs.SupportURL},
+	} {
+		if field.value == "" {
+			continue
+		}
+		// The request schema declares these attributes as URI-formatted strings.
+		// Scheme-specific suitability remains a non-blocking validation concern.
+		parsed, err := url.Parse(field.value)
+		if err != nil || !parsed.IsAbs() || strings.ContainsAny(field.value, " \t\r\n") {
+			return fmt.Errorf("%s must be a valid URI", field.name)
+		}
+	}
+	return nil
 }
 
 // ValidateVersionLocalizationValues validates .strings keys and value limits for one locale.

--- a/internal/cli/shared/localizations_test.go
+++ b/internal/cli/shared/localizations_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 func TestParseStringsContent(t *testing.T) {
@@ -244,6 +245,61 @@ func TestValidateVersionLocalizationAttributesRejectsRawKeywordCharacters(t *tes
 	}
 	if err.Error() != "keywords exceed 100 characters" {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVersionLocalizationAttributesRejectsKnownConstraints(t *testing.T) {
+	tests := []struct {
+		name      string
+		attrs     asc.AppStoreVersionLocalizationAttributes
+		wantError string
+	}{
+		{
+			name:      "description length",
+			attrs:     asc.AppStoreVersionLocalizationAttributes{Description: strings.Repeat("d", validation.LimitDescription+1)},
+			wantError: "description exceeds 4000 characters",
+		},
+		{
+			name:      "whats new length",
+			attrs:     asc.AppStoreVersionLocalizationAttributes{WhatsNew: strings.Repeat("n", validation.LimitWhatsNew+1)},
+			wantError: "whatsNew exceeds 4000 characters",
+		},
+		{
+			name:      "promotional text length",
+			attrs:     asc.AppStoreVersionLocalizationAttributes{PromotionalText: strings.Repeat("p", validation.LimitPromotionalText+1)},
+			wantError: "promotionalText exceeds 170 characters",
+		},
+		{
+			name:      "marketing URI",
+			attrs:     asc.AppStoreVersionLocalizationAttributes{MarketingURL: "://invalid"},
+			wantError: "marketingUrl must be a valid URI",
+		},
+		{
+			name:      "support URI",
+			attrs:     asc.AppStoreVersionLocalizationAttributes{SupportURL: "://invalid"},
+			wantError: "supportUrl must be a valid URI",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateVersionLocalizationAttributes(test.attrs)
+			if err == nil {
+				t.Fatal("expected attribute validation error")
+			}
+			if err.Error() != test.wantError {
+				t.Fatalf("validation error = %q, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateVersionLocalizationAttributesKeepsWarningsNonfatal(t *testing.T) {
+	err := ValidateVersionLocalizationAttributes(asc.AppStoreVersionLocalizationAttributes{
+		MarketingURL: "ftp://example.com/archive#part",
+	})
+	if err != nil {
+		t.Fatalf("expected valid absolute URI to remain nonfatal, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- prepare and validate every version-localization request before client creation, preserving locale order and duplicate entries
- read every page of version-localization state before classifying version metadata and screenshot bootstrap create or update targets
- enforce the canonical description, keywords, whatsNew, and promotionalText lengths plus the OpenAPI absolute-URI format for marketing and support URLs
- validate the exact six-field version payload for `asc localizations update` before client creation and reuse it unchanged for the PATCH
- read every page of App Info localization state before localization writes, plan exact create or update targets, require a name only for creates, validate canonical name and subtitle lengths, and reuse that plan during upload
- after remote snapshots, reject catalog-known unsupported would-create locale shorthands for version metadata, App Info, and screenshot bootstrap targets while preserving existing updates and unknown well-formed locale codes

## Contract and compatibility

- valid imports keep their existing output, warnings, ordering, and duplicate behavior; existing subtitle-only App Info updates remain valid
- the shared version-localization validator now enforces every locally knowable request constraint for all callers instead of validating keywords alone
- preflight prevents locally detectable localization failures from occurring after earlier localization writes; it does not make the workflow transactional, so later network failures or server-only rejections may still follow prior successful writes

## Verification

- focused migration, App Info, shared-validator, localization-update, and command tests, including race coverage
- client-factory sentinels prove local validation happens before client creation; a real HTTP test server verifies remote planning order, exact update bodies, limit=200 first reads, opaque authenticated continuation requests for both version and App Info localizations, page-two updates, and zero-mutation App Info pagination failures
- realistic built-binary fixtures for an invalid later migration locale and an invalid direct localization update, both with empty stdout and zero proxy bytes
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788923807&installation_model_id=10418&pr_number=1930&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1930&signature=a81e0d8a7b6babeed608d9f2219707447aef3efea41cc2989c888b239402ca8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration imports now validate localization data and target locales before making network requests or changes.
  * Imports stop safely when descriptions, keywords, release notes, promotional text, or URLs exceed supported limits.
  * Marketing and support URLs must be absolute, whitespace-free addresses.
  * App information updates containing only subtitle changes now complete successfully.
  * Paginated localization data is handled correctly, including pagination failures.
  * Localization order and duplicate locales are preserved during migration imports.
* **Tests**
  * Added coverage for validation failures, request prevention, URL handling, pagination, subtitle updates, ordering, and duplicate locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->