### PR TITLE
Resolve apps info versions across all pages

### DIFF
--- a/internal/cli/apps/app_info.go
+++ b/internal/cli/apps/app_info.go
@@ -1103,11 +1103,21 @@ func resolveAppStoreVersionForAppInfo(
 	if err != nil {
 		return asc.Resource[asc.AppStoreVersionAttributes]{}, err
 	}
-	if len(resp.Data) == 0 {
+	allPages, err := asc.PaginateAll(ctx, resp, func(pageCtx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetAppStoreVersions(pageCtx, appID, asc.WithAppStoreVersionsNextURL(nextURL))
+	})
+	if err != nil {
+		return asc.Resource[asc.AppStoreVersionAttributes]{}, err
+	}
+	versions, ok := allPages.(*asc.AppStoreVersionsResponse)
+	if !ok {
+		return asc.Resource[asc.AppStoreVersionAttributes]{}, fmt.Errorf("unexpected app store versions response type %T", allPages)
+	}
+	if len(versions.Data) == 0 {
 		return asc.Resource[asc.AppStoreVersionAttributes]{}, fmt.Errorf("no app store versions found for app %q", appID)
 	}
 
-	return selectLatestAppStoreVersion(resp.Data), nil
+	return selectLatestAppStoreVersion(versions.Data), nil
 }
 
 func selectLatestAppStoreVersion(versions []asc.Resource[asc.AppStoreVersionAttributes]) asc.Resource[asc.AppStoreVersionAttributes] {

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -7,8 +7,11 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -67,18 +70,26 @@ func TestResolveAppStoreVersionForAppInfoPaginatesBeforeSelectingLatest(t *testi
 	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appStoreVersions?cursor=page-2"
 
 	requests := make([]string, 0, 2)
-	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.String())
-		switch len(requests) {
-		case 1:
-			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"old","attributes":{"createdDate":"2026-01-01T00:00:00Z"}}],"links":{"next":"`+nextURL+`"}}`), nil
-		case 2:
-			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"new","attributes":{"createdDate":"2026-02-01T00:00:00Z"}}]}`), nil
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("request is missing bearer authorization: %s %s", req.Method, req.URL.String())
+			http.Error(w, "missing authorization", http.StatusUnauthorized)
+			return
+		}
+		requests = append(requests, req.Method+" "+req.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Query().Get("cursor") {
+		case "":
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreVersions","id":"old","attributes":{"createdDate":"2026-01-01T00:00:00Z"}}],"links":{"next":"`+nextURL+`"}}`)
+		case "page-2":
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreVersions","id":"new","attributes":{"createdDate":"2026-02-01T00:00:00Z"}}]}`)
 		default:
-			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
 		}
 	}))
+	t.Cleanup(server.Close)
+	client := newAppInfoTestServerClient(t, server)
 
 	selected, err := resolveAppStoreVersionForAppInfo(context.Background(), client, "app-1", "", "", nil, nil)
 	if err != nil {
@@ -88,8 +99,8 @@ func TestResolveAppStoreVersionForAppInfoPaginatesBeforeSelectingLatest(t *testi
 		t.Fatalf("expected latest version %q, got %q", "new", selected.ID)
 	}
 	wantRequests := []string{
-		"GET https://api.appstoreconnect.apple.com/v1/apps/app-1/appStoreVersions?limit=200",
-		"GET " + nextURL,
+		"GET /v1/apps/app-1/appStoreVersions?limit=200",
+		"GET /v1/apps/app-1/appStoreVersions?cursor=page-2",
 	}
 	if !slices.Equal(requests, wantRequests) {
 		t.Fatalf("request sequence = %v, want %v", requests, wantRequests)
@@ -503,4 +514,24 @@ func newAppInfoTestClient(t *testing.T, transport http.RoundTripper) *asc.Client
 		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
 	}
 	return client
+}
+
+func newAppInfoTestServerClient(t *testing.T, server *httptest.Server) *asc.Client {
+	t.Helper()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Scheme != "https" || req.URL.Host != "api.appstoreconnect.apple.com" {
+			return nil, fmt.Errorf("unexpected App Store Connect URL %q", req.URL.String())
+		}
+		routed := req.Clone(req.Context())
+		routed.URL.Scheme = serverURL.Scheme
+		routed.URL.Host = serverURL.Host
+		routed.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(routed)
+	})
+	return newAppInfoTestClient(t, transport)
 }

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -71,7 +71,8 @@ func TestResolveAppStoreVersionForAppInfoPaginatesBeforeSelectingLatest(t *testi
 
 	requests := make([]string, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+		token, ok := strings.CutPrefix(req.Header.Get("Authorization"), "Bearer ")
+		if !ok || strings.TrimSpace(token) == "" {
 			t.Errorf("request is missing bearer authorization: %s %s", req.Method, req.URL.String())
 			http.Error(w, "missing authorization", http.StatusUnauthorized)
 			return
@@ -97,6 +98,45 @@ func TestResolveAppStoreVersionForAppInfoPaginatesBeforeSelectingLatest(t *testi
 	}
 	if selected.ID != "new" {
 		t.Fatalf("expected latest version %q, got %q", "new", selected.ID)
+	}
+	wantRequests := []string{
+		"GET /v1/apps/app-1/appStoreVersions?limit=200",
+		"GET /v1/apps/app-1/appStoreVersions?cursor=page-2",
+	}
+	if !slices.Equal(requests, wantRequests) {
+		t.Fatalf("request sequence = %v, want %v", requests, wantRequests)
+	}
+}
+
+func TestResolveAppStoreVersionForAppInfoRejectsPartialResults(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appStoreVersions?cursor=page-2"
+
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests = append(requests, req.Method+" "+req.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Query().Get("cursor") {
+		case "":
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreVersions","id":"old","attributes":{"createdDate":"2026-01-01T00:00:00Z"}}],"links":{"next":"`+nextURL+`"}}`)
+		case "page-2":
+			_, _ = io.WriteString(w, `{`)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newAppInfoTestServerClient(t, server)
+
+	selected, err := resolveAppStoreVersionForAppInfo(context.Background(), client, "app-1", "", "", nil, nil)
+	if err == nil {
+		t.Fatal("expected continuation error, got nil")
+	}
+	if selected.ID != "" {
+		t.Fatalf("expected no version from partial results, got %q", selected.ID)
+	}
+	if !strings.Contains(err.Error(), "page 2") {
+		t.Fatalf("expected continuation error to identify page 2, got %v", err)
 	}
 	wantRequests := []string{
 		"GET /v1/apps/app-1/appStoreVersions?limit=200",

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -91,8 +91,10 @@ func TestResolveAppStoreVersionForAppInfoPaginatesBeforeSelectingLatest(t *testi
 	}))
 	t.Cleanup(server.Close)
 	client := newAppInfoTestServerClient(t, server)
+	requestCtx, cancel := shared.ContextWithTimeout(context.Background())
+	defer cancel()
 
-	selected, err := resolveAppStoreVersionForAppInfo(context.Background(), client, "app-1", "", "", nil, nil)
+	selected, err := resolveAppStoreVersionForAppInfo(requestCtx, client, "app-1", "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("resolveAppStoreVersionForAppInfo() error: %v", err)
 	}
@@ -127,8 +129,10 @@ func TestResolveAppStoreVersionForAppInfoRejectsPartialResults(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	client := newAppInfoTestServerClient(t, server)
+	requestCtx, cancel := shared.ContextWithTimeout(context.Background())
+	defer cancel()
 
-	selected, err := resolveAppStoreVersionForAppInfo(context.Background(), client, "app-1", "", "", nil, nil)
+	selected, err := resolveAppStoreVersionForAppInfo(requestCtx, client, "app-1", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected continuation error, got nil")
 	}

--- a/internal/cli/apps/app_info_test.go
+++ b/internal/cli/apps/app_info_test.go
@@ -63,6 +63,39 @@ func TestSelectLatestAppStoreVersionFallsBackToFirst(t *testing.T) {
 	}
 }
 
+func TestResolveAppStoreVersionForAppInfoPaginatesBeforeSelectingLatest(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appStoreVersions?cursor=page-2"
+
+	requests := make([]string, 0, 2)
+	client := newAppInfoTestClient(t, appInfoRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.String())
+		switch len(requests) {
+		case 1:
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"old","attributes":{"createdDate":"2026-01-01T00:00:00Z"}}],"links":{"next":"`+nextURL+`"}}`), nil
+		case 2:
+			return appInfoJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"new","attributes":{"createdDate":"2026-02-01T00:00:00Z"}}]}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	selected, err := resolveAppStoreVersionForAppInfo(context.Background(), client, "app-1", "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("resolveAppStoreVersionForAppInfo() error: %v", err)
+	}
+	if selected.ID != "new" {
+		t.Fatalf("expected latest version %q, got %q", "new", selected.ID)
+	}
+	wantRequests := []string{
+		"GET https://api.appstoreconnect.apple.com/v1/apps/app-1/appStoreVersions?limit=200",
+		"GET " + nextURL,
+	}
+	if !slices.Equal(requests, wantRequests) {
+		t.Fatalf("request sequence = %v, want %v", requests, wantRequests)
+	}
+}
+
 func TestWarnAppInfoSetSubmitIncompleteLocaleMentionsCanonicalPublishFlow(t *testing.T) {
 	stderr := captureAppsCreateOutput(t, func() {
 		warnAppInfoSetSubmitIncompleteLocale("en-US", asc.AppStoreVersionLocalizationAttributes{})

--- a/internal/cli/cmdtest/app_info_set_batch_test.go
+++ b/internal/cli/cmdtest/app_info_set_batch_test.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -15,6 +17,8 @@ import (
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestAppInfoSetBatchValidationErrors(t *testing.T) {
@@ -334,35 +338,71 @@ func TestAppsInfoEditTargetsLatestVersionAcrossPages(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
 	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appStoreVersions?cursor=page-2"
 	requests := make([]string, 0, 4)
 	patchBody := ""
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	oldVersionRequested := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("request is missing bearer authorization: %s %s", req.Method, req.URL.String())
+			http.Error(w, "missing authorization", http.StatusUnauthorized)
+			return
+		}
 		requests = append(requests, req.Method+" "+req.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions" && req.URL.Query().Get("cursor") == "":
-			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"old","attributes":{"createdDate":"2026-01-01T00:00:00Z"}}],"links":{"next":"`+nextURL+`"}}`), nil
-		case req.Method == http.MethodGet && req.URL.String() == nextURL:
-			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"new","attributes":{"createdDate":"2026-02-01T00:00:00Z"}}]}`), nil
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreVersions","id":"old","attributes":{"createdDate":"2026-01-01T00:00:00Z"}}],"links":{"next":"`+nextURL+`"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions" && req.URL.Query().Get("cursor") == "page-2":
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreVersions","id":"new","attributes":{"createdDate":"2026-02-01T00:00:00Z"}}]}`)
 		case req.Method == http.MethodGet && (req.URL.Path == "/v1/appStoreVersions/new/appStoreVersionLocalizations" || req.URL.Path == "/v1/appStoreVersions/old/appStoreVersionLocalizations"):
 			versionID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/appStoreVersions/"), "/appStoreVersionLocalizations")
-			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-`+versionID+`","attributes":{"locale":"en-US","description":"Description","keywords":"keywords","supportUrl":"https://example.com/support","whatsNew":"Old notes"}}]}`), nil
+			oldVersionRequested = versionID == "old"
+			_, _ = io.WriteString(w, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-`+versionID+`","attributes":{"locale":"en-US","description":"Description","keywords":"keywords","supportUrl":"https://example.com/support","whatsNew":"Old notes"}}]}`)
 		case req.Method == http.MethodPatch && (req.URL.Path == "/v1/appStoreVersionLocalizations/loc-new" || req.URL.Path == "/v1/appStoreVersionLocalizations/loc-old"):
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
-				t.Fatalf("read PATCH body: %v", err)
+				t.Errorf("read PATCH body: %v", err)
+				http.Error(w, "failed to read body", http.StatusInternalServerError)
+				return
 			}
 			patchBody = string(body)
 			localizationID := strings.TrimPrefix(req.URL.Path, "/v1/appStoreVersionLocalizations/")
-			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"`+localizationID+`","attributes":{"locale":"en-US","whatsNew":"Fixes"}}}`), nil
+			oldVersionRequested = oldVersionRequested || localizationID == "loc-old"
+			_, _ = io.WriteString(w, `{"data":{"type":"appStoreVersionLocalizations","id":"`+localizationID+`","attributes":{"locale":"en-US","whatsNew":"Fixes"}}}`)
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
 		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Scheme != "https" || req.URL.Host != "api.appstoreconnect.apple.com" {
+			return nil, errors.New("test transport received a non-App Store Connect URL")
+		}
+		routed := req.Clone(req.Context())
+		routed.URL.Scheme = serverURL.Scheme
+		routed.URL.Host = serverURL.Host
+		routed.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(routed)
 	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -390,6 +430,9 @@ func TestAppsInfoEditTargetsLatestVersionAcrossPages(t *testing.T) {
 	}
 	if !slices.Equal(requests, wantRequests) {
 		t.Fatalf("request sequence = %v, want %v", requests, wantRequests)
+	}
+	if oldVersionRequested {
+		t.Fatal("edit requested the older version's localization")
 	}
 	if !strings.Contains(patchBody, `"whatsNew":"Fixes"`) {
 		t.Fatalf("expected latest localization PATCH body to contain whatsNew, got %q", patchBody)

--- a/internal/cli/cmdtest/app_info_set_batch_test.go
+++ b/internal/cli/cmdtest/app_info_set_batch_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -325,6 +326,73 @@ func TestAppInfoSetBatchDryRunInlineLocales(t *testing.T) {
 	}
 	if byLocale["de-DE"]["action"] != "create" || byLocale["de-DE"]["status"] != "planned" {
 		t.Fatalf("expected de-DE to be planned create, got %+v", byLocale["de-DE"])
+	}
+}
+
+func TestAppsInfoEditTargetsLatestVersionAcrossPages(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appStoreVersions?cursor=page-2"
+	requests := make([]string, 0, 4)
+	patchBody := ""
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.RequestURI())
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions" && req.URL.Query().Get("cursor") == "":
+			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"old","attributes":{"createdDate":"2026-01-01T00:00:00Z"}}],"links":{"next":"`+nextURL+`"}}`), nil
+		case req.Method == http.MethodGet && req.URL.String() == nextURL:
+			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"new","attributes":{"createdDate":"2026-02-01T00:00:00Z"}}]}`), nil
+		case req.Method == http.MethodGet && (req.URL.Path == "/v1/appStoreVersions/new/appStoreVersionLocalizations" || req.URL.Path == "/v1/appStoreVersions/old/appStoreVersionLocalizations"):
+			versionID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/appStoreVersions/"), "/appStoreVersionLocalizations")
+			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-`+versionID+`","attributes":{"locale":"en-US","description":"Description","keywords":"keywords","supportUrl":"https://example.com/support","whatsNew":"Old notes"}}]}`), nil
+		case req.Method == http.MethodPatch && (req.URL.Path == "/v1/appStoreVersionLocalizations/loc-new" || req.URL.Path == "/v1/appStoreVersionLocalizations/loc-old"):
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read PATCH body: %v", err)
+			}
+			patchBody = string(body)
+			localizationID := strings.TrimPrefix(req.URL.Path, "/v1/appStoreVersionLocalizations/")
+			return appInfoSetBatchJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersionLocalizations","id":"`+localizationID+`","attributes":{"locale":"en-US","whatsNew":"Fixes"}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"apps", "info", "edit",
+			"--app", "app-1",
+			"--locale", "en-US",
+			"--whats-new", "Fixes",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	wantRequests := []string{
+		"GET /v1/apps/app-1/appStoreVersions?limit=200",
+		"GET /v1/apps/app-1/appStoreVersions?cursor=page-2",
+		"GET /v1/appStoreVersions/new/appStoreVersionLocalizations?filter%5Blocale%5D=en-US&limit=200",
+		"PATCH /v1/appStoreVersionLocalizations/loc-new",
+	}
+	if !slices.Equal(requests, wantRequests) {
+		t.Fatalf("request sequence = %v, want %v", requests, wantRequests)
+	}
+	if !strings.Contains(patchBody, `"whatsNew":"Fixes"`) {
+		t.Fatalf("expected latest localization PATCH body to contain whatsNew, got %q", patchBody)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Follow every `appStoreVersions` continuation before choosing the newest version for implicit `apps info view` and `apps info edit` resolution.
- Return continuation errors instead of selecting a version from partial data.

## Tests

- Two-page resolver test checks the selected version and exact GET order.
- Command test checks that `apps info edit` reads the newest version's localization and PATCHes its payload.
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built `/tmp/asc-app-info-complete-version-pages`; checked both command help surfaces and ran a read-only single-page lookup against the disposable app.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788930269&installation_model_id=10418&pr_number=1939&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1939&signature=163b2287394e9a3097cd1063c5624fe2b98da044787d8cd0f29daa19c33aab66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App information updates now reliably identify the latest App Store version across all available pages.
  * Localization updates are applied to the correct latest version when version results are paginated.
  * Unexpected response formats now produce a clear error instead of potentially incorrect behavior.

* **Tests**
  * Added coverage for multi-page version retrieval, authorization, error handling, and update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->