### PR TITLE
fix(signing): preflight fetch output before profile creation

### DIFF
--- a/internal/cli/cmdtest/signing_fetch_output_preflight_test.go
+++ b/internal/cli/cmdtest/signing_fetch_output_preflight_test.go
@@ -1,0 +1,140 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestSigningFetchPreflightsOutputBeforeProfileCreation(t *testing.T) {
+	setupAuth(t)
+
+	outputPath := filepath.Join(t.TempDir(), "not-a-directory")
+	sentinel := []byte("keep this file")
+	if err := os.WriteFile(outputPath, sentinel, 0o600); err != nil {
+		t.Fatalf("write output sentinel: %v", err)
+	}
+
+	certificateContent := base64.StdEncoding.EncodeToString([]byte("certificate"))
+	profileContent := base64.StdEncoding.EncodeToString([]byte("profile"))
+	var bundleLookups atomic.Int32
+	var profileLookups atomic.Int32
+	var certificateLookups atomic.Int32
+	var profileCreates atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds":
+			bundleLookups.Add(1)
+			if got := req.URL.Query().Get("filter[identifier]"); got != "com.example.app" {
+				t.Errorf("bundle identifier filter = %q, want com.example.app", got)
+			}
+			writeSigningFetchOutputJSON(t, w, http.StatusOK, `{"data":[{"type":"bundleIds","id":"bundle-main","attributes":{"identifier":"com.example.app"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/bundleIds/bundle-main/profiles":
+			profileLookups.Add(1)
+			writeSigningFetchOutputJSON(t, w, http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/certificates":
+			certificateLookups.Add(1)
+			writeSigningFetchOutputJSON(t, w, http.StatusOK, fmt.Sprintf(
+				`{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION","serialNumber":"CERT1","certificateContent":%q,"activated":true,"expirationDate":"2100-01-01T00:00:00Z"}}]}`,
+				certificateContent,
+			))
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/profiles":
+			profileCreates.Add(1)
+			writeSigningFetchOutputJSON(t, w, http.StatusCreated, fmt.Sprintf(
+				`{"data":{"type":"profiles","id":"profile-created","attributes":{"name":"Created Profile","profileType":"IOS_APP_STORE","profileState":"ACTIVE","profileContent":%q}}}`,
+				profileContent,
+			))
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	serverTransport := server.Client().Transport
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			cloned := req.Clone(req.Context())
+			cloned.URL.Scheme = serverURL.Scheme
+			cloned.URL.Host = serverURL.Host
+			return serverTransport.RoundTrip(cloned)
+		})},
+	)
+	if err != nil {
+		t.Fatalf("create signing fetch test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"signing", "fetch",
+			"--bundle-id", "com.example.app",
+			"--profile-type", "IOS_APP_STORE",
+			"--create-missing",
+			"--output", outputPath,
+			"--format", "json",
+		}); err != nil {
+			t.Fatalf("parse signing fetch: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("signing fetch succeeded with a regular file as its output directory")
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty output", stdout)
+	}
+	if got := profileCreates.Load(); got != 0 {
+		t.Fatalf("profile create requests = %d, want 0", got)
+	}
+	if got := bundleLookups.Load(); got != 1 {
+		t.Fatalf("bundle ID lookups = %d, want 1", got)
+	}
+	if got := profileLookups.Load(); got != 1 {
+		t.Fatalf("profile lookups = %d, want 1", got)
+	}
+	if got := certificateLookups.Load(); got != 1 {
+		t.Fatalf("certificate lookups = %d, want 1", got)
+	}
+	gotSentinel, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output sentinel: %v", err)
+	}
+	if string(gotSentinel) != string(sentinel) {
+		t.Fatalf("output sentinel = %q, want %q", gotSentinel, sentinel)
+	}
+}
+
+func writeSigningFetchOutputJSON(t *testing.T, w http.ResponseWriter, status int, body string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := io.WriteString(w, body); err != nil {
+		t.Errorf("write JSON response: %v", err)
+	}
+}

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -70,6 +70,12 @@ Examples:
 			if outputDir == "" {
 				outputDir = "./signing"
 			}
+			prepareOutputDir := onceAfterSuccess(func() error {
+				if err := os.MkdirAll(outputDir, 0o755); err != nil {
+					return fmt.Errorf("create output dir: %w", err)
+				}
+				return nil
+			})
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -108,6 +114,7 @@ Examples:
 					CertificateType:    *certType,
 					DeviceIDs:          shared.SplitCSV(*deviceIDs),
 					CreateMissing:      *createMissing,
+					BeforeCreate:       prepareOutputDir,
 				},
 			)
 			if err != nil {
@@ -117,8 +124,8 @@ Examples:
 			result.ProfileID = profile.Data.ID
 			result.Created = created
 
-			if err := os.MkdirAll(outputDir, 0o755); err != nil {
-				return fmt.Errorf("signing fetch: create output dir: %w", err)
+			if err := prepareOutputDir(); err != nil {
+				return fmt.Errorf("signing fetch: %w", err)
 			}
 
 			profileName := safeFileName(profile.Data.Attributes.Name, profile.Data.ID)


### PR DESCRIPTION
## Summary

- prepare the signing fetch output directory before a missing profile can be created
- reuse the same successful preparation before writing existing or newly created assets
- keep auth, lookup, and no-profile failures from creating an output directory eagerly

## Contract

The command and flags are unchanged. When --create-missing reaches profile creation, a locally invalid --output path now stops before POST /v1/profiles. Existing-profile fetches still prepare the directory immediately before local writes.

This change is intentionally limited to directory preparation. It does not add remote rollback or change later filename-collision and file-publication behavior.

## Verification

- deterministic RED on the previous behavior: an existing regular file used as --output still allowed one profile create request
- focused regression test repeated 20 times
- focused race test repeated 10 times
- adjacent signing and command tests
- built binary help and required-flag exit behavior
- read-only disposable-app check confirmed the no-profile path leaves a nonexistent output directory absent
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788932516&installation_model_id=10418&pr_number=1942&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1942&signature=bec09af77bc0fe4dbd935688578d9e480506a80957caf100f003c2a9ad0b49d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signing fetch now validates and resolves signing assets before creating output directories.
  * Invalid output paths fail earlier without creating profiles or writing output.
  * Existing files remain unchanged when preflight validation fails.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->