### PR TITLE
fix(game-center): return metrics authentication errors

### DIFF
--- a/internal/cli/cmdtest/game_center_metrics_auth_test.go
+++ b/internal/cli/cmdtest/game_center_metrics_auth_test.go
@@ -1,0 +1,106 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestGameCenterMetricsPropagateClientErrorsBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "matchmaking queue metrics",
+			args: []string{"game-center", "matchmaking", "metrics", "queue-sizes", "--queue-id", "queue-1", "--granularity", "P1D", "--output", "json"},
+		},
+		{
+			name: "matchmaking rule metrics",
+			args: []string{"game-center", "matchmaking", "metrics", "rule-errors", "--rule-id", "rule-1", "--granularity", "P1D", "--output", "json"},
+		},
+		{
+			name: "detail metrics",
+			args: []string{"game-center", "details", "metrics", "classic-matchmaking", "--id", "detail-1", "--granularity", "P1D", "--output", "json"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+
+			requestCount := 0
+			client, err := asc.NewClientWithHTTPClient(
+				os.Getenv("ASC_KEY_ID"),
+				os.Getenv("ASC_ISSUER_ID"),
+				os.Getenv("ASC_PRIVATE_KEY_PATH"),
+				&http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					requestCount++
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"data":[],"links":{}}`)),
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+					}, nil
+				})},
+			)
+			if err != nil {
+				t.Fatalf("create poisoned metrics client: %v", err)
+			}
+
+			authErr := errors.New("metrics auth unavailable")
+			factoryCalls := 0
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				factoryCalls++
+				// The error is authoritative even if a factory also returns a client.
+				return client, authErr
+			})
+			t.Cleanup(restore)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			var recovered any
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				func() {
+					defer func() {
+						recovered = recover()
+					}()
+					runErr = root.Run(context.Background())
+				}()
+			})
+
+			if recovered != nil {
+				t.Fatalf("command panicked instead of returning the auth error: %v", recovered)
+			}
+			if !errors.Is(runErr, authErr) {
+				t.Fatalf("run error = %v, want %v", runErr, authErr)
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitError {
+				t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitError)
+			}
+			if factoryCalls != 1 {
+				t.Fatalf("client factory calls = %d, want 1", factoryCalls)
+			}
+			if requestCount != 0 {
+				t.Fatalf("HTTP request count = %d, want 0", requestCount)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty before top-level error formatting", stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/gamecenter/game_center_details.go
+++ b/internal/cli/gamecenter/game_center_details.go
@@ -1122,8 +1122,8 @@ func GameCenterDetailsClassicMatchmakingCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return detailsMetricsCommand("classic-matchmaking", fs, detailID, granularity, groupBy, filterResult, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error) {
-		return ascClient().GetGameCenterDetailsClassicMatchmakingRequests(ctx, id, opts...)
+	return detailsMetricsCommand("classic-matchmaking", fs, detailID, granularity, groupBy, filterResult, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error) {
+		return client.GetGameCenterDetailsClassicMatchmakingRequests(ctx, id, opts...)
 	})
 }
 
@@ -1141,12 +1141,12 @@ func GameCenterDetailsRuleBasedMatchmakingCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return detailsMetricsCommand("rule-based-matchmaking", fs, detailID, granularity, groupBy, filterResult, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error) {
-		return ascClient().GetGameCenterDetailsRuleBasedMatchmakingRequests(ctx, id, opts...)
+	return detailsMetricsCommand("rule-based-matchmaking", fs, detailID, granularity, groupBy, filterResult, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error) {
+		return client.GetGameCenterDetailsRuleBasedMatchmakingRequests(ctx, id, opts...)
 	})
 }
 
-func detailsMetricsCommand(name string, fs *flag.FlagSet, detailID *string, granularity *string, groupBy *string, filterResult *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error)) *ffcli.Command {
+func detailsMetricsCommand(name string, fs *flag.FlagSet, detailID *string, granularity *string, groupBy *string, filterResult *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error)) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       name,
 		ShortUsage: "asc game-center details metrics " + name + " --id \"DETAIL_ID\" --granularity P1D",
@@ -1163,7 +1163,7 @@ Examples:
 	}
 }
 
-func runDetailsMetrics(ctx context.Context, name string, detailID *string, granularity *string, groupBy *string, filterResult *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error)) error {
+func runDetailsMetrics(ctx context.Context, name string, detailID *string, granularity *string, groupBy *string, filterResult *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMetricsResponse, error)) error {
 	if *limit != 0 && (*limit < 1 || *limit > 200) {
 		return fmt.Errorf("game-center details metrics %s: --limit must be between 1 and 200", name)
 	}
@@ -1182,6 +1182,11 @@ func runDetailsMetrics(ctx context.Context, name string, detailID *string, granu
 		return shared.MissingRequiredUsageError()
 	}
 
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return fmt.Errorf("game-center details metrics %s: %w", name, err)
+	}
+
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
@@ -1196,13 +1201,13 @@ func runDetailsMetrics(ctx context.Context, name string, detailID *string, granu
 
 	if *paginate {
 		paginateOpts := append(opts, asc.WithGCMatchmakingMetricsLimit(200))
-		firstPage, err := fetch(requestCtx, id, paginateOpts...)
+		firstPage, err := fetch(client, requestCtx, id, paginateOpts...)
 		if err != nil {
 			return fmt.Errorf("game-center details metrics %s: failed to fetch: %w", name, err)
 		}
 
 		resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-			return fetch(ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
+			return fetch(client, ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
 		})
 		if err != nil {
 			return fmt.Errorf("game-center details metrics %s: %w", name, err)
@@ -1211,7 +1216,7 @@ func runDetailsMetrics(ctx context.Context, name string, detailID *string, granu
 		return shared.PrintOutput(resp, *output, *pretty)
 	}
 
-	resp, err := fetch(requestCtx, id, opts...)
+	resp, err := fetch(client, requestCtx, id, opts...)
 	if err != nil {
 		return fmt.Errorf("game-center details metrics %s: failed to fetch: %w", name, err)
 	}

--- a/internal/cli/gamecenter/game_center_matchmaking.go
+++ b/internal/cli/gamecenter/game_center_matchmaking.go
@@ -1406,8 +1406,8 @@ func GameCenterMatchmakingQueueSizesCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsQueueCommand("queue-sizes", fs, queueID, granularity, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSizesResponse, error) {
-		return ascClient().GetGameCenterMatchmakingQueueSizes(ctx, id, opts...)
+	return metricsQueueCommand("queue-sizes", fs, queueID, granularity, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSizesResponse, error) {
+		return client.GetGameCenterMatchmakingQueueSizes(ctx, id, opts...)
 	})
 }
 
@@ -1426,8 +1426,8 @@ func GameCenterMatchmakingQueueRequestsCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsQueueCommandWithFilters("queue-requests", fs, queueID, granularity, groupBy, filterResult, filterDetail, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueRequestsResponse, error) {
-		return ascClient().GetGameCenterMatchmakingQueueRequests(ctx, id, opts...)
+	return metricsQueueCommandWithFilters("queue-requests", fs, queueID, granularity, groupBy, filterResult, filterDetail, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueRequestsResponse, error) {
+		return client.GetGameCenterMatchmakingQueueRequests(ctx, id, opts...)
 	})
 }
 
@@ -1443,8 +1443,8 @@ func GameCenterMatchmakingQueueSessionsCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsQueueCommand("queue-sessions", fs, queueID, granularity, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSessionsResponse, error) {
-		return ascClient().GetGameCenterMatchmakingQueueSessions(ctx, id, opts...)
+	return metricsQueueCommand("queue-sessions", fs, queueID, granularity, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSessionsResponse, error) {
+		return client.GetGameCenterMatchmakingQueueSessions(ctx, id, opts...)
 	})
 }
 
@@ -1460,8 +1460,8 @@ func GameCenterMatchmakingQueueExperimentSizesCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsQueueCommand("experiment-queue-sizes", fs, queueID, granularity, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueExperimentSizesResponse, error) {
-		return ascClient().GetGameCenterMatchmakingQueueExperimentSizes(ctx, id, opts...)
+	return metricsQueueCommand("experiment-queue-sizes", fs, queueID, granularity, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueExperimentSizesResponse, error) {
+		return client.GetGameCenterMatchmakingQueueExperimentSizes(ctx, id, opts...)
 	})
 }
 
@@ -1480,8 +1480,8 @@ func GameCenterMatchmakingQueueExperimentRequestsCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsQueueCommandWithFilters("experiment-queue-requests", fs, queueID, granularity, groupBy, filterResult, filterDetail, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueExperimentRequestsResponse, error) {
-		return ascClient().GetGameCenterMatchmakingQueueExperimentRequests(ctx, id, opts...)
+	return metricsQueueCommandWithFilters("experiment-queue-requests", fs, queueID, granularity, groupBy, filterResult, filterDetail, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueExperimentRequestsResponse, error) {
+		return client.GetGameCenterMatchmakingQueueExperimentRequests(ctx, id, opts...)
 	})
 }
 
@@ -1500,8 +1500,8 @@ func GameCenterMatchmakingBooleanRuleResultsCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsRuleCommand("rule-boolean-results", fs, ruleID, granularity, groupBy, filterResult, filterQueue, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingBooleanRuleResultsResponse, error) {
-		return ascClient().GetGameCenterMatchmakingBooleanRuleResults(ctx, id, opts...)
+	return metricsRuleCommand("rule-boolean-results", fs, ruleID, granularity, groupBy, filterResult, filterQueue, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingBooleanRuleResultsResponse, error) {
+		return client.GetGameCenterMatchmakingBooleanRuleResults(ctx, id, opts...)
 	})
 }
 
@@ -1520,8 +1520,8 @@ func GameCenterMatchmakingNumberRuleResultsCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsRuleCommand("rule-number-results", fs, ruleID, granularity, groupBy, filterResult, filterQueue, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingNumberRuleResultsResponse, error) {
-		return ascClient().GetGameCenterMatchmakingNumberRuleResults(ctx, id, opts...)
+	return metricsRuleCommand("rule-number-results", fs, ruleID, granularity, groupBy, filterResult, filterQueue, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingNumberRuleResultsResponse, error) {
+		return client.GetGameCenterMatchmakingNumberRuleResults(ctx, id, opts...)
 	})
 }
 
@@ -1540,12 +1540,12 @@ func GameCenterMatchmakingRuleErrorsCommand() *ffcli.Command {
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
-	return metricsRuleCommand("rule-errors", fs, ruleID, granularity, groupBy, filterResult, filterQueue, sort, limit, next, paginate, output.Output, output.Pretty, func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingRuleErrorsResponse, error) {
-		return ascClient().GetGameCenterMatchmakingRuleErrors(ctx, id, opts...)
+	return metricsRuleCommand("rule-errors", fs, ruleID, granularity, groupBy, filterResult, filterQueue, sort, limit, next, paginate, output.Output, output.Pretty, func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingRuleErrorsResponse, error) {
+		return client.GetGameCenterMatchmakingRuleErrors(ctx, id, opts...)
 	})
 }
 
-func metricsQueueCommand(name string, fs *flag.FlagSet, queueID *string, granularity *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSizesResponse, error)) *ffcli.Command {
+func metricsQueueCommand(name string, fs *flag.FlagSet, queueID *string, granularity *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSizesResponse, error)) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       name,
 		ShortUsage: "asc game-center matchmaking metrics " + name + " --queue-id \"QUEUE_ID\" --granularity P1D",
@@ -1562,7 +1562,7 @@ Examples:
 	}
 }
 
-func metricsQueueCommandWithFilters(name string, fs *flag.FlagSet, queueID *string, granularity *string, groupBy *string, filterResult *string, filterDetail *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueRequestsResponse, error)) *ffcli.Command {
+func metricsQueueCommandWithFilters(name string, fs *flag.FlagSet, queueID *string, granularity *string, groupBy *string, filterResult *string, filterDetail *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueRequestsResponse, error)) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       name,
 		ShortUsage: "asc game-center matchmaking metrics " + name + " --queue-id \"QUEUE_ID\" --granularity P1D",
@@ -1579,7 +1579,7 @@ Examples:
 	}
 }
 
-func metricsRuleCommand(name string, fs *flag.FlagSet, ruleID *string, granularity *string, groupBy *string, filterResult *string, filterQueue *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingBooleanRuleResultsResponse, error)) *ffcli.Command {
+func metricsRuleCommand(name string, fs *flag.FlagSet, ruleID *string, granularity *string, groupBy *string, filterResult *string, filterQueue *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingBooleanRuleResultsResponse, error)) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       name,
 		ShortUsage: "asc game-center matchmaking metrics " + name + " --rule-id \"RULE_ID\" --granularity P1D",
@@ -1596,7 +1596,7 @@ Examples:
 	}
 }
 
-func runMetricsQueue(ctx context.Context, name string, queueID *string, granularity *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetchSizes func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSizesResponse, error), fetchRequests func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueRequestsResponse, error), groupBy string, filterResult string, filterDetail string) error {
+func runMetricsQueue(ctx context.Context, name string, queueID *string, granularity *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetchSizes func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueSizesResponse, error), fetchRequests func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingQueueRequestsResponse, error), groupBy string, filterResult string, filterDetail string) error {
 	if *limit != 0 && (*limit < 1 || *limit > 200) {
 		return fmt.Errorf("game-center matchmaking metrics %s: --limit must be between 1 and 200", name)
 	}
@@ -1615,7 +1615,11 @@ func runMetricsQueue(ctx context.Context, name string, queueID *string, granular
 		return shared.MissingRequiredUsageError()
 	}
 
-	var err error
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return fmt.Errorf("game-center matchmaking metrics %s: %w", name, err)
+	}
+
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
@@ -1640,9 +1644,9 @@ func runMetricsQueue(ctx context.Context, name string, queueID *string, granular
 		var firstPage asc.PaginatedResponse
 		var err error
 		if fetchRequests != nil {
-			firstPage, err = fetchRequests(requestCtx, id, paginateOpts...)
+			firstPage, err = fetchRequests(client, requestCtx, id, paginateOpts...)
 		} else {
-			firstPage, err = fetchSizes(requestCtx, id, paginateOpts...)
+			firstPage, err = fetchSizes(client, requestCtx, id, paginateOpts...)
 		}
 		if err != nil {
 			return fmt.Errorf("game-center matchmaking metrics %s: failed to fetch: %w", name, err)
@@ -1650,9 +1654,9 @@ func runMetricsQueue(ctx context.Context, name string, queueID *string, granular
 
 		resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
 			if fetchRequests != nil {
-				return fetchRequests(ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
+				return fetchRequests(client, ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
 			}
-			return fetchSizes(ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
+			return fetchSizes(client, ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
 		})
 		if err != nil {
 			return fmt.Errorf("game-center matchmaking metrics %s: %w", name, err)
@@ -1663,9 +1667,9 @@ func runMetricsQueue(ctx context.Context, name string, queueID *string, granular
 
 	var resp any
 	if fetchRequests != nil {
-		resp, err = fetchRequests(requestCtx, id, opts...)
+		resp, err = fetchRequests(client, requestCtx, id, opts...)
 	} else {
-		resp, err = fetchSizes(requestCtx, id, opts...)
+		resp, err = fetchSizes(client, requestCtx, id, opts...)
 	}
 	if err != nil {
 		return fmt.Errorf("game-center matchmaking metrics %s: failed to fetch: %w", name, err)
@@ -1674,7 +1678,7 @@ func runMetricsQueue(ctx context.Context, name string, queueID *string, granular
 	return shared.PrintOutput(resp, *output, *pretty)
 }
 
-func runMetricsRule(ctx context.Context, name string, ruleID *string, granularity *string, groupBy *string, filterResult *string, filterQueue *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingBooleanRuleResultsResponse, error)) error {
+func runMetricsRule(ctx context.Context, name string, ruleID *string, granularity *string, groupBy *string, filterResult *string, filterQueue *string, sort *string, limit *int, next *string, paginate *bool, output *string, pretty *bool, fetch func(client *asc.Client, ctx context.Context, id string, opts ...asc.GCMatchmakingMetricsOption) (*asc.GameCenterMatchmakingBooleanRuleResultsResponse, error)) error {
 	if *limit != 0 && (*limit < 1 || *limit > 200) {
 		return fmt.Errorf("game-center matchmaking metrics %s: --limit must be between 1 and 200", name)
 	}
@@ -1693,6 +1697,11 @@ func runMetricsRule(ctx context.Context, name string, ruleID *string, granularit
 		return shared.MissingRequiredUsageError()
 	}
 
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return fmt.Errorf("game-center matchmaking metrics %s: %w", name, err)
+	}
+
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
@@ -1708,13 +1717,13 @@ func runMetricsRule(ctx context.Context, name string, ruleID *string, granularit
 
 	if *paginate {
 		paginateOpts := append(opts, asc.WithGCMatchmakingMetricsLimit(200))
-		firstPage, err := fetch(requestCtx, id, paginateOpts...)
+		firstPage, err := fetch(client, requestCtx, id, paginateOpts...)
 		if err != nil {
 			return fmt.Errorf("game-center matchmaking metrics %s: failed to fetch: %w", name, err)
 		}
 
 		resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-			return fetch(ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
+			return fetch(client, ctx, id, asc.WithGCMatchmakingMetricsNextURL(nextURL))
 		})
 		if err != nil {
 			return fmt.Errorf("game-center matchmaking metrics %s: %w", name, err)
@@ -1723,7 +1732,7 @@ func runMetricsRule(ctx context.Context, name string, ruleID *string, granularit
 		return shared.PrintOutput(resp, *output, *pretty)
 	}
 
-	resp, err := fetch(requestCtx, id, opts...)
+	resp, err := fetch(client, requestCtx, id, opts...)
 	if err != nil {
 		return fmt.Errorf("game-center matchmaking metrics %s: failed to fetch: %w", name, err)
 	}
@@ -1799,9 +1808,4 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
-}
-
-func ascClient() *asc.Client {
-	client, _ := shared.GetASCClient()
-	return client
 }


### PR DESCRIPTION
## Summary

- resolve the authenticated client before Game Center metric callbacks run
- propagate client setup failures without issuing metric requests
- reuse the validated client across pagination and cover queue, rule, and detail metric paths

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run "^TestGameCenterMetricsPropagateClientErrorsBeforeHTTP$" -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run "^TestGameCenter(Matchmaking|Details)" -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run "GameCenter(Matchmaking|Details)" -count=1`
- task-specific built binary: valid metric shapes with an unavailable profile exit cleanly with empty stdout; required-flag validation still exits 2 before auth
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788929462&installation_model_id=10418&pr_number=1938&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1938&signature=aa519d721137e45b9f8f1a175d510aafab38168c7c505a06635a177f7cc6ffe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Game Center matchmaking and detail metrics commands so authentication errors are reported cleanly before any network requests or output occur.
  * Ensured authentication failures do not cause command crashes.
* **Tests**
  * Added coverage for authentication error propagation across matchmaking and detail metrics commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->