### PR TITLE
Renew ratings country request deadlines

### DIFF
--- a/internal/cli/reviews/reviews_ratings.go
+++ b/internal/cli/reviews/reviews_ratings.go
@@ -85,19 +85,20 @@ func executeRatingsWithClient(ctx context.Context, client *itunes.Client, appID,
 		return err
 	}
 
-	requestCtx, cancel := shared.ContextWithTimeout(ctx)
-	defer cancel()
-
-	resolvedAppID, err := resolveRatingsAppID(requestCtx, client, appID, ratingsAppLookupCountry(country, all))
+	resolveCtx, resolveCancel := shared.ContextWithTimeout(ctx)
+	resolvedAppID, err := resolveRatingsAppID(resolveCtx, client, appID, ratingsAppLookupCountry(country, all))
+	resolveCancel()
 	if err != nil {
 		return fmt.Errorf("reviews ratings: %w", err)
 	}
 
 	if all {
-		return executeAllRatings(requestCtx, client, resolvedAppID, workers, format, pretty)
+		return executeAllRatings(ctx, client, resolvedAppID, workers, format, pretty)
 	}
 
-	return executeSingleRatings(requestCtx, client, resolvedAppID, country, format, pretty)
+	countryCtx, countryCancel := shared.ContextWithTimeout(ctx)
+	defer countryCancel()
+	return executeSingleRatings(countryCtx, client, resolvedAppID, country, format, pretty)
 }
 
 func ratingsAppLookupCountry(country string, all bool) string {
@@ -182,7 +183,7 @@ func executeSingleRatings(ctx context.Context, client *itunes.Client, appID, cou
 }
 
 func executeAllRatings(ctx context.Context, client *itunes.Client, appID string, workers int, output string, pretty bool) error {
-	global, err := client.GetAllRatings(ctx, appID, workers)
+	global, err := client.GetAllRatings(ctx, appID, workers, shared.ContextWithTimeout)
 	if err != nil {
 		return fmt.Errorf("reviews ratings: %w", err)
 	}

--- a/internal/cli/reviews/reviews_ratings_test.go
+++ b/internal/cli/reviews/reviews_ratings_test.go
@@ -2,6 +2,7 @@ package reviews
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -132,6 +133,43 @@ func TestRatingsAllRenewsCountryOperationDeadlines(t *testing.T) {
 	}
 	if !firstCountryHistogram.deadline.Equal(countryLookups[0].deadline) {
 		t.Fatalf("first country histogram deadline = %s, want country operation deadline %s", firstCountryHistogram.deadline, countryLookups[0].deadline)
+	}
+}
+
+func TestRatingsAllDeadlineDoesNotPrintSuccessOutput(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "1ns")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"resultCount":1,"results":[{"trackId":123,"trackName":"Deadline App","averageUserRating":4.5,"userRatingCount":10}]}`)
+	}))
+	defer server.Close()
+
+	client := &itunes.Client{BaseURL: server.URL, HTTPClient: server.Client()}
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	originalStdout := os.Stdout
+	os.Stdout = stdoutWriter
+	commandErr := executeRatingsWithClient(context.Background(), client, "123", "us", true, 1, "json", false)
+	os.Stdout = originalStdout
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	output, err := io.ReadAll(stdoutReader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := stdoutReader.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+
+	if !errors.Is(commandErr, context.DeadlineExceeded) {
+		t.Fatalf("executeRatingsWithClient() error = %v, want context.DeadlineExceeded", commandErr)
+	}
+	if len(output) != 0 {
+		t.Fatalf("stdout = %q, want no success output", output)
 	}
 }
 

--- a/internal/cli/reviews/reviews_ratings_test.go
+++ b/internal/cli/reviews/reviews_ratings_test.go
@@ -5,12 +5,135 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/itunes"
 )
+
+func TestRatingsAllRenewsCountryOperationDeadlines(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", time.Hour.String())
+
+	type observedRequest struct {
+		kind     string
+		country  string
+		deadline time.Time
+	}
+
+	var (
+		mu                 sync.Mutex
+		observed           []observedRequest
+		countryLookupCount int
+	)
+	record := func(req *http.Request, kind, country string) int {
+		t.Helper()
+		deadline, ok := req.Context().Deadline()
+		if !ok {
+			t.Errorf("%s request for %q has no deadline", kind, country)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		observed = append(observed, observedRequest{kind: kind, country: country, deadline: deadline})
+		if kind == "country lookup" {
+			countryLookupCount++
+			return countryLookupCount
+		}
+		return 0
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.URL.Path == "/lookup" && req.URL.Query().Get("bundleId") != "":
+			time.Sleep(5 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"resultCount":1,"results":[{"trackId":123,"trackName":"Deadline App","bundleId":"com.example.deadlines"}]}`)
+		case req.URL.Path == "/lookup":
+			mu.Lock()
+			lookupNumber := countryLookupCount
+			mu.Unlock()
+			if lookupNumber == 1 {
+				time.Sleep(5 * time.Millisecond)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"resultCount":1,"results":[{"trackId":123,"trackName":"Deadline App","averageUserRating":4.5,"userRatingCount":10}]}`)
+		case strings.Contains(req.URL.Path, "/customer-reviews/id123"):
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = io.WriteString(w, `<span class="total">10</span>`)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer server.Close()
+
+	serverClient := server.Client()
+	baseTransport := serverClient.Transport
+	serverClient.Transport = reviewRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.Path == "/lookup" && req.URL.Query().Get("bundleId") != "":
+			record(req, "app resolution", req.URL.Query().Get("country"))
+		case req.URL.Path == "/lookup":
+			record(req, "country lookup", req.URL.Query().Get("country"))
+		case strings.Contains(req.URL.Path, "/customer-reviews/id123"):
+			parts := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+			country := ""
+			if len(parts) > 0 {
+				country = parts[0]
+			}
+			record(req, "histogram", country)
+		}
+		return baseTransport.RoundTrip(req)
+	})
+	client := &itunes.Client{BaseURL: server.URL, HTTPClient: serverClient}
+	stdout, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open stdout sink: %v", err)
+	}
+	defer stdout.Close()
+	originalStdout := os.Stdout
+	os.Stdout = stdout
+	defer func() { os.Stdout = originalStdout }()
+
+	if err := executeRatingsWithClient(context.Background(), client, "com.example.deadlines", "us", true, 1, "json", false); err != nil {
+		t.Fatalf("executeRatingsWithClient() error: %v", err)
+	}
+
+	mu.Lock()
+	requests := append([]observedRequest(nil), observed...)
+	mu.Unlock()
+
+	var resolution observedRequest
+	var countryLookups []observedRequest
+	var firstCountryHistogram observedRequest
+	for _, request := range requests {
+		switch request.kind {
+		case "app resolution":
+			resolution = request
+		case "country lookup":
+			countryLookups = append(countryLookups, request)
+		case "histogram":
+			if len(countryLookups) > 0 && request.country == countryLookups[0].country && firstCountryHistogram.deadline.IsZero() {
+				firstCountryHistogram = request
+			}
+		}
+	}
+	if resolution.deadline.IsZero() || len(countryLookups) < 2 || firstCountryHistogram.deadline.IsZero() {
+		t.Fatalf("missing deadline observations: resolution=%v lookups=%d histogram=%v", resolution, len(countryLookups), firstCountryHistogram)
+	}
+	if !countryLookups[0].deadline.After(resolution.deadline) {
+		t.Fatalf("first country deadline = %s, want later than app resolution deadline %s", countryLookups[0].deadline, resolution.deadline)
+	}
+	if !countryLookups[1].deadline.After(countryLookups[0].deadline) {
+		t.Fatalf("second country deadline = %s, want later than first country deadline %s", countryLookups[1].deadline, countryLookups[0].deadline)
+	}
+	if !firstCountryHistogram.deadline.Equal(countryLookups[0].deadline) {
+		t.Fatalf("first country histogram deadline = %s, want country operation deadline %s", firstCountryHistogram.deadline, countryLookups[0].deadline)
+	}
+}
 
 func TestNormalizeRatingsOutput(t *testing.T) {
 	tests := []struct {

--- a/internal/itunes/client_test.go
+++ b/internal/itunes/client_test.go
@@ -2,6 +2,7 @@ package itunes
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -271,7 +272,7 @@ func TestGetAllRatings_Aggregation(t *testing.T) {
 		},
 	}
 
-	global, err := client.GetAllRatings(context.Background(), "123", 5)
+	global, err := client.GetAllRatings(context.Background(), "123", 5, context.WithCancel)
 	if err != nil {
 		t.Fatalf("GetAllRatings() error: %v", err)
 	}
@@ -318,12 +319,12 @@ func TestGetAllRatings_InvalidWorkers(t *testing.T) {
 	}
 
 	// Should not panic with workers < 1
-	_, err := client.GetAllRatings(context.Background(), "123", 0)
+	_, err := client.GetAllRatings(context.Background(), "123", 0, context.WithCancel)
 	if err != nil {
 		t.Logf("GetAllRatings with workers=0 returned: %v", err)
 	}
 
-	_, err = client.GetAllRatings(context.Background(), "123", -5)
+	_, err = client.GetAllRatings(context.Background(), "123", -5, context.WithCancel)
 	if err != nil {
 		t.Logf("GetAllRatings with workers=-5 returned: %v", err)
 	}
@@ -359,7 +360,7 @@ func TestGetAllRatings_NoRatings(t *testing.T) {
 		},
 	}
 
-	global, err := client.GetAllRatings(context.Background(), "123", 5)
+	global, err := client.GetAllRatings(context.Background(), "123", 5, context.WithCancel)
 	if err != nil {
 		t.Fatalf("GetAllRatings() error: %v", err)
 	}
@@ -390,9 +391,9 @@ func TestGetAllRatings_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, err := client.GetAllRatings(ctx, "123", 5)
-	if err == nil {
-		t.Log("GetAllRatings completed despite cancelled context (may have cached)")
+	_, err := client.GetAllRatings(ctx, "123", 5, context.WithCancel)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAllRatings() error = %v, want context.Canceled", err)
 	}
 }
 

--- a/internal/itunes/client_test.go
+++ b/internal/itunes/client_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestGetRatings_Success(t *testing.T) {
@@ -397,6 +400,87 @@ func TestGetAllRatings_ContextCancellation(t *testing.T) {
 	}
 }
 
+func TestGetAllRatings_CountryDeadlineExceeded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeBody(t, w, `{"resultCount":1,"results":[{"trackId":123,"trackName":"Test","averageUserRating":4.0,"userRatingCount":10}]}`)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		HTTPClient: &http.Client{
+			Transport: &testTransport{baseURL: server.URL},
+		},
+	}
+
+	var countries atomic.Int32
+	newCountryContext := func(parent context.Context) (context.Context, context.CancelFunc) {
+		if countries.Add(1) == 1 {
+			return context.WithDeadline(parent, time.Now().Add(-time.Second))
+		}
+		return context.WithCancel(parent)
+	}
+
+	_, err := client.GetAllRatings(context.Background(), "123", 1, newCountryContext)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetAllRatings() error = %v, want context.DeadlineExceeded", err)
+	}
+	if got := countries.Load(); got != 1 {
+		t.Fatalf("country context factory called %d times, want 1 after deadline cancellation", got)
+	}
+}
+
+func TestGetAllRatings_HistogramDeadlineIsNonFatal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/lookup":
+			w.Header().Set("Content-Type", "application/json")
+			writeBody(t, w, `{"resultCount":1,"results":[{"trackId":123,"trackName":"Test","averageUserRating":4.0,"userRatingCount":10}]}`)
+		case strings.Contains(r.URL.Path, "/customer-reviews/id123"):
+			w.Header().Set("Content-Type", "text/html")
+			writeBody(t, w, `<span class="total">10</span>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	baseTransport := &testTransport{baseURL: server.URL}
+	var histogramTimedOut atomic.Bool
+	client := &Client{
+		HTTPClient: &http.Client{
+			Transport: ratingsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, "/customer-reviews/") && req.Context().Value(histogramDeadlineContextKey{}) != nil {
+					<-req.Context().Done()
+					histogramTimedOut.Store(true)
+					return nil, req.Context().Err()
+				}
+				return baseTransport.RoundTrip(req)
+			}),
+		},
+	}
+
+	var countries atomic.Int32
+	newCountryContext := func(parent context.Context) (context.Context, context.CancelFunc) {
+		if countries.Add(1) == 1 {
+			marked := context.WithValue(parent, histogramDeadlineContextKey{}, true)
+			return context.WithTimeout(marked, 500*time.Millisecond)
+		}
+		return context.WithCancel(parent)
+	}
+
+	global, err := client.GetAllRatings(context.Background(), "123", 1, newCountryContext)
+	if err != nil {
+		t.Fatalf("GetAllRatings() error: %v", err)
+	}
+	if !histogramTimedOut.Load() {
+		t.Fatal("expected one best-effort histogram request to reach its child deadline")
+	}
+	if global.CountryCount != len(AllCountries()) {
+		t.Fatalf("CountryCount = %d, want %d", global.CountryCount, len(AllCountries()))
+	}
+}
+
 // testTransport rewrites requests to use the test server URL.
 type testTransport struct {
 	baseURL string
@@ -407,6 +491,14 @@ func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.URL.Scheme = "http"
 	req.URL.Host = t.baseURL[7:] // strip "http://"
 	return http.DefaultTransport.RoundTrip(req)
+}
+
+type histogramDeadlineContextKey struct{}
+
+type ratingsRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn ratingsRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func writeBody(t *testing.T, w http.ResponseWriter, body string) {

--- a/internal/itunes/ratings.go
+++ b/internal/itunes/ratings.go
@@ -115,9 +115,17 @@ func (c *Client) fetchHistogram(ctx context.Context, appID, country string, rati
 }
 
 // GetAllRatings fetches rating statistics for an app across all supported countries.
-func (c *Client) GetAllRatings(ctx context.Context, appID string, workers int) (*GlobalRatings, error) {
+func (c *Client) GetAllRatings(
+	ctx context.Context,
+	appID string,
+	workers int,
+	newCountryContext func(context.Context) (context.Context, context.CancelFunc),
+) (*GlobalRatings, error) {
 	if workers < 1 {
 		workers = 10
+	}
+	if newCountryContext == nil {
+		return nil, fmt.Errorf("country context factory is required")
 	}
 
 	countries := AllCountries()
@@ -148,7 +156,9 @@ func (c *Client) GetAllRatings(ctx context.Context, appID string, workers int) (
 				defer func() { <-sem }()
 			}
 
-			ratings, err := c.GetRatings(ctx, appID, country)
+			countryCtx, countryCancel := newCountryContext(ctx)
+			ratings, err := c.GetRatings(countryCtx, appID, country)
+			countryCancel()
 			if err != nil {
 				return
 			}

--- a/internal/itunes/ratings.go
+++ b/internal/itunes/ratings.go
@@ -2,6 +2,7 @@ package itunes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -128,18 +129,23 @@ func (c *Client) GetAllRatings(
 		return nil, fmt.Errorf("country context factory is required")
 	}
 
+	workCtx, cancelWork := context.WithCancel(ctx)
+	defer cancelWork()
+
 	countries := AllCountries()
 
 	var (
-		mu        sync.Mutex
-		wg        sync.WaitGroup
-		results   []*AppRatings
-		appName   string
-		appIDInt  int64
-		total     int64
-		weighted  float64
-		found     bool
-		histogram = make(map[int]int64)
+		mu                 sync.Mutex
+		wg                 sync.WaitGroup
+		deadlineOnce       sync.Once
+		countryDeadlineErr error
+		results            []*AppRatings
+		appName            string
+		appIDInt           int64
+		total              int64
+		weighted           float64
+		found              bool
+		histogram          = make(map[int]int64)
 	)
 
 	sem := make(chan struct{}, workers)
@@ -150,15 +156,26 @@ func (c *Client) GetAllRatings(
 			defer wg.Done()
 
 			select {
-			case <-ctx.Done():
+			case <-workCtx.Done():
 				return
 			case sem <- struct{}{}:
 				defer func() { <-sem }()
 			}
+			if workCtx.Err() != nil {
+				return
+			}
 
-			countryCtx, countryCancel := newCountryContext(ctx)
+			countryCtx, countryCancel := newCountryContext(workCtx)
 			ratings, err := c.GetRatings(countryCtx, appID, country)
+			countryErr := countryCtx.Err()
 			countryCancel()
+			if err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(countryErr, context.DeadlineExceeded)) {
+				deadlineOnce.Do(func() {
+					countryDeadlineErr = context.DeadlineExceeded
+					cancelWork()
+				})
+				return
+			}
 			if err != nil {
 				return
 			}
@@ -188,6 +205,9 @@ func (c *Client) GetAllRatings(
 
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
+	}
+	if countryDeadlineErr != nil {
+		return nil, countryDeadlineErr
 	}
 	if !found {
 		return nil, fmt.Errorf("app not found in any country: %s", appID)


### PR DESCRIPTION
## Summary
- give app identifier resolution its own request deadline
- renew the deadline for each all-country ratings operation
- cancel queued country work and return `DeadlineExceeded` when a country lookup exhausts its child deadline, preventing partial success output
- preserve best-effort handling for unavailable storefronts and histogram-only timeouts

## Validation
- focused ratings contracts and race tests repeated 10 times
- focused reviews, iTunes, and command-level ratings tests
- built-binary single-country and all-country read-only checks with `ASC_TIMEOUT=2s`
- built-binary forced timeout: nonzero exit, zero stdout bytes, standard timeout diagnostic
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`