### PR TITLE
fix(app-setup): validate localization plans before writes

### DIFF
--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 // AppSetupCommand returns the app-setup command group.
@@ -158,6 +159,13 @@ Examples:
 					fmt.Fprintf(os.Stderr, "Error: --content-rights must be %s or %s\n", asc.ContentRightsDeclarationDoesNotUseThirdPartyContent, asc.ContentRightsDeclarationUsesThirdPartyContent)
 					return flag.ErrHelp
 				}
+			}
+
+			for _, issue := range validation.AppInfoLocalizationLengthIssues(validation.AppInfoLocalization{
+				Name:     nameValue,
+				Subtitle: subtitleValue,
+			}) {
+				return shared.UsageErrorf("--%s exceeds %d %s", issue.Field, issue.Limit, issue.Unit)
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -168,6 +168,56 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
+			var localizationAttrs asc.AppInfoLocalizationAttributes
+			var resolvedAppInfoID string
+			var localizationID string
+			createLocalization := false
+			if hasLocalization {
+				resolvedAppInfoID, err = shared.ResolveAppInfoID(requestCtx, client, appIDValue, strings.TrimSpace(*appInfoID))
+				if err != nil {
+					return fmt.Errorf("app-setup info set: %w", err)
+				}
+
+				localizations, err := client.GetAppInfoLocalizations(
+					requestCtx,
+					resolvedAppInfoID,
+					asc.WithAppInfoLocalizationsLimit(200),
+					asc.WithAppInfoLocalizationLocales([]string{localeValue}),
+				)
+				if err != nil {
+					return fmt.Errorf("app-setup info set: failed to fetch app info localizations: %w", err)
+				}
+
+				if nameValue != "" {
+					localizationAttrs.Name = nameValue
+				}
+				if subtitleValue != "" {
+					localizationAttrs.Subtitle = subtitleValue
+				}
+				if privacyPolicyURLValue != "" {
+					localizationAttrs.PrivacyPolicyURL = privacyPolicyURLValue
+				}
+				if privacyChoicesURLValue != "" {
+					localizationAttrs.PrivacyChoicesURL = privacyChoicesURLValue
+				}
+				if privacyPolicyTextValue != "" {
+					localizationAttrs.PrivacyPolicyText = privacyPolicyTextValue
+				}
+
+				if len(localizations.Data) == 0 {
+					if nameValue == "" {
+						return shared.UsageError("--name is required when creating an app info localization")
+					}
+					localizationAttrs.Locale = localeValue
+					createLocalization = true
+				} else {
+					localizationID = strings.TrimSpace(localizations.Data[0].ID)
+					if localizationID == "" {
+						return fmt.Errorf("app-setup info set: localization id is empty")
+					}
+				}
+			}
+
 			var appResp *asc.AppResponse
 			if hasAppUpdate {
 				attrs := asc.AppUpdateAttributes{}
@@ -188,50 +238,13 @@ Examples:
 
 			var appInfoResp *asc.AppInfoLocalizationResponse
 			if hasLocalization {
-				resolvedAppInfoID, err := shared.ResolveAppInfoID(requestCtx, client, appIDValue, strings.TrimSpace(*appInfoID))
-				if err != nil {
-					return fmt.Errorf("app-setup info set: %w", err)
-				}
-
-				localizations, err := client.GetAppInfoLocalizations(
-					requestCtx,
-					resolvedAppInfoID,
-					asc.WithAppInfoLocalizationsLimit(200),
-					asc.WithAppInfoLocalizationLocales([]string{localeValue}),
-				)
-				if err != nil {
-					return fmt.Errorf("app-setup info set: failed to fetch app info localizations: %w", err)
-				}
-
-				attrs := asc.AppInfoLocalizationAttributes{}
-				if nameValue != "" {
-					attrs.Name = nameValue
-				}
-				if subtitleValue != "" {
-					attrs.Subtitle = subtitleValue
-				}
-				if privacyPolicyURLValue != "" {
-					attrs.PrivacyPolicyURL = privacyPolicyURLValue
-				}
-				if privacyChoicesURLValue != "" {
-					attrs.PrivacyChoicesURL = privacyChoicesURLValue
-				}
-				if privacyPolicyTextValue != "" {
-					attrs.PrivacyPolicyText = privacyPolicyTextValue
-				}
-
-				if len(localizations.Data) == 0 {
-					attrs.Locale = localeValue
-					appInfoResp, err = client.CreateAppInfoLocalization(requestCtx, resolvedAppInfoID, attrs)
+				if createLocalization {
+					appInfoResp, err = client.CreateAppInfoLocalization(requestCtx, resolvedAppInfoID, localizationAttrs)
 					if err != nil {
 						return fmt.Errorf("app-setup info set: %w", err)
 					}
 				} else {
-					localizationID := strings.TrimSpace(localizations.Data[0].ID)
-					if localizationID == "" {
-						return fmt.Errorf("app-setup info set: localization id is empty")
-					}
-					appInfoResp, err = client.UpdateAppInfoLocalization(requestCtx, localizationID, attrs)
+					appInfoResp, err = client.UpdateAppInfoLocalization(requestCtx, localizationID, localizationAttrs)
 					if err != nil {
 						return fmt.Errorf("app-setup info set: %w", err)
 					}

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -218,6 +218,8 @@ Examples:
 					}
 					localizationAttrs.Locale = localeValue
 					createLocalization = true
+				} else if len(localizations.Data) > 1 {
+					return fmt.Errorf("app-setup info set: multiple app info localizations found for locale %q", localeValue)
 				} else {
 					localizationID = strings.TrimSpace(localizations.Data[0].ID)
 					if localizationID == "" {

--- a/internal/cli/cmdtest/app_setup_info_preflight_test.go
+++ b/internal/cli/cmdtest/app_setup_info_preflight_test.go
@@ -170,6 +170,17 @@ func TestAppSetupInfoSetPlansExplicitLocalizationTargetBeforeWrites(t *testing.T
 					"locale":"en-US","name":"Existing App","subtitle":"Updated Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}}`,
 			},
 		},
+		{
+			name:          "update privacy policy without name",
+			args:          []string{"--privacy-policy-url", "https://example.com/privacy"},
+			localizations: `{"data":[{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Existing App"}}]}`,
+			localizationWrite: appSetupInfoHTTPStep{
+				method:       http.MethodPatch,
+				uri:          "/v1/appInfoLocalizations/loc-1",
+				requestBody:  `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"privacyPolicyUrl":"https://example.com/privacy"}}}`,
+				responseBody: `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Existing App","privacyPolicyUrl":"https://example.com/privacy"}}}`,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/app_setup_info_preflight_test.go
+++ b/internal/cli/cmdtest/app_setup_info_preflight_test.go
@@ -1,0 +1,259 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAppSetupInfoSetPlansAmbiguousLocalizationTargetBeforeMutation(t *testing.T) {
+	setupAppSetupInfoPreflightAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var requests []string
+	mutationCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		if appSetupInfoMutation(req.Method) {
+			mutationCount++
+		}
+
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appInfos":
+			return appSetupInfoResponse(http.StatusOK, `{
+				"data":[
+					{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_SALE"}},
+					{"type":"appInfos","id":"info-2","attributes":{"state":"READY_FOR_SALE"}}
+				]
+			}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/apps/app-1":
+			return appSetupInfoResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	_, _, runErr := runAppSetupInfoSet(
+		t,
+		"--app", "app-1",
+		"--bundle-id", "com.example.changed",
+		"--locale", "en-US",
+		"--name", "Example App",
+	)
+	if runErr == nil || !strings.Contains(runErr.Error(), "multiple app infos found") {
+		t.Fatalf("expected ambiguous app info error, got %v", runErr)
+	}
+	if mutationCount != 0 {
+		t.Errorf("mutation count = %d, want 0", mutationCount)
+	}
+	wantRequests := []string{"GET /v1/apps/app-1/appInfos"}
+	if !reflect.DeepEqual(requests, wantRequests) {
+		t.Errorf("requests = %v, want %v", requests, wantRequests)
+	}
+}
+
+func TestAppSetupInfoSetRejectsCreateWithoutNameBeforeMutation(t *testing.T) {
+	setupAppSetupInfoPreflightAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var requests []string
+	mutationCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		if appSetupInfoMutation(req.Method) {
+			mutationCount++
+		}
+
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-1/appInfoLocalizations":
+			assertAppSetupInfoLocalizationQuery(t, req)
+			return appSetupInfoResponse(http.StatusOK, `{"data":[]}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/apps/app-1":
+			return appSetupInfoResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appInfoLocalizations":
+			return appSetupInfoResponse(http.StatusCreated, `{"data":{"type":"appInfoLocalizations","id":"loc-created","attributes":{"locale":"en-US","subtitle":"Subtitle"}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	stdout, stderr, runErr := runAppSetupInfoSet(
+		t,
+		"--app", "app-1",
+		"--app-info", "info-1",
+		"--bundle-id", "com.example.changed",
+		"--locale", "en-US",
+		"--subtitle", "Subtitle",
+	)
+	if runErr == nil || !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--name is required when creating an app info localization") {
+		t.Errorf("expected create name usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --name is required when creating an app info localization") {
+		t.Errorf("stderr = %q, want missing name diagnostic", stderr)
+	}
+	if mutationCount != 0 {
+		t.Errorf("mutation count = %d, want 0", mutationCount)
+	}
+	wantRequests := []string{"GET /v1/appInfos/info-1/appInfoLocalizations"}
+	if !reflect.DeepEqual(requests, wantRequests) {
+		t.Errorf("requests = %v, want %v", requests, wantRequests)
+	}
+}
+
+func TestAppSetupInfoSetPlansExplicitLocalizationTargetBeforeWrites(t *testing.T) {
+	tests := []struct {
+		name                 string
+		localizations        string
+		args                 []string
+		localizationMethod   string
+		localizationPath     string
+		localizationRequest  string
+		localizationResponse string
+	}{
+		{
+			name:                "create",
+			localizations:       `{"data":[]}`,
+			args:                []string{"--name", "Example App", "--subtitle", "Subtitle"},
+			localizationMethod:  http.MethodPost,
+			localizationPath:    "/v1/appInfoLocalizations",
+			localizationRequest: `{"data":{"type":"appInfoLocalizations","attributes":{"locale":"en-US","name":"Example App","subtitle":"Subtitle"},"relationships":{"appInfo":{"data":{"type":"appInfos","id":"info-1"}}}}}`,
+			localizationResponse: `{
+				"data":{"type":"appInfoLocalizations","id":"loc-created","attributes":{"locale":"en-US","name":"Example App","subtitle":"Subtitle"}}
+			}`,
+		},
+		{
+			name:                "update without name",
+			localizations:       `{"data":[{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Existing App"}}]}`,
+			args:                []string{"--subtitle", "Updated Subtitle", "--privacy-policy-url", "https://example.com/privacy"},
+			localizationMethod:  http.MethodPatch,
+			localizationPath:    "/v1/appInfoLocalizations/loc-1",
+			localizationRequest: `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"subtitle":"Updated Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}}`,
+			localizationResponse: `{
+				"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Existing App","subtitle":"Updated Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAppSetupInfoPreflightAuth(t)
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() {
+				http.DefaultTransport = originalTransport
+			})
+
+			var requests []string
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests = append(requests, req.Method+" "+req.URL.Path)
+
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-1/appInfoLocalizations":
+					assertAppSetupInfoLocalizationQuery(t, req)
+					return appSetupInfoResponse(http.StatusOK, test.localizations), nil
+				case req.Method == http.MethodPatch && req.URL.Path == "/v1/apps/app-1":
+					assertJSONDocument(t, req.Body, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`)
+					return appSetupInfoResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`), nil
+				case req.Method == test.localizationMethod && req.URL.Path == test.localizationPath:
+					assertJSONDocument(t, req.Body, test.localizationRequest)
+					return appSetupInfoResponse(http.StatusOK, test.localizationResponse), nil
+				default:
+					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+			})
+
+			args := []string{
+				"--app", "app-1",
+				"--app-info", "info-1",
+				"--bundle-id", "com.example.changed",
+				"--locale", "en-US",
+			}
+			args = append(args, test.args...)
+			stdout, stderr, runErr := runAppSetupInfoSet(t, args...)
+			if runErr != nil {
+				t.Fatalf("run error: %v (stderr=%q)", runErr, stderr)
+			}
+			if !strings.Contains(stdout, `"appId":"app-1"`) {
+				t.Fatalf("unexpected stdout: %q", stdout)
+			}
+
+			wantRequests := []string{
+				"GET /v1/appInfos/info-1/appInfoLocalizations",
+				"PATCH /v1/apps/app-1",
+				test.localizationMethod + " " + test.localizationPath,
+			}
+			if !reflect.DeepEqual(requests, wantRequests) {
+				t.Errorf("requests = %v, want %v", requests, wantRequests)
+			}
+		})
+	}
+}
+
+func setupAppSetupInfoPreflightAuth(t *testing.T) {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+}
+
+func runAppSetupInfoSet(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		parseArgs := append([]string{"app-setup", "info", "set"}, args...)
+		if err := root.Parse(parseArgs); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func assertAppSetupInfoLocalizationQuery(t *testing.T, req *http.Request) {
+	t.Helper()
+	if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
+		t.Fatalf("filter[locale] = %q, want en-US", got)
+	}
+	if got := req.URL.Query().Get("limit"); got != "200" {
+		t.Fatalf("limit = %q, want 200", got)
+	}
+}
+
+func appSetupInfoMutation(method string) bool {
+	switch method {
+	case http.MethodPatch, http.MethodPost, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func appSetupInfoResponse(status int, body string) *http.Response {
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/internal/cli/cmdtest/app_setup_info_preflight_test.go
+++ b/internal/cli/cmdtest/app_setup_info_preflight_test.go
@@ -7,204 +7,258 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
-func TestAppSetupInfoSetPlansAmbiguousLocalizationTargetBeforeMutation(t *testing.T) {
-	setupAppSetupInfoPreflightAuth(t)
+const appSetupInfoLocalizationsURI = "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200"
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	var requests []string
-	mutationCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.Path)
-		if appSetupInfoMutation(req.Method) {
-			mutationCount++
-		}
-
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appInfos":
-			return appSetupInfoResponse(http.StatusOK, `{
-				"data":[
-					{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_SALE"}},
-					{"type":"appInfos","id":"info-2","attributes":{"state":"READY_FOR_SALE"}}
-				]
-			}`), nil
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/apps/app-1":
-			return appSetupInfoResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`), nil
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-		}
-	})
-
-	_, _, runErr := runAppSetupInfoSet(
-		t,
-		"--app", "app-1",
-		"--bundle-id", "com.example.changed",
-		"--locale", "en-US",
-		"--name", "Example App",
-	)
-	if runErr == nil || !strings.Contains(runErr.Error(), "multiple app infos found") {
-		t.Fatalf("expected ambiguous app info error, got %v", runErr)
-	}
-	if mutationCount != 0 {
-		t.Errorf("mutation count = %d, want 0", mutationCount)
-	}
-	wantRequests := []string{"GET /v1/apps/app-1/appInfos"}
-	if !reflect.DeepEqual(requests, wantRequests) {
-		t.Errorf("requests = %v, want %v", requests, wantRequests)
-	}
+type appSetupInfoHTTPStep struct {
+	method       string
+	uri          string
+	requestBody  string
+	responseBody string
+	status       int
 }
 
-func TestAppSetupInfoSetRejectsCreateWithoutNameBeforeMutation(t *testing.T) {
-	setupAppSetupInfoPreflightAuth(t)
+func TestAppSetupInfoSetRejectsOverLimitLocalizationBeforeClient(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	var requests []string
-	mutationCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests = append(requests, req.Method+" "+req.URL.Path)
-		if appSetupInfoMutation(req.Method) {
-			mutationCount++
-		}
-
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-1/appInfoLocalizations":
-			assertAppSetupInfoLocalizationQuery(t, req)
-			return appSetupInfoResponse(http.StatusOK, `{"data":[]}`), nil
-		case req.Method == http.MethodPatch && req.URL.Path == "/v1/apps/app-1":
-			return appSetupInfoResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`), nil
-		case req.Method == http.MethodPost && req.URL.Path == "/v1/appInfoLocalizations":
-			return appSetupInfoResponse(http.StatusCreated, `{"data":{"type":"appInfoLocalizations","id":"loc-created","attributes":{"locale":"en-US","subtitle":"Subtitle"}}}`), nil
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-		}
-	})
-
-	stdout, stderr, runErr := runAppSetupInfoSet(
-		t,
-		"--app", "app-1",
-		"--app-info", "info-1",
-		"--bundle-id", "com.example.changed",
-		"--locale", "en-US",
-		"--subtitle", "Subtitle",
-	)
-	if runErr == nil || !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--name is required when creating an app info localization") {
-		t.Errorf("expected create name usage error, got %v", runErr)
-	}
-	if stdout != "" {
-		t.Errorf("stdout = %q, want empty", stdout)
-	}
-	if !strings.Contains(stderr, "Error: --name is required when creating an app info localization") {
-		t.Errorf("stderr = %q, want missing name diagnostic", stderr)
-	}
-	if mutationCount != 0 {
-		t.Errorf("mutation count = %d, want 0", mutationCount)
-	}
-	wantRequests := []string{"GET /v1/appInfos/info-1/appInfoLocalizations"}
-	if !reflect.DeepEqual(requests, wantRequests) {
-		t.Errorf("requests = %v, want %v", requests, wantRequests)
-	}
-}
-
-func TestAppSetupInfoSetPlansExplicitLocalizationTargetBeforeWrites(t *testing.T) {
 	tests := []struct {
-		name                 string
-		localizations        string
-		args                 []string
-		localizationMethod   string
-		localizationPath     string
-		localizationRequest  string
-		localizationResponse string
+		field     string
+		limit     int
+		fieldFlag string
+	}{
+		{field: "name", limit: validation.LimitName, fieldFlag: "--name"},
+		{field: "subtitle", limit: validation.LimitSubtitle, fieldFlag: "--subtitle"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.field, func(t *testing.T) {
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return nil, errors.New("client should not be created")
+			}))
+
+			stdout, stderr, runErr := runAppSetupInfoSet(
+				t,
+				"--app", "app-1",
+				"--bundle-id", "com.example.changed",
+				"--locale", "en-US",
+				test.fieldFlag, strings.Repeat("x", test.limit+1),
+			)
+			wantError := fmt.Sprintf("--%s exceeds %d characters", test.field, test.limit)
+			if runErr == nil || !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), wantError) {
+				t.Errorf("expected %q usage error, got %v", wantError, runErr)
+			}
+			if stdout != "" || !strings.Contains(stderr, "Error: "+wantError) {
+				t.Errorf("stdout = %q, stderr = %q, want only %q diagnostic", stdout, stderr, "Error: "+wantError)
+			}
+			if clientFactoryCalls != 0 {
+				t.Errorf("client factory calls = %d, want 0", clientFactoryCalls)
+			}
+		})
+	}
+}
+
+func TestAppSetupInfoSetPlanningFailuresDoNotMutate(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		steps     []appSetupInfoHTTPStep
+		wantError string
+		usage     bool
 	}{
 		{
-			name:                "create",
-			localizations:       `{"data":[]}`,
-			args:                []string{"--name", "Example App", "--subtitle", "Subtitle"},
-			localizationMethod:  http.MethodPost,
-			localizationPath:    "/v1/appInfoLocalizations",
-			localizationRequest: `{"data":{"type":"appInfoLocalizations","attributes":{"locale":"en-US","name":"Example App","subtitle":"Subtitle"},"relationships":{"appInfo":{"data":{"type":"appInfos","id":"info-1"}}}}}`,
-			localizationResponse: `{
-				"data":{"type":"appInfoLocalizations","id":"loc-created","attributes":{"locale":"en-US","name":"Example App","subtitle":"Subtitle"}}
-			}`,
+			name: "ambiguous app info",
+			args: []string{"--app", "app-1", "--bundle-id", "com.example.changed", "--locale", "en-US", "--name", "Example App"},
+			steps: []appSetupInfoHTTPStep{{
+				method: http.MethodGet,
+				uri:    "/v1/apps/app-1/appInfos",
+				responseBody: `{"data":[
+					{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_SALE"}},
+					{"type":"appInfos","id":"info-2","attributes":{"state":"READY_FOR_SALE"}}
+				]}`,
+			}},
+			wantError: "multiple app infos found",
 		},
 		{
-			name:                "update without name",
-			localizations:       `{"data":[{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Existing App"}}]}`,
-			args:                []string{"--subtitle", "Updated Subtitle", "--privacy-policy-url", "https://example.com/privacy"},
-			localizationMethod:  http.MethodPatch,
-			localizationPath:    "/v1/appInfoLocalizations/loc-1",
-			localizationRequest: `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"subtitle":"Updated Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}}`,
-			localizationResponse: `{
-				"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Existing App","subtitle":"Updated Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}
-			}`,
+			name:      "create without name",
+			args:      []string{"--app", "app-1", "--app-info", "info-1", "--bundle-id", "com.example.changed", "--locale", "en-US", "--subtitle", "Subtitle"},
+			steps:     []appSetupInfoHTTPStep{{method: http.MethodGet, uri: appSetupInfoLocalizationsURI, responseBody: `{"data":[]}`}},
+			wantError: "--name is required when creating an app info localization",
+			usage:     true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			setupAppSetupInfoPreflightAuth(t)
-
-			originalTransport := http.DefaultTransport
-			t.Cleanup(func() {
-				http.DefaultTransport = originalTransport
-			})
-
-			var requests []string
-			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				requests = append(requests, req.Method+" "+req.URL.Path)
-
-				switch {
-				case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-1/appInfoLocalizations":
-					assertAppSetupInfoLocalizationQuery(t, req)
-					return appSetupInfoResponse(http.StatusOK, test.localizations), nil
-				case req.Method == http.MethodPatch && req.URL.Path == "/v1/apps/app-1":
-					assertJSONDocument(t, req.Body, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`)
-					return appSetupInfoResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`), nil
-				case req.Method == test.localizationMethod && req.URL.Path == test.localizationPath:
-					assertJSONDocument(t, req.Body, test.localizationRequest)
-					return appSetupInfoResponse(http.StatusOK, test.localizationResponse), nil
-				default:
-					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-				}
-			})
-
-			args := []string{
-				"--app", "app-1",
-				"--app-info", "info-1",
-				"--bundle-id", "com.example.changed",
-				"--locale", "en-US",
+			stdout, stderr, mutationCount, runErr := runAppSetupInfoSetWithServer(t, test.steps, test.args...)
+			if runErr == nil || !strings.Contains(runErr.Error(), test.wantError) {
+				t.Fatalf("expected %q error, got %v", test.wantError, runErr)
 			}
-			args = append(args, test.args...)
-			stdout, stderr, runErr := runAppSetupInfoSet(t, args...)
-			if runErr != nil {
-				t.Fatalf("run error: %v (stderr=%q)", runErr, stderr)
+			if test.usage && !errors.Is(runErr, flag.ErrHelp) {
+				t.Errorf("error = %v, want usage classification", runErr)
 			}
-			if !strings.Contains(stdout, `"appId":"app-1"`) {
-				t.Fatalf("unexpected stdout: %q", stdout)
+			if stdout != "" || mutationCount != 0 {
+				t.Errorf("stdout = %q, mutation count = %d; want empty output and zero mutations", stdout, mutationCount)
 			}
-
-			wantRequests := []string{
-				"GET /v1/appInfos/info-1/appInfoLocalizations",
-				"PATCH /v1/apps/app-1",
-				test.localizationMethod + " " + test.localizationPath,
-			}
-			if !reflect.DeepEqual(requests, wantRequests) {
-				t.Errorf("requests = %v, want %v", requests, wantRequests)
+			if test.usage && !strings.Contains(stderr, "Error: "+test.wantError) {
+				t.Errorf("stderr = %q, want %q", stderr, "Error: "+test.wantError)
 			}
 		})
 	}
+}
+
+func TestAppSetupInfoSetPlansExplicitLocalizationTargetBeforeWrites(t *testing.T) {
+	appPatch := appSetupInfoHTTPStep{
+		method:       http.MethodPatch,
+		uri:          "/v1/apps/app-1",
+		requestBody:  `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`,
+		responseBody: `{"data":{"type":"apps","id":"app-1","attributes":{"bundleId":"com.example.changed"}}}`,
+	}
+	tests := []struct {
+		name              string
+		args              []string
+		localizations     string
+		localizationWrite appSetupInfoHTTPStep
+	}{
+		{
+			name:          "create",
+			args:          []string{"--name", "Example App", "--subtitle", "Subtitle"},
+			localizations: `{"data":[]}`,
+			localizationWrite: appSetupInfoHTTPStep{
+				method:      http.MethodPost,
+				uri:         "/v1/appInfoLocalizations",
+				status:      http.StatusCreated,
+				requestBody: `{"data":{"type":"appInfoLocalizations","attributes":{"locale":"en-US","name":"Example App","subtitle":"Subtitle"},"relationships":{"appInfo":{"data":{"type":"appInfos","id":"info-1"}}}}}`,
+				responseBody: `{"data":{"type":"appInfoLocalizations","id":"loc-created","attributes":{
+					"locale":"en-US","name":"Example App","subtitle":"Subtitle"}}}`,
+			},
+		},
+		{
+			name:          "update without name",
+			args:          []string{"--subtitle", "Updated Subtitle", "--privacy-policy-url", "https://example.com/privacy"},
+			localizations: `{"data":[{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Existing App"}}]}`,
+			localizationWrite: appSetupInfoHTTPStep{
+				method:      http.MethodPatch,
+				uri:         "/v1/appInfoLocalizations/loc-1",
+				requestBody: `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"subtitle":"Updated Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}}`,
+				responseBody: `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{
+					"locale":"en-US","name":"Existing App","subtitle":"Updated Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}}`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			steps := []appSetupInfoHTTPStep{
+				{method: http.MethodGet, uri: appSetupInfoLocalizationsURI, responseBody: test.localizations},
+				appPatch,
+				test.localizationWrite,
+			}
+			args := []string{"--app", "app-1", "--app-info", "info-1", "--bundle-id", "com.example.changed", "--locale", "en-US"}
+			args = append(args, test.args...)
+			stdout, stderr, mutationCount, runErr := runAppSetupInfoSetWithServer(t, steps, args...)
+			if runErr != nil {
+				t.Fatalf("run error: %v (stderr=%q)", runErr, stderr)
+			}
+			if !strings.Contains(stdout, `"appId":"app-1"`) || mutationCount != 2 {
+				t.Errorf("stdout = %q, mutation count = %d; want app result and two ordered writes", stdout, mutationCount)
+			}
+		})
+	}
+}
+
+func runAppSetupInfoSetWithServer(t *testing.T, steps []appSetupInfoHTTPStep, args ...string) (string, string, int, error) {
+	t.Helper()
+	setupAppSetupInfoPreflightAuth(t)
+
+	var mu sync.Mutex
+	requestCount := 0
+	mutationCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		stepIndex := requestCount
+		requestCount++
+		if appSetupInfoMutation(req.Method) {
+			mutationCount++
+		}
+		mu.Unlock()
+
+		if stepIndex >= len(steps) {
+			t.Errorf("unexpected request %d: %s %s", stepIndex+1, req.Method, req.URL.RequestURI())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		step := steps[stepIndex]
+		if req.Method != step.method || req.URL.RequestURI() != step.uri {
+			t.Errorf("request %d = %s %s, want %s %s", stepIndex+1, req.Method, req.URL.RequestURI(), step.method, step.uri)
+		}
+		if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("request %d is missing bearer authorization", stepIndex+1)
+		}
+		if step.requestBody != "" {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("read request %d body: %v", stepIndex+1, err)
+			} else if strings.TrimSpace(string(body)) != step.requestBody {
+				t.Errorf("request %d body = %s, want %s", stepIndex+1, body, step.requestBody)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		status := step.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, step.responseBody)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	serverTransport := server.Client().Transport
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			cloned := req.Clone(req.Context())
+			cloned.URL.Scheme = serverURL.Scheme
+			cloned.URL.Host = serverURL.Host
+			return serverTransport.RoundTrip(cloned)
+		})},
+	)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) { return client, nil }))
+
+	stdout, stderr, runErr := runAppSetupInfoSet(t, args...)
+	mu.Lock()
+	gotRequestCount := requestCount
+	gotMutationCount := mutationCount
+	mu.Unlock()
+	if gotRequestCount != len(steps) {
+		t.Errorf("request count = %d, want %d", gotRequestCount, len(steps))
+	}
+	return stdout, stderr, gotMutationCount, runErr
 }
 
 func setupAppSetupInfoPreflightAuth(t *testing.T) {
@@ -230,30 +284,11 @@ func runAppSetupInfoSet(t *testing.T, args ...string) (string, string, error) {
 	return stdout, stderr, runErr
 }
 
-func assertAppSetupInfoLocalizationQuery(t *testing.T, req *http.Request) {
-	t.Helper()
-	if got := req.URL.Query().Get("filter[locale]"); got != "en-US" {
-		t.Fatalf("filter[locale] = %q, want en-US", got)
-	}
-	if got := req.URL.Query().Get("limit"); got != "200" {
-		t.Fatalf("limit = %q, want 200", got)
-	}
-}
-
 func appSetupInfoMutation(method string) bool {
 	switch method {
 	case http.MethodPatch, http.MethodPost, http.MethodDelete:
 		return true
 	default:
 		return false
-	}
-}
-
-func appSetupInfoResponse(status int, body string) *http.Response {
-	return &http.Response{
-		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
-		StatusCode: status,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }

--- a/internal/cli/cmdtest/app_setup_info_preflight_test.go
+++ b/internal/cli/cmdtest/app_setup_info_preflight_test.go
@@ -101,6 +101,16 @@ func TestAppSetupInfoSetPlanningFailuresDoNotMutate(t *testing.T) {
 			wantError: "--name is required when creating an app info localization",
 			usage:     true,
 		},
+		{
+			name: "ambiguous localization",
+			args: []string{"--app", "app-1", "--app-info", "info-1", "--bundle-id", "com.example.changed", "--locale", "en-US", "--name", "Example App"},
+			steps: []appSetupInfoHTTPStep{{
+				method:       http.MethodGet,
+				uri:          appSetupInfoLocalizationsURI,
+				responseBody: `{"data":[{"type":"appInfoLocalizations","id":"loc-1"},{"type":"appInfoLocalizations","id":"loc-2"}]}`,
+			}},
+			wantError: `multiple app info localizations found for locale "en-US"`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- resolve the App Info localization target before updating app attributes
- require --name only when the requested locale needs to be created
- reject over-limit localized names and subtitles before authentication or network access
- preserve existing-target subtitle and privacy-only updates and existing write payloads

## Behavior

Combined updates now complete their read-only target planning before the first write. Successful operations still update the app first and then create or update the localization. This does not add rollback or make the two writes atomic.

## Verification

- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/apps -run TestAppSetupInfoSet -count=1
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestAppSetupInfoSet -count=1
- ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run TestAppSetupInfoSet -count=1
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

No live App Store Connect mutations were used; request order and bodies are covered through a local HTTP test server.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788930595&installation_model_id=10418&pr_number=1941&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1941&signature=7777093be2a5c6fa2791f1ec80ebd40ad7fcc80bd068a69cbe82f95ff886eff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization updates for app information.
  * Commands now identify the correct localization before making changes.
  * Name and subtitle length limits are validated before updates begin.
  * Missing names are rejected when creating a localization.
  * Existing localizations are updated correctly, while new ones are created for the selected locale.
  * Failed validation or ambiguous targets no longer trigger partial changes.
* **Tests**
  * Added coverage for validation, ambiguous targets, missing names, and localization create/update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->