### PR TITLE
Preserve early Xcode failure diagnostics

### DIFF
--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-const xcodeCommandErrorOutputLimit = 64 * 1024
+const xcodebuildErrorTailLimit = 64 * 1024
 
 type ArchiveOptions struct {
 	WorkspacePath  string
@@ -773,7 +773,7 @@ func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) 
 		ctx = context.Background()
 	}
 	cmd := commandContextFn(ctx, "xcrun", args...)
-	outputTail := newTailBuffer(xcodeCommandErrorOutputLimit)
+	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
 	combinedOutput := io.Writer(outputTail)
 	if logWriter != nil {
 		combinedOutput = io.MultiWriter(logWriter, outputTail)
@@ -789,7 +789,7 @@ func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) 
 
 	details := append(stdoutOutput.Details(), stderrOutput.Details()...)
 	details = UniqueDiagnosticDetails(details)
-	details = boundDiagnosticDetails(details, xcodeCommandErrorOutputLimit)
+	details = boundDiagnosticDetails(details, xcodebuildErrorTailLimit)
 	if len(details) == 0 {
 		return nil
 	}
@@ -883,7 +883,7 @@ func (w *altoolValidationOutputWriter) consume(p []byte) {
 }
 
 func (w *altoolValidationOutputWriter) appendLine(fragment []byte) {
-	remaining := xcodeCommandErrorOutputLimit - len(w.line)
+	remaining := xcodebuildErrorTailLimit - len(w.line)
 	if remaining <= 0 {
 		return
 	}
@@ -904,7 +904,7 @@ func (w *altoolValidationOutputWriter) recordLine() {
 	if len(w.details) > 0 {
 		separatorBytes = len("; ")
 	}
-	remaining := xcodeCommandErrorOutputLimit - w.detailBytes - separatorBytes
+	remaining := xcodebuildErrorTailLimit - w.detailBytes - separatorBytes
 	if remaining <= 0 {
 		return
 	}
@@ -952,7 +952,7 @@ func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer
 	cmd := commandContextFn(ctx, "xcrun", args...)
 	var stdout strings.Builder
 	var stderr strings.Builder
-	outputTail := newTailBuffer(xcodeCommandErrorOutputLimit)
+	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
 	stdoutWriter := io.Writer(&stdout)
 	stderrWriter := io.Writer(io.MultiWriter(&stderr, outputTail))
 	if logWriter != nil {
@@ -968,7 +968,7 @@ func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer
 		}
 		if detail != "" {
 			if outputTail.Truncated() {
-				return "", fmt.Errorf("xcrun altool %s failed (showing last %d bytes): %s", action, xcodeCommandErrorOutputLimit, detail)
+				return "", fmt.Errorf("xcrun altool %s failed (showing last %d bytes): %s", action, xcodebuildErrorTailLimit, detail)
 			}
 			return "", fmt.Errorf("xcrun altool %s failed: %s", action, detail)
 		}
@@ -1256,9 +1256,9 @@ func runCommandWithBoundedOutputMode(ctx context.Context, name string, args []st
 		ctx = context.Background()
 	}
 	cmd := commandContextFn(ctx, name, args...)
-	outputWindow := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
-	cmd.Stdout = outputWindow.newStreamWriter(logWriter)
-	cmd.Stderr = outputWindow.newStreamWriter(logWriter)
+	outputWindow := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, logWriter)
+	cmd.Stdout = outputWindow.newStreamWriter()
+	cmd.Stderr = outputWindow.newStreamWriter()
 	if err := runXcodeCommand(cmd); err != nil {
 		return formatCommandOutputError(ctx, err, outputWindow, action, commandLabel, preserveProcessError)
 	}
@@ -1367,12 +1367,12 @@ type xcodeDiagnosticBuffer struct {
 	mu              sync.Mutex
 	limit           int
 	tail            *tailBuffer
+	logWriter       io.Writer
 	totalBytes      int64
 	diagnostics     []string
 	diagnosticSet   map[string]struct{}
 	diagnosticBytes int
 	streams         []*xcodeDiagnosticLineState
-	defaultStream   *xcodeDiagnosticLineState
 }
 
 type xcodeDiagnosticLineState struct {
@@ -1381,32 +1381,25 @@ type xcodeDiagnosticLineState struct {
 }
 
 type xcodeDiagnosticStreamWriter struct {
-	buffer    *xcodeDiagnosticBuffer
-	state     *xcodeDiagnosticLineState
-	logWriter io.Writer
+	buffer *xcodeDiagnosticBuffer
+	state  *xcodeDiagnosticLineState
 }
 
-func newXcodeDiagnosticBuffer(limit int) *xcodeDiagnosticBuffer {
-	defaultStream := &xcodeDiagnosticLineState{}
+func newXcodeDiagnosticBuffer(limit int, logWriter io.Writer) *xcodeDiagnosticBuffer {
 	return &xcodeDiagnosticBuffer{
 		limit:         max(0, limit),
 		tail:          newTailBuffer(max(0, limit)),
+		logWriter:     logWriter,
 		diagnosticSet: make(map[string]struct{}),
-		streams:       []*xcodeDiagnosticLineState{defaultStream},
-		defaultStream: defaultStream,
 	}
 }
 
-func (b *xcodeDiagnosticBuffer) newStreamWriter(logWriter io.Writer) io.Writer {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
+func (b *xcodeDiagnosticBuffer) newStreamWriter() io.Writer {
 	state := &xcodeDiagnosticLineState{}
 	b.streams = append(b.streams, state)
 	return &xcodeDiagnosticStreamWriter{
-		buffer:    b,
-		state:     state,
-		logWriter: logWriter,
+		buffer: b,
+		state:  state,
 	}
 }
 
@@ -1414,8 +1407,8 @@ func (w *xcodeDiagnosticStreamWriter) Write(p []byte) (int, error) {
 	w.buffer.mu.Lock()
 	defer w.buffer.mu.Unlock()
 
-	if w.logWriter != nil {
-		written, err := w.logWriter.Write(p)
+	if w.buffer.logWriter != nil {
+		written, err := w.buffer.logWriter.Write(p)
 		if err != nil {
 			return written, err
 		}
@@ -1424,12 +1417,6 @@ func (w *xcodeDiagnosticStreamWriter) Write(p []byte) (int, error) {
 		}
 	}
 	return w.buffer.writeStreamLocked(w.state, p), nil
-}
-
-func (b *xcodeDiagnosticBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.writeStreamLocked(b.defaultStream, p), nil
 }
 
 func (b *xcodeDiagnosticBuffer) writeStreamLocked(state *xcodeDiagnosticLineState, p []byte) int {

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -1369,8 +1369,19 @@ func (b *headTailBuffer) String() string {
 
 	head := trimIncompleteUTF8Suffix(b.head)
 	tail := b.tail.String()
+	marker := fmt.Sprintf("\n... %d bytes omitted ...\n", b.totalBytes)
+	contentLimit := b.limit - len(marker)
+	if contentLimit < 0 {
+		marker = ""
+		contentLimit = b.limit
+	}
+	head, tail = retainHeadAndTail(head, tail, contentLimit)
+	if marker == "" {
+		return head + tail
+	}
 	omittedBytes := b.totalBytes - int64(len(head)) - int64(len(tail))
-	return fmt.Sprintf("%s\n... %d bytes omitted ...\n%s", head, omittedBytes, tail)
+	marker = fmt.Sprintf("\n... %d bytes omitted ...\n", omittedBytes)
+	return head + marker + tail
 }
 
 func (b *headTailBuffer) Truncated() bool {
@@ -1386,6 +1397,25 @@ func trimIncompleteUTF8Suffix(data []byte) string {
 		data = data[:len(data)-1]
 	}
 	return string(data)
+}
+
+func retainHeadAndTail(head string, tail string, limit int) (string, string) {
+	if limit <= 0 {
+		return "", ""
+	}
+
+	headLimit := (limit + 1) / 2
+	tailLimit := limit - headLimit
+	if len(head) > headLimit {
+		head = trimIncompleteUTF8Suffix([]byte(head[:headLimit]))
+	}
+	if len(tail) > tailLimit {
+		tail = tail[len(tail)-tailLimit:]
+		for len(tail) > 0 && !utf8.RuneStart(tail[0]) {
+			tail = tail[1:]
+		}
+	}
+	return head, tail
 }
 
 type tailBuffer struct {

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -1256,13 +1256,9 @@ func runCommandWithBoundedOutputMode(ctx context.Context, name string, args []st
 		ctx = context.Background()
 	}
 	cmd := commandContextFn(ctx, name, args...)
-	outputWindow := newHeadTailBuffer(xcodeCommandErrorOutputLimit)
-	writer := io.Writer(outputWindow)
-	if logWriter != nil {
-		writer = io.MultiWriter(logWriter, outputWindow)
-	}
-	cmd.Stdout = writer
-	cmd.Stderr = writer
+	outputWindow := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	cmd.Stdout = outputWindow.newStreamWriter(logWriter)
+	cmd.Stderr = outputWindow.newStreamWriter(logWriter)
 	if err := runXcodeCommand(cmd); err != nil {
 		return formatCommandOutputError(ctx, err, outputWindow, action, commandLabel, preserveProcessError)
 	}
@@ -1321,101 +1317,344 @@ func formatCommandOutputError(ctx context.Context, err error, output formattedCo
 	return fmt.Errorf("%s %s failed: %w", commandLabel, action, err)
 }
 
-type headTailBuffer struct {
-	limit      int
-	headLimit  int
-	head       []byte
-	tail       *tailBuffer
-	totalBytes int64
+const (
+	xcodeDiagnosticLineLimit   = 8 * 1024
+	xcodeDiagnosticPrefixLimit = 16 * 1024
+)
+
+var sourceLocationXcodeErrorPattern = regexp.MustCompile(
+	`^.+:[0-9]+(:[0-9]+)?:[[:space:]]+(fatal[[:space:]]+)?error:[[:space:]]+[^[:space:]]`,
+)
+
+var xcodeErrorToolPrefixes = map[string]struct{}{
+	"actool":     {},
+	"clang":      {},
+	"clang++":    {},
+	"codesign":   {},
+	"ibtool":     {},
+	"ld":         {},
+	"swiftc":     {},
+	"xcodebuild": {},
+	"xcrun":      {},
 }
 
-func newHeadTailBuffer(limit int) *headTailBuffer {
-	headLimit := 0
-	if limit > 0 {
-		headLimit = (limit + 1) / 2
-	}
-	return &headTailBuffer{
-		limit:     limit,
-		headLimit: headLimit,
-		tail:      newTailBuffer(max(0, limit-headLimit)),
+var xcodeDiagnosticPathExtensions = map[string]struct{}{
+	".app":          {},
+	".appex":        {},
+	".c":            {},
+	".cc":           {},
+	".cpp":          {},
+	".entitlements": {},
+	".framework":    {},
+	".h":            {},
+	".hpp":          {},
+	".m":            {},
+	".metal":        {},
+	".mm":           {},
+	".modulemap":    {},
+	".plist":        {},
+	".storyboard":   {},
+	".strings":      {},
+	".swift":        {},
+	".xcassets":     {},
+	".xcconfig":     {},
+	".xcodeproj":    {},
+	".xcworkspace":  {},
+	".xib":          {},
+}
+
+type xcodeDiagnosticBuffer struct {
+	mu              sync.Mutex
+	limit           int
+	tail            *tailBuffer
+	totalBytes      int64
+	diagnostics     []string
+	diagnosticSet   map[string]struct{}
+	diagnosticBytes int
+	streams         []*xcodeDiagnosticLineState
+	defaultStream   *xcodeDiagnosticLineState
+}
+
+type xcodeDiagnosticLineState struct {
+	pending  []byte
+	overflow bool
+}
+
+type xcodeDiagnosticStreamWriter struct {
+	buffer    *xcodeDiagnosticBuffer
+	state     *xcodeDiagnosticLineState
+	logWriter io.Writer
+}
+
+func newXcodeDiagnosticBuffer(limit int) *xcodeDiagnosticBuffer {
+	defaultStream := &xcodeDiagnosticLineState{}
+	return &xcodeDiagnosticBuffer{
+		limit:         max(0, limit),
+		tail:          newTailBuffer(max(0, limit)),
+		diagnosticSet: make(map[string]struct{}),
+		streams:       []*xcodeDiagnosticLineState{defaultStream},
+		defaultStream: defaultStream,
 	}
 }
 
-func (b *headTailBuffer) Write(p []byte) (int, error) {
-	written := len(p)
-	b.totalBytes += int64(written)
-	if b.limit <= 0 {
-		return written, nil
-	}
+func (b *xcodeDiagnosticBuffer) newStreamWriter(logWriter io.Writer) io.Writer {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	if remaining := b.headLimit - len(b.head); remaining > 0 {
-		prefixLength := min(remaining, len(p))
-		b.head = append(b.head, p[:prefixLength]...)
-		p = p[prefixLength:]
+	state := &xcodeDiagnosticLineState{}
+	b.streams = append(b.streams, state)
+	return &xcodeDiagnosticStreamWriter{
+		buffer:    b,
+		state:     state,
+		logWriter: logWriter,
 	}
-	if len(p) > 0 {
-		_, _ = b.tail.Write(p)
-	}
-	return written, nil
 }
 
-func (b *headTailBuffer) String() string {
-	if !b.Truncated() {
-		data := make([]byte, 0, len(b.head)+len(b.tail.data))
-		data = append(data, b.head...)
-		data = append(data, b.tail.data...)
-		return string(data)
-	}
+func (w *xcodeDiagnosticStreamWriter) Write(p []byte) (int, error) {
+	w.buffer.mu.Lock()
+	defer w.buffer.mu.Unlock()
 
-	head := trimIncompleteUTF8Suffix(b.head)
-	tail := b.tail.String()
-	marker := fmt.Sprintf("\n... %d bytes omitted ...\n", b.totalBytes)
-	contentLimit := b.limit - len(marker)
-	if contentLimit < 0 {
-		marker = ""
-		contentLimit = b.limit
-	}
-	head, tail = retainHeadAndTail(head, tail, contentLimit)
-	if marker == "" {
-		return head + tail
-	}
-	omittedBytes := b.totalBytes - int64(len(head)) - int64(len(tail))
-	marker = fmt.Sprintf("\n... %d bytes omitted ...\n", omittedBytes)
-	return head + marker + tail
-}
-
-func (b *headTailBuffer) Truncated() bool {
-	return b.totalBytes > int64(max(0, b.limit))
-}
-
-func (b *headTailBuffer) TruncationDescription() string {
-	return fmt.Sprintf("output truncated to %d bytes; preserving beginning and end", max(0, b.limit))
-}
-
-func trimIncompleteUTF8Suffix(data []byte) string {
-	for trim := 0; trim < utf8.UTFMax && len(data) > 0 && !utf8.Valid(data); trim++ {
-		data = data[:len(data)-1]
-	}
-	return string(data)
-}
-
-func retainHeadAndTail(head string, tail string, limit int) (string, string) {
-	if limit <= 0 {
-		return "", ""
-	}
-
-	headLimit := (limit + 1) / 2
-	tailLimit := limit - headLimit
-	if len(head) > headLimit {
-		head = trimIncompleteUTF8Suffix([]byte(head[:headLimit]))
-	}
-	if len(tail) > tailLimit {
-		tail = tail[len(tail)-tailLimit:]
-		for len(tail) > 0 && !utf8.RuneStart(tail[0]) {
-			tail = tail[1:]
+	if w.logWriter != nil {
+		written, err := w.logWriter.Write(p)
+		if err != nil {
+			return written, err
+		}
+		if written != len(p) {
+			return written, io.ErrShortWrite
 		}
 	}
-	return head, tail
+	return w.buffer.writeStreamLocked(w.state, p), nil
+}
+
+func (b *xcodeDiagnosticBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.writeStreamLocked(b.defaultStream, p), nil
+}
+
+func (b *xcodeDiagnosticBuffer) writeStreamLocked(state *xcodeDiagnosticLineState, p []byte) int {
+	written := len(p)
+	b.totalBytes += int64(written)
+	_, _ = b.tail.Write(p)
+	b.consumeDiagnosticLinesLocked(state, p)
+	return written
+}
+
+func (b *xcodeDiagnosticBuffer) consumeDiagnosticLinesLocked(state *xcodeDiagnosticLineState, p []byte) {
+	for len(p) > 0 {
+		newline := bytes.IndexByte(p, '\n')
+		if newline < 0 {
+			b.appendDiagnosticFragmentLocked(state, p)
+			return
+		}
+		b.appendDiagnosticFragmentLocked(state, p[:newline])
+		b.finishDiagnosticLineLocked(state)
+		p = p[newline+1:]
+	}
+}
+
+func (b *xcodeDiagnosticBuffer) appendDiagnosticFragmentLocked(state *xcodeDiagnosticLineState, fragment []byte) {
+	remaining := xcodeDiagnosticLineLimit - len(state.pending)
+	if remaining > 0 {
+		prefixLength := min(remaining, len(fragment))
+		state.pending = append(state.pending, fragment[:prefixLength]...)
+		fragment = fragment[prefixLength:]
+	}
+	if len(fragment) > 0 {
+		state.overflow = true
+	}
+}
+
+func (b *xcodeDiagnosticBuffer) finishDiagnosticLineLocked(state *xcodeDiagnosticLineState) {
+	if len(state.pending) == 0 && !state.overflow {
+		return
+	}
+
+	line := strings.TrimSuffix(strings.ToValidUTF8(string(state.pending), ""), "\r")
+	if state.overflow {
+		const omissionMarker = "…"
+		line = truncateUTF8Prefix(line, xcodeDiagnosticLineLimit-len(omissionMarker)) + omissionMarker
+	}
+	state.pending = state.pending[:0]
+	state.overflow = false
+
+	line = strings.TrimSpace(line)
+	if !isXcodeErrorDiagnostic(line) {
+		return
+	}
+	b.addDiagnosticLocked(line)
+}
+
+func (b *xcodeDiagnosticBuffer) addDiagnosticLocked(line string) {
+	if _, exists := b.diagnosticSet[line]; exists {
+		return
+	}
+
+	remaining := b.diagnosticBudget() - b.diagnosticBytes
+	if remaining <= 1 {
+		return
+	}
+	line = truncateUTF8Prefix(line, remaining-1)
+	if line == "" {
+		return
+	}
+
+	b.diagnosticSet[line] = struct{}{}
+	b.diagnostics = append(b.diagnostics, line)
+	b.diagnosticBytes += len(line) + 1
+}
+
+func (b *xcodeDiagnosticBuffer) diagnosticBudget() int {
+	return min(b.limit/2, xcodeDiagnosticPrefixLimit)
+}
+
+func (b *xcodeDiagnosticBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, stream := range b.streams {
+		b.finishDiagnosticLineLocked(stream)
+	}
+	tail := strings.ToValidUTF8(b.tail.String(), "")
+	if b.totalBytes <= int64(b.limit) {
+		return tail
+	}
+
+	tailDiagnostics := newXcodeDiagnosticTailIndex(tail)
+	prefixBytes := 0
+	for {
+		boundary := max(0, len(tail)-(b.limit-prefixBytes))
+		newPrefixBytes := 0
+		for _, diagnostic := range b.diagnostics {
+			if !tailDiagnostics.containsAtOrAfter(diagnostic, boundary) {
+				newPrefixBytes += len(diagnostic) + 1
+			}
+		}
+		if newPrefixBytes == prefixBytes {
+			break
+		}
+		prefixBytes = newPrefixBytes
+	}
+	boundary := max(0, len(tail)-(b.limit-prefixBytes))
+
+	var prefix strings.Builder
+	prefix.Grow(prefixBytes)
+	for _, diagnostic := range b.diagnostics {
+		if tailDiagnostics.containsAtOrAfter(diagnostic, boundary) {
+			continue
+		}
+		prefix.WriteString(diagnostic)
+		prefix.WriteByte('\n')
+	}
+
+	diagnosticPrefix := prefix.String()
+	if len(diagnosticPrefix) > b.diagnosticBudget() {
+		diagnosticPrefix = truncateUTF8Prefix(diagnosticPrefix, b.diagnosticBudget())
+	}
+	tail = truncateUTF8Suffix(tail, b.limit-len(diagnosticPrefix))
+	return diagnosticPrefix + tail
+}
+
+type xcodeDiagnosticTailIndex map[string]int
+
+func newXcodeDiagnosticTailIndex(tail string) xcodeDiagnosticTailIndex {
+	index := make(xcodeDiagnosticTailIndex)
+	offset := 0
+	for {
+		newline := strings.IndexByte(tail[offset:], '\n')
+		lineEnd := len(tail)
+		if newline >= 0 {
+			lineEnd = offset + newline
+		}
+		line := tail[offset:lineEnd]
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line != "" {
+			lineStart := offset + strings.Index(tail[offset:lineEnd], line)
+			index[line] = max(index[line], lineStart)
+		}
+		if newline < 0 {
+			return index
+		}
+		offset = lineEnd + 1
+	}
+}
+
+func (i xcodeDiagnosticTailIndex) containsAtOrAfter(diagnostic string, boundary int) bool {
+	diagnostic = strings.TrimSpace(diagnostic)
+	if diagnostic == "" {
+		return false
+	}
+	if start, exists := i[diagnostic]; exists && start >= boundary {
+		return true
+	}
+
+	if !strings.HasSuffix(diagnostic, "…") {
+		return false
+	}
+	match := strings.TrimSuffix(diagnostic, "…")
+	for line, start := range i {
+		if start >= boundary && strings.HasPrefix(line, match) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *xcodeDiagnosticBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.totalBytes > int64(b.limit)
+}
+
+func (b *xcodeDiagnosticBuffer) TruncationDescription() string {
+	return fmt.Sprintf("output truncated to %d bytes; preserving recognized errors and final output", b.limit)
+}
+
+func isXcodeErrorDiagnostic(line string) bool {
+	line = strings.TrimSpace(line)
+	if hasXcodeErrorMessagePrefix(line) || sourceLocationXcodeErrorPattern.MatchString(line) {
+		return true
+	}
+
+	colon := strings.IndexByte(line, ':')
+	if colon <= 0 {
+		return false
+	}
+	prefix := line[:colon]
+	if !hasXcodeErrorMessagePrefix(strings.TrimSpace(line[colon+1:])) {
+		return false
+	}
+	if _, ok := xcodeErrorToolPrefixes[prefix]; ok {
+		return true
+	}
+	if strings.ContainsRune(prefix, filepath.Separator) {
+		return true
+	}
+	_, ok := xcodeDiagnosticPathExtensions[strings.ToLower(filepath.Ext(prefix))]
+	return ok
+}
+
+func hasXcodeErrorMessagePrefix(line string) bool {
+	for _, prefix := range []string{"error:", "fatal error:"} {
+		if strings.HasPrefix(line, prefix) && strings.TrimSpace(line[len(prefix):]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func truncateUTF8Suffix(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(value) <= limit {
+		return value
+	}
+	value = value[len(value)-limit:]
+	for len(value) > 0 && !utf8.RuneStart(value[0]) {
+		value = value[1:]
+	}
+	return value
 }
 
 type tailBuffer struct {

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -1456,17 +1456,14 @@ func (b *xcodeDiagnosticBuffer) addDiagnosticLocked(line string) {
 	}
 
 	remaining := b.diagnosticBudget() - b.diagnosticBytes
-	if remaining <= 1 {
-		return
-	}
-	line = truncateUTF8Prefix(line, remaining-1)
-	if line == "" {
+	required := len(line) + 1
+	if required > remaining {
 		return
 	}
 
 	b.diagnosticSet[line] = struct{}{}
 	b.diagnostics = append(b.diagnostics, line)
-	b.diagnosticBytes += len(line) + 1
+	b.diagnosticBytes += required
 }
 
 func (b *xcodeDiagnosticBuffer) diagnosticBudget() int {
@@ -1497,17 +1494,10 @@ func (b *xcodeDiagnosticBuffer) String() string {
 	prefixBytes := 0
 	for {
 		boundary := max(0, len(tail)-(b.limit-prefixBytes))
-		newPrefixBytes := 0
-		for _, diagnostic := range diagnostics {
-			if !tailDiagnostics.containsAtOrAfter(diagnostic, boundary) {
-				newPrefixBytes += len(diagnostic) + 1
-				if newPrefixBytes >= b.diagnosticBudget() {
-					newPrefixBytes = b.diagnosticBudget()
-					break
-				}
-			}
-		}
-		if newPrefixBytes == prefixBytes {
+		newPrefixBytes := appendMissingXcodeDiagnostics(
+			nil, diagnostics, tailDiagnostics, boundary, b.diagnosticBudget(),
+		)
+		if newPrefixBytes <= prefixBytes {
 			break
 		}
 		prefixBytes = newPrefixBytes
@@ -1516,23 +1506,36 @@ func (b *xcodeDiagnosticBuffer) String() string {
 
 	var prefix strings.Builder
 	prefix.Grow(prefixBytes)
+	appendMissingXcodeDiagnostics(&prefix, diagnostics, tailDiagnostics, boundary, b.diagnosticBudget())
+	diagnosticPrefix := prefix.String()
+	// Preserve the calculated tail boundary when complete-line packing leaves unused prefix space.
+	tail = truncateUTF8Suffix(tail, b.limit-prefixBytes)
+	return diagnosticPrefix + tail
+}
+
+func appendMissingXcodeDiagnostics(
+	destination *strings.Builder,
+	diagnostics []string,
+	tailDiagnostics xcodeDiagnosticTailIndex,
+	boundary int,
+	limit int,
+) int {
+	written := 0
 	for _, diagnostic := range diagnostics {
 		if tailDiagnostics.containsAtOrAfter(diagnostic, boundary) {
 			continue
 		}
-		prefix.WriteString(diagnostic)
-		prefix.WriteByte('\n')
-		if prefix.Len() >= b.diagnosticBudget() {
-			break
+		required := len(diagnostic) + 1
+		if required > limit-written {
+			continue
 		}
+		if destination != nil {
+			destination.WriteString(diagnostic)
+			destination.WriteByte('\n')
+		}
+		written += required
 	}
-
-	diagnosticPrefix := prefix.String()
-	if len(diagnosticPrefix) > b.diagnosticBudget() {
-		diagnosticPrefix = truncateUTF8Prefix(diagnosticPrefix, b.diagnosticBudget())
-	}
-	tail = truncateUTF8Suffix(tail, b.limit-len(diagnosticPrefix))
-	return diagnosticPrefix + tail
+	return written
 }
 
 type xcodeDiagnosticTailIndex struct {

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-const xcodebuildErrorTailLimit = 64 * 1024
+const xcodeCommandErrorOutputLimit = 64 * 1024
 
 type ArchiveOptions struct {
 	WorkspacePath  string
@@ -761,11 +761,11 @@ func cloneStrings(values []string) []string {
 }
 
 func runXcodebuild(ctx context.Context, args []string, logWriter io.Writer) error {
-	return runCommandWithTail(ctx, "xcodebuild", args, logWriter, summarizeAction(args), "xcodebuild")
+	return runCommandWithBoundedOutput(ctx, "xcodebuild", args, logWriter, summarizeAction(args), "xcodebuild")
 }
 
 func runXcodebuildForBuild(ctx context.Context, args []string, logWriter io.Writer) error {
-	return runCommandWithTailMode(ctx, "xcodebuild", args, logWriter, summarizeAction(args), "xcodebuild", true)
+	return runCommandWithBoundedOutputMode(ctx, "xcodebuild", args, logWriter, summarizeAction(args), "xcodebuild", true)
 }
 
 func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) error {
@@ -773,7 +773,7 @@ func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) 
 		ctx = context.Background()
 	}
 	cmd := commandContextFn(ctx, "xcrun", args...)
-	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
+	outputTail := newTailBuffer(xcodeCommandErrorOutputLimit)
 	combinedOutput := io.Writer(outputTail)
 	if logWriter != nil {
 		combinedOutput = io.MultiWriter(logWriter, outputTail)
@@ -784,12 +784,12 @@ func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) 
 	cmd.Stdout = stdoutOutput
 	cmd.Stderr = stderrOutput
 	if err := runXcodeCommand(cmd); err != nil {
-		return formatCommandTailError(ctx, err, outputTail, "validate", "xcrun altool", false)
+		return formatCommandOutputError(ctx, err, outputTail, "validate", "xcrun altool", false)
 	}
 
 	details := append(stdoutOutput.Details(), stderrOutput.Details()...)
 	details = UniqueDiagnosticDetails(details)
-	details = boundDiagnosticDetails(details, xcodebuildErrorTailLimit)
+	details = boundDiagnosticDetails(details, xcodeCommandErrorOutputLimit)
 	if len(details) == 0 {
 		return nil
 	}
@@ -883,7 +883,7 @@ func (w *altoolValidationOutputWriter) consume(p []byte) {
 }
 
 func (w *altoolValidationOutputWriter) appendLine(fragment []byte) {
-	remaining := xcodebuildErrorTailLimit - len(w.line)
+	remaining := xcodeCommandErrorOutputLimit - len(w.line)
 	if remaining <= 0 {
 		return
 	}
@@ -904,7 +904,7 @@ func (w *altoolValidationOutputWriter) recordLine() {
 	if len(w.details) > 0 {
 		separatorBytes = len("; ")
 	}
-	remaining := xcodebuildErrorTailLimit - w.detailBytes - separatorBytes
+	remaining := xcodeCommandErrorOutputLimit - w.detailBytes - separatorBytes
 	if remaining <= 0 {
 		return
 	}
@@ -952,7 +952,7 @@ func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer
 	cmd := commandContextFn(ctx, "xcrun", args...)
 	var stdout strings.Builder
 	var stderr strings.Builder
-	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
+	outputTail := newTailBuffer(xcodeCommandErrorOutputLimit)
 	stdoutWriter := io.Writer(&stdout)
 	stderrWriter := io.Writer(io.MultiWriter(&stderr, outputTail))
 	if logWriter != nil {
@@ -968,7 +968,7 @@ func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer
 		}
 		if detail != "" {
 			if outputTail.Truncated() {
-				return "", fmt.Errorf("xcrun altool %s failed (showing last %d bytes): %s", action, xcodebuildErrorTailLimit, detail)
+				return "", fmt.Errorf("xcrun altool %s failed (showing last %d bytes): %s", action, xcodeCommandErrorOutputLimit, detail)
 			}
 			return "", fmt.Errorf("xcrun altool %s failed: %s", action, detail)
 		}
@@ -1247,38 +1247,44 @@ func parseBuildStatusMetadataField(line string) (string, string, bool) {
 	return key, strings.TrimSpace(line[index+1:]), true
 }
 
-func runCommandWithTail(ctx context.Context, name string, args []string, logWriter io.Writer, action string, commandLabel string) error {
-	return runCommandWithTailMode(ctx, name, args, logWriter, action, commandLabel, false)
+func runCommandWithBoundedOutput(ctx context.Context, name string, args []string, logWriter io.Writer, action string, commandLabel string) error {
+	return runCommandWithBoundedOutputMode(ctx, name, args, logWriter, action, commandLabel, false)
 }
 
-func runCommandWithTailMode(ctx context.Context, name string, args []string, logWriter io.Writer, action string, commandLabel string, preserveProcessError bool) error {
+func runCommandWithBoundedOutputMode(ctx context.Context, name string, args []string, logWriter io.Writer, action string, commandLabel string, preserveProcessError bool) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	cmd := commandContextFn(ctx, name, args...)
-	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
-	writer := io.Writer(outputTail)
+	outputWindow := newHeadTailBuffer(xcodeCommandErrorOutputLimit)
+	writer := io.Writer(outputWindow)
 	if logWriter != nil {
-		writer = io.MultiWriter(logWriter, outputTail)
+		writer = io.MultiWriter(logWriter, outputWindow)
 	}
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	if err := runXcodeCommand(cmd); err != nil {
-		return formatCommandTailError(ctx, err, outputTail, action, commandLabel, preserveProcessError)
+		return formatCommandOutputError(ctx, err, outputWindow, action, commandLabel, preserveProcessError)
 	}
 	return nil
 }
 
-func formatCommandTailError(ctx context.Context, err error, outputTail *tailBuffer, action string, commandLabel string, preserveProcessError bool) error {
-	detail := strings.TrimSpace(outputTail.String())
+type formattedCommandOutput interface {
+	String() string
+	Truncated() bool
+	TruncationDescription() string
+}
+
+func formatCommandOutputError(ctx context.Context, err error, output formattedCommandOutput, action string, commandLabel string, preserveProcessError bool) error {
+	detail := strings.TrimSpace(output.String())
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		if detail != "" {
-			if outputTail.Truncated() {
+			if output.Truncated() {
 				return fmt.Errorf(
-					"%s %s timed out or was canceled (showing last %d bytes): %s: %w",
+					"%s %s timed out or was canceled (%s): %s: %w",
 					commandLabel,
 					action,
-					xcodebuildErrorTailLimit,
+					output.TruncationDescription(),
 					detail,
 					ctxErr,
 				)
@@ -1288,22 +1294,22 @@ func formatCommandTailError(ctx context.Context, err error, outputTail *tailBuff
 		return fmt.Errorf("%s %s timed out or was canceled: %w", commandLabel, action, ctxErr)
 	}
 	if detail != "" {
-		if outputTail.Truncated() {
+		if output.Truncated() {
 			if preserveProcessError {
 				return fmt.Errorf(
-					"%s %s failed (showing last %d bytes): %s: %w",
+					"%s %s failed (%s): %s: %w",
 					commandLabel,
 					action,
-					xcodebuildErrorTailLimit,
+					output.TruncationDescription(),
 					detail,
 					err,
 				)
 			}
 			return fmt.Errorf(
-				"%s %s failed (showing last %d bytes): %s",
+				"%s %s failed (%s): %s",
 				commandLabel,
 				action,
-				xcodebuildErrorTailLimit,
+				output.TruncationDescription(),
 				detail,
 			)
 		}
@@ -1313,6 +1319,73 @@ func formatCommandTailError(ctx context.Context, err error, outputTail *tailBuff
 		return fmt.Errorf("%s %s failed: %s", commandLabel, action, detail)
 	}
 	return fmt.Errorf("%s %s failed: %w", commandLabel, action, err)
+}
+
+type headTailBuffer struct {
+	limit      int
+	headLimit  int
+	head       []byte
+	tail       *tailBuffer
+	totalBytes int64
+}
+
+func newHeadTailBuffer(limit int) *headTailBuffer {
+	headLimit := 0
+	if limit > 0 {
+		headLimit = (limit + 1) / 2
+	}
+	return &headTailBuffer{
+		limit:     limit,
+		headLimit: headLimit,
+		tail:      newTailBuffer(max(0, limit-headLimit)),
+	}
+}
+
+func (b *headTailBuffer) Write(p []byte) (int, error) {
+	written := len(p)
+	b.totalBytes += int64(written)
+	if b.limit <= 0 {
+		return written, nil
+	}
+
+	if remaining := b.headLimit - len(b.head); remaining > 0 {
+		prefixLength := min(remaining, len(p))
+		b.head = append(b.head, p[:prefixLength]...)
+		p = p[prefixLength:]
+	}
+	if len(p) > 0 {
+		_, _ = b.tail.Write(p)
+	}
+	return written, nil
+}
+
+func (b *headTailBuffer) String() string {
+	if !b.Truncated() {
+		data := make([]byte, 0, len(b.head)+len(b.tail.data))
+		data = append(data, b.head...)
+		data = append(data, b.tail.data...)
+		return string(data)
+	}
+
+	head := trimIncompleteUTF8Suffix(b.head)
+	tail := b.tail.String()
+	omittedBytes := b.totalBytes - int64(len(head)) - int64(len(tail))
+	return fmt.Sprintf("%s\n... %d bytes omitted ...\n%s", head, omittedBytes, tail)
+}
+
+func (b *headTailBuffer) Truncated() bool {
+	return b.totalBytes > int64(max(0, b.limit))
+}
+
+func (b *headTailBuffer) TruncationDescription() string {
+	return fmt.Sprintf("output truncated to %d bytes; preserving beginning and end", max(0, b.limit))
+}
+
+func trimIncompleteUTF8Suffix(data []byte) string {
+	for trim := 0; trim < utf8.UTFMax && len(data) > 0 && !utf8.Valid(data); trim++ {
+		data = data[:len(data)-1]
+	}
+	return string(data)
 }
 
 type tailBuffer struct {
@@ -1360,6 +1433,10 @@ func (b *tailBuffer) String() string {
 
 func (b *tailBuffer) Truncated() bool {
 	return b.truncated
+}
+
+func (b *tailBuffer) TruncationDescription() string {
+	return fmt.Sprintf("showing last %d bytes", b.limit)
 }
 
 func summarizeAction(args []string) string {

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -1484,13 +1484,27 @@ func (b *xcodeDiagnosticBuffer) String() string {
 	}
 
 	tailDiagnostics := newXcodeDiagnosticTailIndex(tail)
+	diagnostics := make([]string, 0, len(tailDiagnostics.diagnostics)+len(b.diagnostics))
+	diagnosticSet := make(map[string]struct{}, cap(diagnostics))
+	for _, diagnostic := range append(tailDiagnostics.diagnostics, b.diagnostics...) {
+		if _, exists := diagnosticSet[diagnostic]; exists {
+			continue
+		}
+		diagnosticSet[diagnostic] = struct{}{}
+		diagnostics = append(diagnostics, diagnostic)
+	}
+
 	prefixBytes := 0
 	for {
 		boundary := max(0, len(tail)-(b.limit-prefixBytes))
 		newPrefixBytes := 0
-		for _, diagnostic := range b.diagnostics {
+		for _, diagnostic := range diagnostics {
 			if !tailDiagnostics.containsAtOrAfter(diagnostic, boundary) {
 				newPrefixBytes += len(diagnostic) + 1
+				if newPrefixBytes >= b.diagnosticBudget() {
+					newPrefixBytes = b.diagnosticBudget()
+					break
+				}
 			}
 		}
 		if newPrefixBytes == prefixBytes {
@@ -1502,12 +1516,15 @@ func (b *xcodeDiagnosticBuffer) String() string {
 
 	var prefix strings.Builder
 	prefix.Grow(prefixBytes)
-	for _, diagnostic := range b.diagnostics {
+	for _, diagnostic := range diagnostics {
 		if tailDiagnostics.containsAtOrAfter(diagnostic, boundary) {
 			continue
 		}
 		prefix.WriteString(diagnostic)
 		prefix.WriteByte('\n')
+		if prefix.Len() >= b.diagnosticBudget() {
+			break
+		}
 	}
 
 	diagnosticPrefix := prefix.String()
@@ -1518,10 +1535,14 @@ func (b *xcodeDiagnosticBuffer) String() string {
 	return diagnosticPrefix + tail
 }
 
-type xcodeDiagnosticTailIndex map[string]int
+type xcodeDiagnosticTailIndex struct {
+	lines       map[string]int
+	diagnostics []string
+}
 
 func newXcodeDiagnosticTailIndex(tail string) xcodeDiagnosticTailIndex {
-	index := make(xcodeDiagnosticTailIndex)
+	index := xcodeDiagnosticTailIndex{lines: make(map[string]int)}
+	diagnosticSet := make(map[string]struct{})
 	offset := 0
 	for {
 		newline := strings.IndexByte(tail[offset:], '\n')
@@ -1533,7 +1554,18 @@ func newXcodeDiagnosticTailIndex(tail string) xcodeDiagnosticTailIndex {
 		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
 		if line != "" {
 			lineStart := offset + strings.Index(tail[offset:lineEnd], line)
-			index[line] = max(index[line], lineStart)
+			index.lines[line] = max(index.lines[line], lineStart)
+			diagnostic := line
+			if len(diagnostic) > xcodeDiagnosticLineLimit {
+				const omissionMarker = "…"
+				diagnostic = truncateUTF8Prefix(diagnostic, xcodeDiagnosticLineLimit-len(omissionMarker)) + omissionMarker
+			}
+			if isXcodeErrorDiagnostic(diagnostic) {
+				if _, exists := diagnosticSet[diagnostic]; !exists {
+					diagnosticSet[diagnostic] = struct{}{}
+					index.diagnostics = append(index.diagnostics, diagnostic)
+				}
+			}
 		}
 		if newline < 0 {
 			return index
@@ -1547,7 +1579,7 @@ func (i xcodeDiagnosticTailIndex) containsAtOrAfter(diagnostic string, boundary 
 	if diagnostic == "" {
 		return false
 	}
-	if start, exists := i[diagnostic]; exists && start >= boundary {
+	if start, exists := i.lines[diagnostic]; exists && start >= boundary {
 		return true
 	}
 
@@ -1555,7 +1587,7 @@ func (i xcodeDiagnosticTailIndex) containsAtOrAfter(diagnostic string, boundary 
 		return false
 	}
 	match := strings.TrimSuffix(diagnostic, "…")
-	for line, start := range i {
+	for line, start := range i.lines {
 		if start >= boundary && strings.HasPrefix(line, match) {
 			return true
 		}

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -1257,8 +1257,8 @@ func runCommandWithBoundedOutputMode(ctx context.Context, name string, args []st
 	}
 	cmd := commandContextFn(ctx, name, args...)
 	outputWindow := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, logWriter)
-	cmd.Stdout = outputWindow.newStreamWriter()
-	cmd.Stderr = outputWindow.newStreamWriter()
+	cmd.Stdout = outputWindow
+	cmd.Stderr = outputWindow
 	if err := runXcodeCommand(cmd); err != nil {
 		return formatCommandOutputError(ctx, err, outputWindow, action, commandLabel, preserveProcessError)
 	}
@@ -1372,17 +1372,8 @@ type xcodeDiagnosticBuffer struct {
 	diagnostics     []string
 	diagnosticSet   map[string]struct{}
 	diagnosticBytes int
-	streams         []*xcodeDiagnosticLineState
-}
-
-type xcodeDiagnosticLineState struct {
-	pending  []byte
-	overflow bool
-}
-
-type xcodeDiagnosticStreamWriter struct {
-	buffer *xcodeDiagnosticBuffer
-	state  *xcodeDiagnosticLineState
+	pending         []byte
+	overflow        bool
 }
 
 func newXcodeDiagnosticBuffer(limit int, logWriter io.Writer) *xcodeDiagnosticBuffer {
@@ -1394,21 +1385,12 @@ func newXcodeDiagnosticBuffer(limit int, logWriter io.Writer) *xcodeDiagnosticBu
 	}
 }
 
-func (b *xcodeDiagnosticBuffer) newStreamWriter() io.Writer {
-	state := &xcodeDiagnosticLineState{}
-	b.streams = append(b.streams, state)
-	return &xcodeDiagnosticStreamWriter{
-		buffer: b,
-		state:  state,
-	}
-}
+func (b *xcodeDiagnosticBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-func (w *xcodeDiagnosticStreamWriter) Write(p []byte) (int, error) {
-	w.buffer.mu.Lock()
-	defer w.buffer.mu.Unlock()
-
-	if w.buffer.logWriter != nil {
-		written, err := w.buffer.logWriter.Write(p)
+	if b.logWriter != nil {
+		written, err := b.logWriter.Write(p)
 		if err != nil {
 			return written, err
 		}
@@ -1416,54 +1398,50 @@ func (w *xcodeDiagnosticStreamWriter) Write(p []byte) (int, error) {
 			return written, io.ErrShortWrite
 		}
 	}
-	return w.buffer.writeStreamLocked(w.state, p), nil
-}
-
-func (b *xcodeDiagnosticBuffer) writeStreamLocked(state *xcodeDiagnosticLineState, p []byte) int {
 	written := len(p)
 	b.totalBytes += int64(written)
 	_, _ = b.tail.Write(p)
-	b.consumeDiagnosticLinesLocked(state, p)
-	return written
+	b.consumeDiagnosticLinesLocked(p)
+	return written, nil
 }
 
-func (b *xcodeDiagnosticBuffer) consumeDiagnosticLinesLocked(state *xcodeDiagnosticLineState, p []byte) {
+func (b *xcodeDiagnosticBuffer) consumeDiagnosticLinesLocked(p []byte) {
 	for len(p) > 0 {
 		newline := bytes.IndexByte(p, '\n')
 		if newline < 0 {
-			b.appendDiagnosticFragmentLocked(state, p)
+			b.appendDiagnosticFragmentLocked(p)
 			return
 		}
-		b.appendDiagnosticFragmentLocked(state, p[:newline])
-		b.finishDiagnosticLineLocked(state)
+		b.appendDiagnosticFragmentLocked(p[:newline])
+		b.finishDiagnosticLineLocked()
 		p = p[newline+1:]
 	}
 }
 
-func (b *xcodeDiagnosticBuffer) appendDiagnosticFragmentLocked(state *xcodeDiagnosticLineState, fragment []byte) {
-	remaining := xcodeDiagnosticLineLimit - len(state.pending)
+func (b *xcodeDiagnosticBuffer) appendDiagnosticFragmentLocked(fragment []byte) {
+	remaining := xcodeDiagnosticLineLimit - len(b.pending)
 	if remaining > 0 {
 		prefixLength := min(remaining, len(fragment))
-		state.pending = append(state.pending, fragment[:prefixLength]...)
+		b.pending = append(b.pending, fragment[:prefixLength]...)
 		fragment = fragment[prefixLength:]
 	}
 	if len(fragment) > 0 {
-		state.overflow = true
+		b.overflow = true
 	}
 }
 
-func (b *xcodeDiagnosticBuffer) finishDiagnosticLineLocked(state *xcodeDiagnosticLineState) {
-	if len(state.pending) == 0 && !state.overflow {
+func (b *xcodeDiagnosticBuffer) finishDiagnosticLineLocked() {
+	if len(b.pending) == 0 && !b.overflow {
 		return
 	}
 
-	line := strings.TrimSuffix(strings.ToValidUTF8(string(state.pending), ""), "\r")
-	if state.overflow {
+	line := strings.TrimSuffix(strings.ToValidUTF8(string(b.pending), ""), "\r")
+	if b.overflow {
 		const omissionMarker = "…"
 		line = truncateUTF8Prefix(line, xcodeDiagnosticLineLimit-len(omissionMarker)) + omissionMarker
 	}
-	state.pending = state.pending[:0]
-	state.overflow = false
+	b.pending = b.pending[:0]
+	b.overflow = false
 
 	line = strings.TrimSpace(line)
 	if !isXcodeErrorDiagnostic(line) {
@@ -1499,9 +1477,7 @@ func (b *xcodeDiagnosticBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	for _, stream := range b.streams {
-		b.finishDiagnosticLineLocked(stream)
-	}
+	b.finishDiagnosticLineLocked()
 	tail := strings.ToValidUTF8(b.tail.String(), "")
 	if b.totalBytes <= int64(b.limit) {
 		return tail

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -446,7 +446,7 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 		},
 		{
 			name:       "timestamped error before long diagnostics",
-			output:     "2026-08-10 06:47:56.580 ERROR: Early server rejection.\n" + strings.Repeat("x", xcodebuildErrorTailLimit+1) + "\n",
+			output:     "2026-08-10 06:47:56.580 ERROR: Early server rejection.\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+1) + "\n",
 			wantErr:    true,
 			wantDetail: "Early server rejection.",
 		},
@@ -459,11 +459,11 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 		},
 		{
 			name:           "aggregate details from both streams stay bounded",
-			stdout:         "2026-08-10 06:47:56.580 ERROR: " + strings.Repeat("a", xcodebuildErrorTailLimit/2) + "\n",
-			output:         "*** Error: " + strings.Repeat("b", xcodebuildErrorTailLimit/2) + "\n",
+			stdout:         "2026-08-10 06:47:56.580 ERROR: " + strings.Repeat("a", xcodeCommandErrorOutputLimit/2) + "\n",
+			output:         "*** Error: " + strings.Repeat("b", xcodeCommandErrorOutputLimit/2) + "\n",
 			wantErr:        true,
 			wantDetail:     strings.Repeat("a", 32),
-			maxDetailBytes: xcodebuildErrorTailLimit,
+			maxDetailBytes: xcodeCommandErrorOutputLimit,
 		},
 		{
 			name:   "benign output containing error text",
@@ -1246,7 +1246,60 @@ func TestExportRejectsExistingIPAWithoutOverwrite(t *testing.T) {
 	}
 }
 
-func TestRunXcodebuildWithLogWriterKeepsOnlyTailInErrorMessage(t *testing.T) {
+func TestRunXcodebuildFailurePreservesBeginningAndEndWithinBound(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Cleanup(restore)
+
+	tests := []struct {
+		name                 string
+		action               string
+		preserveProcessError bool
+	}{
+		{name: "build", action: "build", preserveProcessError: true},
+		{name: "archive", action: "archive"},
+		{name: "export", action: "export"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := runCommandWithBoundedOutputMode(
+				context.Background(),
+				"xcodebuild",
+				[]string{"fail-large-output"},
+				nil,
+				test.action,
+				"xcodebuild",
+				test.preserveProcessError,
+			)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			errorText := err.Error()
+			for _, want := range []string{
+				"file.m:4:3: error: root cause",
+				"FINAL-DIAGNOSTIC",
+				"output truncated to 65536 bytes; preserving beginning and end",
+				"bytes omitted",
+			} {
+				if !strings.Contains(errorText, want) {
+					t.Fatalf("error = %q, want %q", errorText, want)
+				}
+			}
+
+			var exitErr *exec.ExitError
+			if got := errors.As(err, &exitErr); got != test.preserveProcessError {
+				t.Fatalf("errors.As(*exec.ExitError) = %t, want %t; error = %v", got, test.preserveProcessError, err)
+			}
+		})
+	}
+}
+
+func TestRunXcodebuildFailureStillStreamsCompleteOutputOnce(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := filepath.Join(tempDir, "commands.log")
 
@@ -1261,22 +1314,17 @@ func TestRunXcodebuildWithLogWriterKeepsOnlyTailInErrorMessage(t *testing.T) {
 	}
 
 	streamedOutput := streamed.String()
-	if !strings.Contains(streamedOutput, "EARLY-MARKER") {
-		t.Fatalf("expected streamed output to include early marker, got %q", streamedOutput)
-	}
-	if !strings.Contains(streamedOutput, "LATE-MARKER") {
-		t.Fatalf("expected streamed output to include late marker, got %q", streamedOutput)
+	for _, want := range []string{"file.m:4:3: error: root cause", "FINAL-DIAGNOSTIC"} {
+		if got := strings.Count(streamedOutput, want); got != 1 {
+			t.Fatalf("streamed diagnostic %q count = %d, want 1", want, got)
+		}
 	}
 
 	errorText := err.Error()
-	if !strings.Contains(errorText, "showing last") {
-		t.Fatalf("expected truncated tail message, got %v", err)
-	}
-	if strings.Contains(errorText, "EARLY-MARKER") {
-		t.Fatalf("expected early marker to be dropped from tail, got %v", err)
-	}
-	if !strings.Contains(errorText, "LATE-MARKER") {
-		t.Fatalf("expected late marker in error tail, got %v", err)
+	for _, want := range []string{"file.m:4:3: error: root cause", "FINAL-DIAGNOSTIC"} {
+		if !strings.Contains(errorText, want) {
+			t.Fatalf("error = %q, want %q", errorText, want)
+		}
 	}
 	if strings.Contains(errorText, "exit status 1") {
 		t.Fatalf("legacy archive/export runner error text changed: %v", err)
@@ -1284,6 +1332,57 @@ func TestRunXcodebuildWithLogWriterKeepsOnlyTailInErrorMessage(t *testing.T) {
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		t.Fatalf("legacy archive/export runner unexpectedly exposes process error: %v", err)
+	}
+}
+
+func TestRunXcodebuildInterruptionPreservesBeginningAndEndWithinBound(t *testing.T) {
+	tempDir := t.TempDir()
+	restore := overrideTestEnvironment(t)
+	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
+	t.Cleanup(restore)
+
+	tests := []struct {
+		name       string
+		newContext func() (context.Context, context.CancelFunc)
+		wantCause  error
+	}{
+		{
+			name: "deadline",
+			newContext: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 50*time.Millisecond)
+			},
+			wantCause: context.DeadlineExceeded,
+		},
+		{
+			name: "cancellation",
+			newContext: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				time.AfterFunc(50*time.Millisecond, cancel)
+				return ctx, cancel
+			},
+			wantCause: context.Canceled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := test.newContext()
+			defer cancel()
+
+			err := runXcodebuild(ctx, []string{"large-output-then-wait"}, nil)
+			if !errors.Is(err, test.wantCause) {
+				t.Fatalf("runXcodebuild() error = %v, want %v", err, test.wantCause)
+			}
+			for _, want := range []string{
+				"file.m:4:3: error: root cause",
+				"FINAL-BEFORE-INTERRUPTION",
+				"output truncated to 65536 bytes; preserving beginning and end",
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want %q", err, want)
+				}
+			}
+		})
 	}
 }
 
@@ -1299,6 +1398,62 @@ func TestTailBufferStringRemainsValidUTF8AfterByteTruncation(t *testing.T) {
 	}
 	if !strings.Contains(got, "界") {
 		t.Fatalf("String() = %q, want intact trailing diagnostic", got)
+	}
+}
+
+func TestHeadTailBufferPreservesUntruncatedOutput(t *testing.T) {
+	buffer := newHeadTailBuffer(8)
+	for _, chunk := range []string{"ab", "cd", "ef"} {
+		if _, err := buffer.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write(%q) error = %v", chunk, err)
+		}
+	}
+
+	if buffer.Truncated() {
+		t.Fatal("Truncated() = true, want false")
+	}
+	if got := buffer.String(); got != "abcdef" {
+		t.Fatalf("String() = %q, want %q", got, "abcdef")
+	}
+}
+
+func TestHeadTailBufferRepairsUTF8AtBothTruncationBoundaries(t *testing.T) {
+	buffer := newHeadTailBuffer(8)
+	if _, err := buffer.Write([]byte("始界界終")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if !utf8.ValidString(got) {
+		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
+	}
+	for _, want := range []string{"始", "終", "6 bytes omitted"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("String() = %q, want %q", got, want)
+		}
+	}
+	if stored := len(buffer.head) + len(buffer.tail.data); stored > buffer.limit {
+		t.Fatalf("stored bytes = %d, limit = %d", stored, buffer.limit)
+	}
+}
+
+func TestHeadTailBufferHandlesZeroAndSingleByteLimits(t *testing.T) {
+	for _, limit := range []int{0, 1} {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			buffer := newHeadTailBuffer(limit)
+			if _, err := buffer.Write([]byte("ab")); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+			if !buffer.Truncated() {
+				t.Fatal("Truncated() = false, want true")
+			}
+			if !utf8.ValidString(buffer.String()) {
+				t.Fatalf("String() returned invalid UTF-8: %q", buffer.String())
+			}
+			if stored := len(buffer.head) + len(buffer.tail.data); stored > limit {
+				t.Fatalf("stored bytes = %d, limit = %d", stored, limit)
+			}
+		})
 	}
 }
 
@@ -1552,10 +1707,18 @@ func TestXcodeHelperProcess(t *testing.T) {
 	}
 
 	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "fail-large-output" {
-		fmt.Fprint(os.Stderr, "EARLY-MARKER\n")
-		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodebuildErrorTailLimit+128))
-		fmt.Fprint(os.Stderr, "\nLATE-MARKER\n")
+		fmt.Fprint(os.Stderr, "file.m:4:3: error: root cause\n")
+		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+		fmt.Fprint(os.Stderr, "\nFINAL-DIAGNOSTIC\n")
 		os.Exit(1)
+	}
+
+	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "large-output-then-wait" {
+		fmt.Fprint(os.Stderr, "file.m:4:3: error: root cause\n")
+		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+		fmt.Fprint(os.Stderr, "\nFINAL-BEFORE-INTERRUPTION\n")
+		time.Sleep(2 * time.Second)
+		os.Exit(0)
 	}
 
 	fmt.Fprintf(os.Stderr, "unexpected helper invocation: %v\n", commandArgs)

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1562,10 +1562,14 @@ func TestXcodeDiagnosticBufferRetainsDiagnosticDisplacedByMissingPrefix(t *testi
 
 func TestXcodeDiagnosticBufferRetainsUncollectedTailBoundaryError(t *testing.T) {
 	var input strings.Builder
+	expectedDiagnostics := make(map[string]struct{})
 	for i := range 1000 {
-		fmt.Fprintf(&input, "error: early failure %04d\n", i)
+		diagnostic := fmt.Sprintf("error: early failure %04d", i)
+		expectedDiagnostics[diagnostic] = struct{}{}
+		input.WriteString(diagnostic + "\n")
 	}
 	boundaryDiagnostic := "error: actionable tail-boundary failure"
+	expectedDiagnostics[boundaryDiagnostic] = struct{}{}
 	input.WriteString(boundaryDiagnostic + "\n")
 	input.WriteString(strings.Repeat("x", xcodebuildErrorTailLimit-len(boundaryDiagnostic)-1))
 
@@ -1579,6 +1583,13 @@ func TestXcodeDiagnosticBufferRetainsUncollectedTailBoundaryError(t *testing.T) 
 
 	_, got := renderXcodeDiagnosticOutput(t, input.String())
 	requireBoundedXcodeDiagnosticOutput(t, got, "error: early failure 0000", boundaryDiagnostic)
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "error:") {
+			if _, exists := expectedDiagnostics[line]; !exists {
+				t.Fatalf("String() emitted partial diagnostic line prefix %q", truncateUTF8Prefix(line, 120))
+			}
+		}
+	}
 }
 
 func TestXcodeDiagnosticBufferDoesNotDeduplicateAgainstBenignTailSubstring(t *testing.T) {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1342,36 +1342,56 @@ func TestRunXcodebuildInterruptionPreservesBeginningAndEndWithinBound(t *testing
 	t.Cleanup(restore)
 
 	tests := []struct {
-		name       string
-		newContext func() (context.Context, context.CancelFunc)
-		wantCause  error
+		name            string
+		timeout         time.Duration
+		cancelWhenReady bool
+		wantCause       error
 	}{
 		{
-			name: "deadline",
-			newContext: func() (context.Context, context.CancelFunc) {
-				return context.WithTimeout(context.Background(), 50*time.Millisecond)
-			},
+			name:      "deadline",
+			timeout:   2 * time.Second,
 			wantCause: context.DeadlineExceeded,
 		},
 		{
-			name: "cancellation",
-			newContext: func() (context.Context, context.CancelFunc) {
-				ctx, cancel := context.WithCancel(context.Background())
-				time.AfterFunc(50*time.Millisecond, cancel)
-				return ctx, cancel
-			},
-			wantCause: context.Canceled,
+			name:            "cancellation",
+			cancelWhenReady: true,
+			wantCause:       context.Canceled,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx, cancel := test.newContext()
+			ctx, cancel := context.WithCancel(context.Background())
+			if test.timeout > 0 {
+				ctx, cancel = context.WithTimeout(context.Background(), test.timeout)
+			}
 			defer cancel()
 
-			err := runXcodebuild(ctx, []string{"large-output-then-wait"}, nil)
+			readyPath := filepath.Join(tempDir, test.name+".ready")
+			var readyResult <-chan error
+			if test.cancelWhenReady {
+				result := make(chan error, 1)
+				readyResult = result
+				go func() {
+					err := waitForHelperSignal(readyPath, 2*time.Second)
+					if err == nil {
+						cancel()
+					}
+					result <- err
+				}()
+			}
+
+			err := runXcodebuild(ctx, []string{"large-output-then-wait", readyPath}, nil)
+			if readyResult != nil {
+				if readyErr := <-readyResult; readyErr != nil {
+					t.Fatalf("wait for helper readiness: %v", readyErr)
+				}
+			}
 			if !errors.Is(err, test.wantCause) {
 				t.Fatalf("runXcodebuild() error = %v, want %v", err, test.wantCause)
+			}
+			if _, statErr := os.Stat(readyPath); statErr != nil {
+				t.Fatalf("helper readiness signal: %v", statErr)
 			}
 			for _, want := range []string{
 				"file.m:4:3: error: root cause",
@@ -1383,6 +1403,21 @@ func TestRunXcodebuildInterruptionPreservesBeginningAndEndWithinBound(t *testing
 				}
 			}
 		})
+	}
+}
+
+func waitForHelperSignal(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 
@@ -1417,9 +1452,32 @@ func TestHeadTailBufferPreservesUntruncatedOutput(t *testing.T) {
 	}
 }
 
+func TestHeadTailBufferRenderedOutputStaysWithinLimit(t *testing.T) {
+	buffer := newHeadTailBuffer(xcodeCommandErrorOutputLimit)
+	input := "file.m:4:3: error: root cause\n" +
+		strings.Repeat("界", xcodeCommandErrorOutputLimit) +
+		"\nFINAL-DIAGNOSTIC\n"
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if len(got) > xcodeCommandErrorOutputLimit {
+		t.Fatalf("rendered bytes = %d, limit = %d", len(got), xcodeCommandErrorOutputLimit)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
+	}
+	for _, want := range []string{"file.m:4:3: error: root cause", "FINAL-DIAGNOSTIC", "bytes omitted"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("String() = %q, want %q", got, want)
+		}
+	}
+}
+
 func TestHeadTailBufferRepairsUTF8AtBothTruncationBoundaries(t *testing.T) {
-	buffer := newHeadTailBuffer(8)
-	if _, err := buffer.Write([]byte("始界界終")); err != nil {
+	buffer := newHeadTailBuffer(40)
+	if _, err := buffer.Write([]byte("始" + strings.Repeat("界", 20) + "終")); err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
 
@@ -1427,10 +1485,13 @@ func TestHeadTailBufferRepairsUTF8AtBothTruncationBoundaries(t *testing.T) {
 	if !utf8.ValidString(got) {
 		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
 	}
-	for _, want := range []string{"始", "終", "6 bytes omitted"} {
+	for _, want := range []string{"始", "終", "54 bytes omitted"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("String() = %q, want %q", got, want)
 		}
+	}
+	if len(got) > buffer.limit {
+		t.Fatalf("rendered bytes = %d, limit = %d", len(got), buffer.limit)
 	}
 	if stored := len(buffer.head) + len(buffer.tail.data); stored > buffer.limit {
 		t.Fatalf("stored bytes = %d, limit = %d", stored, buffer.limit)
@@ -1449,6 +1510,9 @@ func TestHeadTailBufferHandlesZeroAndSingleByteLimits(t *testing.T) {
 			}
 			if !utf8.ValidString(buffer.String()) {
 				t.Fatalf("String() returned invalid UTF-8: %q", buffer.String())
+			}
+			if rendered := len(buffer.String()); rendered > limit {
+				t.Fatalf("rendered bytes = %d, limit = %d", rendered, limit)
 			}
 			if stored := len(buffer.head) + len(buffer.tail.data); stored > limit {
 				t.Fatalf("stored bytes = %d, limit = %d", stored, limit)
@@ -1714,10 +1778,18 @@ func TestXcodeHelperProcess(t *testing.T) {
 	}
 
 	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "large-output-then-wait" {
+		if len(commandArgs) < 3 {
+			fmt.Fprintln(os.Stderr, "missing helper readiness path")
+			os.Exit(2)
+		}
 		fmt.Fprint(os.Stderr, "file.m:4:3: error: root cause\n")
 		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
 		fmt.Fprint(os.Stderr, "\nFINAL-BEFORE-INTERRUPTION\n")
-		time.Sleep(2 * time.Second)
+		if err := os.WriteFile(commandArgs[2], []byte("ready"), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		time.Sleep(5 * time.Second)
 		os.Exit(0)
 	}
 

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -1246,7 +1247,7 @@ func TestExportRejectsExistingIPAWithoutOverwrite(t *testing.T) {
 	}
 }
 
-func TestRunXcodebuildFailurePreservesBeginningAndEndWithinBound(t *testing.T) {
+func TestRunXcodebuildFailurePreservesRecognizedErrorsAndFinalOutputWithinBound(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := filepath.Join(tempDir, "commands.log")
 
@@ -1283,8 +1284,7 @@ func TestRunXcodebuildFailurePreservesBeginningAndEndWithinBound(t *testing.T) {
 			for _, want := range []string{
 				"file.m:4:3: error: root cause",
 				"FINAL-DIAGNOSTIC",
-				"output truncated to 65536 bytes; preserving beginning and end",
-				"bytes omitted",
+				"output truncated to 65536 bytes; preserving recognized errors and final output",
 			} {
 				if !strings.Contains(errorText, want) {
 					t.Fatalf("error = %q, want %q", errorText, want)
@@ -1335,7 +1335,7 @@ func TestRunXcodebuildFailureStillStreamsCompleteOutputOnce(t *testing.T) {
 	}
 }
 
-func TestRunXcodebuildInterruptionPreservesBeginningAndEndWithinBound(t *testing.T) {
+func TestRunXcodebuildInterruptionPreservesRecognizedErrorsAndFinalOutputWithinBound(t *testing.T) {
 	tempDir := t.TempDir()
 	restore := overrideTestEnvironment(t)
 	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
@@ -1396,7 +1396,7 @@ func TestRunXcodebuildInterruptionPreservesBeginningAndEndWithinBound(t *testing
 			for _, want := range []string{
 				"file.m:4:3: error: root cause",
 				"FINAL-BEFORE-INTERRUPTION",
-				"output truncated to 65536 bytes; preserving beginning and end",
+				"output truncated to 65536 bytes; preserving recognized errors and final output",
 			} {
 				if !strings.Contains(err.Error(), want) {
 					t.Fatalf("error = %q, want %q", err, want)
@@ -1436,8 +1436,8 @@ func TestTailBufferStringRemainsValidUTF8AfterByteTruncation(t *testing.T) {
 	}
 }
 
-func TestHeadTailBufferPreservesUntruncatedOutput(t *testing.T) {
-	buffer := newHeadTailBuffer(8)
+func TestXcodeDiagnosticBufferPreservesUntruncatedOutput(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(8)
 	for _, chunk := range []string{"ab", "cd", "ef"} {
 		if _, err := buffer.Write([]byte(chunk)); err != nil {
 			t.Fatalf("Write(%q) error = %v", chunk, err)
@@ -1452,8 +1452,41 @@ func TestHeadTailBufferPreservesUntruncatedOutput(t *testing.T) {
 	}
 }
 
-func TestHeadTailBufferRenderedOutputStaysWithinLimit(t *testing.T) {
-	buffer := newHeadTailBuffer(xcodeCommandErrorOutputLimit)
+func TestXcodeDiagnosticBufferPreservesMiddleCompilerErrorFromLegacyTail(t *testing.T) {
+	const totalBytes = 90 * 1024
+	diagnostic := "file.m:4:3: error: middle root cause"
+	input := strings.Repeat("h", 40*1024) + "\n" + diagnostic + "\n"
+	input += strings.Repeat("t", totalBytes-len(input))
+
+	legacyTail := newTailBuffer(xcodeCommandErrorOutputLimit)
+	if _, err := legacyTail.Write([]byte(input)); err != nil {
+		t.Fatalf("legacy tail Write() error = %v", err)
+	}
+	if !strings.Contains(legacyTail.String(), diagnostic) {
+		t.Fatal("test precondition failed: legacy 64 KiB tail does not contain middle diagnostic")
+	}
+
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	got := buffer.String()
+	if !strings.Contains(got, diagnostic) {
+		t.Fatalf("String() dropped middle compiler diagnostic retained by legacy tail")
+	}
+	if got != legacyTail.String() {
+		t.Fatalf("String() did not preserve legacy tail when diagnostic was already present")
+	}
+	if len(got) > xcodeCommandErrorOutputLimit {
+		t.Fatalf("rendered bytes = %d, limit = %d", len(got), xcodeCommandErrorOutputLimit)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("String() returned invalid UTF-8")
+	}
+}
+
+func TestXcodeDiagnosticBufferRenderedOutputStaysWithinLimit(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	input := "file.m:4:3: error: root cause\n" +
 		strings.Repeat("界", xcodeCommandErrorOutputLimit) +
 		"\nFINAL-DIAGNOSTIC\n"
@@ -1468,15 +1501,15 @@ func TestHeadTailBufferRenderedOutputStaysWithinLimit(t *testing.T) {
 	if !utf8.ValidString(got) {
 		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
 	}
-	for _, want := range []string{"file.m:4:3: error: root cause", "FINAL-DIAGNOSTIC", "bytes omitted"} {
+	for _, want := range []string{"file.m:4:3: error: root cause", "FINAL-DIAGNOSTIC"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("String() = %q, want %q", got, want)
 		}
 	}
 }
 
-func TestHeadTailBufferRepairsUTF8AtBothTruncationBoundaries(t *testing.T) {
-	buffer := newHeadTailBuffer(40)
+func TestXcodeDiagnosticBufferRepairsUTF8AtTailBoundary(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(40)
 	if _, err := buffer.Write([]byte("始" + strings.Repeat("界", 20) + "終")); err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
@@ -1485,23 +1518,21 @@ func TestHeadTailBufferRepairsUTF8AtBothTruncationBoundaries(t *testing.T) {
 	if !utf8.ValidString(got) {
 		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
 	}
-	for _, want := range []string{"始", "終", "54 bytes omitted"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("String() = %q, want %q", got, want)
-		}
+	if !strings.Contains(got, "終") {
+		t.Fatalf("String() = %q, want trailing marker", got)
 	}
 	if len(got) > buffer.limit {
 		t.Fatalf("rendered bytes = %d, limit = %d", len(got), buffer.limit)
 	}
-	if stored := len(buffer.head) + len(buffer.tail.data); stored > buffer.limit {
+	if stored := len(buffer.tail.data) + buffer.diagnosticBytes; stored > buffer.limit+buffer.diagnosticBudget() {
 		t.Fatalf("stored bytes = %d, limit = %d", stored, buffer.limit)
 	}
 }
 
-func TestHeadTailBufferHandlesZeroAndSingleByteLimits(t *testing.T) {
+func TestXcodeDiagnosticBufferHandlesZeroAndSingleByteLimits(t *testing.T) {
 	for _, limit := range []int{0, 1} {
 		t.Run(strconv.Itoa(limit), func(t *testing.T) {
-			buffer := newHeadTailBuffer(limit)
+			buffer := newXcodeDiagnosticBuffer(limit)
 			if _, err := buffer.Write([]byte("ab")); err != nil {
 				t.Fatalf("Write() error = %v", err)
 			}
@@ -1514,8 +1545,316 @@ func TestHeadTailBufferHandlesZeroAndSingleByteLimits(t *testing.T) {
 			if rendered := len(buffer.String()); rendered > limit {
 				t.Fatalf("rendered bytes = %d, limit = %d", rendered, limit)
 			}
-			if stored := len(buffer.head) + len(buffer.tail.data); stored > limit {
+			if stored := len(buffer.tail.data) + buffer.diagnosticBytes; stored > limit+buffer.diagnosticBudget() {
 				t.Fatalf("stored bytes = %d, limit = %d", stored, limit)
+			}
+		})
+	}
+}
+
+func TestXcodeDiagnosticBufferRetainsMissingErrorsOnce(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	diagnostic := "error: earliest root cause"
+	benign := "Build summary mentions error: only as prose"
+	input := diagnostic + "\n" + diagnostic + "\n" + benign + "\n"
+	input += strings.Repeat("x", xcodeCommandErrorOutputLimit+128) + "\nFINAL-DIAGNOSTIC\n"
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if count := strings.Count(got, diagnostic); count != 1 {
+		t.Fatalf("diagnostic count = %d, want 1", count)
+	}
+	if strings.Contains(got, benign) {
+		t.Fatalf("String() retained benign prose as a diagnostic: %q", got)
+	}
+	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
+		t.Fatalf("String() dropped final output marker")
+	}
+	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
+		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
+	}
+}
+
+func TestXcodeDiagnosticBufferDoesNotPrependDiagnosticAlreadyInTail(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	diagnostic := "error: repeated root cause"
+	input := diagnostic + "\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
+	input += "\n" + diagnostic + "\nFINAL-DIAGNOSTIC\n"
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if count := strings.Count(got, diagnostic); count != 1 {
+		t.Fatalf("diagnostic count = %d, want 1", count)
+	}
+	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
+		t.Fatalf("String() dropped final output marker")
+	}
+}
+
+func TestXcodeDiagnosticBufferRetainsDiagnosticDisplacedByMissingPrefix(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	missingDiagnostic := "error: " + strings.Repeat("a", 1024)
+	displacedDiagnostic := "error: displaced from the start of the legacy tail"
+	tail := "\n" + displacedDiagnostic + "\n"
+	tail += strings.Repeat("x", xcodeCommandErrorOutputLimit-len(tail))
+	input := missingDiagnostic + "\n" + strings.Repeat("o", 128) + tail
+
+	legacyTail := newTailBuffer(xcodeCommandErrorOutputLimit)
+	if _, err := legacyTail.Write([]byte(input)); err != nil {
+		t.Fatalf("legacy tail Write() error = %v", err)
+	}
+	if !strings.Contains(legacyTail.String(), displacedDiagnostic) {
+		t.Fatal("test precondition failed: displaced diagnostic is absent from the legacy tail")
+	}
+	if strings.Contains(legacyTail.String(), missingDiagnostic) {
+		t.Fatal("test precondition failed: missing diagnostic is present in the legacy tail")
+	}
+
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	got := buffer.String()
+	for _, diagnostic := range []string{missingDiagnostic, displacedDiagnostic} {
+		if !strings.Contains(got, diagnostic) {
+			t.Fatalf("String() dropped diagnostic %q", diagnostic)
+		}
+	}
+	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
+		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
+	}
+}
+
+func TestXcodeDiagnosticBufferDoesNotDeduplicateAgainstBenignTailSubstring(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	diagnostic := "error: root cause"
+	benign := "note: previous error: root cause was discussed"
+	input := diagnostic + "\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
+	input += "\n" + benign + "\nFINAL-DIAGNOSTIC\n"
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	exactCount := 0
+	for _, line := range strings.Split(got, "\n") {
+		if strings.TrimSpace(line) == diagnostic {
+			exactCount++
+		}
+	}
+	if exactCount != 1 {
+		t.Fatalf("exact diagnostic line count = %d, want 1", exactCount)
+	}
+	if !strings.Contains(got, benign) {
+		t.Fatalf("String() dropped benign final output")
+	}
+}
+
+func TestXcodeDiagnosticBufferRetainsPathOnlyErrorOutsideTail(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	diagnostic := "/tmp/App/Assets.xcassets: error: App icon set missing"
+	input := diagnostic + "\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
+	input += "\nFINAL-DIAGNOSTIC\n"
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if !strings.Contains(got, diagnostic) {
+		t.Fatalf("String() dropped path-only Xcode diagnostic")
+	}
+	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
+		t.Fatalf("String() dropped final output marker")
+	}
+}
+
+func TestXcodeDiagnosticBufferDoesNotLetVersionedProseExhaustDiagnosticBudget(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	var input strings.Builder
+	for i := range 1000 {
+		fmt.Fprintf(&input, "Build 1.%d: error: only prose\n", i)
+	}
+	diagnostic := "error: actual root cause"
+	input.WriteString(diagnostic + "\n")
+	input.WriteString(strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+	input.WriteString("\nFINAL-DIAGNOSTIC\n")
+	if _, err := buffer.Write([]byte(input.String())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if !strings.Contains(got, diagnostic) {
+		t.Fatalf("String() dropped real diagnostic after versioned prose")
+	}
+	if strings.Contains(got, "error: only prose") {
+		t.Fatalf("String() retained versioned prose as diagnostics")
+	}
+}
+
+func TestXcodeDiagnosticBufferIndexesDenseTailOnce(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	var input strings.Builder
+	for i := range 32 {
+		fmt.Fprintf(&input, "error: early failure %02d\n", i)
+	}
+	input.WriteString(strings.Repeat("\n", xcodeCommandErrorOutputLimit+128))
+	if _, err := buffer.Write([]byte(input.String())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	if allocations := testing.AllocsPerRun(1, func() {
+		_ = buffer.String()
+	}); allocations > 16 {
+		t.Fatalf("String() allocations = %.0f, want at most 16", allocations)
+	}
+}
+
+func TestXcodeDiagnosticBufferBoundsVeryLongErrorLine(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	longDiagnostic := "error: " + strings.Repeat("界", xcodeDiagnosticLineLimit)
+	input := longDiagnostic + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
+	if _, err := buffer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if !strings.Contains(got, "error: ") {
+		t.Fatalf("String() dropped bounded long diagnostic")
+	}
+	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
+		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
+	}
+	if buffer.diagnosticBytes > buffer.diagnosticBudget() {
+		t.Fatalf("stored diagnostic bytes = %d, budget = %d", buffer.diagnosticBytes, buffer.diagnosticBudget())
+	}
+	for _, diagnostic := range buffer.diagnostics {
+		if len(diagnostic) > xcodeDiagnosticLineLimit {
+			t.Fatalf("stored diagnostic bytes = %d, line limit = %d", len(diagnostic), xcodeDiagnosticLineLimit)
+		}
+	}
+}
+
+func TestXcodeDiagnosticBufferBoundsManyUniqueErrors(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	var input strings.Builder
+	for i := range 5000 {
+		fmt.Fprintf(&input, "error: distinct failure %04d\n", i)
+	}
+	input.WriteString(strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+	input.WriteString("\nFINAL-DIAGNOSTIC\n")
+	if _, err := buffer.Write([]byte(input.String())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
+		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
+	}
+	if buffer.diagnosticBytes > buffer.diagnosticBudget() {
+		t.Fatalf("stored diagnostic bytes = %d, budget = %d", buffer.diagnosticBytes, buffer.diagnosticBudget())
+	}
+	if !strings.Contains(got, "error: distinct failure 0000") {
+		t.Fatalf("String() dropped earliest bounded diagnostic")
+	}
+	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
+		t.Fatalf("String() dropped final output marker")
+	}
+}
+
+func TestXcodeDiagnosticBufferKeepsStreamFragmentsIndependent(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	stdout := buffer.newStreamWriter(nil)
+	stderr := buffer.newStreamWriter(nil)
+	if _, err := stdout.Write([]byte("file.m:4:3: err")); err != nil {
+		t.Fatalf("stdout Write() error = %v", err)
+	}
+	if _, err := stderr.Write([]byte("or: cross-stream false positive\n")); err != nil {
+		t.Fatalf("stderr Write() error = %v", err)
+	}
+	if _, err := stdout.Write([]byte("\n")); err != nil {
+		t.Fatalf("stdout newline Write() error = %v", err)
+	}
+	if _, err := buffer.Write([]byte(strings.Repeat("x", xcodeCommandErrorOutputLimit+128))); err != nil {
+		t.Fatalf("tail Write() error = %v", err)
+	}
+
+	_ = buffer.String()
+	if len(buffer.diagnostics) != 0 {
+		t.Fatalf("captured cross-stream diagnostic fragments: %q", buffer.diagnostics)
+	}
+}
+
+func TestXcodeDiagnosticBufferRecognizesLineSplitWithinStream(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	stream := buffer.newStreamWriter(nil)
+	for _, chunk := range []string{
+		"Sources/App.swift:12:7: er",
+		"ror: split root cause",
+		"\n",
+		strings.Repeat("x", xcodeCommandErrorOutputLimit+128),
+	} {
+		if _, err := stream.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+	}
+
+	if got := buffer.String(); !strings.Contains(got, "Sources/App.swift:12:7: error: split root cause") {
+		t.Fatalf("String() dropped diagnostic split across writes")
+	}
+}
+
+func TestXcodeDiagnosticBufferSerializesConcurrentStreamWrites(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
+	var streamed bytes.Buffer
+	stdout := buffer.newStreamWriter(&streamed)
+	stderr := buffer.newStreamWriter(&streamed)
+
+	var writers sync.WaitGroup
+	for _, writer := range []io.Writer{stdout, stderr} {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for range 100 {
+				if _, err := writer.Write([]byte("ordinary build output\n")); err != nil {
+					t.Errorf("Write() error = %v", err)
+					return
+				}
+			}
+		}()
+	}
+	writers.Wait()
+
+	if got := buffer.String(); got != streamed.String() {
+		t.Fatalf("captured output differs from streamed output")
+	}
+}
+
+func TestIsXcodeErrorDiagnostic(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{name: "source location", line: "Sources/App.swift:12:7: error: cannot find value", want: true},
+		{name: "line leading", line: "error: emit-module command failed", want: true},
+		{name: "fatal line leading", line: "fatal error: module map missing", want: true},
+		{name: "known tool", line: "clang: error: linker command failed", want: true},
+		{name: "xcrun tool", line: "xcrun: error: invalid active developer path", want: true},
+		{name: "path only", line: "/tmp/App/Assets.xcassets: error: App icon set missing", want: true},
+		{name: "project path only", line: "App.xcodeproj: error: Missing package product", want: true},
+		{name: "benign prose", line: "Build summary mentions error: only as prose"},
+		{name: "versioned prose", line: "Build 1.2: error: only prose"},
+		{name: "quoted note", line: "note: error: appeared in generated documentation"},
+		{name: "empty error", line: "error:"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isXcodeErrorDiagnostic(test.line); got != test.want {
+				t.Fatalf("isXcodeErrorDiagnostic(%q) = %t, want %t", test.line, got, test.want)
 			}
 		})
 	}

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1560,6 +1560,27 @@ func TestXcodeDiagnosticBufferRetainsDiagnosticDisplacedByMissingPrefix(t *testi
 	requireBoundedXcodeDiagnosticOutput(t, got, missingDiagnostic, displacedDiagnostic)
 }
 
+func TestXcodeDiagnosticBufferRetainsUncollectedTailBoundaryError(t *testing.T) {
+	var input strings.Builder
+	for i := range 1000 {
+		fmt.Fprintf(&input, "error: early failure %04d\n", i)
+	}
+	boundaryDiagnostic := "error: actionable tail-boundary failure"
+	input.WriteString(boundaryDiagnostic + "\n")
+	input.WriteString(strings.Repeat("x", xcodebuildErrorTailLimit-len(boundaryDiagnostic)-1))
+
+	legacyTail := newTailBuffer(xcodebuildErrorTailLimit)
+	if _, err := io.WriteString(legacyTail, input.String()); err != nil {
+		t.Fatalf("legacy tail Write() error = %v", err)
+	}
+	if !strings.Contains(legacyTail.String(), boundaryDiagnostic) {
+		t.Fatal("test precondition failed: boundary diagnostic is absent from the legacy tail")
+	}
+
+	_, got := renderXcodeDiagnosticOutput(t, input.String())
+	requireBoundedXcodeDiagnosticOutput(t, got, "error: early failure 0000", boundaryDiagnostic)
+}
+
 func TestXcodeDiagnosticBufferDoesNotDeduplicateAgainstBenignTailSubstring(t *testing.T) {
 	diagnostic := "error: root cause"
 	benign := "note: previous error: root cause was discussed"

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -447,7 +447,7 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 		},
 		{
 			name:       "timestamped error before long diagnostics",
-			output:     "2026-08-10 06:47:56.580 ERROR: Early server rejection.\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+1) + "\n",
+			output:     "2026-08-10 06:47:56.580 ERROR: Early server rejection.\n" + strings.Repeat("x", xcodebuildErrorTailLimit+1) + "\n",
 			wantErr:    true,
 			wantDetail: "Early server rejection.",
 		},
@@ -460,11 +460,11 @@ func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 		},
 		{
 			name:           "aggregate details from both streams stay bounded",
-			stdout:         "2026-08-10 06:47:56.580 ERROR: " + strings.Repeat("a", xcodeCommandErrorOutputLimit/2) + "\n",
-			output:         "*** Error: " + strings.Repeat("b", xcodeCommandErrorOutputLimit/2) + "\n",
+			stdout:         "2026-08-10 06:47:56.580 ERROR: " + strings.Repeat("a", xcodebuildErrorTailLimit/2) + "\n",
+			output:         "*** Error: " + strings.Repeat("b", xcodebuildErrorTailLimit/2) + "\n",
 			wantErr:        true,
 			wantDetail:     strings.Repeat("a", 32),
-			maxDetailBytes: xcodeCommandErrorOutputLimit,
+			maxDetailBytes: xcodebuildErrorTailLimit,
 		},
 		{
 			name:   "benign output containing error text",
@@ -1421,44 +1421,65 @@ func waitForHelperSignal(path string, timeout time.Duration) error {
 	}
 }
 
-func TestTailBufferStringRemainsValidUTF8AfterByteTruncation(t *testing.T) {
-	buffer := newTailBuffer(4)
-	if _, err := buffer.Write([]byte("界界")); err != nil {
+func renderXcodeDiagnosticOutput(t *testing.T, input string) (*xcodeDiagnosticBuffer, string) {
+	t.Helper()
+	buffer := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, nil)
+	if _, err := io.WriteString(buffer.newStreamWriter(), input); err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
+	return buffer, buffer.String()
+}
 
-	got := buffer.String()
-	if !utf8.ValidString(got) {
-		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
+func requireBoundedXcodeDiagnosticOutput(t *testing.T, output string, values ...string) {
+	t.Helper()
+	if len(output) > xcodebuildErrorTailLimit || !utf8.ValidString(output) {
+		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(output), utf8.ValidString(output))
 	}
-	if !strings.Contains(got, "界") {
-		t.Fatalf("String() = %q, want intact trailing diagnostic", got)
+	for _, value := range values {
+		if !strings.Contains(output, value) {
+			t.Fatalf("String() dropped %q", value)
+		}
 	}
 }
 
-func TestXcodeDiagnosticBufferPreservesUntruncatedOutput(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(8)
-	for _, chunk := range []string{"ab", "cd", "ef"} {
-		if _, err := buffer.Write([]byte(chunk)); err != nil {
-			t.Fatalf("Write(%q) error = %v", chunk, err)
+func countExactOutputLines(output string, value string) int {
+	count := 0
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == value {
+			count++
 		}
 	}
+	return count
+}
 
-	if buffer.Truncated() {
-		t.Fatal("Truncated() = true, want false")
-	}
-	if got := buffer.String(); got != "abcdef" {
-		t.Fatalf("String() = %q, want %q", got, "abcdef")
+func TestXcodeDiagnosticBufferPreservesUntruncatedOutput(t *testing.T) {
+	for _, chunks := range [][]string{{"ab", "cd", "ef"}, {"abcd", "efgh"}} {
+		buffer := newXcodeDiagnosticBuffer(8, nil)
+		stream := buffer.newStreamWriter()
+		for _, chunk := range chunks {
+			if _, err := io.WriteString(stream, chunk); err != nil {
+				t.Fatalf("Write(%q) error = %v", chunk, err)
+			}
+		}
+
+		want := strings.Join(chunks, "")
+		if buffer.Truncated() {
+			t.Fatalf("Truncated() = true for %q, want false", want)
+		}
+		if got := buffer.String(); got != want {
+			t.Fatalf("String() = %q, want %q", got, want)
+		}
 	}
 }
 
 func TestXcodeDiagnosticBufferPreservesMiddleCompilerErrorFromLegacyTail(t *testing.T) {
 	const totalBytes = 90 * 1024
 	diagnostic := "file.m:4:3: error: middle root cause"
-	input := strings.Repeat("h", 40*1024) + "\n" + diagnostic + "\n"
+	input := diagnostic + "\n"
+	input += strings.Repeat("h", 40*1024-len(input)) + "\n" + diagnostic + "\n"
 	input += strings.Repeat("t", totalBytes-len(input))
 
-	legacyTail := newTailBuffer(xcodeCommandErrorOutputLimit)
+	legacyTail := newTailBuffer(xcodebuildErrorTailLimit)
 	if _, err := legacyTail.Write([]byte(input)); err != nil {
 		t.Fatalf("legacy tail Write() error = %v", err)
 	}
@@ -1466,144 +1487,51 @@ func TestXcodeDiagnosticBufferPreservesMiddleCompilerErrorFromLegacyTail(t *test
 		t.Fatal("test precondition failed: legacy 64 KiB tail does not contain middle diagnostic")
 	}
 
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-	got := buffer.String()
+	_, got := renderXcodeDiagnosticOutput(t, input)
 	if !strings.Contains(got, diagnostic) {
 		t.Fatalf("String() dropped middle compiler diagnostic retained by legacy tail")
 	}
 	if got != legacyTail.String() {
 		t.Fatalf("String() did not preserve legacy tail when diagnostic was already present")
 	}
-	if len(got) > xcodeCommandErrorOutputLimit {
-		t.Fatalf("rendered bytes = %d, limit = %d", len(got), xcodeCommandErrorOutputLimit)
+	if count := countExactOutputLines(got, diagnostic); count != 1 {
+		t.Fatalf("diagnostic line count = %d, want 1", count)
 	}
-	if !utf8.ValidString(got) {
-		t.Fatalf("String() returned invalid UTF-8")
-	}
+	requireBoundedXcodeDiagnosticOutput(t, got)
 }
 
 func TestXcodeDiagnosticBufferRenderedOutputStaysWithinLimit(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	input := "file.m:4:3: error: root cause\n" +
-		strings.Repeat("界", xcodeCommandErrorOutputLimit) +
+		strings.Repeat("界", xcodebuildErrorTailLimit) +
 		"\nFINAL-DIAGNOSTIC\n"
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
-	if len(got) > xcodeCommandErrorOutputLimit {
-		t.Fatalf("rendered bytes = %d, limit = %d", len(got), xcodeCommandErrorOutputLimit)
-	}
-	if !utf8.ValidString(got) {
-		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
-	}
-	for _, want := range []string{"file.m:4:3: error: root cause", "FINAL-DIAGNOSTIC"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("String() = %q, want %q", got, want)
-		}
-	}
-}
-
-func TestXcodeDiagnosticBufferRepairsUTF8AtTailBoundary(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(40)
-	if _, err := buffer.Write([]byte("始" + strings.Repeat("界", 20) + "終")); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
-	if !utf8.ValidString(got) {
-		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
-	}
-	if !strings.Contains(got, "終") {
-		t.Fatalf("String() = %q, want trailing marker", got)
-	}
-	if len(got) > buffer.limit {
-		t.Fatalf("rendered bytes = %d, limit = %d", len(got), buffer.limit)
-	}
-	if stored := len(buffer.tail.data) + buffer.diagnosticBytes; stored > buffer.limit+buffer.diagnosticBudget() {
-		t.Fatalf("stored bytes = %d, limit = %d", stored, buffer.limit)
-	}
-}
-
-func TestXcodeDiagnosticBufferHandlesZeroAndSingleByteLimits(t *testing.T) {
-	for _, limit := range []int{0, 1} {
-		t.Run(strconv.Itoa(limit), func(t *testing.T) {
-			buffer := newXcodeDiagnosticBuffer(limit)
-			if _, err := buffer.Write([]byte("ab")); err != nil {
-				t.Fatalf("Write() error = %v", err)
-			}
-			if !buffer.Truncated() {
-				t.Fatal("Truncated() = false, want true")
-			}
-			if !utf8.ValidString(buffer.String()) {
-				t.Fatalf("String() returned invalid UTF-8: %q", buffer.String())
-			}
-			if rendered := len(buffer.String()); rendered > limit {
-				t.Fatalf("rendered bytes = %d, limit = %d", rendered, limit)
-			}
-			if stored := len(buffer.tail.data) + buffer.diagnosticBytes; stored > limit+buffer.diagnosticBudget() {
-				t.Fatalf("stored bytes = %d, limit = %d", stored, limit)
-			}
-		})
-	}
+	_, got := renderXcodeDiagnosticOutput(t, input)
+	requireBoundedXcodeDiagnosticOutput(t, got, "file.m:4:3: error: root cause", "FINAL-DIAGNOSTIC")
 }
 
 func TestXcodeDiagnosticBufferRetainsMissingErrorsOnce(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
-	diagnostic := "error: earliest root cause"
+	diagnostic := "/tmp/App/Assets.xcassets: error: App icon set missing"
 	benign := "Build summary mentions error: only as prose"
 	input := diagnostic + "\n" + diagnostic + "\n" + benign + "\n"
-	input += strings.Repeat("x", xcodeCommandErrorOutputLimit+128) + "\nFINAL-DIAGNOSTIC\n"
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
+	input += strings.Repeat("x", xcodebuildErrorTailLimit+128) + "\nFINAL-DIAGNOSTIC\n"
 
-	got := buffer.String()
-	if count := strings.Count(got, diagnostic); count != 1 {
+	_, got := renderXcodeDiagnosticOutput(t, input)
+	if count := countExactOutputLines(got, diagnostic); count != 1 {
 		t.Fatalf("diagnostic count = %d, want 1", count)
 	}
 	if strings.Contains(got, benign) {
 		t.Fatalf("String() retained benign prose as a diagnostic: %q", got)
 	}
-	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
-		t.Fatalf("String() dropped final output marker")
-	}
-	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
-		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
-	}
-}
-
-func TestXcodeDiagnosticBufferDoesNotPrependDiagnosticAlreadyInTail(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
-	diagnostic := "error: repeated root cause"
-	input := diagnostic + "\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
-	input += "\n" + diagnostic + "\nFINAL-DIAGNOSTIC\n"
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
-	if count := strings.Count(got, diagnostic); count != 1 {
-		t.Fatalf("diagnostic count = %d, want 1", count)
-	}
-	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
-		t.Fatalf("String() dropped final output marker")
-	}
+	requireBoundedXcodeDiagnosticOutput(t, got, "FINAL-DIAGNOSTIC")
 }
 
 func TestXcodeDiagnosticBufferRetainsDiagnosticDisplacedByMissingPrefix(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	missingDiagnostic := "error: " + strings.Repeat("a", 1024)
 	displacedDiagnostic := "error: displaced from the start of the legacy tail"
 	tail := "\n" + displacedDiagnostic + "\n"
-	tail += strings.Repeat("x", xcodeCommandErrorOutputLimit-len(tail))
+	tail += strings.Repeat("x", xcodebuildErrorTailLimit-len(tail))
 	input := missingDiagnostic + "\n" + strings.Repeat("o", 128) + tail
 
-	legacyTail := newTailBuffer(xcodeCommandErrorOutputLimit)
+	legacyTail := newTailBuffer(xcodebuildErrorTailLimit)
 	if _, err := legacyTail.Write([]byte(input)); err != nil {
 		t.Fatalf("legacy tail Write() error = %v", err)
 	}
@@ -1614,38 +1542,17 @@ func TestXcodeDiagnosticBufferRetainsDiagnosticDisplacedByMissingPrefix(t *testi
 		t.Fatal("test precondition failed: missing diagnostic is present in the legacy tail")
 	}
 
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-	got := buffer.String()
-	for _, diagnostic := range []string{missingDiagnostic, displacedDiagnostic} {
-		if !strings.Contains(got, diagnostic) {
-			t.Fatalf("String() dropped diagnostic %q", diagnostic)
-		}
-	}
-	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
-		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
-	}
+	_, got := renderXcodeDiagnosticOutput(t, input)
+	requireBoundedXcodeDiagnosticOutput(t, got, missingDiagnostic, displacedDiagnostic)
 }
 
 func TestXcodeDiagnosticBufferDoesNotDeduplicateAgainstBenignTailSubstring(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	diagnostic := "error: root cause"
 	benign := "note: previous error: root cause was discussed"
-	input := diagnostic + "\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
+	input := diagnostic + "\n" + strings.Repeat("x", xcodebuildErrorTailLimit+128)
 	input += "\n" + benign + "\nFINAL-DIAGNOSTIC\n"
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
-	exactCount := 0
-	for _, line := range strings.Split(got, "\n") {
-		if strings.TrimSpace(line) == diagnostic {
-			exactCount++
-		}
-	}
-	if exactCount != 1 {
+	_, got := renderXcodeDiagnosticOutput(t, input)
+	if exactCount := countExactOutputLines(got, diagnostic); exactCount != 1 {
 		t.Fatalf("exact diagnostic line count = %d, want 1", exactCount)
 	}
 	if !strings.Contains(got, benign) {
@@ -1653,39 +1560,16 @@ func TestXcodeDiagnosticBufferDoesNotDeduplicateAgainstBenignTailSubstring(t *te
 	}
 }
 
-func TestXcodeDiagnosticBufferRetainsPathOnlyErrorOutsideTail(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
-	diagnostic := "/tmp/App/Assets.xcassets: error: App icon set missing"
-	input := diagnostic + "\n" + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
-	input += "\nFINAL-DIAGNOSTIC\n"
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
-	if !strings.Contains(got, diagnostic) {
-		t.Fatalf("String() dropped path-only Xcode diagnostic")
-	}
-	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
-		t.Fatalf("String() dropped final output marker")
-	}
-}
-
 func TestXcodeDiagnosticBufferDoesNotLetVersionedProseExhaustDiagnosticBudget(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	var input strings.Builder
 	for i := range 1000 {
 		fmt.Fprintf(&input, "Build 1.%d: error: only prose\n", i)
 	}
 	diagnostic := "error: actual root cause"
 	input.WriteString(diagnostic + "\n")
-	input.WriteString(strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+	input.WriteString(strings.Repeat("x", xcodebuildErrorTailLimit+128))
 	input.WriteString("\nFINAL-DIAGNOSTIC\n")
-	if _, err := buffer.Write([]byte(input.String())); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
+	_, got := renderXcodeDiagnosticOutput(t, input.String())
 	if !strings.Contains(got, diagnostic) {
 		t.Fatalf("String() dropped real diagnostic after versioned prose")
 	}
@@ -1695,15 +1579,12 @@ func TestXcodeDiagnosticBufferDoesNotLetVersionedProseExhaustDiagnosticBudget(t 
 }
 
 func TestXcodeDiagnosticBufferIndexesDenseTailOnce(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	var input strings.Builder
 	for i := range 32 {
 		fmt.Fprintf(&input, "error: early failure %02d\n", i)
 	}
-	input.WriteString(strings.Repeat("\n", xcodeCommandErrorOutputLimit+128))
-	if _, err := buffer.Write([]byte(input.String())); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
+	input.WriteString(strings.Repeat("\n", xcodebuildErrorTailLimit+128))
+	buffer, _ := renderXcodeDiagnosticOutput(t, input.String())
 
 	if allocations := testing.AllocsPerRun(1, func() {
 		_ = buffer.String()
@@ -1713,20 +1594,13 @@ func TestXcodeDiagnosticBufferIndexesDenseTailOnce(t *testing.T) {
 }
 
 func TestXcodeDiagnosticBufferBoundsVeryLongErrorLine(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	longDiagnostic := "error: " + strings.Repeat("界", xcodeDiagnosticLineLimit)
-	input := longDiagnostic + strings.Repeat("x", xcodeCommandErrorOutputLimit+128)
-	if _, err := buffer.Write([]byte(input)); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
+	input := longDiagnostic + strings.Repeat("x", xcodebuildErrorTailLimit+128)
+	buffer, got := renderXcodeDiagnosticOutput(t, input)
 	if !strings.Contains(got, "error: ") {
 		t.Fatalf("String() dropped bounded long diagnostic")
 	}
-	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
-		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
-	}
+	requireBoundedXcodeDiagnosticOutput(t, got)
 	if buffer.diagnosticBytes > buffer.diagnosticBudget() {
 		t.Fatalf("stored diagnostic bytes = %d, budget = %d", buffer.diagnosticBytes, buffer.diagnosticBudget())
 	}
@@ -1738,79 +1612,49 @@ func TestXcodeDiagnosticBufferBoundsVeryLongErrorLine(t *testing.T) {
 }
 
 func TestXcodeDiagnosticBufferBoundsManyUniqueErrors(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	var input strings.Builder
 	for i := range 5000 {
 		fmt.Fprintf(&input, "error: distinct failure %04d\n", i)
 	}
-	input.WriteString(strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+	input.WriteString(strings.Repeat("x", xcodebuildErrorTailLimit+128))
 	input.WriteString("\nFINAL-DIAGNOSTIC\n")
-	if _, err := buffer.Write([]byte(input.String())); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-
-	got := buffer.String()
-	if len(got) > xcodeCommandErrorOutputLimit || !utf8.ValidString(got) {
-		t.Fatalf("rendered output bytes = %d, valid UTF-8 = %t", len(got), utf8.ValidString(got))
-	}
+	buffer, got := renderXcodeDiagnosticOutput(t, input.String())
+	requireBoundedXcodeDiagnosticOutput(t, got, "error: distinct failure 0000", "FINAL-DIAGNOSTIC")
 	if buffer.diagnosticBytes > buffer.diagnosticBudget() {
 		t.Fatalf("stored diagnostic bytes = %d, budget = %d", buffer.diagnosticBytes, buffer.diagnosticBudget())
 	}
-	if !strings.Contains(got, "error: distinct failure 0000") {
-		t.Fatalf("String() dropped earliest bounded diagnostic")
-	}
-	if !strings.Contains(got, "FINAL-DIAGNOSTIC") {
-		t.Fatalf("String() dropped final output marker")
-	}
 }
 
-func TestXcodeDiagnosticBufferKeepsStreamFragmentsIndependent(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
-	stdout := buffer.newStreamWriter(nil)
-	stderr := buffer.newStreamWriter(nil)
+func TestXcodeDiagnosticBufferFramesStreamFragmentsIndependently(t *testing.T) {
+	buffer := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, nil)
+	stdout := buffer.newStreamWriter()
+	stderr := buffer.newStreamWriter()
 	if _, err := stdout.Write([]byte("file.m:4:3: err")); err != nil {
 		t.Fatalf("stdout Write() error = %v", err)
 	}
 	if _, err := stderr.Write([]byte("or: cross-stream false positive\n")); err != nil {
 		t.Fatalf("stderr Write() error = %v", err)
 	}
-	if _, err := stdout.Write([]byte("\n")); err != nil {
-		t.Fatalf("stdout newline Write() error = %v", err)
-	}
-	if _, err := buffer.Write([]byte(strings.Repeat("x", xcodeCommandErrorOutputLimit+128))); err != nil {
-		t.Fatalf("tail Write() error = %v", err)
-	}
-
-	_ = buffer.String()
-	if len(buffer.diagnostics) != 0 {
-		t.Fatalf("captured cross-stream diagnostic fragments: %q", buffer.diagnostics)
-	}
-}
-
-func TestXcodeDiagnosticBufferRecognizesLineSplitWithinStream(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
-	stream := buffer.newStreamWriter(nil)
-	for _, chunk := range []string{
-		"Sources/App.swift:12:7: er",
-		"ror: split root cause",
-		"\n",
-		strings.Repeat("x", xcodeCommandErrorOutputLimit+128),
-	} {
-		if _, err := stream.Write([]byte(chunk)); err != nil {
+	for _, chunk := range []string{"or: split root cause\n", strings.Repeat("x", xcodebuildErrorTailLimit+128)} {
+		if _, err := io.WriteString(stdout, chunk); err != nil {
 			t.Fatalf("Write() error = %v", err)
 		}
 	}
 
-	if got := buffer.String(); !strings.Contains(got, "Sources/App.swift:12:7: error: split root cause") {
+	got := buffer.String()
+	if !strings.Contains(got, "file.m:4:3: error: split root cause") {
 		t.Fatalf("String() dropped diagnostic split across writes")
+	}
+	if strings.Contains(got, "cross-stream false positive") {
+		t.Fatalf("String() joined fragments across streams: %q", got)
 	}
 }
 
 func TestXcodeDiagnosticBufferSerializesConcurrentStreamWrites(t *testing.T) {
-	buffer := newXcodeDiagnosticBuffer(xcodeCommandErrorOutputLimit)
 	var streamed bytes.Buffer
-	stdout := buffer.newStreamWriter(&streamed)
-	stderr := buffer.newStreamWriter(&streamed)
+	buffer := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, &streamed)
+	stdout := buffer.newStreamWriter()
+	stderr := buffer.newStreamWriter()
 
 	var writers sync.WaitGroup
 	for _, writer := range []io.Writer{stdout, stderr} {
@@ -2111,7 +1955,7 @@ func TestXcodeHelperProcess(t *testing.T) {
 
 	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "fail-large-output" {
 		fmt.Fprint(os.Stderr, "file.m:4:3: error: root cause\n")
-		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodebuildErrorTailLimit+128))
 		fmt.Fprint(os.Stderr, "\nFINAL-DIAGNOSTIC\n")
 		os.Exit(1)
 	}
@@ -2122,7 +1966,7 @@ func TestXcodeHelperProcess(t *testing.T) {
 			os.Exit(2)
 		}
 		fmt.Fprint(os.Stderr, "file.m:4:3: error: root cause\n")
-		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodeCommandErrorOutputLimit+128))
+		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodebuildErrorTailLimit+128))
 		fmt.Fprint(os.Stderr, "\nFINAL-BEFORE-INTERRUPTION\n")
 		if err := os.WriteFile(commandArgs[2], []byte("ready"), 0o600); err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1421,6 +1421,21 @@ func waitForHelperSignal(path string, timeout time.Duration) error {
 	}
 }
 
+func TestTailBufferStringRemainsValidUTF8AfterByteTruncation(t *testing.T) {
+	buffer := newTailBuffer(4)
+	if _, err := buffer.Write([]byte("界界")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got := buffer.String()
+	if !utf8.ValidString(got) {
+		t.Fatalf("String() returned invalid UTF-8 after truncation: %q", got)
+	}
+	if !strings.Contains(got, "界") {
+		t.Fatalf("String() = %q, want intact trailing diagnostic", got)
+	}
+}
+
 func renderXcodeDiagnosticOutput(t *testing.T, input string) (*xcodeDiagnosticBuffer, string) {
 	t.Helper()
 	buffer := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, nil)

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1439,7 +1439,7 @@ func TestTailBufferStringRemainsValidUTF8AfterByteTruncation(t *testing.T) {
 func renderXcodeDiagnosticOutput(t *testing.T, input string) (*xcodeDiagnosticBuffer, string) {
 	t.Helper()
 	buffer := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, nil)
-	if _, err := io.WriteString(buffer.newStreamWriter(), input); err != nil {
+	if _, err := io.WriteString(buffer, input); err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
 	return buffer, buffer.String()
@@ -1470,9 +1470,8 @@ func countExactOutputLines(output string, value string) int {
 func TestXcodeDiagnosticBufferPreservesUntruncatedOutput(t *testing.T) {
 	for _, chunks := range [][]string{{"ab", "cd", "ef"}, {"abcd", "efgh"}} {
 		buffer := newXcodeDiagnosticBuffer(8, nil)
-		stream := buffer.newStreamWriter()
 		for _, chunk := range chunks {
-			if _, err := io.WriteString(stream, chunk); err != nil {
+			if _, err := io.WriteString(buffer, chunk); err != nil {
 				t.Fatalf("Write(%q) error = %v", chunk, err)
 			}
 		}
@@ -1640,44 +1639,36 @@ func TestXcodeDiagnosticBufferBoundsManyUniqueErrors(t *testing.T) {
 	}
 }
 
-func TestXcodeDiagnosticBufferFramesStreamFragmentsIndependently(t *testing.T) {
+func TestXcodeDiagnosticBufferRecognizesDiagnosticSplitAcrossWrites(t *testing.T) {
 	buffer := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, nil)
-	stdout := buffer.newStreamWriter()
-	stderr := buffer.newStreamWriter()
-	if _, err := stdout.Write([]byte("file.m:4:3: err")); err != nil {
-		t.Fatalf("stdout Write() error = %v", err)
-	}
-	if _, err := stderr.Write([]byte("or: cross-stream false positive\n")); err != nil {
-		t.Fatalf("stderr Write() error = %v", err)
-	}
-	for _, chunk := range []string{"or: split root cause\n", strings.Repeat("x", xcodebuildErrorTailLimit+128)} {
-		if _, err := io.WriteString(stdout, chunk); err != nil {
+	for _, chunk := range []string{
+		"Sources/App.swift:12:7: er",
+		"ror: split root cause",
+		"\n",
+		strings.Repeat("x", xcodebuildErrorTailLimit+128),
+	} {
+		if _, err := io.WriteString(buffer, chunk); err != nil {
 			t.Fatalf("Write() error = %v", err)
 		}
 	}
 
 	got := buffer.String()
-	if !strings.Contains(got, "file.m:4:3: error: split root cause") {
+	if !strings.Contains(got, "Sources/App.swift:12:7: error: split root cause") {
 		t.Fatalf("String() dropped diagnostic split across writes")
-	}
-	if strings.Contains(got, "cross-stream false positive") {
-		t.Fatalf("String() joined fragments across streams: %q", got)
 	}
 }
 
-func TestXcodeDiagnosticBufferSerializesConcurrentStreamWrites(t *testing.T) {
+func TestXcodeDiagnosticBufferSerializesConcurrentWrites(t *testing.T) {
 	var streamed bytes.Buffer
 	buffer := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, &streamed)
-	stdout := buffer.newStreamWriter()
-	stderr := buffer.newStreamWriter()
 
 	var writers sync.WaitGroup
-	for _, writer := range []io.Writer{stdout, stderr} {
+	for range 2 {
 		writers.Add(1)
 		go func() {
 			defer writers.Done()
 			for range 100 {
-				if _, err := writer.Write([]byte("ordinary build output\n")); err != nil {
+				if _, err := buffer.Write([]byte("ordinary build output\n")); err != nil {
 					t.Errorf("Write() error = %v", err)
 					return
 				}
@@ -1688,6 +1679,21 @@ func TestXcodeDiagnosticBufferSerializesConcurrentStreamWrites(t *testing.T) {
 
 	if got := buffer.String(); got != streamed.String() {
 		t.Fatalf("captured output differs from streamed output")
+	}
+}
+
+func TestRunXcodebuildPreservesCombinedChildStreamOrder(t *testing.T) {
+	restore := overrideTestEnvironment(t)
+	commandContextFn = helperCommandContext(t, filepath.Join(t.TempDir(), "commands.log"))
+	t.Cleanup(restore)
+
+	const want = "FIRST-STDOUT\nSECOND-STDERR\nTHIRD-STDOUT\nFINAL-STDERR\n"
+	var streamed bytes.Buffer
+	if err := runXcodebuild(context.Background(), []string{"alternating-stream-output"}, &streamed); err != nil {
+		t.Fatalf("runXcodebuild() error = %v", err)
+	}
+	if got := streamed.String(); got != want {
+		t.Fatalf("streamed output = %q, want child write order %q", got, want)
 	}
 }
 
@@ -1973,6 +1979,20 @@ func TestXcodeHelperProcess(t *testing.T) {
 		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodebuildErrorTailLimit+128))
 		fmt.Fprint(os.Stderr, "\nFINAL-DIAGNOSTIC\n")
 		os.Exit(1)
+	}
+
+	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "alternating-stream-output" {
+		stdoutInfo, stdoutErr := os.Stdout.Stat()
+		stderrInfo, stderrErr := os.Stderr.Stat()
+		fmt.Fprint(os.Stdout, "FIRST-STDOUT\n")
+		fmt.Fprint(os.Stderr, "SECOND-STDERR\n")
+		fmt.Fprint(os.Stdout, "THIRD-STDOUT\n")
+		fmt.Fprint(os.Stderr, "FINAL-STDERR\n")
+		if stdoutErr != nil || stderrErr != nil || !os.SameFile(stdoutInfo, stderrInfo) {
+			fmt.Fprintln(os.Stderr, "stdout and stderr do not share one ordered descriptor")
+			os.Exit(3)
+		}
+		os.Exit(0)
 	}
 
 	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "large-output-then-wait" {


### PR DESCRIPTION
## Summary

- keep the existing final 64 KiB tail for failed Xcode build, archive, and export commands
- retain unique, recognized Xcode error lines that would otherwise fall outside that tail, while keeping the complete diagnostic text within the same 64 KiB bound
- preserve complete live log streaming, child output order, process and context error semantics, and the existing validation-output path

## Behavior

Long Xcode failures can emit an actionable compiler, tool, or path-qualified error before tens of kilobytes of later output. Failed commands now collect precise `error:` diagnostics while streaming, then prepend only those missing from the final retained tail. If prepending one error moves the tail boundary past another, the displaced error is retained as well.

Collection is bounded per line and in aggregate, deduplicated by complete normalized lines, and parsed from the same ordered byte stream used for live logs. The command gives stdout and stderr one comparable writer so the child keeps the pre-existing combined-descriptor interleaving and the tail reflects its actual final output. Benign prose containing `error:` is ignored. The formatted diagnostic remains at most 64 KiB and valid UTF-8; the recognized-error prefix uses at most 16 KiB, leaving the rest for final Xcode output.

Non-truncated failures are unchanged. Timeout and cancellation causes remain discoverable, build failures still preserve the subprocess exit error used for structured results, and validation continues to use its existing bounded classifier.

## Verification

The regression coverage proves that:

- a compiler error around byte 40 KiB of a 90 KiB log remains available exactly as it was in the prior 64 KiB tail
- an earlier error outside the tail and any error displaced by the added prefix both survive
- path-only, source-location, line-leading, and known-tool diagnostics are retained without accepting versioned prose
- alternating child stdout/stderr writes share one descriptor and preserve their exact combined-stream order
- duplicate, very long, numerous, split-write, concurrent-writer, timeout, cancellation, UTF-8, and no-log-writer cases remain bounded and deterministic
- validation-output behavior is unchanged

A freshly built binary was exercised with a deterministic failing `xcodebuild` helper. It streamed mixed stdout/stderr noise, an early path error, a middle compiler error, benign error-like prose, and the final marker in byte order and exactly once; structured output reported `success: false` and exit status 65.

Exact-head gates:

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused Xcode package and race tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Xcode command failure messages by preserving recognized diagnostics and final output within a bounded size.
  * Added clear indications when command output has been truncated.
  * Preserved process errors and ensured truncated output remains valid UTF-8.
  * Improved diagnostics for build, archive, export, and interrupted commands.
  * Prevented duplicate diagnostic information while maintaining complete command-log streaming across concurrent output streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->