### PR TITLE
fix(certificates): validate generated outputs before writing

### DIFF
--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -411,6 +411,16 @@ func TestCertificatesCreateCommand_GenerateCSRWriteFailures(t *testing.T) {
 	}
 }
 
+func TestValidateCSRFileOutputPathRejectsAlternateWindowsSeparator(t *testing.T) {
+	windowsPathSeparator := func(character uint8) bool {
+		return character == '\\' || character == '/'
+	}
+
+	if _, err := validateCSRFileOutputPathWithSeparator("output/", windowsPathSeparator); err == nil {
+		t.Fatal("expected alternate Windows path separator to be rejected")
+	}
+}
+
 func TestCertificatesRevokeCommand_MissingID(t *testing.T) {
 	cmd := CertificatesRevokeCommand()
 

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -340,11 +340,15 @@ func preflightCSRParentDirectory(path string) error {
 }
 
 func validateCSRFileOutputPath(path string) (string, error) {
+	return validateCSRFileOutputPathWithSeparator(path, os.IsPathSeparator)
+}
+
+func validateCSRFileOutputPathWithSeparator(path string, isPathSeparator func(uint8) bool) (string, error) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" {
 		return "", fmt.Errorf("output path is required")
 	}
-	if strings.HasSuffix(trimmed, string(filepath.Separator)) {
+	if isPathSeparator(trimmed[len(trimmed)-1]) {
 		return "", fmt.Errorf("output path must be a file")
 	}
 	return trimmed, nil

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -180,18 +180,18 @@ func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, erro
 		subject.CommonName = "asc"
 	}
 
-	// Pre-check output paths to avoid leaving an orphaned key when CSR write fails.
-	// This is not atomic (TOCTOU), but it prevents the common confusing case.
-	if !opts.Force {
-		if _, err := os.Lstat(keyOutValue); err == nil {
-			return nil, nil, fmt.Errorf("write --key-out: output file already exists: %w", os.ErrExist)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("write --key-out: %w", err)
-		}
-		if _, err := os.Lstat(csrOutValue); err == nil {
-			return nil, nil, fmt.Errorf("write --csr-out: output file already exists: %w", os.ErrExist)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("write --csr-out: %w", err)
+	// Preflight both outputs before generating or replacing either file. This is
+	// not a cross-file transaction, but locally knowable path failures must not
+	// split the generated key and CSR pair.
+	for _, output := range []struct {
+		flag string
+		path string
+	}{
+		{flag: "--key-out", path: keyOutValue},
+		{flag: "--csr-out", path: csrOutValue},
+	} {
+		if err := preflightCSRFileWrite(output.path, opts.Force); err != nil {
+			return nil, nil, fmt.Errorf("write %s: %w", output.flag, err)
 		}
 	}
 
@@ -286,16 +286,77 @@ func renderCSRGenerateResult(result *csrGenerateResult, markdown bool) error {
 	return nil
 }
 
-func writeFileBytesNoSymlink(path string, data []byte, perm os.FileMode, force bool) error {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
-		return fmt.Errorf("output path is required")
+func preflightCSRFileWrite(path string, force bool) error {
+	trimmed, err := validateCSRFileOutputPath(path)
+	if err != nil {
+		return err
 	}
-	if strings.HasSuffix(trimmed, string(filepath.Separator)) {
-		return fmt.Errorf("output path must be a file")
+	if err := preflightCSRParentDirectory(trimmed); err != nil {
+		return err
 	}
 
-	_, err := shared.SafeWriteFileNoSymlink(
+	info, err := os.Lstat(trimmed)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !force {
+		return fmt.Errorf("output file already exists: %w", os.ErrExist)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to overwrite symlink %q", trimmed)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("output path %q is a directory", trimmed)
+	}
+	return nil
+}
+
+func preflightCSRParentDirectory(path string) error {
+	for parent := filepath.Dir(path); ; parent = filepath.Dir(parent) {
+		info, err := os.Lstat(parent)
+		if errors.Is(err, os.ErrNotExist) {
+			if next := filepath.Dir(parent); next != parent {
+				continue
+			}
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			info, err = os.Stat(parent)
+			if err != nil {
+				return err
+			}
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%q is not a directory", parent)
+		}
+		return nil
+	}
+}
+
+func validateCSRFileOutputPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("output path is required")
+	}
+	if strings.HasSuffix(trimmed, string(filepath.Separator)) {
+		return "", fmt.Errorf("output path must be a file")
+	}
+	return trimmed, nil
+}
+
+func writeFileBytesNoSymlink(path string, data []byte, perm os.FileMode, force bool) error {
+	trimmed, err := validateCSRFileOutputPath(path)
+	if err != nil {
+		return err
+	}
+
+	_, err = shared.SafeWriteFileNoSymlink(
 		trimmed,
 		perm,
 		force,

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -367,78 +367,45 @@ func validateCSRPairOutputPaths(keyOut, csrOut string) error {
 }
 
 func classifyCSRFilesystemRelation(keyPath, csrPath string) (same bool, nested bool, err error) {
-	keyDepth := csrPathDepth(keyPath)
-	csrDepth := csrPathDepth(csrPath)
-	if keyDepth == csrDepth {
-		same, err = areCSRPathsFilesystemEquivalent(keyPath, csrPath)
-		return same, false, err
-	}
+	return classifyCSRFilesystemRelationWithStat(keyPath, csrPath, os.Stat)
+}
 
-	shorter := keyPath
-	longer := csrPath
-	shorterDepth := keyDepth
-	longerDepth := csrDepth
-	if keyDepth > csrDepth {
-		shorter = csrPath
-		longer = keyPath
-		shorterDepth = csrDepth
-		longerDepth = keyDepth
+func classifyCSRFilesystemRelationWithStat(keyPath, csrPath string, stat csrStatFunc) (same bool, nested bool, err error) {
+	if keyPath == csrPath {
+		return true, false, nil
 	}
-	longerPrefix := longer
-	for range longerDepth - shorterDepth {
-		longerPrefix = filepath.Dir(longerPrefix)
+	// Bind mounts and other filesystem aliases can have unrelated spellings and
+	// lexical depths. Anchor the comparison on the deepest existing inode, then
+	// compare only the unresolved destination components beneath it.
+	keyAncestor, keyInfo, keyMissing, err := deepestExistingCSRPath(keyPath, stat)
+	if err != nil {
+		return false, false, err
 	}
-	if !normalizedFoldEqual(shorter, longerPrefix) {
+	_, csrInfo, csrMissing, err := deepestExistingCSRPath(csrPath, stat)
+	if err != nil {
+		return false, false, err
+	}
+	if !os.SameFile(keyInfo, csrInfo) {
 		return false, false, nil
 	}
 
-	nested, err = areCSRPathsFilesystemEquivalent(shorter, longerPrefix)
+	keyComponents := csrMissingPathComponents(keyPath, keyMissing)
+	csrComponents := csrMissingPathComponents(csrPath, csrMissing)
+	if len(keyComponents) == len(csrComponents) {
+		same, err = areCSRPathComponentsEquivalent(keyAncestor, keyInfo, keyComponents, csrComponents)
+		return same, false, err
+	}
+	shorter := keyComponents
+	longer := csrComponents
+	if len(csrComponents) < len(keyComponents) {
+		shorter = csrComponents
+		longer = keyComponents
+	}
+	nested, err = areCSRPathComponentsEquivalent(keyAncestor, keyInfo, shorter, longer[:len(shorter)])
 	return false, nested, err
 }
 
-func csrPathDepth(path string) int {
-	depth := 0
-	for current := filepath.Clean(path); ; current = filepath.Dir(current) {
-		parent := filepath.Dir(current)
-		if parent == current {
-			return depth
-		}
-		depth++
-	}
-}
-
-func areCSRPathsFilesystemEquivalent(leftPath, rightPath string) (bool, error) {
-	if leftPath == rightPath {
-		return true, nil
-	}
-	if !normalizedFoldEqual(leftPath, rightPath) {
-		return false, nil
-	}
-
-	leftAncestor, leftInfo, leftMissing, err := deepestExistingCSRPath(leftPath)
-	if err != nil {
-		return false, err
-	}
-	_, rightInfo, rightMissing, err := deepestExistingCSRPath(rightPath)
-	if err != nil {
-		return false, err
-	}
-	if !os.SameFile(leftInfo, rightInfo) || leftMissing != rightMissing {
-		return false, nil
-	}
-	if leftMissing == 0 {
-		return true, nil
-	}
-	if !leftInfo.IsDir() {
-		return false, nil
-	}
-	leftComponents := csrMissingPathComponents(leftPath, leftMissing)
-	rightComponents := csrMissingPathComponents(rightPath, rightMissing)
-	if sameCSRPathComponents(leftComponents, rightComponents) {
-		return true, nil
-	}
-	return probeCSRPathComponentsEquivalent(leftAncestor, leftComponents, rightComponents)
-}
+type csrStatFunc func(string) (os.FileInfo, error)
 
 func normalizedFoldEqual(left, right string) bool {
 	return strings.EqualFold(norm.NFC.String(left), norm.NFC.String(right))
@@ -466,11 +433,21 @@ func sameCSRPathComponents(left, right []string) bool {
 	return true
 }
 
-func deepestExistingCSRPath(path string) (string, os.FileInfo, int, error) {
+func areCSRPathComponentsEquivalent(parent string, parentInfo os.FileInfo, left, right []string) (bool, error) {
+	if sameCSRPathComponents(left, right) {
+		return true, nil
+	}
+	if !parentInfo.IsDir() {
+		return false, nil
+	}
+	return probeCSRPathComponentsEquivalent(parent, left, right)
+}
+
+func deepestExistingCSRPath(path string, stat csrStatFunc) (string, os.FileInfo, int, error) {
 	current := path
 	missing := 0
 	for {
-		info, err := os.Stat(current)
+		info, err := stat(current)
 		if err == nil {
 			return current, info, missing, nil
 		}

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 type csrGenerateSubject struct {
@@ -291,27 +292,27 @@ func preflightCSRFileWrite(path string, force bool) error {
 	if err != nil {
 		return err
 	}
-	if err := preflightCSRParentDirectory(trimmed); err != nil {
+	existingParent, err := preflightCSRParentDirectory(trimmed)
+	if err != nil {
 		return err
 	}
 
 	info, err := os.Lstat(trimmed)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	if !force {
-		return fmt.Errorf("output file already exists: %w", os.ErrExist)
+	if err == nil {
+		if !force {
+			return fmt.Errorf("output file already exists: %w", os.ErrExist)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink %q", trimmed)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("output path %q is a directory", trimmed)
+		}
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to overwrite symlink %q", trimmed)
-	}
-	if info.IsDir() {
-		return fmt.Errorf("output path %q is a directory", trimmed)
-	}
-	return nil
+	return probeCSRParentWrite(existingParent, force)
 }
 
 func validateCSRPairOutputPaths(keyOut, csrOut string) error {
@@ -329,42 +330,99 @@ func validateCSRPairOutputPaths(keyOut, csrOut string) error {
 	if (keyRelativeErr == nil && keyToCSR == ".") || (csrRelativeErr == nil && csrToKey == ".") {
 		return shared.UsageError("--key-out and --csr-out must be different paths")
 	}
-	caseEquivalent, err := areCSRPathsCaseEquivalent(keyPath, csrPath)
+	caseEquivalent, caseNested, err := classifyCSRCaseFoldRelation(keyPath, csrPath)
 	if err != nil {
 		return fmt.Errorf("compare --key-out and --csr-out: %w", err)
 	}
 	if caseEquivalent {
 		return shared.UsageError("--key-out and --csr-out must be different paths")
 	}
-	if isCSRDescendantPath(keyToCSR, keyRelativeErr) || isCSRDescendantPath(csrToKey, csrRelativeErr) {
+	if caseNested || isCSRDescendantPath(keyToCSR, keyRelativeErr) || isCSRDescendantPath(csrToKey, csrRelativeErr) {
 		return shared.UsageError("--key-out and --csr-out must not contain one another")
 	}
 	return nil
 }
 
-func areCSRPathsCaseEquivalent(keyPath, csrPath string) (bool, error) {
-	if !strings.EqualFold(keyPath, csrPath) {
+func classifyCSRCaseFoldRelation(keyPath, csrPath string) (same bool, nested bool, err error) {
+	keyDepth := csrPathDepth(keyPath)
+	csrDepth := csrPathDepth(csrPath)
+	if keyDepth == csrDepth {
+		same, err = areCSRPathsFilesystemEquivalent(keyPath, csrPath)
+		return same, false, err
+	}
+
+	shorter := keyPath
+	longer := csrPath
+	shorterDepth := keyDepth
+	longerDepth := csrDepth
+	if keyDepth > csrDepth {
+		shorter = csrPath
+		longer = keyPath
+		shorterDepth = csrDepth
+		longerDepth = keyDepth
+	}
+	longerPrefix := longer
+	for range longerDepth - shorterDepth {
+		longerPrefix = filepath.Dir(longerPrefix)
+	}
+	if !strings.EqualFold(shorter, longerPrefix) {
+		return false, false, nil
+	}
+
+	nested, err = areCSRPathsFilesystemEquivalent(shorter, longerPrefix)
+	return false, nested, err
+}
+
+func csrPathDepth(path string) int {
+	depth := 0
+	for current := filepath.Clean(path); ; current = filepath.Dir(current) {
+		parent := filepath.Dir(current)
+		if parent == current {
+			return depth
+		}
+		depth++
+	}
+}
+
+func areCSRPathsFilesystemEquivalent(leftPath, rightPath string) (bool, error) {
+	if leftPath == rightPath {
+		return true, nil
+	}
+	if !strings.EqualFold(leftPath, rightPath) {
 		return false, nil
 	}
 
-	keyAncestor, keyInfo, keyMissing, err := deepestExistingCSRPath(keyPath)
+	leftAncestor, leftInfo, leftMissing, err := deepestExistingCSRPath(leftPath)
 	if err != nil {
 		return false, err
 	}
-	_, csrInfo, csrMissing, err := deepestExistingCSRPath(csrPath)
+	_, rightInfo, rightMissing, err := deepestExistingCSRPath(rightPath)
 	if err != nil {
 		return false, err
 	}
-	if !os.SameFile(keyInfo, csrInfo) {
+	if !os.SameFile(leftInfo, rightInfo) || leftMissing != rightMissing {
 		return false, nil
 	}
-	if keyMissing == 0 && csrMissing == 0 {
+	if leftMissing == 0 || haveSameCSRMissingSuffix(leftPath, rightPath, leftMissing) {
 		return true, nil
 	}
-	if !keyInfo.IsDir() {
+	if !leftInfo.IsDir() {
 		return false, nil
 	}
-	return isCSRDirectoryCaseInsensitive(keyAncestor)
+	return isCSRDirectoryCaseInsensitive(leftAncestor)
+}
+
+func haveSameCSRMissingSuffix(leftPath, rightPath string, missing int) bool {
+	left := leftPath
+	right := rightPath
+	for range missing {
+		if filepath.Base(left) != filepath.Base(right) {
+			return false
+		}
+		left = filepath.Dir(left)
+		right = filepath.Dir(right)
+	}
+	return true
 }
 
 func deepestExistingCSRPath(path string) (string, os.FileInfo, int, error) {
@@ -469,29 +527,84 @@ func isCSRDescendantPath(relative string, err error) bool {
 		!filepath.IsAbs(relative) && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
-func preflightCSRParentDirectory(path string) error {
+func preflightCSRParentDirectory(path string) (string, error) {
 	for parent := filepath.Dir(path); ; parent = filepath.Dir(parent) {
 		info, err := os.Lstat(parent)
 		if errors.Is(err, os.ErrNotExist) {
 			if next := filepath.Dir(parent); next != parent {
 				continue
 			}
-			return err
+			return "", err
 		}
 		if err != nil {
-			return err
+			return "", err
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
 			info, err = os.Stat(parent)
 			if err != nil {
-				return err
+				return "", err
 			}
 		}
 		if !info.IsDir() {
-			return fmt.Errorf("%q is not a directory", parent)
+			return "", fmt.Errorf("%q is not a directory", parent)
 		}
+		return parent, nil
+	}
+}
+
+func probeCSRParentWrite(parent string, requireRename bool) (err error) {
+	rooted, err := os.OpenRoot(parent)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := rooted.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+
+	probe, probeName, err := secureopen.CreateTempNoFollowInRoot(rooted, ".", ".asc-csr-preflight-*", 0o600)
+	if err != nil {
+		return err
+	}
+	if closeErr := probe.Close(); closeErr != nil {
+		return errors.Join(closeErr, rooted.Remove(probeName))
+	}
+	currentName := probeName
+	defer func() {
+		if removeErr := rooted.Remove(currentName); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, removeErr)
+		}
+	}()
+
+	if !requireRename {
 		return nil
 	}
+
+	spare, spareName, err := secureopen.CreateTempNoFollowInRoot(rooted, ".", ".asc-csr-preflight-*", 0o600)
+	if err != nil {
+		return err
+	}
+	spareNeedsCleanup := true
+	defer func() {
+		if spareNeedsCleanup {
+			if removeErr := rooted.Remove(spareName); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				err = errors.Join(err, removeErr)
+			}
+		}
+	}()
+	if closeErr := spare.Close(); closeErr != nil {
+		return closeErr
+	}
+	if removeErr := rooted.Remove(spareName); removeErr != nil {
+		return removeErr
+	}
+	spareNeedsCleanup = false
+	if renameErr := rooted.Rename(probeName, spareName); renameErr != nil {
+		return renameErr
+	}
+	currentName = spareName
+	return nil
 }
 
 func validateCSRFileOutputPath(path string) (string, error) {

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
@@ -330,20 +331,20 @@ func validateCSRPairOutputPaths(keyOut, csrOut string) error {
 	if (keyRelativeErr == nil && keyToCSR == ".") || (csrRelativeErr == nil && csrToKey == ".") {
 		return shared.UsageError("--key-out and --csr-out must be different paths")
 	}
-	caseEquivalent, caseNested, err := classifyCSRCaseFoldRelation(keyPath, csrPath)
+	sameOutput, nestedOutput, err := classifyCSRFilesystemRelation(keyPath, csrPath)
 	if err != nil {
 		return fmt.Errorf("compare --key-out and --csr-out: %w", err)
 	}
-	if caseEquivalent {
+	if sameOutput {
 		return shared.UsageError("--key-out and --csr-out must be different paths")
 	}
-	if caseNested || isCSRDescendantPath(keyToCSR, keyRelativeErr) || isCSRDescendantPath(csrToKey, csrRelativeErr) {
+	if nestedOutput || isCSRDescendantPath(keyToCSR, keyRelativeErr) || isCSRDescendantPath(csrToKey, csrRelativeErr) {
 		return shared.UsageError("--key-out and --csr-out must not contain one another")
 	}
 	return nil
 }
 
-func classifyCSRCaseFoldRelation(keyPath, csrPath string) (same bool, nested bool, err error) {
+func classifyCSRFilesystemRelation(keyPath, csrPath string) (same bool, nested bool, err error) {
 	keyDepth := csrPathDepth(keyPath)
 	csrDepth := csrPathDepth(csrPath)
 	if keyDepth == csrDepth {
@@ -365,7 +366,7 @@ func classifyCSRCaseFoldRelation(keyPath, csrPath string) (same bool, nested boo
 	for range longerDepth - shorterDepth {
 		longerPrefix = filepath.Dir(longerPrefix)
 	}
-	if !strings.EqualFold(shorter, longerPrefix) {
+	if !normalizedFoldEqual(shorter, longerPrefix) {
 		return false, false, nil
 	}
 
@@ -388,7 +389,7 @@ func areCSRPathsFilesystemEquivalent(leftPath, rightPath string) (bool, error) {
 	if leftPath == rightPath {
 		return true, nil
 	}
-	if !strings.EqualFold(leftPath, rightPath) {
+	if !normalizedFoldEqual(leftPath, rightPath) {
 		return false, nil
 	}
 
@@ -403,24 +404,42 @@ func areCSRPathsFilesystemEquivalent(leftPath, rightPath string) (bool, error) {
 	if !os.SameFile(leftInfo, rightInfo) || leftMissing != rightMissing {
 		return false, nil
 	}
-	if leftMissing == 0 || haveSameCSRMissingSuffix(leftPath, rightPath, leftMissing) {
+	if leftMissing == 0 {
 		return true, nil
 	}
 	if !leftInfo.IsDir() {
 		return false, nil
 	}
-	return isCSRDirectoryCaseInsensitive(leftAncestor)
+	leftComponents := csrMissingPathComponents(leftPath, leftMissing)
+	rightComponents := csrMissingPathComponents(rightPath, rightMissing)
+	if sameCSRPathComponents(leftComponents, rightComponents) {
+		return true, nil
+	}
+	return probeCSRPathComponentsEquivalent(leftAncestor, leftComponents, rightComponents)
 }
 
-func haveSameCSRMissingSuffix(leftPath, rightPath string, missing int) bool {
-	left := leftPath
-	right := rightPath
-	for range missing {
-		if filepath.Base(left) != filepath.Base(right) {
+func normalizedFoldEqual(left, right string) bool {
+	return strings.EqualFold(norm.NFC.String(left), norm.NFC.String(right))
+}
+
+func csrMissingPathComponents(path string, missing int) []string {
+	components := make([]string, missing)
+	current := path
+	for i := missing - 1; i >= 0; i-- {
+		components[i] = filepath.Base(current)
+		current = filepath.Dir(current)
+	}
+	return components
+}
+
+func sameCSRPathComponents(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
 			return false
 		}
-		left = filepath.Dir(left)
-		right = filepath.Dir(right)
 	}
 	return true
 }
@@ -445,49 +464,68 @@ func deepestExistingCSRPath(path string) (string, os.FileInfo, int, error) {
 	}
 }
 
-func isCSRDirectoryCaseInsensitive(path string) (insensitive bool, err error) {
-	probePath, err := os.MkdirTemp(path, ".asc-csr-case-*")
+func probeCSRPathComponentsEquivalent(parent string, left, right []string) (equivalent bool, err error) {
+	if len(left) != len(right) {
+		return false, nil
+	}
+	for i := range left {
+		if !normalizedFoldEqual(left[i], right[i]) {
+			return false, nil
+		}
+	}
+
+	// Replay unresolved components beneath a private directory on the target
+	// filesystem. SameFile, rather than normalization alone, decides whether
+	// the two spellings would address the same destination.
+	probePath, err := os.MkdirTemp(parent, ".asc-csr-equivalence-*")
 	if err != nil {
 		return false, err
 	}
+	rooted, err := os.OpenRoot(probePath)
+	if err != nil {
+		return false, errors.Join(err, os.Remove(probePath))
+	}
+	created := []string{}
 	defer func() {
-		if removeErr := os.Remove(probePath); removeErr != nil {
-			cleanupErr := fmt.Errorf("remove case-sensitivity probe: %w", removeErr)
-			if err == nil {
-				err = cleanupErr
-			} else {
-				err = errors.Join(err, cleanupErr)
+		for i := len(created) - 1; i >= 0; i-- {
+			if removeErr := rooted.Remove(created[i]); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				err = errors.Join(err, fmt.Errorf("remove equivalence probe component: %w", removeErr))
 			}
+		}
+		if closeErr := rooted.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+		if removeErr := os.Remove(probePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, fmt.Errorf("remove equivalence probe: %w", removeErr))
 		}
 	}()
 
-	probeInfo, err := os.Lstat(probePath)
-	if err != nil {
-		return false, err
-	}
-	caseVariantInfo, err := os.Lstat(csrCaseVariantPath(probePath))
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return os.SameFile(probeInfo, caseVariantInfo), nil
-}
+	leftPath := "."
+	rightPath := "."
+	for i := range left {
+		leftPath = filepath.Join(leftPath, left[i])
+		rightPath = filepath.Join(rightPath, right[i])
+		if err := rooted.Mkdir(leftPath, 0o700); err != nil {
+			return false, err
+		}
+		created = append(created, leftPath)
 
-func csrCaseVariantPath(path string) string {
-	name := []byte(filepath.Base(path))
-	for i, character := range name {
-		switch {
-		case character >= 'a' && character <= 'z':
-			name[i] = character - ('a' - 'A')
-			return filepath.Join(filepath.Dir(path), string(name))
-		case character >= 'A' && character <= 'Z':
-			name[i] = character + ('a' - 'A')
-			return filepath.Join(filepath.Dir(path), string(name))
+		leftInfo, err := rooted.Stat(leftPath)
+		if err != nil {
+			return false, err
+		}
+		rightInfo, err := rooted.Stat(rightPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if !os.SameFile(leftInfo, rightInfo) {
+			return false, nil
 		}
 	}
-	return path
+	return true, nil
 }
 
 func resolveCSRDestinationPath(path string) (string, error) {

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -64,6 +65,7 @@ type preparedCSRWrite struct {
 	existed      bool
 	root         rootfs.Root
 	name         string
+	backupName   string
 }
 
 // CertificatesCSRCommand returns the certificates csr command group.
@@ -257,10 +259,11 @@ func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, erro
 	if err != nil {
 		return nil, nil, fmt.Errorf("write --key-out: %w", err)
 	}
-	writes := []preparedCSRWrite{
-		keyWrite,
-		{flag: "--csr-out", path: csrOutValue, data: csrPEM, mode: 0o644, force: opts.Force},
+	csrWrite, err := prepareCSRWrite("--csr-out", csrOutValue, csrPEM, 0o644, opts.Force)
+	if err != nil {
+		return nil, nil, fmt.Errorf("write --csr-out: %w", err)
 	}
+	writes := []preparedCSRWrite{keyWrite, csrWrite}
 
 	// Write key first so a successful command never exposes a CSR before its key.
 	// If the CSR commit fails, restore the key's pre-command state.
@@ -706,24 +709,19 @@ func prepareCSRWrite(flagName, path string, data []byte, mode os.FileMode, force
 		root:  root,
 		name:  name,
 	}
-	file, err := root.OpenFile(name)
-	if errors.Is(err, os.ErrNotExist) {
-		return write, nil
-	}
+	rooted, err := os.OpenRoot(root.Path())
 	if err != nil {
 		return preparedCSRWrite{}, err
 	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
+	defer rooted.Close()
+	// Only record existence here. Backing up the destination happens at commit
+	// time and does not require read access to the existing file.
+	if _, err := rooted.Lstat(name); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return write, nil
+		}
 		return preparedCSRWrite{}, err
 	}
-	original, err := io.ReadAll(file)
-	if err != nil {
-		return preparedCSRWrite{}, err
-	}
-	write.original = original
-	write.originalMode = info.Mode().Perm()
 	write.existed = true
 	return write, nil
 }
@@ -731,27 +729,161 @@ func prepareCSRWrite(flagName, path string, data []byte, mode os.FileMode, force
 type csrWriteFileFunc func(path string, data []byte, mode os.FileMode, force bool) error
 
 func commitCSRWrites(writes []preparedCSRWrite, writeFile csrWriteFileFunc) error {
-	committed := make([]preparedCSRWrite, 0, len(writes))
-	for _, write := range writes {
+	committed := make([]*preparedCSRWrite, 0, len(writes))
+	rollback := func(writeErr error) error {
+		var rollbackErrors []error
+		for index := len(committed) - 1; index >= 0; index-- {
+			if rollbackErr := restoreCSRWrite(committed[index], writeFile); rollbackErr != nil {
+				rollbackErrors = append(rollbackErrors, fmt.Errorf("restore %s: %w", committed[index].flag, rollbackErr))
+			}
+		}
+		if len(rollbackErrors) == 0 {
+			return writeErr
+		}
+		return errors.Join(writeErr, fmt.Errorf("rollback failed: %w", errors.Join(rollbackErrors...)))
+	}
+
+	for index := range writes {
+		write := &writes[index]
+		if err := backupCSRDestination(write); err != nil {
+			return rollback(fmt.Errorf("write %s: %w", write.flag, err))
+		}
 		if err := writeFile(write.path, write.data, write.mode, write.force); err != nil {
 			writeErr := fmt.Errorf("write %s: %w", write.flag, err)
-			var rollbackErrors []error
-			for index := len(committed) - 1; index >= 0; index-- {
-				if rollbackErr := restoreCSRWrite(committed[index], writeFile); rollbackErr != nil {
-					rollbackErrors = append(rollbackErrors, fmt.Errorf("restore %s: %w", committed[index].flag, rollbackErr))
-				}
+			// The overwrite path preserves the destination on failure, in which
+			// case restoring from the backup link is a no-op that drops the
+			// extra directory entry.
+			if restoreErr := restoreCSRBackup(write); restoreErr != nil {
+				writeErr = errors.Join(writeErr, fmt.Errorf("restore %s: %w", write.flag, restoreErr))
 			}
-			if len(rollbackErrors) == 0 {
-				return writeErr
-			}
-			return errors.Join(writeErr, fmt.Errorf("rollback failed: %w", errors.Join(rollbackErrors...)))
+			return rollback(writeErr)
 		}
 		committed = append(committed, write)
 	}
+
+	var cleanupErrors []error
+	for _, write := range committed {
+		if err := discardCSRBackup(write); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+// backupCSRDestination preserves an existing destination before a forced
+// replacement. It prefers a hard link to the original directory entry, which
+// requires no read access and lets rollback restore the original file with its
+// full metadata and inode identity. Filesystems without hard links fall back
+// to an in-memory snapshot of the file contents and permissions.
+func backupCSRDestination(write *preparedCSRWrite) error {
+	if !write.existed || !write.force {
+		return nil
+	}
+	linkErr := linkCSRBackup(write)
+	if linkErr == nil {
+		return nil
+	}
+	if write.original != nil {
+		return nil
+	}
+	original, originalMode, err := snapshotCSRDestination(write.root, write.name)
+	if err != nil {
+		return errors.Join(fmt.Errorf("back up existing %s before replacement: %w", write.flag, linkErr), err)
+	}
+	write.original = original
+	write.originalMode = originalMode
 	return nil
 }
 
-func restoreCSRWrite(write preparedCSRWrite, writeFile csrWriteFileFunc) error {
+func linkCSRBackup(write *preparedCSRWrite) error {
+	rooted, err := os.OpenRoot(write.root.Path())
+	if err != nil {
+		return err
+	}
+	defer rooted.Close()
+
+	dir := filepath.Dir(write.name)
+	var randBytes [12]byte
+	const maxAttempts = 10_000
+	for range maxAttempts {
+		if _, err := rand.Read(randBytes[:]); err != nil {
+			return err
+		}
+		backupName := filepath.Join(dir, ".asc-csr-keybackup-"+hex.EncodeToString(randBytes[:]))
+		err := rooted.Link(write.name, backupName)
+		if err == nil {
+			write.backupName = backupName
+			return nil
+		}
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("create backup link for %q", write.path)
+}
+
+func snapshotCSRDestination(root rootfs.Root, name string) ([]byte, os.FileMode, error) {
+	file, err := root.OpenFile(name)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+	original, err := io.ReadAll(file)
+	if err != nil {
+		return nil, 0, err
+	}
+	return original, info.Mode().Perm(), nil
+}
+
+// restoreCSRBackup puts the backed-up original directory entry back at the
+// destination. Rename atomically replaces a failed or partial replacement with
+// the original file. When the destination still names the original file, POSIX
+// defines the same-file rename as a no-op, so the leftover backup entry is
+// removed afterwards.
+func restoreCSRBackup(write *preparedCSRWrite) error {
+	if write.backupName == "" {
+		return nil
+	}
+	rooted, err := os.OpenRoot(write.root.Path())
+	if err != nil {
+		return err
+	}
+	defer rooted.Close()
+	if err := rooted.Rename(write.backupName, write.name); err != nil {
+		return err
+	}
+	if err := rooted.Remove(write.backupName); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	write.backupName = ""
+	return nil
+}
+
+func discardCSRBackup(write *preparedCSRWrite) error {
+	if write.backupName == "" {
+		return nil
+	}
+	rooted, err := os.OpenRoot(write.root.Path())
+	if err != nil {
+		return fmt.Errorf("remove backup of replaced %s at %q: %w", write.flag, filepath.Join(write.root.Path(), write.backupName), err)
+	}
+	defer rooted.Close()
+	if err := rooted.Remove(write.backupName); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove backup of replaced %s at %q: %w", write.flag, filepath.Join(write.root.Path(), write.backupName), err)
+	}
+	write.backupName = ""
+	return nil
+}
+
+func restoreCSRWrite(write *preparedCSRWrite, writeFile csrWriteFileFunc) error {
+	if write.backupName != "" {
+		return restoreCSRBackup(write)
+	}
 	if write.existed {
 		return writeFile(write.path, write.original, write.originalMode, true)
 	}

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -315,11 +315,11 @@ func preflightCSRFileWrite(path string, force bool) error {
 }
 
 func validateCSRPairOutputPaths(keyOut, csrOut string) error {
-	keyPath, err := filepath.Abs(keyOut)
+	keyPath, err := resolveCSRDestinationPath(keyOut)
 	if err != nil {
 		return fmt.Errorf("resolve --key-out: %w", err)
 	}
-	csrPath, err := filepath.Abs(csrOut)
+	csrPath, err := resolveCSRDestinationPath(csrOut)
 	if err != nil {
 		return fmt.Errorf("resolve --csr-out: %w", err)
 	}
@@ -333,6 +333,38 @@ func validateCSRPairOutputPaths(keyOut, csrOut string) error {
 		return shared.UsageError("--key-out and --csr-out must not contain one another")
 	}
 	return nil
+}
+
+func resolveCSRDestinationPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	current := absolute
+	missing := []string{}
+	// Resolve the deepest existing ancestor so absent output names keep their
+	// intended spelling while aliases in the directory chain are canonicalized.
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			resolved, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return filepath.Clean(absolute), nil
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
 }
 
 func isCSRDescendantPath(relative string, err error) bool {

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -114,8 +114,8 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --csr-out is required")
 				return shared.MissingRequiredUsageError()
 			}
-			if filepath.Clean(keyOutValue) == filepath.Clean(csrOutValue) {
-				return shared.UsageError("--key-out and --csr-out must be different paths")
+			if err := validateCSRPairOutputPaths(keyOutValue, csrOutValue); err != nil {
+				return err
 			}
 
 			result, _, err := generateCSRFiles(csrGenerateOptions{
@@ -154,8 +154,8 @@ func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, erro
 	if csrOutValue == "" {
 		return nil, nil, fmt.Errorf("--csr-out is required")
 	}
-	if filepath.Clean(keyOutValue) == filepath.Clean(csrOutValue) {
-		return nil, nil, shared.UsageError("--key-out and --csr-out must be different paths")
+	if err := validateCSRPairOutputPaths(keyOutValue, csrOutValue); err != nil {
+		return nil, nil, err
 	}
 
 	normalizedKeyType := strings.ToLower(strings.TrimSpace(opts.KeyType))
@@ -312,6 +312,32 @@ func preflightCSRFileWrite(path string, force bool) error {
 		return fmt.Errorf("output path %q is a directory", trimmed)
 	}
 	return nil
+}
+
+func validateCSRPairOutputPaths(keyOut, csrOut string) error {
+	keyPath, err := filepath.Abs(keyOut)
+	if err != nil {
+		return fmt.Errorf("resolve --key-out: %w", err)
+	}
+	csrPath, err := filepath.Abs(csrOut)
+	if err != nil {
+		return fmt.Errorf("resolve --csr-out: %w", err)
+	}
+
+	keyToCSR, keyRelativeErr := filepath.Rel(keyPath, csrPath)
+	csrToKey, csrRelativeErr := filepath.Rel(csrPath, keyPath)
+	if (keyRelativeErr == nil && keyToCSR == ".") || (csrRelativeErr == nil && csrToKey == ".") {
+		return shared.UsageError("--key-out and --csr-out must be different paths")
+	}
+	if isCSRDescendantPath(keyToCSR, keyRelativeErr) || isCSRDescendantPath(csrToKey, csrRelativeErr) {
+		return shared.UsageError("--key-out and --csr-out must not contain one another")
+	}
+	return nil
+}
+
+func isCSRDescendantPath(relative string, err error) bool {
+	return err == nil && relative != "" && relative != "." && relative != ".." &&
+		!filepath.IsAbs(relative) && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func preflightCSRParentDirectory(path string) error {

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -329,10 +329,107 @@ func validateCSRPairOutputPaths(keyOut, csrOut string) error {
 	if (keyRelativeErr == nil && keyToCSR == ".") || (csrRelativeErr == nil && csrToKey == ".") {
 		return shared.UsageError("--key-out and --csr-out must be different paths")
 	}
+	caseEquivalent, err := areCSRPathsCaseEquivalent(keyPath, csrPath)
+	if err != nil {
+		return fmt.Errorf("compare --key-out and --csr-out: %w", err)
+	}
+	if caseEquivalent {
+		return shared.UsageError("--key-out and --csr-out must be different paths")
+	}
 	if isCSRDescendantPath(keyToCSR, keyRelativeErr) || isCSRDescendantPath(csrToKey, csrRelativeErr) {
 		return shared.UsageError("--key-out and --csr-out must not contain one another")
 	}
 	return nil
+}
+
+func areCSRPathsCaseEquivalent(keyPath, csrPath string) (bool, error) {
+	if !strings.EqualFold(keyPath, csrPath) {
+		return false, nil
+	}
+
+	keyAncestor, keyInfo, keyMissing, err := deepestExistingCSRPath(keyPath)
+	if err != nil {
+		return false, err
+	}
+	_, csrInfo, csrMissing, err := deepestExistingCSRPath(csrPath)
+	if err != nil {
+		return false, err
+	}
+	if !os.SameFile(keyInfo, csrInfo) {
+		return false, nil
+	}
+	if keyMissing == 0 && csrMissing == 0 {
+		return true, nil
+	}
+	if !keyInfo.IsDir() {
+		return false, nil
+	}
+	return isCSRDirectoryCaseInsensitive(keyAncestor)
+}
+
+func deepestExistingCSRPath(path string) (string, os.FileInfo, int, error) {
+	current := path
+	missing := 0
+	for {
+		info, err := os.Stat(current)
+		if err == nil {
+			return current, info, missing, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", nil, 0, err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", nil, 0, err
+		}
+		current = parent
+		missing++
+	}
+}
+
+func isCSRDirectoryCaseInsensitive(path string) (insensitive bool, err error) {
+	probePath, err := os.MkdirTemp(path, ".asc-csr-case-*")
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if removeErr := os.Remove(probePath); removeErr != nil {
+			cleanupErr := fmt.Errorf("remove case-sensitivity probe: %w", removeErr)
+			if err == nil {
+				err = cleanupErr
+			} else {
+				err = errors.Join(err, cleanupErr)
+			}
+		}
+	}()
+
+	probeInfo, err := os.Lstat(probePath)
+	if err != nil {
+		return false, err
+	}
+	caseVariantInfo, err := os.Lstat(csrCaseVariantPath(probePath))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(probeInfo, caseVariantInfo), nil
+}
+
+func csrCaseVariantPath(path string) string {
+	name := []byte(filepath.Base(path))
+	for i, character := range name {
+		switch {
+		case character >= 'a' && character <= 'z':
+			name[i] = character - ('a' - 'A')
+			return filepath.Join(filepath.Dir(path), string(name))
+		case character >= 'A' && character <= 'Z':
+			name[i] = character + ('a' - 'A')
+			return filepath.Join(filepath.Dir(path), string(name))
+		}
+	}
+	return path
 }
 
 func resolveCSRDestinationPath(path string) (string, error) {

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
@@ -49,6 +51,19 @@ type csrGenerateOptions struct {
 	KeyType            string
 	KeySize            int
 	Force              bool
+}
+
+type preparedCSRWrite struct {
+	flag         string
+	path         string
+	data         []byte
+	mode         os.FileMode
+	force        bool
+	original     []byte
+	originalMode os.FileMode
+	existed      bool
+	root         rootfs.Root
+	name         string
 }
 
 // CertificatesCSRCommand returns the certificates csr command group.
@@ -238,12 +253,19 @@ func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, erro
 		return nil, nil, fmt.Errorf("encode csr PEM failed")
 	}
 
-	// Write key first: if anything fails, do not leave a CSR without its key.
-	if err := writeFileBytesNoSymlink(keyOutValue, keyPEM, 0o600, opts.Force); err != nil {
+	keyWrite, err := prepareCSRWrite("--key-out", keyOutValue, keyPEM, 0o600, opts.Force)
+	if err != nil {
 		return nil, nil, fmt.Errorf("write --key-out: %w", err)
 	}
-	if err := writeFileBytesNoSymlink(csrOutValue, csrPEM, 0o644, opts.Force); err != nil {
-		return nil, nil, fmt.Errorf("write --csr-out: %w", err)
+	writes := []preparedCSRWrite{
+		keyWrite,
+		{flag: "--csr-out", path: csrOutValue, data: csrPEM, mode: 0o644, force: opts.Force},
+	}
+
+	// Write key first so a successful command never exposes a CSR before its key.
+	// If the CSR commit fails, restore the key's pre-command state.
+	if err := commitCSRWrites(writes, writeFileBytesNoSymlink); err != nil {
+		return nil, nil, err
 	}
 
 	result := &csrGenerateResult{
@@ -678,4 +700,91 @@ func writeFileBytesNoSymlink(path string, data []byte, perm os.FileMode, force b
 		},
 	)
 	return err
+}
+
+func prepareCSRWrite(flagName, path string, data []byte, mode os.FileMode, force bool) (preparedCSRWrite, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return preparedCSRWrite{}, err
+	}
+	existingParent, err := preflightCSRParentDirectory(absolute)
+	if err != nil {
+		return preparedCSRWrite{}, err
+	}
+	root, err := rootfs.New(existingParent)
+	if err != nil {
+		return preparedCSRWrite{}, err
+	}
+	name, err := filepath.Rel(root.Path(), absolute)
+	if err != nil {
+		return preparedCSRWrite{}, err
+	}
+
+	write := preparedCSRWrite{
+		flag:  flagName,
+		path:  path,
+		data:  data,
+		mode:  mode,
+		force: force,
+		root:  root,
+		name:  name,
+	}
+	file, err := root.OpenFile(name)
+	if errors.Is(err, os.ErrNotExist) {
+		return write, nil
+	}
+	if err != nil {
+		return preparedCSRWrite{}, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return preparedCSRWrite{}, err
+	}
+	original, err := io.ReadAll(file)
+	if err != nil {
+		return preparedCSRWrite{}, err
+	}
+	write.original = original
+	write.originalMode = info.Mode().Perm()
+	write.existed = true
+	return write, nil
+}
+
+type csrWriteFileFunc func(path string, data []byte, mode os.FileMode, force bool) error
+
+func commitCSRWrites(writes []preparedCSRWrite, writeFile csrWriteFileFunc) error {
+	committed := make([]preparedCSRWrite, 0, len(writes))
+	for _, write := range writes {
+		if err := writeFile(write.path, write.data, write.mode, write.force); err != nil {
+			writeErr := fmt.Errorf("write %s: %w", write.flag, err)
+			var rollbackErrors []error
+			for index := len(committed) - 1; index >= 0; index-- {
+				if rollbackErr := restoreCSRWrite(committed[index], writeFile); rollbackErr != nil {
+					rollbackErrors = append(rollbackErrors, fmt.Errorf("restore %s: %w", committed[index].flag, rollbackErr))
+				}
+			}
+			if len(rollbackErrors) == 0 {
+				return writeErr
+			}
+			return errors.Join(writeErr, fmt.Errorf("rollback failed: %w", errors.Join(rollbackErrors...)))
+		}
+		committed = append(committed, write)
+	}
+	return nil
+}
+
+func restoreCSRWrite(write preparedCSRWrite, writeFile csrWriteFileFunc) error {
+	if write.existed {
+		return writeFile(write.path, write.original, write.originalMode, true)
+	}
+	rooted, err := os.OpenRoot(write.root.Path())
+	if err != nil {
+		return err
+	}
+	defer rooted.Close()
+	if err := rooted.Remove(write.name); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }

--- a/internal/cli/certificates/csr_commit_test.go
+++ b/internal/cli/certificates/csr_commit_test.go
@@ -94,6 +94,183 @@ func TestCommitCSRWrites_RestoresKeyWhenSecondWriteFails(t *testing.T) {
 	}
 }
 
+func TestCommitCSRWrites_RollbackPreservesKeyIdentity(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "cert.key")
+	keyAlias := filepath.Join(dir, "cert.key.alias")
+	csrOut := filepath.Join(dir, "cert.csr")
+	originalKey := []byte("original-private-key")
+	if err := os.WriteFile(keyOut, originalKey, 0o640); err != nil {
+		t.Fatalf("WriteFile(keyOut) error: %v", err)
+	}
+	if err := os.Link(keyOut, keyAlias); err != nil {
+		t.Skipf("temporary volume does not support hard links: %v", err)
+	}
+
+	keyWrite, err := prepareCSRWrite("--key-out", keyOut, []byte("replacement-key"), 0o600, true)
+	if err != nil {
+		t.Fatalf("prepareCSRWrite() error: %v", err)
+	}
+	writeFailure := errors.New("injected CSR write failure")
+	writeFile := func(path string, data []byte, mode os.FileMode, force bool) error {
+		if path == csrOut {
+			return writeFailure
+		}
+		return writeFileBytesNoSymlink(path, data, mode, force)
+	}
+
+	err = commitCSRWrites([]preparedCSRWrite{
+		keyWrite,
+		{flag: "--csr-out", path: csrOut, data: []byte("replacement-csr"), mode: 0o644, force: true},
+	}, writeFile)
+	if !errors.Is(err, writeFailure) {
+		t.Fatalf("commitCSRWrites() error = %v, want CSR write failure", err)
+	}
+
+	keyContents, err := os.ReadFile(keyOut)
+	if err != nil {
+		t.Fatalf("ReadFile(keyOut) error: %v", err)
+	}
+	if string(keyContents) != string(originalKey) {
+		t.Errorf("key contents = %q, want original contents", keyContents)
+	}
+	keyInfo, err := os.Lstat(keyOut)
+	if err != nil {
+		t.Fatalf("Lstat(keyOut) error: %v", err)
+	}
+	aliasInfo, err := os.Lstat(keyAlias)
+	if err != nil {
+		t.Fatalf("Lstat(keyAlias) error: %v", err)
+	}
+	if !os.SameFile(keyInfo, aliasInfo) {
+		t.Error("rollback replaced the key's directory entry instead of restoring the original file")
+	}
+	if got := keyInfo.Mode().Perm(); got != 0o640 {
+		t.Errorf("key mode = %o, want 640", got)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(dir) error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("unexpected pair-write artifacts: %v", entries)
+	}
+}
+
+func TestCommitCSRWrites_ForceReplacesUnreadableKey(t *testing.T) {
+	for _, csrFails := range []bool{false, true} {
+		name := "csr write succeeds"
+		if csrFails {
+			name = "csr write fails"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			keyOut := filepath.Join(dir, "cert.key")
+			keyAlias := filepath.Join(dir, "cert.key.alias")
+			csrOut := filepath.Join(dir, "cert.csr")
+			originalKey := []byte("original-private-key")
+			if err := os.WriteFile(keyOut, originalKey, 0o640); err != nil {
+				t.Fatalf("WriteFile(keyOut) error: %v", err)
+			}
+			if err := os.Link(keyOut, keyAlias); err != nil {
+				t.Skipf("temporary volume does not support hard links: %v", err)
+			}
+			if err := os.Chmod(keyOut, 0o000); err != nil {
+				t.Fatalf("Chmod(keyOut) error: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = os.Chmod(keyOut, 0o600)
+				_ = os.Chmod(keyAlias, 0o600)
+			})
+			if probe, err := os.Open(keyOut); err == nil {
+				_ = probe.Close()
+				t.Skip("environment does not enforce file read permissions")
+			}
+
+			keyWrite, err := prepareCSRWrite("--key-out", keyOut, []byte("replacement-key"), 0o600, true)
+			if err != nil {
+				t.Fatalf("prepareCSRWrite() error: %v", err)
+			}
+			writeFailure := errors.New("injected CSR write failure")
+			writeFile := func(path string, data []byte, mode os.FileMode, force bool) error {
+				if csrFails && path == csrOut {
+					return writeFailure
+				}
+				return writeFileBytesNoSymlink(path, data, mode, force)
+			}
+
+			err = commitCSRWrites([]preparedCSRWrite{
+				keyWrite,
+				{flag: "--csr-out", path: csrOut, data: []byte("replacement-csr"), mode: 0o644, force: true},
+			}, writeFile)
+
+			keyInfo, statErr := os.Lstat(keyOut)
+			if statErr != nil {
+				t.Fatalf("Lstat(keyOut) error: %v", statErr)
+			}
+			aliasInfo, statErr := os.Lstat(keyAlias)
+			if statErr != nil {
+				t.Fatalf("Lstat(keyAlias) error: %v", statErr)
+			}
+
+			if csrFails {
+				if !errors.Is(err, writeFailure) {
+					t.Fatalf("commitCSRWrites() error = %v, want CSR write failure", err)
+				}
+				if !os.SameFile(keyInfo, aliasInfo) {
+					t.Error("rollback did not restore the original unreadable key file")
+				}
+				if got := keyInfo.Mode().Perm(); got != 0o000 {
+					t.Errorf("restored key mode = %o, want 000", got)
+				}
+				if err := os.Chmod(keyOut, 0o600); err != nil {
+					t.Fatalf("Chmod(keyOut) error: %v", err)
+				}
+				keyContents, err := os.ReadFile(keyOut)
+				if err != nil {
+					t.Fatalf("ReadFile(keyOut) error: %v", err)
+				}
+				if string(keyContents) != string(originalKey) {
+					t.Errorf("key contents = %q, want original contents", keyContents)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("commitCSRWrites() error = %v, want forced replacement of unreadable key", err)
+				}
+				if os.SameFile(keyInfo, aliasInfo) {
+					t.Error("forced replacement kept the original key file")
+				}
+				keyContents, err := os.ReadFile(keyOut)
+				if err != nil {
+					t.Fatalf("ReadFile(keyOut) error: %v", err)
+				}
+				if string(keyContents) != "replacement-key" {
+					t.Errorf("key contents = %q, want replacement contents", keyContents)
+				}
+				csrContents, err := os.ReadFile(csrOut)
+				if err != nil {
+					t.Fatalf("ReadFile(csrOut) error: %v", err)
+				}
+				if string(csrContents) != "replacement-csr" {
+					t.Errorf("CSR contents = %q, want replacement contents", csrContents)
+				}
+			}
+
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("ReadDir(dir) error: %v", err)
+			}
+			wantEntries := 2
+			if !csrFails {
+				wantEntries = 3
+			}
+			if len(entries) != wantEntries {
+				t.Errorf("unexpected pair-write artifacts: %v", entries)
+			}
+		})
+	}
+}
+
 func TestCommitCSRWrites_ReportsRollbackFailure(t *testing.T) {
 	writeFailure := errors.New("CSR write failed")
 	rollbackFailure := errors.New("key restore failed")

--- a/internal/cli/certificates/csr_commit_test.go
+++ b/internal/cli/certificates/csr_commit_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestCommitCSRWrites_RestoresKeyWhenSecondWriteFails(t *testing.T) {
@@ -130,5 +132,56 @@ func TestCommitCSRWrites_ReportsRollbackFailure(t *testing.T) {
 		if !strings.Contains(err.Error(), text) {
 			t.Errorf("commitCSRWrites() error = %q, want %q", err, text)
 		}
+	}
+}
+
+func TestCommitCSRWrites_RemovesPartialNonForceCSR(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "cert.key")
+	csrOut := filepath.Join(dir, "cert.csr")
+	keyWrite, err := prepareCSRWrite("--key-out", keyOut, []byte("replacement-key"), 0o600, false)
+	if err != nil {
+		t.Fatalf("prepareCSRWrite() error: %v", err)
+	}
+	writeFailure := errors.New("injected CSR write failure")
+	writeFile := func(path string, data []byte, mode os.FileMode, force bool) error {
+		if path != csrOut {
+			return writeFileBytesNoSymlink(path, data, mode, force)
+		}
+		_, err := shared.SafeWriteFileNoSymlink(
+			path,
+			mode,
+			false,
+			".asc-csr-*",
+			".asc-csr-backup-*",
+			func(file *os.File) (int64, error) {
+				written, err := file.Write([]byte("partial-csr"))
+				if err != nil {
+					return int64(written), err
+				}
+				return int64(written), writeFailure
+			},
+		)
+		return err
+	}
+
+	err = commitCSRWrites([]preparedCSRWrite{
+		keyWrite,
+		{flag: "--csr-out", path: csrOut, data: []byte("replacement-csr"), mode: 0o644},
+	}, writeFile)
+	if !errors.Is(err, writeFailure) {
+		t.Fatalf("commitCSRWrites() error = %v, want CSR write failure", err)
+	}
+	for _, output := range []string{keyOut, csrOut} {
+		if _, err := os.Lstat(output); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("pair output remained after partial CSR failure: %q (stat error: %v)", output, err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(dir) error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("pair directory contains failure residue: %v", entries)
 	}
 }

--- a/internal/cli/certificates/csr_commit_test.go
+++ b/internal/cli/certificates/csr_commit_test.go
@@ -1,0 +1,134 @@
+package certificates
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommitCSRWrites_RestoresKeyWhenSecondWriteFails(t *testing.T) {
+	for _, keyExists := range []bool{false, true} {
+		name := "new key"
+		if keyExists {
+			name = "existing key"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			keyOut := filepath.Join(dir, "cert.key")
+			csrOut := filepath.Join(dir, "cert.csr")
+			originalKey := []byte("original-private-key")
+			originalCSR := []byte("original-csr")
+			if keyExists {
+				if err := os.WriteFile(keyOut, originalKey, 0o640); err != nil {
+					t.Fatalf("WriteFile(keyOut) error: %v", err)
+				}
+			}
+			if err := os.WriteFile(csrOut, originalCSR, 0o644); err != nil {
+				t.Fatalf("WriteFile(csrOut) error: %v", err)
+			}
+
+			keyWrite, err := prepareCSRWrite("--key-out", keyOut, []byte("replacement-key"), 0o600, true)
+			if err != nil {
+				t.Fatalf("prepareCSRWrite() error: %v", err)
+			}
+			writeFailure := errors.New("destination rejects replacement")
+			writeFile := func(path string, data []byte, mode os.FileMode, force bool) error {
+				if path == csrOut {
+					return writeFailure
+				}
+				return writeFileBytesNoSymlink(path, data, mode, force)
+			}
+
+			err = commitCSRWrites([]preparedCSRWrite{
+				keyWrite,
+				{flag: "--csr-out", path: csrOut, data: []byte("replacement-csr"), mode: 0o644, force: true},
+			}, writeFile)
+			if !errors.Is(err, writeFailure) {
+				t.Fatalf("commitCSRWrites() error = %v, want destination failure", err)
+			}
+			if !strings.Contains(err.Error(), "write --csr-out") {
+				t.Errorf("commitCSRWrites() error = %q, want CSR flag", err)
+			}
+
+			if keyExists {
+				keyContents, err := os.ReadFile(keyOut)
+				if err != nil {
+					t.Fatalf("ReadFile(keyOut) error: %v", err)
+				}
+				if string(keyContents) != string(originalKey) {
+					t.Errorf("key contents = %q, want original contents", keyContents)
+				}
+				info, err := os.Stat(keyOut)
+				if err != nil {
+					t.Fatalf("Stat(keyOut) error: %v", err)
+				}
+				if got := info.Mode().Perm(); got != 0o640 {
+					t.Errorf("key mode = %o, want 640", got)
+				}
+			} else if _, err := os.Lstat(keyOut); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("new key remained after second write failed: %v", err)
+			}
+			csrContents, err := os.ReadFile(csrOut)
+			if err != nil {
+				t.Fatalf("ReadFile(csrOut) error: %v", err)
+			}
+			if string(csrContents) != string(originalCSR) {
+				t.Errorf("CSR contents = %q, want original contents", csrContents)
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("ReadDir(dir) error: %v", err)
+			}
+			wantEntries := 1
+			if keyExists {
+				wantEntries = 2
+			}
+			if len(entries) != wantEntries {
+				t.Errorf("unexpected pair-write artifacts: %v", entries)
+			}
+		})
+	}
+}
+
+func TestCommitCSRWrites_ReportsRollbackFailure(t *testing.T) {
+	writeFailure := errors.New("CSR write failed")
+	rollbackFailure := errors.New("key restore failed")
+	calls := 0
+	writeFile := func(string, []byte, os.FileMode, bool) error {
+		calls++
+		switch calls {
+		case 1:
+			return nil
+		case 2:
+			return writeFailure
+		default:
+			return rollbackFailure
+		}
+	}
+	err := commitCSRWrites([]preparedCSRWrite{
+		{
+			flag:         "--key-out",
+			path:         "cert.key",
+			data:         []byte("replacement-key"),
+			mode:         0o600,
+			force:        true,
+			original:     []byte("original-key"),
+			originalMode: 0o600,
+			existed:      true,
+		},
+		{flag: "--csr-out", path: "cert.csr", data: []byte("replacement-csr"), mode: 0o644, force: true},
+	}, writeFile)
+	if !errors.Is(err, writeFailure) {
+		t.Fatalf("commitCSRWrites() error = %v, want write failure", err)
+	}
+	if !errors.Is(err, rollbackFailure) {
+		t.Fatalf("commitCSRWrites() error = %v, want rollback failure", err)
+	}
+	for _, text := range []string{"write --csr-out", "rollback failed", "restore --key-out"} {
+		if !strings.Contains(err.Error(), text) {
+			t.Errorf("commitCSRWrites() error = %q, want %q", err, text)
+		}
+	}
+}

--- a/internal/cli/certificates/csr_paths_test.go
+++ b/internal/cli/certificates/csr_paths_test.go
@@ -1,0 +1,103 @@
+package certificates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClassifyCSRFilesystemRelation_MountAliases(t *testing.T) {
+	sharedParent := t.TempDir()
+	sharedInfo, err := os.Stat(sharedParent)
+	if err != nil {
+		t.Fatalf("Stat(sharedParent) error: %v", err)
+	}
+	aliasRoot := t.TempDir()
+	leftParent := filepath.Join(aliasRoot, "first-mount")
+	rightParent := filepath.Join(aliasRoot, "different", "depth", "second-mount")
+	stat := func(path string) (os.FileInfo, error) {
+		switch filepath.Clean(path) {
+		case leftParent, rightParent:
+			return sharedInfo, nil
+		default:
+			if strings.HasPrefix(path, leftParent+string(filepath.Separator)) ||
+				strings.HasPrefix(path, rightParent+string(filepath.Separator)) {
+				return nil, &os.PathError{Op: "stat", Path: path, Err: os.ErrNotExist}
+			}
+			return os.Stat(path)
+		}
+	}
+
+	t.Run("same output", func(t *testing.T) {
+		same, nested, err := classifyCSRFilesystemRelationWithStat(
+			filepath.Join(leftParent, "pair"),
+			filepath.Join(rightParent, "pair"),
+			stat,
+		)
+		if err != nil {
+			t.Fatalf("classifyCSRFilesystemRelationWithStat() error: %v", err)
+		}
+		if !same || nested {
+			t.Fatalf("relation = same %t, nested %t; want same output", same, nested)
+		}
+	})
+
+	t.Run("nested output", func(t *testing.T) {
+		same, nested, err := classifyCSRFilesystemRelationWithStat(
+			filepath.Join(leftParent, "pair"),
+			filepath.Join(rightParent, "pair", "request.csr"),
+			stat,
+		)
+		if err != nil {
+			t.Fatalf("classifyCSRFilesystemRelationWithStat() error: %v", err)
+		}
+		if same || !nested {
+			t.Fatalf("relation = same %t, nested %t; want nested output", same, nested)
+		}
+	})
+
+	t.Run("reverse nested output", func(t *testing.T) {
+		same, nested, err := classifyCSRFilesystemRelationWithStat(
+			filepath.Join(leftParent, "pair", "request.key"),
+			filepath.Join(rightParent, "pair"),
+			stat,
+		)
+		if err != nil {
+			t.Fatalf("classifyCSRFilesystemRelationWithStat() error: %v", err)
+		}
+		if same || !nested {
+			t.Fatalf("relation = same %t, nested %t; want nested output", same, nested)
+		}
+	})
+
+	t.Run("distinct leaves", func(t *testing.T) {
+		same, nested, err := classifyCSRFilesystemRelationWithStat(
+			filepath.Join(leftParent, "pair.key"),
+			filepath.Join(rightParent, "pair.csr"),
+			stat,
+		)
+		if err != nil {
+			t.Fatalf("classifyCSRFilesystemRelationWithStat() error: %v", err)
+		}
+		if same || nested {
+			t.Fatalf("relation = same %t, nested %t; want distinct outputs", same, nested)
+		}
+	})
+}
+
+func TestClassifyCSRFilesystemRelation_DistinctAncestors(t *testing.T) {
+	leftParent := t.TempDir()
+	rightParent := t.TempDir()
+
+	same, nested, err := classifyCSRFilesystemRelation(
+		filepath.Join(leftParent, "pair"),
+		filepath.Join(rightParent, "pair"),
+	)
+	if err != nil {
+		t.Fatalf("classifyCSRFilesystemRelation() error: %v", err)
+	}
+	if same || nested {
+		t.Fatalf("relation = same %t, nested %t; want distinct outputs", same, nested)
+	}
+}

--- a/internal/cli/cmdtest/certificates_csr_generate_darwin_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_darwin_test.go
@@ -1,0 +1,108 @@
+//go:build darwin
+
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCertificatesCSRGenerate_ForceRestoresKeyWhenCSRDestinationRejectsReplacement(t *testing.T) {
+	for _, keyExists := range []bool{false, true} {
+		name := "new key"
+		if keyExists {
+			name = "existing key"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			keyOut := filepath.Join(dir, "cert.key")
+			csrOut := filepath.Join(dir, "cert.csr")
+			originalKey := []byte("original-private-key")
+			originalCSR := []byte("original-csr")
+			if keyExists {
+				if err := os.WriteFile(keyOut, originalKey, 0o600); err != nil {
+					t.Fatalf("WriteFile(keyOut) error: %v", err)
+				}
+			}
+			if err := os.WriteFile(csrOut, originalCSR, 0o644); err != nil {
+				t.Fatalf("WriteFile(csrOut) error: %v", err)
+			}
+			if err := unix.Chflags(csrOut, unix.UF_IMMUTABLE); err != nil {
+				t.Fatalf("mark CSR destination immutable: %v", err)
+			}
+			defer func() {
+				if err := unix.Chflags(csrOut, 0); err != nil {
+					t.Errorf("restore CSR destination flags: %v", err)
+				}
+			}()
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			if err := root.Parse([]string{
+				"certificates", "csr", "generate",
+				"--key-out", keyOut,
+				"--csr-out", csrOut,
+				"--force",
+				"--output", "json",
+			}); err != nil {
+				t.Fatalf("parse command: %v", err)
+			}
+
+			var runErr error
+			stdout, _ := captureOutput(t, func() {
+				runErr = root.Run(context.Background())
+			})
+			if runErr == nil {
+				t.Fatal("expected CSR replacement failure")
+			}
+			if errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected runtime error, got usage error: %v", runErr)
+			}
+			if !strings.Contains(runErr.Error(), "write --csr-out") {
+				t.Fatalf("expected CSR write error, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Errorf("expected empty stdout, got %q", stdout)
+			}
+
+			if keyExists {
+				keyContents, err := os.ReadFile(keyOut)
+				if err != nil {
+					t.Fatalf("ReadFile(keyOut) error: %v", err)
+				}
+				if string(keyContents) != string(originalKey) {
+					t.Errorf("existing key changed after CSR replacement failure")
+				}
+			} else if _, err := os.Lstat(keyOut); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("new key remained after CSR replacement failure: %v", err)
+			}
+
+			csrContents, err := os.ReadFile(csrOut)
+			if err != nil {
+				t.Fatalf("ReadFile(csrOut) error: %v", err)
+			}
+			if string(csrContents) != string(originalCSR) {
+				t.Errorf("CSR destination changed after rejected replacement")
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("ReadDir(dir) error: %v", err)
+			}
+			wantEntries := 1
+			if keyExists {
+				wantEntries = 2
+			}
+			if len(entries) != wantEntries {
+				t.Errorf("unexpected pair-write artifacts: %v", entries)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/certificates_csr_generate_darwin_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_darwin_test.go
@@ -106,3 +106,98 @@ func TestCertificatesCSRGenerate_ForceRestoresKeyWhenCSRDestinationRejectsReplac
 		})
 	}
 }
+
+func TestCertificatesCSRGenerate_RejectsMountAliasEquivalentOutputsBeforeWriting(t *testing.T) {
+	physicalParent, err := os.MkdirTemp("/private/tmp", "asc-csr-mount-alias-")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error: %v", err)
+	}
+	t.Cleanup(func() {
+		entries, readErr := os.ReadDir(physicalParent)
+		if readErr == nil {
+			for _, entry := range entries {
+				if removeErr := os.Remove(filepath.Join(physicalParent, entry.Name())); removeErr != nil {
+					t.Errorf("remove mount-alias test artifact %q: %v", entry.Name(), removeErr)
+				}
+			}
+		}
+		if removeErr := os.Remove(physicalParent); removeErr != nil {
+			t.Errorf("remove mount-alias test directory: %v", removeErr)
+		}
+	})
+
+	aliasParent := filepath.Join("/System/Volumes/Data", physicalParent)
+	physicalInfo, err := os.Stat(physicalParent)
+	if err != nil {
+		t.Fatalf("Stat(physicalParent) error: %v", err)
+	}
+	aliasInfo, err := os.Stat(aliasParent)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skip("macOS data-volume alias is unavailable")
+	}
+	if err != nil {
+		t.Fatalf("Stat(aliasParent) error: %v", err)
+	}
+	if !os.SameFile(physicalInfo, aliasInfo) {
+		t.Skip("macOS data-volume paths do not alias the same directory")
+	}
+	physicalResolved, err := filepath.EvalSymlinks(physicalParent)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(physicalParent) error: %v", err)
+	}
+	aliasResolved, err := filepath.EvalSymlinks(aliasParent)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(aliasParent) error: %v", err)
+	}
+	if physicalResolved == aliasResolved {
+		t.Skip("mount aliases are already canonicalized as symlinks")
+	}
+
+	for _, force := range []bool{false, true} {
+		name := "without force"
+		if force {
+			name = "with force"
+		}
+		t.Run(name, func(t *testing.T) {
+			keyOut := filepath.Join(physicalParent, strings.ReplaceAll(name, " ", "-"))
+			csrOut := filepath.Join(aliasParent, strings.ReplaceAll(name, " ", "-"))
+			args := []string{
+				"certificates", "csr", "generate",
+				"--key-out", keyOut,
+				"--csr-out", csrOut,
+				"--output", "json",
+			}
+			if force {
+				args = append(args, "--force")
+			}
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse command: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Errorf("expected usage error, got %v", runErr)
+			}
+			const expected = "--key-out and --csr-out must be different paths"
+			if runErr == nil || runErr.Error() != expected {
+				t.Errorf("error = %v, want %q", runErr, expected)
+			}
+			if stdout != "" {
+				t.Errorf("expected empty stdout, got %q", stdout)
+			}
+			entries, err := os.ReadDir(physicalParent)
+			if err != nil {
+				t.Fatalf("ReadDir(physicalParent) error: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Errorf("outputs were created before mount aliases were rejected: %v", entries)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -304,6 +304,64 @@ func TestCertificatesCSRGenerate_ForcePreservesExistingKeyWhenCSROutCannotBeWrit
 	}
 }
 
+func TestCertificatesCSRGenerate_ForceReplacesUnreadableExistingKey(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "cert.key")
+	csrOut := filepath.Join(dir, "cert.csr")
+	if err := os.WriteFile(keyOut, []byte("existing-private-key"), 0o000); err != nil {
+		t.Fatalf("WriteFile(keyOut) error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(keyOut, 0o600)
+	})
+	if probe, err := os.Open(keyOut); err == nil {
+		_ = probe.Close()
+		t.Skip("environment does not enforce file read permissions")
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	_, _ = captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"certificates", "csr", "generate",
+			"--common-name", "ASC Signing",
+			"--key-out", keyOut,
+			"--csr-out", csrOut,
+			"--force",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse force command: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("expected forced replacement of unreadable key, got %v", runErr)
+	}
+
+	keyContents, err := os.ReadFile(keyOut)
+	if err != nil {
+		t.Fatalf("ReadFile(keyOut) error: %v", err)
+	}
+	if !strings.Contains(string(keyContents), "PRIVATE KEY") {
+		t.Errorf("key output does not contain a PEM private key: %q", keyContents)
+	}
+	csrContents, err := os.ReadFile(csrOut)
+	if err != nil {
+		t.Fatalf("ReadFile(csrOut) error: %v", err)
+	}
+	if !strings.Contains(string(csrContents), "CERTIFICATE REQUEST") {
+		t.Errorf("CSR output does not contain a PEM request: %q", csrContents)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(dir) error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("unexpected pair-write artifacts: %v", entries)
+	}
+}
+
 func TestCertificatesCSRGenerate_RejectsNestedOutputPathsBeforeWriting(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -400,8 +400,14 @@ func TestCertificatesCSRGenerate_RejectsAliasEquivalentOutputsBeforeWriting(t *t
 
 			if runErr == nil {
 				t.Error("expected alias-equivalent output path error")
-			} else if !strings.Contains(runErr.Error(), "must be different paths") {
-				t.Errorf("expected different output path error, got %v", runErr)
+			} else {
+				if !errors.Is(runErr, flag.ErrHelp) {
+					t.Errorf("expected usage error, got %v", runErr)
+				}
+				const expected = "--key-out and --csr-out must be different paths"
+				if runErr.Error() != expected {
+					t.Errorf("error = %q, want %q", runErr, expected)
+				}
 			}
 			if stdout != "" {
 				t.Errorf("expected empty stdout, got %q", stdout)
@@ -412,6 +418,127 @@ func TestCertificatesCSRGenerate_RejectsAliasEquivalentOutputsBeforeWriting(t *t
 				}
 			}
 		})
+	}
+}
+
+func TestCertificatesCSRGenerate_RejectsCaseEquivalentOutputsBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	probe := filepath.Join(dir, "case-probe")
+	if err := os.Mkdir(probe, 0o755); err != nil {
+		t.Fatalf("Mkdir(probe) error: %v", err)
+	}
+	probeInfo, err := os.Stat(probe)
+	if err != nil {
+		t.Fatalf("Stat(probe) error: %v", err)
+	}
+	caseVariantInfo, err := os.Stat(filepath.Join(dir, "CASE-PROBE"))
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skip("temporary volume is demonstrably case-sensitive")
+	}
+	if err != nil {
+		t.Fatalf("Stat(case variant) error: %v", err)
+	}
+	if !os.SameFile(probeInfo, caseVariantInfo) {
+		t.Skip("temporary volume resolves case variants to distinct entries")
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Fatalf("Remove(probe) error: %v", err)
+	}
+
+	for _, force := range []bool{false, true} {
+		name := "without force"
+		if force {
+			name = "with force"
+		}
+		t.Run(name, func(t *testing.T) {
+			outputDir := filepath.Join(dir, strings.ReplaceAll(name, " ", "-"))
+			if err := os.Mkdir(outputDir, 0o755); err != nil {
+				t.Fatalf("Mkdir(outputDir) error: %v", err)
+			}
+			keyOut := filepath.Join(outputDir, "cert.key")
+			csrOut := filepath.Join(outputDir, "CERT.KEY")
+			args := []string{
+				"certificates", "csr", "generate",
+				"--key-out", keyOut,
+				"--csr-out", csrOut,
+				"--output", "json",
+			}
+			if force {
+				args = append(args, "--force")
+			}
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse command: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Errorf("expected usage error, got %v", runErr)
+			}
+			const expected = "--key-out and --csr-out must be different paths"
+			if runErr == nil || runErr.Error() != expected {
+				t.Errorf("error = %v, want %q", runErr, expected)
+			}
+			if stdout != "" {
+				t.Errorf("expected empty stdout, got %q", stdout)
+			}
+			entries, err := os.ReadDir(outputDir)
+			if err != nil {
+				t.Fatalf("ReadDir(outputDir) error: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Errorf("outputs were created before case-equivalent paths were rejected: %v", entries)
+			}
+		})
+	}
+}
+
+func TestCertificatesCSRGenerate_AllowsCaseDistinctOutputsOnCaseSensitiveVolume(t *testing.T) {
+	dir := t.TempDir()
+	probe := filepath.Join(dir, "case-probe")
+	if err := os.Mkdir(probe, 0o755); err != nil {
+		t.Fatalf("Mkdir(probe) error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "CASE-PROBE")); err == nil {
+		t.Skip("temporary volume is case-insensitive")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Stat(case variant) error: %v", err)
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Fatalf("Remove(probe) error: %v", err)
+	}
+
+	keyOut := filepath.Join(dir, "cert.key")
+	csrOut := filepath.Join(dir, "CERT.KEY")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"certificates", "csr", "generate",
+		"--key-out", keyOut,
+		"--csr-out", csrOut,
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run command: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if _, err := os.Stat(keyOut); err != nil {
+		t.Fatalf("expected case-distinct key output: %v", err)
+	}
+	if _, err := os.Stat(csrOut); err != nil {
+		t.Fatalf("expected case-distinct CSR output: %v", err)
 	}
 }
 

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -690,6 +690,195 @@ func TestCertificatesCSRGenerate_AllowsCaseVariantNonNestedOutputsOnCaseSensitiv
 	}
 }
 
+func TestCertificatesCSRGenerate_RejectsUnicodeEquivalentOutputsBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	if !temporaryVolumeAliasesUnicodeNames(t, dir) {
+		t.Skip("temporary volume preserves canonically distinct Unicode names")
+	}
+
+	for _, relation := range []struct {
+		name     string
+		keyOut   func(string) string
+		csrOut   func(string) string
+		expected string
+	}{
+		{
+			name: "equivalent names",
+			keyOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "caf\u00e9.key")
+			},
+			csrOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "cafe\u0301.key")
+			},
+			expected: "--key-out and --csr-out must be different paths",
+		},
+		{
+			name: "key is Unicode-equivalent ancestor",
+			keyOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "caf\u00e9")
+			},
+			csrOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "cafe\u0301", "cert.csr")
+			},
+			expected: "--key-out and --csr-out must not contain one another",
+		},
+		{
+			name: "CSR is Unicode-equivalent ancestor",
+			keyOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "cafe\u0301", "cert.key")
+			},
+			csrOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "caf\u00e9")
+			},
+			expected: "--key-out and --csr-out must not contain one another",
+		},
+	} {
+		t.Run(relation.name, func(t *testing.T) {
+			for _, force := range []bool{false, true} {
+				name := "without force"
+				if force {
+					name = "with force"
+				}
+				t.Run(name, func(t *testing.T) {
+					outputDir := filepath.Join(dir, strings.ReplaceAll(relation.name+"-"+name, " ", "-"))
+					if err := os.Mkdir(outputDir, 0o755); err != nil {
+						t.Fatalf("Mkdir(outputDir) error: %v", err)
+					}
+					args := []string{
+						"certificates", "csr", "generate",
+						"--key-out", relation.keyOut(outputDir),
+						"--csr-out", relation.csrOut(outputDir),
+						"--output", "json",
+					}
+					if force {
+						args = append(args, "--force")
+					}
+
+					root := RootCommand("1.2.3")
+					root.FlagSet.SetOutput(io.Discard)
+					var runErr error
+					stdout, _ := captureOutput(t, func() {
+						if err := root.Parse(args); err != nil {
+							t.Fatalf("parse command: %v", err)
+						}
+						runErr = root.Run(context.Background())
+					})
+
+					if !errors.Is(runErr, flag.ErrHelp) {
+						t.Errorf("expected usage error, got %v", runErr)
+					}
+					if runErr == nil || runErr.Error() != relation.expected {
+						t.Errorf("error = %v, want %q", runErr, relation.expected)
+					}
+					if stdout != "" {
+						t.Errorf("expected empty stdout, got %q", stdout)
+					}
+					entries, err := os.ReadDir(outputDir)
+					if err != nil {
+						t.Fatalf("ReadDir(outputDir) error: %v", err)
+					}
+					if len(entries) != 0 {
+						t.Errorf("outputs were created before Unicode-equivalent paths were rejected: %v", entries)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCertificatesCSRGenerate_AllowsUnicodeDistinctOutputsOnNormalizationSensitiveVolume(t *testing.T) {
+	dir := t.TempDir()
+	if temporaryVolumeAliasesUnicodeNames(t, dir) {
+		t.Skip("temporary volume normalizes canonically equivalent Unicode names")
+	}
+
+	for _, relation := range []struct {
+		name   string
+		keyOut func(string) string
+		csrOut func(string) string
+	}{
+		{
+			name: "distinct names",
+			keyOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "caf\u00e9.key")
+			},
+			csrOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "cafe\u0301.key")
+			},
+		},
+		{
+			name: "distinct nested-looking names",
+			keyOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "caf\u00e9")
+			},
+			csrOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "cafe\u0301", "cert.csr")
+			},
+		},
+	} {
+		t.Run(relation.name, func(t *testing.T) {
+			outputDir := filepath.Join(dir, strings.ReplaceAll(relation.name, " ", "-"))
+			if err := os.Mkdir(outputDir, 0o755); err != nil {
+				t.Fatalf("Mkdir(outputDir) error: %v", err)
+			}
+			keyOut := relation.keyOut(outputDir)
+			csrOut := relation.csrOut(outputDir)
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			if err := root.Parse([]string{
+				"certificates", "csr", "generate",
+				"--key-out", keyOut,
+				"--csr-out", csrOut,
+				"--output", "json",
+			}); err != nil {
+				t.Fatalf("parse command: %v", err)
+			}
+
+			_, stderr := captureOutput(t, func() {
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run command: %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if _, err := os.Stat(keyOut); err != nil {
+				t.Fatalf("expected key output: %v", err)
+			}
+			if _, err := os.Stat(csrOut); err != nil {
+				t.Fatalf("expected CSR output: %v", err)
+			}
+		})
+	}
+}
+
+func temporaryVolumeAliasesUnicodeNames(t *testing.T, dir string) bool {
+	t.Helper()
+	probeDir := filepath.Join(dir, "normalization-probe")
+	if err := os.Mkdir(probeDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(probeDir) error: %v", err)
+	}
+	composed := filepath.Join(probeDir, "caf\u00e9")
+	if err := os.Mkdir(composed, 0o755); err != nil {
+		t.Fatalf("Mkdir(composed) error: %v", err)
+	}
+	composedInfo, err := os.Stat(composed)
+	if err != nil {
+		t.Fatalf("Stat(composed) error: %v", err)
+	}
+	decomposedInfo, decomposedErr := os.Stat(filepath.Join(probeDir, "cafe\u0301"))
+	if decomposedErr != nil && !errors.Is(decomposedErr, os.ErrNotExist) {
+		t.Fatalf("Stat(decomposed) error: %v", decomposedErr)
+	}
+	if err := os.Remove(composed); err != nil {
+		t.Fatalf("Remove(composed) error: %v", err)
+	}
+	if err := os.Remove(probeDir); err != nil {
+		t.Fatalf("Remove(probeDir) error: %v", err)
+	}
+	return decomposedErr == nil && os.SameFile(composedInfo, decomposedInfo)
+}
+
 func TestCertificatesCSRGenerate_ForcePreservesExistingKeyWhenCSRParentIsNotWritable(t *testing.T) {
 	dir := t.TempDir()
 	keyDir := filepath.Join(dir, "key")

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -359,6 +359,102 @@ func TestCertificatesCSRGenerate_RejectsNestedOutputPathsBeforeWriting(t *testin
 	}
 }
 
+func TestCertificatesCSRGenerate_RejectsAliasEquivalentOutputsBeforeWriting(t *testing.T) {
+	for _, force := range []bool{false, true} {
+		name := "without force"
+		if force {
+			name = "with force"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			realDir := filepath.Join(dir, "real")
+			if err := os.Mkdir(realDir, 0o755); err != nil {
+				t.Fatalf("Mkdir(realDir) error: %v", err)
+			}
+			aliasDir := filepath.Join(dir, "alias")
+			if err := os.Symlink(realDir, aliasDir); err != nil {
+				t.Fatalf("Symlink() error: %v", err)
+			}
+
+			keyOut := filepath.Join(realDir, "pair")
+			csrOut := filepath.Join(aliasDir, "pair")
+			args := []string{
+				"certificates", "csr", "generate",
+				"--key-out", keyOut,
+				"--csr-out", csrOut,
+				"--output", "json",
+			}
+			if force {
+				args = append(args, "--force")
+			}
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse command: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Error("expected alias-equivalent output path error")
+			} else if !strings.Contains(runErr.Error(), "must be different paths") {
+				t.Errorf("expected different output path error, got %v", runErr)
+			}
+			if stdout != "" {
+				t.Errorf("expected empty stdout, got %q", stdout)
+			}
+			for _, output := range []string{keyOut, csrOut} {
+				if _, err := os.Lstat(output); !errors.Is(err, os.ErrNotExist) {
+					t.Errorf("output was created before alias-equivalent paths were rejected: %q (stat error: %v)", output, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCertificatesCSRGenerate_AllowsDistinctOutputsBelowSymlinkedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(realDir) error: %v", err)
+	}
+	aliasDir := filepath.Join(dir, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Fatalf("Symlink() error: %v", err)
+	}
+
+	keyOut := filepath.Join(aliasDir, "cert.key")
+	csrOut := filepath.Join(aliasDir, "cert.csr")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"certificates", "csr", "generate",
+		"--key-out", keyOut,
+		"--csr-out", csrOut,
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run command: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if _, err := os.Stat(keyOut); err != nil {
+		t.Fatalf("expected key output below symlinked directory: %v", err)
+	}
+	if _, err := os.Stat(csrOut); err != nil {
+		t.Fatalf("expected CSR output below symlinked directory: %v", err)
+	}
+}
+
 func TestCertificatesCSRGenerate_RefusesSymlinkOutputs(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -498,6 +498,110 @@ func TestCertificatesCSRGenerate_RejectsCaseEquivalentOutputsBeforeWriting(t *te
 	}
 }
 
+func TestCertificatesCSRGenerate_RejectsCaseVariantNestedOutputsBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	probe := filepath.Join(dir, "case-probe")
+	if err := os.Mkdir(probe, 0o755); err != nil {
+		t.Fatalf("Mkdir(probe) error: %v", err)
+	}
+	probeInfo, err := os.Stat(probe)
+	if err != nil {
+		t.Fatalf("Stat(probe) error: %v", err)
+	}
+	caseVariantInfo, err := os.Stat(filepath.Join(dir, "CASE-PROBE"))
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skip("temporary volume is demonstrably case-sensitive")
+	}
+	if err != nil {
+		t.Fatalf("Stat(case variant) error: %v", err)
+	}
+	if !os.SameFile(probeInfo, caseVariantInfo) {
+		t.Skip("temporary volume resolves case variants to distinct entries")
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Fatalf("Remove(probe) error: %v", err)
+	}
+
+	for _, relation := range []struct {
+		name   string
+		keyOut func(string) string
+		csrOut func(string) string
+	}{
+		{
+			name: "key is case-variant ancestor",
+			keyOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "pair")
+			},
+			csrOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "PAIR", "cert.csr")
+			},
+		},
+		{
+			name: "CSR is case-variant ancestor",
+			keyOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "PAIR", "cert.key")
+			},
+			csrOut: func(outputDir string) string {
+				return filepath.Join(outputDir, "pair")
+			},
+		},
+	} {
+		t.Run(relation.name, func(t *testing.T) {
+			for _, force := range []bool{false, true} {
+				name := "without force"
+				if force {
+					name = "with force"
+				}
+				t.Run(name, func(t *testing.T) {
+					outputDir := filepath.Join(dir, strings.ReplaceAll(relation.name+"-"+name, " ", "-"))
+					if err := os.Mkdir(outputDir, 0o755); err != nil {
+						t.Fatalf("Mkdir(outputDir) error: %v", err)
+					}
+					keyOut := relation.keyOut(outputDir)
+					csrOut := relation.csrOut(outputDir)
+					args := []string{
+						"certificates", "csr", "generate",
+						"--key-out", keyOut,
+						"--csr-out", csrOut,
+						"--output", "json",
+					}
+					if force {
+						args = append(args, "--force")
+					}
+
+					root := RootCommand("1.2.3")
+					root.FlagSet.SetOutput(io.Discard)
+					var runErr error
+					stdout, _ := captureOutput(t, func() {
+						if err := root.Parse(args); err != nil {
+							t.Fatalf("parse command: %v", err)
+						}
+						runErr = root.Run(context.Background())
+					})
+
+					if !errors.Is(runErr, flag.ErrHelp) {
+						t.Errorf("expected usage error, got %v", runErr)
+					}
+					const expected = "--key-out and --csr-out must not contain one another"
+					if runErr == nil || runErr.Error() != expected {
+						t.Errorf("error = %v, want %q", runErr, expected)
+					}
+					if stdout != "" {
+						t.Errorf("expected empty stdout, got %q", stdout)
+					}
+					entries, err := os.ReadDir(outputDir)
+					if err != nil {
+						t.Fatalf("ReadDir(outputDir) error: %v", err)
+					}
+					if len(entries) != 0 {
+						t.Errorf("outputs were created before case-variant nested paths were rejected: %v", entries)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestCertificatesCSRGenerate_AllowsCaseDistinctOutputsOnCaseSensitiveVolume(t *testing.T) {
 	dir := t.TempDir()
 	probe := filepath.Join(dir, "case-probe")
@@ -539,6 +643,123 @@ func TestCertificatesCSRGenerate_AllowsCaseDistinctOutputsOnCaseSensitiveVolume(
 	}
 	if _, err := os.Stat(csrOut); err != nil {
 		t.Fatalf("expected case-distinct CSR output: %v", err)
+	}
+}
+
+func TestCertificatesCSRGenerate_AllowsCaseVariantNonNestedOutputsOnCaseSensitiveVolume(t *testing.T) {
+	dir := t.TempDir()
+	probe := filepath.Join(dir, "case-probe")
+	if err := os.Mkdir(probe, 0o755); err != nil {
+		t.Fatalf("Mkdir(probe) error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "CASE-PROBE")); err == nil {
+		t.Skip("temporary volume is case-insensitive")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Stat(case variant) error: %v", err)
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Fatalf("Remove(probe) error: %v", err)
+	}
+
+	keyOut := filepath.Join(dir, "pair")
+	csrOut := filepath.Join(dir, "PAIR", "cert.csr")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"certificates", "csr", "generate",
+		"--key-out", keyOut,
+		"--csr-out", csrOut,
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run command: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if _, err := os.Stat(keyOut); err != nil {
+		t.Fatalf("expected key output: %v", err)
+	}
+	if _, err := os.Stat(csrOut); err != nil {
+		t.Fatalf("expected case-distinct nested-looking CSR output: %v", err)
+	}
+}
+
+func TestCertificatesCSRGenerate_ForcePreservesExistingKeyWhenCSRParentIsNotWritable(t *testing.T) {
+	dir := t.TempDir()
+	keyDir := filepath.Join(dir, "key")
+	csrDir := filepath.Join(dir, "csr")
+	if err := os.Mkdir(keyDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(keyDir) error: %v", err)
+	}
+	if err := os.Mkdir(csrDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(csrDir) error: %v", err)
+	}
+	if err := os.Chmod(csrDir, 0o555); err != nil {
+		t.Fatalf("Chmod(csrDir) error: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(csrDir, 0o755); err != nil {
+			t.Errorf("restore csrDir permissions: %v", err)
+		}
+	}()
+	permissionProbe, err := os.CreateTemp(csrDir, "permission-probe-")
+	if err == nil {
+		probePath := permissionProbe.Name()
+		_ = permissionProbe.Close()
+		_ = os.Remove(probePath)
+		t.Skip("temporary volume does not enforce directory write permissions")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("CreateTemp permission probe error = %v, want permission error", err)
+	}
+
+	keyOut := filepath.Join(keyDir, "existing.key")
+	csrOut := filepath.Join(csrDir, "request.csr")
+	originalKey := []byte("existing-private-key")
+	if err := os.WriteFile(keyOut, originalKey, 0o600); err != nil {
+		t.Fatalf("WriteFile(keyOut) error: %v", err)
+	}
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"certificates", "csr", "generate",
+		"--key-out", keyOut,
+		"--csr-out", csrOut,
+		"--force",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected unwritable CSR parent error")
+	}
+	if stdout != "" {
+		t.Errorf("expected empty stdout, got %q", stdout)
+	}
+	keyContents, err := os.ReadFile(keyOut)
+	if err != nil {
+		t.Fatalf("ReadFile(keyOut) error: %v", err)
+	}
+	if string(keyContents) != string(originalKey) {
+		t.Errorf("existing key was replaced before CSR parent failure: got %q", keyContents)
+	}
+	entries, err := os.ReadDir(csrDir)
+	if err != nil {
+		t.Fatalf("ReadDir(csrDir) error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("CSR parent contains preflight artifacts: %v", entries)
 	}
 }
 

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -255,6 +255,55 @@ func TestCertificatesCSRGenerate_DoesNotOrphanKeyWhenCSROutExistsWithoutForce(t 
 	}
 }
 
+func TestCertificatesCSRGenerate_ForcePreservesExistingKeyWhenCSROutCannotBeWritten(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "cert.key")
+	writeECDSAPEM(t, keyOut)
+	originalKey, err := os.ReadFile(keyOut)
+	if err != nil {
+		t.Fatalf("ReadFile(keyOut) error: %v", err)
+	}
+
+	blockedParent := filepath.Join(dir, "blocked-parent")
+	if err := os.WriteFile(blockedParent, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blockedParent) error: %v", err)
+	}
+	failedCSROut := filepath.Join(blockedParent, "cert.csr")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	_, _ = captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"certificates", "csr", "generate",
+			"--key-out", keyOut,
+			"--csr-out", failedCSROut,
+			"--force",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse force command: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected CSR destination failure")
+	}
+	if !strings.Contains(runErr.Error(), blockedParent) {
+		t.Fatalf("expected error to identify blocked CSR parent %q, got %v", blockedParent, runErr)
+	}
+	currentKey, err := os.ReadFile(keyOut)
+	if err != nil {
+		t.Fatalf("ReadFile(keyOut) after failure: %v", err)
+	}
+	if string(currentKey) != string(originalKey) {
+		t.Fatal("existing private key changed before the CSR destination failure")
+	}
+	if _, err := os.Lstat(failedCSROut); err == nil {
+		t.Fatalf("unexpected CSR output at %q", failedCSROut)
+	}
+}
+
 func TestCertificatesCSRGenerate_RefusesSymlinkOutputs(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -304,6 +304,61 @@ func TestCertificatesCSRGenerate_ForcePreservesExistingKeyWhenCSROutCannotBeWrit
 	}
 }
 
+func TestCertificatesCSRGenerate_RejectsNestedOutputPathsBeforeWriting(t *testing.T) {
+	tests := []struct {
+		name   string
+		keyOut func(string) string
+		csrOut func(string) string
+	}{
+		{
+			name:   "key contains csr",
+			keyOut: func(dir string) string { return filepath.Join(dir, "pair") },
+			csrOut: func(dir string) string { return filepath.Join(dir, "pair", "cert.csr") },
+		},
+		{
+			name:   "csr contains key",
+			keyOut: func(dir string) string { return filepath.Join(dir, "pair", "cert.key") },
+			csrOut: func(dir string) string { return filepath.Join(dir, "pair") },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			keyOut := test.keyOut(dir)
+			csrOut := test.csrOut(dir)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			_, _ = captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"certificates", "csr", "generate",
+					"--key-out", keyOut,
+					"--csr-out", csrOut,
+					"--output", "json",
+				}); err != nil {
+					t.Fatalf("parse command: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected nested output path error")
+			}
+			if _, err := os.Lstat(keyOut); err == nil {
+				t.Errorf("key output was created before nested paths were rejected: %q", keyOut)
+			}
+			if _, err := os.Lstat(csrOut); err == nil {
+				t.Errorf("CSR output was created before nested paths were rejected: %q", csrOut)
+			}
+			if !strings.Contains(runErr.Error(), "must not contain one another") {
+				t.Errorf("expected nested output path error, got %v", runErr)
+			}
+		})
+	}
+}
+
 func TestCertificatesCSRGenerate_RefusesSymlinkOutputs(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/shared/safe_write.go
+++ b/internal/cli/shared/safe_write.go
@@ -10,7 +10,8 @@ import (
 // SafeWriteFileNoSymlink writes a file to path without following symlinks and with an optional
 // overwrite mode that preserves the original destination until the new file is fully written.
 //
-// When overwrite is false, the destination must not already exist.
+// When overwrite is false, the destination must not already exist, and a failed
+// write removes the newly created destination if it still names the same inode.
 // When overwrite is true, we refuse to overwrite symlinks and we use temp+rename; if rename fails
 // because the destination exists (notably on Windows), we fall back to a safe replace that uses a
 // backup file to preserve the original if the final move fails.
@@ -20,21 +21,74 @@ func SafeWriteFileNoSymlink(path string, perm os.FileMode, overwrite bool, tempP
 	}
 
 	if !overwrite {
-		file, err := OpenNewFileNoFollow(path, perm)
-		if err != nil {
-			if errors.Is(err, os.ErrExist) {
-				return 0, fmt.Errorf("output file already exists: %w", err)
-			}
-			return 0, err
-		}
-		defer file.Close()
-
-		written, err := write(file)
-		if err != nil {
-			return 0, err
-		}
-		return written, file.Sync()
+		return writeNewFileNoSymlink(path, perm, write, func(file *os.File) error {
+			return file.Sync()
+		})
 	}
 
 	return writeFileNoSymlinkOverwrite(path, perm, tempPattern, backupPattern, write)
+}
+
+func writeNewFileNoSymlink(
+	path string,
+	perm os.FileMode,
+	write func(*os.File) (int64, error),
+	syncFile func(*os.File) error,
+) (written int64, err error) {
+	file, err := OpenNewFileNoFollow(path, perm)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return 0, fmt.Errorf("output file already exists: %w", err)
+		}
+		return 0, err
+	}
+	createdInfo, err := file.Stat()
+	if err != nil {
+		return 0, errors.Join(err, file.Close(), os.Remove(path))
+	}
+	closed := false
+	success := false
+	defer func() {
+		if !closed {
+			if closeErr := file.Close(); closeErr != nil {
+				err = errors.Join(err, fmt.Errorf("close new output: %w", closeErr))
+			}
+		}
+		if !success {
+			if cleanupErr := removeCreatedOutput(path, createdInfo); cleanupErr != nil {
+				err = errors.Join(err, cleanupErr)
+			}
+		}
+	}()
+
+	written, err = write(file)
+	if err != nil {
+		return 0, err
+	}
+	if err = syncFile(file); err != nil {
+		return 0, err
+	}
+	closed = true
+	if err = file.Close(); err != nil {
+		return 0, err
+	}
+	success = true
+	return written, nil
+}
+
+func removeCreatedOutput(path string, createdInfo os.FileInfo) error {
+	currentInfo, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect failed output %q: %w", path, err)
+	}
+	if !os.SameFile(createdInfo, currentInfo) {
+		return fmt.Errorf("refusing to remove changed output %q after failed write", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove failed output %q: %w", path, err)
+	}
+	return nil
 }

--- a/internal/cli/shared/safe_write_test.go
+++ b/internal/cli/shared/safe_write_test.go
@@ -1,0 +1,102 @@
+package shared
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSafeWriteFileNoSymlink_RemovesNewFileAfterWriteFailure(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "output.pem")
+	writeFailure := errors.New("injected write failure")
+
+	_, err := SafeWriteFileNoSymlink(
+		destination,
+		0o600,
+		false,
+		".test-write-*",
+		".test-backup-*",
+		func(file *os.File) (int64, error) {
+			written, err := file.Write([]byte("partial"))
+			if err != nil {
+				return int64(written), err
+			}
+			return int64(written), writeFailure
+		},
+	)
+	if !errors.Is(err, writeFailure) {
+		t.Fatalf("SafeWriteFileNoSymlink() error = %v, want write failure", err)
+	}
+	if _, err := os.Lstat(destination); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("partial destination remained after write failure: %v", err)
+	}
+}
+
+func TestWriteNewFileNoSymlink_RemovesNewFileAfterSyncFailure(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "output.pem")
+	syncFailure := errors.New("injected sync failure")
+
+	_, err := writeNewFileNoSymlink(
+		destination,
+		0o600,
+		func(file *os.File) (int64, error) {
+			written, err := file.Write([]byte("complete but not durable"))
+			return int64(written), err
+		},
+		func(*os.File) error {
+			return syncFailure
+		},
+	)
+	if !errors.Is(err, syncFailure) {
+		t.Fatalf("writeNewFileNoSymlink() error = %v, want sync failure", err)
+	}
+	if _, err := os.Lstat(destination); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("destination remained after sync failure: %v", err)
+	}
+}
+
+func TestWriteNewFileNoSymlink_DoesNotRemoveChangedDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not permit replacing the pathname while its original file is open")
+	}
+	destination := filepath.Join(t.TempDir(), "output.pem")
+	writeFailure := errors.New("injected write failure")
+	replacement := []byte("concurrent replacement")
+
+	_, err := writeNewFileNoSymlink(
+		destination,
+		0o600,
+		func(file *os.File) (int64, error) {
+			written, err := file.Write([]byte("partial"))
+			if err != nil {
+				return int64(written), err
+			}
+			if err := os.Remove(destination); err != nil {
+				return int64(written), err
+			}
+			if err := os.WriteFile(destination, replacement, 0o600); err != nil {
+				return int64(written), err
+			}
+			return int64(written), writeFailure
+		},
+		func(file *os.File) error {
+			return file.Sync()
+		},
+	)
+	if !errors.Is(err, writeFailure) {
+		t.Fatalf("writeNewFileNoSymlink() error = %v, want write failure", err)
+	}
+	if !strings.Contains(err.Error(), "refusing to remove changed output") {
+		t.Fatalf("writeNewFileNoSymlink() error = %q, want changed-output diagnostic", err)
+	}
+	contents, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("ReadFile(destination) error: %v", err)
+	}
+	if string(contents) != string(replacement) {
+		t.Fatalf("destination contents = %q, want concurrent replacement", contents)
+	}
+}


### PR DESCRIPTION
## What changed

- preflight both key and CSR destination paths before replacing either output
- preserve an existing private key when the CSR output has a deterministic local path failure
- retain the existing staged, no-symlink writes and overwrite behavior

## Scope

This is a read-only preflight for locally detectable path failures. It does not claim cross-file atomicity for later filesystem failures.

## Verification

- reproduced the force-mode key replacement before a CSR parent-file failure
- regression passed 10 consecutive runs
- all certificate CSR command tests and certificate package tests
- built standalone and inline-create paths fail before auth or network access and preserve the key
- Linux and Windows cross-compilation for the CLI and affected tests
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

No live API mutations were performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788928244&installation_model_id=10418&pr_number=1937&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1937&signature=ecc7911c133b39570d65527402412be1cdadcd7b031441efa0affdc2eeb91e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSR generation safeguards when output paths are invalid or unavailable.
  * Rejected identical, nested, or equivalent key and CSR output paths before file creation.
  * Prevented forced generation from overwriting existing private keys if CSR creation fails.
  * Added clearer handling for blocked destinations, symlinks, and directories.
  * Improved validation for alternate path separators on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->