### PR TITLE
fix(notify): reject null Slack block payloads

### DIFF
--- a/internal/cli/cmdtest/notify_test.go
+++ b/internal/cli/cmdtest/notify_test.go
@@ -8,8 +8,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	notifycli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/notify"
 )
 
 func TestNotifySlackValidationErrors(t *testing.T) {
@@ -208,6 +214,115 @@ func TestNotifySlackSuccessWithBlocks(t *testing.T) {
 	}
 	if len(blocksValue) != 1 {
 		t.Fatalf("expected 1 block, got %d", len(blocksValue))
+	}
+}
+
+func TestNotifySlackRejectsNullBlocksBeforeRequest(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	nullBlocksFile := filepath.Join(t.TempDir(), "null-blocks.json")
+	if err := os.WriteFile(nullBlocksFile, []byte("null"), 0o600); err != nil {
+		t.Fatalf("write null blocks file: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		blocksArgs     []string
+		wantDiagnostic string
+	}{
+		{
+			name:           "inline",
+			blocksArgs:     []string{"--blocks-json", "null"},
+			wantDiagnostic: "Error: --blocks-json must contain a JSON array\n",
+		},
+		{
+			name:           "file",
+			blocksArgs:     []string{"--blocks-file", nullBlocksFile},
+			wantDiagnostic: "Error: --blocks-file must contain a JSON array\n",
+		},
+	}
+	slackCommand := notifycli.SlackCommand()
+	usage := slackCommand.UsageFunc(slackCommand) + "\n"
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ASC_SLACK_WEBHOOK", "")
+			t.Setenv("ASC_SLACK_WEBHOOK_ALLOW_LOCALHOST", "1")
+
+			args := []string{"notify", "slack", "--webhook", server.URL, "--message", "Hello"}
+			args = append(args, test.blocksArgs...)
+
+			var exitCode int
+			stdout, stderr := captureOutput(t, func() {
+				exitCode = rootcmd.Run(args, "1.2.3")
+			})
+
+			if exitCode != rootcmd.ExitUsage {
+				t.Fatalf("expected exit code %d, got %d", rootcmd.ExitUsage, exitCode)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			wantStderr := test.wantDiagnostic + usage
+			if stderr != wantStderr {
+				t.Fatalf("expected stderr %q, got %q", wantStderr, stderr)
+			}
+			if got := requestCount.Load(); got != 0 {
+				t.Fatalf("expected no webhook requests, got %d", got)
+			}
+		})
+	}
+}
+
+func TestNotifySlackExplicitEmptyBlocksArrayIsSent(t *testing.T) {
+	var requestCount atomic.Int32
+	var receivedPayload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &receivedPayload); err != nil {
+			t.Errorf("unmarshal payload: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("ASC_SLACK_WEBHOOK", "")
+	t.Setenv("ASC_SLACK_WEBHOOK_ALLOW_LOCALHOST", "1")
+
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{
+			"notify", "slack",
+			"--webhook", server.URL,
+			"--message", "Hello",
+			"--blocks-json", "[]",
+		}, "1.2.3")
+	})
+
+	if exitCode != rootcmd.ExitSuccess {
+		t.Fatalf("expected exit code %d, got %d with stderr %q", rootcmd.ExitSuccess, exitCode, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Message sent to Slack successfully") {
+		t.Fatalf("expected success message, got %q", stderr)
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("expected one webhook request, got %d", got)
+	}
+	blocksValue, ok := receivedPayload["blocks"].([]any)
+	if !ok {
+		t.Fatalf("expected blocks array, got %T", receivedPayload["blocks"])
+	}
+	if len(blocksValue) != 0 {
+		t.Fatalf("expected empty blocks array, got %d blocks", len(blocksValue))
 	}
 }
 

--- a/internal/cli/notify/notify.go
+++ b/internal/cli/notify/notify.go
@@ -308,6 +308,9 @@ func parseSlackBlocks(blocksJSON string, blocksFile string) ([]json.RawMessage, 
 	if err := json.Unmarshal([]byte(blocksJSON), &blocks); err != nil {
 		return nil, fmt.Errorf("%s must contain a JSON array: %w", source, err)
 	}
+	if blocks == nil {
+		return nil, fmt.Errorf("%s must contain a JSON array", source)
+	}
 
 	return blocks, nil
 }


### PR DESCRIPTION
## Summary

- reject JSON `null` from `--blocks-json` and `--blocks-file` instead of silently omitting blocks
- preserve explicit empty block arrays as `"blocks": []`
- verify invalid inputs stop before any webhook request and return a usage error

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestNotifySlack(RejectsNullBlocksBeforeRequest|ExplicitEmptyBlocksArrayIsSent)$' -count=10`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run 'TestNotifySlack(RejectsNullBlocksBeforeRequest|ExplicitEmptyBlocksArrayIsSent)$' -count=10`
- compiled CLI against a local webhook for inline null, file null, and explicit empty-array cases
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788933233&installation_model_id=10418&pr_number=1943&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1943&signature=f62ca979bdc618e96e53380a2015be4654557b876eff07605af52b792a802161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
