### PR TITLE
fix(signing): skip unusable profile certificates

### DIFF
--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -342,7 +342,7 @@ func certificatesForProfileCreation(certificates []asc.Resource[asc.CertificateA
 	if len(candidates) == 0 {
 		return nil
 	}
-	if !isAppStoreDistributionProfile(profileType) {
+	if !isSingleCertificateProfile(profileType) {
 		eligible := make([]asc.Resource[asc.CertificateAttributes], 0, len(candidates))
 		for _, candidate := range candidates {
 			eligible = append(eligible, candidate.certificate)
@@ -360,9 +360,11 @@ func certificatesForProfileCreation(certificates []asc.Resource[asc.CertificateA
 	return []asc.Resource[asc.CertificateAttributes]{selected.certificate}
 }
 
-func isAppStoreDistributionProfile(profileType string) bool {
+func isSingleCertificateProfile(profileType string) bool {
 	switch strings.ToUpper(strings.TrimSpace(profileType)) {
-	case "IOS_APP_STORE", "TVOS_APP_STORE", "MAC_APP_STORE", "MAC_CATALYST_APP_STORE":
+	case "IOS_APP_STORE", "IOS_APP_ADHOC", "IOS_APP_INHOUSE",
+		"TVOS_APP_STORE", "TVOS_APP_ADHOC", "TVOS_APP_INHOUSE",
+		"MAC_APP_STORE", "MAC_CATALYST_APP_STORE":
 		return true
 	default:
 		return false

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -326,7 +326,7 @@ func certificatesForProfileCreation(certificates []asc.Resource[asc.CertificateA
 	candidates := make([]candidate, 0, len(certificates))
 	for _, certificate := range certificates {
 		activated := certificate.Attributes.Activated
-		if activated == nil || !*activated {
+		if activated != nil && !*activated {
 			continue
 		}
 		expiresAt, err := time.Parse(time.RFC3339, strings.TrimSpace(certificate.Attributes.ExpirationDate))

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -281,6 +281,13 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 	if err != nil {
 		return nil, nil, false, err
 	}
+	certificates.Data = certificatesForProfileCreation(certificates.Data, options.ProfileType, time.Now())
+	if len(certificates.Data) == 0 {
+		return nil, nil, false, fmt.Errorf(
+			"no active, unexpired certificates available to create %s profile",
+			options.ProfileType,
+		)
+	}
 	if options.BeforeCreate != nil {
 		if err := options.BeforeCreate(); err != nil {
 			return nil, nil, false, fmt.Errorf("preflight before creating profile: %w", err)
@@ -308,6 +315,58 @@ func resolveSigningAssets(ctx context.Context, client *asc.Client, options signi
 		return nil, nil, false, err
 	}
 	return profile, certificates, true, nil
+}
+
+func certificatesForProfileCreation(certificates []asc.Resource[asc.CertificateAttributes], profileType string, now time.Time) []asc.Resource[asc.CertificateAttributes] {
+	type candidate struct {
+		certificate asc.Resource[asc.CertificateAttributes]
+		expiresAt   time.Time
+	}
+
+	candidates := make([]candidate, 0, len(certificates))
+	for _, certificate := range certificates {
+		activated := certificate.Attributes.Activated
+		if activated == nil || !*activated {
+			continue
+		}
+		expiresAt, err := time.Parse(time.RFC3339, strings.TrimSpace(certificate.Attributes.ExpirationDate))
+		if err != nil || !expiresAt.After(now) {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			certificate: certificate,
+			expiresAt:   expiresAt,
+		})
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+	if !isAppStoreDistributionProfile(profileType) {
+		eligible := make([]asc.Resource[asc.CertificateAttributes], 0, len(candidates))
+		for _, candidate := range candidates {
+			eligible = append(eligible, candidate.certificate)
+		}
+		return eligible
+	}
+
+	selected := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if candidate.expiresAt.After(selected.expiresAt) ||
+			(candidate.expiresAt.Equal(selected.expiresAt) && candidate.certificate.ID < selected.certificate.ID) {
+			selected = candidate
+		}
+	}
+	return []asc.Resource[asc.CertificateAttributes]{selected.certificate}
+}
+
+func isAppStoreDistributionProfile(profileType string) bool {
+	switch strings.ToUpper(strings.TrimSpace(profileType)) {
+	case "IOS_APP_STORE", "TVOS_APP_STORE", "MAC_APP_STORE", "MAC_CATALYST_APP_STORE":
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveSigningCertificateTypes(profileType, raw string) (string, error) {

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -540,61 +540,75 @@ func TestResolveSigningAssetsCreatesWhenActiveProfilesLackRequestedCertificate(t
 	}
 }
 
-func TestResolveSigningAssetsCreatesAppStoreProfileWithNewestEligibleCertificate(t *testing.T) {
-	var profileCreateBody []byte
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
-			signingFetchWriteJSON(t, w, http.StatusOK, `{"data":[]}`)
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
-			signingFetchWriteJSON(t, w, http.StatusOK, `{
-				"data":[
-					{"type":"certificates","id":"cert-inactive","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":false,"expirationDate":"2102-01-01T00:00:00Z"}},
-					{"type":"certificates","id":"cert-expired","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2000-01-01T00:00:00Z"}},
-					{"type":"certificates","id":"cert-older","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}},
-					{"type":"certificates","id":"cert-b","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}},
-					{"type":"certificates","id":"cert-a","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}}
-				]
-			}`)
-		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
-			var err error
-			profileCreateBody, err = io.ReadAll(req.Body)
-			if err != nil {
-				t.Errorf("read profile create request: %v", err)
-				http.Error(w, "invalid request body", http.StatusBadRequest)
-				return
-			}
-			signingFetchWriteJSON(t, w, http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
-		default:
-			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-			http.Error(w, "unexpected request", http.StatusInternalServerError)
-		}
-	}))
-	t.Cleanup(server.Close)
-	client := newSigningFetchServerTestClient(t, server)
+func TestResolveSigningAssetsCreatesSingleCertificateProfileWithNewestEligibleCertificate(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileType string
+		deviceIDs   []string
+	}{
+		{name: "App Store", profileType: "IOS_APP_STORE"},
+		{name: "Ad Hoc", profileType: "IOS_APP_ADHOC", deviceIDs: []string{"device-1"}},
+	}
 
-	profile, certificates, created, err := resolveSigningAssets(
-		context.Background(),
-		client,
-		signingAssetsOptions{
-			BundleIDResourceID: "bundle-main",
-			BundleIdentifier:   "com.example.signing.profile",
-			ProfileType:        "IOS_APP_STORE",
-			CreateMissing:      true,
-		},
-	)
-	if err != nil {
-		t.Fatalf("resolveSigningAssets() error: %v", err)
-	}
-	if !created || profile.Data.ID != "profile-created" {
-		t.Fatalf("expected created profile, got created=%v profile=%#v", created, profile)
-	}
-	createdWithCertificateIDs := profileCreateCertificateIDs(t, bytes.NewReader(profileCreateBody))
-	if got := strings.Join(createdWithCertificateIDs, ","); got != "cert-a" {
-		t.Fatalf("profile certificate IDs = %q, want cert-a", got)
-	}
-	if got := strings.Join(extractIDs(certificates.Data), ","); got != "cert-a" {
-		t.Fatalf("returned certificate IDs = %q, want cert-a", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var profileCreateBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+					signingFetchWriteJSON(t, w, http.StatusOK, `{"data":[]}`)
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+					signingFetchWriteJSON(t, w, http.StatusOK, `{
+						"data":[
+							{"type":"certificates","id":"cert-inactive","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":false,"expirationDate":"2102-01-01T00:00:00Z"}},
+							{"type":"certificates","id":"cert-expired","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2000-01-01T00:00:00Z"}},
+							{"type":"certificates","id":"cert-older","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}},
+							{"type":"certificates","id":"cert-b","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}},
+							{"type":"certificates","id":"cert-a","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}}
+						]
+					}`)
+				case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+					var err error
+					profileCreateBody, err = io.ReadAll(req.Body)
+					if err != nil {
+						t.Errorf("read profile create request: %v", err)
+						http.Error(w, "invalid request body", http.StatusBadRequest)
+						return
+					}
+					signingFetchWriteJSON(t, w, http.StatusCreated, fmt.Sprintf(`{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":%q,"profileState":"ACTIVE"}}}`, tt.profileType))
+				default:
+					t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			t.Cleanup(server.Close)
+			client := newSigningFetchServerTestClient(t, server)
+
+			profile, certificates, created, err := resolveSigningAssets(
+				context.Background(),
+				client,
+				signingAssetsOptions{
+					BundleIDResourceID: "bundle-main",
+					BundleIdentifier:   "com.example.signing.profile",
+					ProfileType:        tt.profileType,
+					DeviceIDs:          tt.deviceIDs,
+					CreateMissing:      true,
+				},
+			)
+			if err != nil {
+				t.Fatalf("resolveSigningAssets() error: %v", err)
+			}
+			if !created || profile.Data.ID != "profile-created" {
+				t.Fatalf("expected created profile, got created=%v profile=%#v", created, profile)
+			}
+			createdWithCertificateIDs := profileCreateCertificateIDs(t, bytes.NewReader(profileCreateBody))
+			if got := strings.Join(createdWithCertificateIDs, ","); got != "cert-a" {
+				t.Fatalf("profile certificate IDs = %q, want cert-a", got)
+			}
+			if got := strings.Join(extractIDs(certificates.Data), ","); got != "cert-a" {
+				t.Fatalf("returned certificate IDs = %q, want cert-a", got)
+			}
+		})
 	}
 }
 
@@ -724,25 +738,31 @@ func TestCertificatesForProfileCreationAcceptsOmittedActivationButRequiresValidE
 	}
 }
 
-func TestIsAppStoreDistributionProfileMatchesOnlyAppStoreTypes(t *testing.T) {
+func TestIsSingleCertificateProfileMatchesDocumentedTypes(t *testing.T) {
 	tests := []struct {
 		profileType string
 		want        bool
 	}{
 		{profileType: "IOS_APP_STORE", want: true},
+		{profileType: "IOS_APP_ADHOC", want: true},
+		{profileType: "IOS_APP_INHOUSE", want: true},
 		{profileType: "TVOS_APP_STORE", want: true},
+		{profileType: "TVOS_APP_ADHOC", want: true},
+		{profileType: "TVOS_APP_INHOUSE", want: true},
 		{profileType: "MAC_APP_STORE", want: true},
 		{profileType: " mac_catalyst_app_store ", want: true},
-		{profileType: "IOS_APP_ADHOC", want: false},
-		{profileType: "IOS_APP_INHOUSE", want: false},
 		{profileType: "MAC_APP_DIRECT", want: false},
+		{profileType: "MAC_CATALYST_APP_DIRECT", want: false},
 		{profileType: "IOS_APP_DEVELOPMENT", want: false},
+		{profileType: "TVOS_APP_DEVELOPMENT", want: false},
+		{profileType: "MAC_APP_DEVELOPMENT", want: false},
+		{profileType: "MAC_CATALYST_APP_DEVELOPMENT", want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(strings.TrimSpace(tt.profileType), func(t *testing.T) {
-			if got := isAppStoreDistributionProfile(tt.profileType); got != tt.want {
-				t.Fatalf("isAppStoreDistributionProfile(%q) = %v, want %v", tt.profileType, got, tt.want)
+			if got := isSingleCertificateProfile(tt.profileType); got != tt.want {
+				t.Fatalf("isSingleCertificateProfile(%q) = %v, want %v", tt.profileType, got, tt.want)
 			}
 		})
 	}

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -687,7 +687,7 @@ func TestResolveSigningAssetsRejectsProfileCreationWhenAllCertificatesAreIneligi
 	}
 }
 
-func TestCertificatesForProfileCreationRequiresCompleteLifecycleMetadata(t *testing.T) {
+func TestCertificatesForProfileCreationAcceptsOmittedActivationButRequiresValidExpiration(t *testing.T) {
 	now := time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)
 	active := true
 	certificates := []asc.Resource[asc.CertificateAttributes]{
@@ -699,8 +699,8 @@ func TestCertificatesForProfileCreationRequiresCompleteLifecycleMetadata(t *test
 	}
 
 	got := certificatesForProfileCreation(certificates, "IOS_APP_DEVELOPMENT", now)
-	if ids := strings.Join(extractIDs(got), ","); ids != "cert-valid" {
-		t.Fatalf("eligible certificate IDs = %q, want cert-valid", ids)
+	if ids := strings.Join(extractIDs(got), ","); ids != "cert-missing-activation,cert-valid" {
+		t.Fatalf("eligible certificate IDs = %q, want omitted-activation and valid certificates", ids)
 	}
 }
 

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -539,13 +541,13 @@ func TestResolveSigningAssetsCreatesWhenActiveProfilesLackRequestedCertificate(t
 }
 
 func TestResolveSigningAssetsCreatesAppStoreProfileWithNewestEligibleCertificate(t *testing.T) {
-	var createdWithCertificateIDs []string
-	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+	var profileCreateBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
-			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+			signingFetchWriteJSON(t, w, http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
-			return signingFetchJSONResponse(http.StatusOK, `{
+			signingFetchWriteJSON(t, w, http.StatusOK, `{
 				"data":[
 					{"type":"certificates","id":"cert-inactive","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":false,"expirationDate":"2102-01-01T00:00:00Z"}},
 					{"type":"certificates","id":"cert-expired","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2000-01-01T00:00:00Z"}},
@@ -555,13 +557,21 @@ func TestResolveSigningAssetsCreatesAppStoreProfileWithNewestEligibleCertificate
 				]
 			}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
-			createdWithCertificateIDs = profileCreateCertificateIDs(t, req)
-			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
+			var err error
+			profileCreateBody, err = io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("read profile create request: %v", err)
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			signingFetchWriteJSON(t, w, http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
 		}
-	})
+	}))
+	t.Cleanup(server.Close)
+	client := newSigningFetchServerTestClient(t, server)
 
 	profile, certificates, created, err := resolveSigningAssets(
 		context.Background(),
@@ -579,6 +589,7 @@ func TestResolveSigningAssetsCreatesAppStoreProfileWithNewestEligibleCertificate
 	if !created || profile.Data.ID != "profile-created" {
 		t.Fatalf("expected created profile, got created=%v profile=%#v", created, profile)
 	}
+	createdWithCertificateIDs := profileCreateCertificateIDs(t, bytes.NewReader(profileCreateBody))
 	if got := strings.Join(createdWithCertificateIDs, ","); got != "cert-a" {
 		t.Fatalf("profile certificate IDs = %q, want cert-a", got)
 	}
@@ -588,16 +599,16 @@ func TestResolveSigningAssetsCreatesAppStoreProfileWithNewestEligibleCertificate
 }
 
 func TestResolveSigningAssetsPreservesEligibleDevelopmentCertificates(t *testing.T) {
-	var createdWithCertificateIDs []string
-	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+	var profileCreateBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
-			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+			signingFetchWriteJSON(t, w, http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
 			if got := req.URL.Query().Get("filter[certificateType]"); got != "IOS_DEVELOPMENT,DEVELOPMENT" {
-				t.Fatalf("certificate type filter = %q, want IOS_DEVELOPMENT,DEVELOPMENT", got)
+				t.Errorf("certificate type filter = %q, want IOS_DEVELOPMENT,DEVELOPMENT", got)
 			}
-			return signingFetchJSONResponse(http.StatusOK, `{
+			signingFetchWriteJSON(t, w, http.StatusOK, `{
 				"data":[
 					{"type":"certificates","id":"cert-ios","attributes":{"certificateType":"IOS_DEVELOPMENT","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}},
 					{"type":"certificates","id":"cert-unified","attributes":{"certificateType":"DEVELOPMENT","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}},
@@ -605,13 +616,21 @@ func TestResolveSigningAssetsPreservesEligibleDevelopmentCertificates(t *testing
 				]
 			}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
-			createdWithCertificateIDs = profileCreateCertificateIDs(t, req)
-			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_DEVELOPMENT","profileState":"ACTIVE"}}}`)
+			var err error
+			profileCreateBody, err = io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("read profile create request: %v", err)
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			signingFetchWriteJSON(t, w, http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_DEVELOPMENT","profileState":"ACTIVE"}}}`)
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
 		}
-	})
+	}))
+	t.Cleanup(server.Close)
+	client := newSigningFetchServerTestClient(t, server)
 
 	_, certificates, created, err := resolveSigningAssets(
 		context.Background(),
@@ -630,6 +649,7 @@ func TestResolveSigningAssetsPreservesEligibleDevelopmentCertificates(t *testing
 	if !created {
 		t.Fatal("expected created profile")
 	}
+	createdWithCertificateIDs := profileCreateCertificateIDs(t, bytes.NewReader(profileCreateBody))
 	want := "cert-ios,cert-unified"
 	if got := strings.Join(createdWithCertificateIDs, ","); got != want {
 		t.Fatalf("profile certificate IDs = %q, want %q", got, want)
@@ -857,6 +877,38 @@ func (fn signingFetchRoundTripFunc) RoundTrip(req *http.Request) (*http.Response
 
 func newSigningFetchTestClient(t *testing.T, fn signingFetchRoundTripFunc) *asc.Client {
 	t.Helper()
+	return newSigningFetchHTTPClient(t, &http.Client{Transport: fn})
+}
+
+type signingFetchServerRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn signingFetchServerRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func newSigningFetchServerTestClient(t *testing.T, server *httptest.Server) *asc.Client {
+	t.Helper()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	httpClient := server.Client()
+	serverTransport := httpClient.Transport
+	httpClient.Transport = signingFetchServerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		routedReq := req.Clone(req.Context())
+		routedURL := *req.URL
+		routedURL.Scheme = serverURL.Scheme
+		routedURL.Host = serverURL.Host
+		routedReq.URL = &routedURL
+		routedReq.Host = serverURL.Host
+		return serverTransport.RoundTrip(routedReq)
+	})
+	return newSigningFetchHTTPClient(t, httpClient)
+}
+
+func newSigningFetchHTTPClient(t *testing.T, httpClient *http.Client) *asc.Client {
+	t.Helper()
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -871,9 +923,7 @@ func newSigningFetchTestClient(t *testing.T, fn signingFetchRoundTripFunc) *asc.
 		t.Fatalf("write key: %v", err)
 	}
 
-	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, &http.Client{
-		Transport: fn,
-	})
+	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, httpClient)
 	if err != nil {
 		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
 	}
@@ -889,11 +939,20 @@ func signingFetchJSONResponse(status int, body string) *http.Response {
 	}
 }
 
-func profileCreateCertificateIDs(t *testing.T, req *http.Request) []string {
+func signingFetchWriteJSON(t *testing.T, w http.ResponseWriter, status int, body string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := io.WriteString(w, body); err != nil {
+		t.Errorf("write JSON response: %v", err)
+	}
+}
+
+func profileCreateCertificateIDs(t *testing.T, body io.Reader) []string {
 	t.Helper()
 
 	var payload asc.ProfileCreateRequest
-	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+	if err := json.NewDecoder(body).Decode(&payload); err != nil {
 		t.Fatalf("decode profile create request: %v", err)
 	}
 	if payload.Data.Relationships == nil || payload.Data.Relationships.Certificates == nil {

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -18,6 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
@@ -501,7 +503,7 @@ func TestResolveSigningAssetsCreatesWhenActiveProfilesLackRequestedCertificate(t
 		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/profiles/"):
 			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-mac","attributes":{"certificateType":"MAC_APP_DISTRIBUTION"}}]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
-			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-ios","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-ios","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}}]}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
 			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
 		default:
@@ -536,6 +538,196 @@ func TestResolveSigningAssetsCreatesWhenActiveProfilesLackRequestedCertificate(t
 	}
 }
 
+func TestResolveSigningAssetsCreatesAppStoreProfileWithNewestEligibleCertificate(t *testing.T) {
+	var createdWithCertificateIDs []string
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+			return signingFetchJSONResponse(http.StatusOK, `{
+				"data":[
+					{"type":"certificates","id":"cert-inactive","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":false,"expirationDate":"2102-01-01T00:00:00Z"}},
+					{"type":"certificates","id":"cert-expired","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2000-01-01T00:00:00Z"}},
+					{"type":"certificates","id":"cert-older","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}},
+					{"type":"certificates","id":"cert-b","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}},
+					{"type":"certificates","id":"cert-a","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}}
+				]
+			}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+			createdWithCertificateIDs = profileCreateCertificateIDs(t, req)
+			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	profile, certificates, created, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+			CreateMissing:      true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveSigningAssets() error: %v", err)
+	}
+	if !created || profile.Data.ID != "profile-created" {
+		t.Fatalf("expected created profile, got created=%v profile=%#v", created, profile)
+	}
+	if got := strings.Join(createdWithCertificateIDs, ","); got != "cert-a" {
+		t.Fatalf("profile certificate IDs = %q, want cert-a", got)
+	}
+	if got := strings.Join(extractIDs(certificates.Data), ","); got != "cert-a" {
+		t.Fatalf("returned certificate IDs = %q, want cert-a", got)
+	}
+}
+
+func TestResolveSigningAssetsPreservesEligibleDevelopmentCertificates(t *testing.T) {
+	var createdWithCertificateIDs []string
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+			if got := req.URL.Query().Get("filter[certificateType]"); got != "IOS_DEVELOPMENT,DEVELOPMENT" {
+				t.Fatalf("certificate type filter = %q, want IOS_DEVELOPMENT,DEVELOPMENT", got)
+			}
+			return signingFetchJSONResponse(http.StatusOK, `{
+				"data":[
+					{"type":"certificates","id":"cert-ios","attributes":{"certificateType":"IOS_DEVELOPMENT","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}},
+					{"type":"certificates","id":"cert-unified","attributes":{"certificateType":"DEVELOPMENT","activated":true,"expirationDate":"2101-01-01T00:00:00Z"}},
+					{"type":"certificates","id":"cert-inactive","attributes":{"certificateType":"DEVELOPMENT","activated":false,"expirationDate":"2102-01-01T00:00:00Z"}}
+				]
+			}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+			createdWithCertificateIDs = profileCreateCertificateIDs(t, req)
+			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_DEVELOPMENT","profileState":"ACTIVE"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	_, certificates, created, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_DEVELOPMENT",
+			DeviceIDs:          []string{"device-1"},
+			CreateMissing:      true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveSigningAssets() error: %v", err)
+	}
+	if !created {
+		t.Fatal("expected created profile")
+	}
+	want := "cert-ios,cert-unified"
+	if got := strings.Join(createdWithCertificateIDs, ","); got != want {
+		t.Fatalf("profile certificate IDs = %q, want %q", got, want)
+	}
+	if got := strings.Join(extractIDs(certificates.Data), ","); got != want {
+		t.Fatalf("returned certificate IDs = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSigningAssetsRejectsProfileCreationWhenAllCertificatesAreIneligible(t *testing.T) {
+	postCalled := false
+	preflightCalled := false
+	client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+			return signingFetchJSONResponse(http.StatusOK, `{
+				"data":[
+					{"type":"certificates","id":"cert-inactive","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":false,"expirationDate":"2100-01-01T00:00:00Z"}},
+					{"type":"certificates","id":"cert-expired","attributes":{"certificateType":"DISTRIBUTION","activated":true,"expirationDate":"2000-01-01T00:00:00Z"}}
+				]
+			}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+			postCalled = true
+			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created"}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return signingFetchJSONResponse(http.StatusInternalServerError, `{}`)
+		}
+	})
+
+	_, _, _, err := resolveSigningAssets(
+		context.Background(),
+		client,
+		signingAssetsOptions{
+			BundleIDResourceID: "bundle-main",
+			BundleIdentifier:   "com.example.signing.profile",
+			ProfileType:        "IOS_APP_STORE",
+			CreateMissing:      true,
+			BeforeCreate: func() error {
+				preflightCalled = true
+				return nil
+			},
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "no active, unexpired certificates available") {
+		t.Fatalf("resolveSigningAssets() error = %v, want no eligible certificate error", err)
+	}
+	if preflightCalled {
+		t.Fatal("repository preflight ran without an eligible certificate")
+	}
+	if postCalled {
+		t.Fatal("profile creation ran without an eligible certificate")
+	}
+}
+
+func TestCertificatesForProfileCreationRequiresCompleteLifecycleMetadata(t *testing.T) {
+	now := time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)
+	active := true
+	certificates := []asc.Resource[asc.CertificateAttributes]{
+		{ID: "cert-missing-activation", Attributes: asc.CertificateAttributes{ExpirationDate: "2031-01-01T00:00:00Z"}},
+		{ID: "cert-missing-expiration", Attributes: asc.CertificateAttributes{Activated: &active}},
+		{ID: "cert-malformed-expiration", Attributes: asc.CertificateAttributes{Activated: &active, ExpirationDate: "not-a-date"}},
+		{ID: "cert-expiring-now", Attributes: asc.CertificateAttributes{Activated: &active, ExpirationDate: "2030-01-01T00:00:00Z"}},
+		{ID: "cert-valid", Attributes: asc.CertificateAttributes{Activated: &active, ExpirationDate: "2030-01-01T00:00:01Z"}},
+	}
+
+	got := certificatesForProfileCreation(certificates, "IOS_APP_DEVELOPMENT", now)
+	if ids := strings.Join(extractIDs(got), ","); ids != "cert-valid" {
+		t.Fatalf("eligible certificate IDs = %q, want cert-valid", ids)
+	}
+}
+
+func TestIsAppStoreDistributionProfileMatchesOnlyAppStoreTypes(t *testing.T) {
+	tests := []struct {
+		profileType string
+		want        bool
+	}{
+		{profileType: "IOS_APP_STORE", want: true},
+		{profileType: "TVOS_APP_STORE", want: true},
+		{profileType: "MAC_APP_STORE", want: true},
+		{profileType: " mac_catalyst_app_store ", want: true},
+		{profileType: "IOS_APP_ADHOC", want: false},
+		{profileType: "IOS_APP_INHOUSE", want: false},
+		{profileType: "MAC_APP_DIRECT", want: false},
+		{profileType: "IOS_APP_DEVELOPMENT", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.TrimSpace(tt.profileType), func(t *testing.T) {
+			if got := isAppStoreDistributionProfile(tt.profileType); got != tt.want {
+				t.Fatalf("isAppStoreDistributionProfile(%q) = %v, want %v", tt.profileType, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveSigningAssetsPreflightsBeforeCreatingProfile(t *testing.T) {
 	certificateContent := base64.StdEncoding.EncodeToString([]byte("certificate"))
 	profileContent := base64.StdEncoding.EncodeToString([]byte("profile"))
@@ -550,7 +742,7 @@ func TestResolveSigningAssetsPreflightsBeforeCreatingProfile(t *testing.T) {
 			return signingFetchJSONResponse(
 				http.StatusOK,
 				fmt.Sprintf(
-					`{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION","serialNumber":"CERT1","certificateContent":%q}}]}`,
+					`{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION","serialNumber":"CERT1","certificateContent":%q,"activated":true,"expirationDate":"2100-01-01T00:00:00Z"}}]}`,
 					certificateContent,
 				),
 			)
@@ -611,7 +803,7 @@ func TestResolveSigningAssetsRefreshesCreateTimeoutAfterPreflight(t *testing.T) 
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
 			return signingFetchJSONResponse(http.StatusOK, `{"data":[]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
-			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+			return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}}]}`)
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
 			return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
 		default:
@@ -695,4 +887,21 @@ func signingFetchJSONResponse(status int, body string) *http.Response {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
+}
+
+func profileCreateCertificateIDs(t *testing.T, req *http.Request) []string {
+	t.Helper()
+
+	var payload asc.ProfileCreateRequest
+	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode profile create request: %v", err)
+	}
+	if payload.Data.Relationships == nil || payload.Data.Relationships.Certificates == nil {
+		t.Fatal("profile create request is missing certificate relationships")
+	}
+	ids := make([]string, 0, len(payload.Data.Relationships.Certificates.Data))
+	for _, certificate := range payload.Data.Relationships.Certificates.Data {
+		ids = append(ids, certificate.ID)
+	}
+	return ids
 }

--- a/internal/cli/signing/signing_sync_test.go
+++ b/internal/cli/signing/signing_sync_test.go
@@ -59,7 +59,7 @@ func TestSigningSyncPreparesRepositoryOnceInAssetOrder(t *testing.T) {
 				case req.Method == http.MethodGet && req.URL.Path == "/v1/profiles/profile-main/certificates":
 					return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
 				case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
-					return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}]}`)
+					return signingFetchJSONResponse(http.StatusOK, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION","activated":true,"expirationDate":"2100-01-01T00:00:00Z"}}]}`)
 				case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
 					return signingFetchJSONResponse(http.StatusCreated, `{"data":{"type":"profiles","id":"profile-created","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}}`)
 				default:


### PR DESCRIPTION
## Summary

- reject certificates that are explicitly inactive, expired, or missing a parseable expiration before profile creation
- use one deterministic certificate for documented App Store, Ad Hoc, and In-House profiles: latest expiration, then resource ID
- keep every eligible unified and legacy development certificate in API order
- stop before repository preflight and `POST /v1/profiles` when no eligible certificate remains

## Contract

Apple documents that revoked certificates invalidate profiles and that expired distribution certificates cannot sign new uploads:

https://developer.apple.com/support/certificates/

Apple documents one distribution certificate for App Store and Ad Hoc profiles. The distribution-profile contract also covers In-House profiles; development profiles can contain one or more certificates. Direct/Developer ID profile cardinality is not documented, so those types keep every eligible certificate:

https://developer.apple.com/help/account/provisioning-profiles/create-an-app-store-provisioning-profile
https://developer.apple.com/help/account/provisioning-profiles/create-an-ad-hoc-provisioning-profile
https://developer.apple.com/help/glossary/distribution-provisioning-profile/
https://developer.apple.com/help/account/provisioning-profiles/create-a-development-provisioning-profile

The repository OpenAPI snapshot exposes `activated` and `expirationDate` on certificate resources, but the certificates collection has no lifecycle filter. Selection therefore happens locally immediately before profile creation.

## Verification

- RED: inactive and expired certificates reached profile creation; Ad Hoc payloads sent every eligible distribution certificate; an all-invalid collection still triggered creation
- RED from live contract evidence: treating an omitted `activated` value as inactive rejected valid certificates
- focused signing tests and targeted race tests
- adjacent certificate and profile HTTP tests
- built `/tmp/asc`; checked help plus missing-required exit code 2
- read-only certificate lookup found six future-dated distribution certificates with `activated` omitted, so omission remains eligible while explicit false is rejected
- read-only fetches against disposable app `6759231657` stopped on missing profiles without creating output or changing Apple state
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788923876&installation_model_id=10418&pr_number=1931&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1931&signature=f7bc8184521eb876e57d070af88b4101efb91d1ff3631e84adc93732e65eebf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signing profile creation by using only active, unexpired certificates.
  * App Store, Ad Hoc, and In-House profiles now select the eligible certificate with the latest expiration date.
  * Other profile types continue using all eligible certificates.
  * Added a clear error when no valid certificates are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->