### PR TITLE
Make signing repository Git operations non-interactive

### DIFF
--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -343,9 +343,29 @@ func hasConfiguredGitSSHCommand(
 	goos string,
 	includeRepositoryConfig bool,
 ) (bool, error) {
+	queryDir := dir
+	queryEnvironment := replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0", goos == "windows")
+	if !includeRepositoryConfig {
+		neutralRoot, err := os.MkdirTemp("", "asc-git-config-")
+		if err != nil {
+			return false, fmt.Errorf("create neutral Git config probe: %w", err)
+		}
+		defer func() {
+			_ = os.Remove(neutralRoot)
+		}()
+
+		queryDir = neutralRoot
+		queryEnvironment = replaceCommandEnvironmentValue(
+			queryEnvironment,
+			"GIT_DIR",
+			filepath.Join(neutralRoot, "nonexistent.git"),
+			goos == "windows",
+		)
+	}
+
 	cmd := exec.CommandContext(ctx, "git", "config", "--show-scope", "--null", "--get-all", "core.sshCommand")
-	cmd.Dir = dir
-	cmd.Env = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0", goos == "windows")
+	cmd.Dir = queryDir
+	cmd.Env = queryEnvironment
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -252,7 +252,8 @@ func newGitCommand(ctx context.Context, dir string, args ...string) (*exec.Cmd, 
 	coreSSHCommandConfigured := false
 	if gitCommandMayUseSSH(args) && !hasGitSSHEnvironmentOverride(environment, runtime.GOOS) {
 		var err error
-		coreSSHCommandConfigured, err = hasConfiguredGitSSHCommand(ctx, dir, environment, runtime.GOOS)
+		includeRepositoryConfig := args[0] != "clone"
+		coreSSHCommandConfigured, err = hasConfiguredGitSSHCommand(ctx, dir, environment, runtime.GOOS, includeRepositoryConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -343,8 +344,14 @@ func gitCommandMayUseSSH(args []string) bool {
 	}
 }
 
-func hasConfiguredGitSSHCommand(ctx context.Context, dir string, environment []string, goos string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "config", "--get", "core.sshCommand")
+func hasConfiguredGitSSHCommand(
+	ctx context.Context,
+	dir string,
+	environment []string,
+	goos string,
+	includeRepositoryConfig bool,
+) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "config", "--show-scope", "--null", "--get-all", "core.sshCommand")
 	cmd.Dir = dir
 	cmd.Env = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0", goos == "windows")
 	var stdout bytes.Buffer
@@ -357,7 +364,27 @@ func hasConfiguredGitSSHCommand(ctx context.Context, dir string, environment []s
 		}
 		return false, fmt.Errorf("check Git core.sshCommand: %w", err)
 	}
-	return strings.TrimSpace(stdout.String()) != "", nil
+	return configuredGitSSHCommandFromScopedOutput(stdout.Bytes(), includeRepositoryConfig)
+}
+
+func configuredGitSSHCommandFromScopedOutput(output []byte, includeRepositoryConfig bool) (bool, error) {
+	fields := bytes.Split(output, []byte{0})
+	if len(fields) > 0 && len(fields[len(fields)-1]) == 0 {
+		fields = fields[:len(fields)-1]
+	}
+	if len(fields)%2 != 0 {
+		return false, fmt.Errorf("parse Git core.sshCommand scopes: unexpected field count %d", len(fields))
+	}
+
+	configured := false
+	for i := 0; i < len(fields); i += 2 {
+		scope := string(fields[i])
+		if !includeRepositoryConfig && (scope == "local" || scope == "worktree") {
+			continue
+		}
+		configured = strings.TrimSpace(string(fields[i+1])) != ""
+	}
+	return configured, nil
 }
 
 func commandEnvironmentValue(environment []string, key string, caseInsensitive bool) (string, bool) {

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -363,40 +363,19 @@ func hasConfiguredGitSSHCommand(
 		)
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "config", "--show-scope", "--null", "--get-all", "core.sshCommand")
+	cmd := exec.CommandContext(ctx, "git", "config", "--get", "core.sshCommand")
 	cmd.Dir = queryDir
 	cmd.Env = queryEnvironment
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	output, err := cmd.Output()
+	if err != nil {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
 			return false, nil
 		}
 		return false, fmt.Errorf("check Git core.sshCommand: %w", err)
 	}
-	return configuredGitSSHCommandFromScopedOutput(stdout.Bytes(), includeRepositoryConfig)
-}
-
-func configuredGitSSHCommandFromScopedOutput(output []byte, includeRepositoryConfig bool) (bool, error) {
-	fields := bytes.Split(output, []byte{0})
-	if len(fields) > 0 && len(fields[len(fields)-1]) == 0 {
-		fields = fields[:len(fields)-1]
-	}
-	if len(fields)%2 != 0 {
-		return false, fmt.Errorf("parse Git core.sshCommand scopes: unexpected field count %d", len(fields))
-	}
-
-	configured := false
-	for i := 0; i < len(fields); i += 2 {
-		scope := string(fields[i])
-		if !includeRepositoryConfig && (scope == "local" || scope == "worktree") {
-			continue
-		}
-		configured = strings.TrimSpace(string(fields[i+1])) != ""
-	}
-	return configured, nil
+	return strings.TrimSpace(string(output)) != "", nil
 }
 
 func commandEnvironmentValue(environment []string, key string, caseInsensitive bool) (string, bool) {
@@ -409,18 +388,11 @@ func commandEnvironmentValue(environment []string, key string, caseInsensitive b
 }
 
 func replaceCommandEnvironmentValue(environment []string, key, value string, caseInsensitive bool) []string {
-	updated := make([]string, 0, len(environment)+1)
-	for _, entry := range environment {
-		if _, ok := commandEnvironmentEntryValue(entry, key, caseInsensitive); ok {
-			continue
-		}
-		updated = append(updated, entry)
-	}
-	return append(updated, key+"="+value)
+	return append(removeCommandEnvironmentValue(environment, key, caseInsensitive), key+"="+value)
 }
 
 func removeCommandEnvironmentValue(environment []string, key string, caseInsensitive bool) []string {
-	updated := make([]string, 0, len(environment))
+	updated := make([]string, 0, len(environment)+1)
 	for _, entry := range environment {
 		if _, ok := commandEnvironmentEntryValue(entry, key, caseInsensitive); ok {
 			continue

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -253,38 +254,52 @@ func newGitCommand(ctx context.Context, dir string, args ...string) *exec.Cmd {
 }
 
 func gitCommandEnvironment(environment []string) []string {
-	environment = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0")
+	return gitCommandEnvironmentForGOOS(environment, runtime.GOOS)
+}
 
-	sshCommand, ok := commandEnvironmentValue(environment, "GIT_SSH_COMMAND")
+func gitCommandEnvironmentForGOOS(environment []string, goos string) []string {
+	caseInsensitive := goos == "windows"
+	environment = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0", caseInsensitive)
+
+	sshCommand, ok := commandEnvironmentValue(environment, "GIT_SSH_COMMAND", caseInsensitive)
 	if !ok || strings.TrimSpace(sshCommand) == "" {
 		sshCommand = "ssh -o BatchMode=yes"
 	}
 
 	// A caller-provided command may contain shell quoting or invoke a wrapper.
 	// Preserve it verbatim instead of trying to append or rewrite SSH options.
-	return replaceCommandEnvironmentValue(environment, "GIT_SSH_COMMAND", sshCommand)
+	return replaceCommandEnvironmentValue(environment, "GIT_SSH_COMMAND", sshCommand, caseInsensitive)
 }
 
-func commandEnvironmentValue(environment []string, key string) (string, bool) {
-	prefix := key + "="
+func commandEnvironmentValue(environment []string, key string, caseInsensitive bool) (string, bool) {
 	for i := len(environment) - 1; i >= 0; i-- {
-		if strings.HasPrefix(environment[i], prefix) {
-			return strings.TrimPrefix(environment[i], prefix), true
+		if value, ok := commandEnvironmentEntryValue(environment[i], key, caseInsensitive); ok {
+			return value, true
 		}
 	}
 	return "", false
 }
 
-func replaceCommandEnvironmentValue(environment []string, key, value string) []string {
-	prefix := key + "="
+func replaceCommandEnvironmentValue(environment []string, key, value string, caseInsensitive bool) []string {
 	updated := make([]string, 0, len(environment)+1)
 	for _, entry := range environment {
-		if strings.HasPrefix(entry, prefix) {
+		if _, ok := commandEnvironmentEntryValue(entry, key, caseInsensitive); ok {
 			continue
 		}
 		updated = append(updated, entry)
 	}
-	return append(updated, prefix+value)
+	return append(updated, key+"="+value)
+}
+
+func commandEnvironmentEntryValue(entry, key string, caseInsensitive bool) (string, bool) {
+	entryKey, value, ok := strings.Cut(entry, "=")
+	if !ok {
+		return "", false
+	}
+	if entryKey != key && (!caseInsensitive || !strings.EqualFold(entryKey, key)) {
+		return "", false
+	}
+	return value, true
 }
 
 func (g *GitStore) gitRun(ctx context.Context, dir string, args ...string) error {

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -289,14 +289,6 @@ func gitEnvironmentWithoutRepositorySelectors(environment []string, goos string)
 	return environment
 }
 
-func gitCommandEnvironment(environment []string) []string {
-	return gitCommandEnvironmentWithConfig(environment, runtime.GOOS, false)
-}
-
-func gitCommandEnvironmentForGOOS(environment []string, goos string) []string {
-	return gitCommandEnvironmentWithConfig(environment, goos, false)
-}
-
 func gitCommandEnvironmentWithConfig(environment []string, goos string, coreSSHCommandConfigured bool) []string {
 	caseInsensitive := goos == "windows"
 	environment = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0", caseInsensitive)

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -245,21 +245,57 @@ func RejectSymlinkIfExists(path string) error {
 	return nil
 }
 
-func (g *GitStore) gitRun(ctx context.Context, dir string, args ...string) error {
+func newGitCommand(ctx context.Context, dir string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
-	if dir != "" {
-		cmd.Dir = dir
+	cmd.Dir = dir
+	cmd.Env = gitCommandEnvironment(os.Environ())
+	return cmd
+}
+
+func gitCommandEnvironment(environment []string) []string {
+	environment = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0")
+
+	sshCommand, ok := commandEnvironmentValue(environment, "GIT_SSH_COMMAND")
+	if !ok || strings.TrimSpace(sshCommand) == "" {
+		sshCommand = "ssh -o BatchMode=yes"
 	}
+
+	// A caller-provided command may contain shell quoting or invoke a wrapper.
+	// Preserve it verbatim instead of trying to append or rewrite SSH options.
+	return replaceCommandEnvironmentValue(environment, "GIT_SSH_COMMAND", sshCommand)
+}
+
+func commandEnvironmentValue(environment []string, key string) (string, bool) {
+	prefix := key + "="
+	for i := len(environment) - 1; i >= 0; i-- {
+		if strings.HasPrefix(environment[i], prefix) {
+			return strings.TrimPrefix(environment[i], prefix), true
+		}
+	}
+	return "", false
+}
+
+func replaceCommandEnvironmentValue(environment []string, key, value string) []string {
+	prefix := key + "="
+	updated := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		updated = append(updated, entry)
+	}
+	return append(updated, prefix+value)
+}
+
+func (g *GitStore) gitRun(ctx context.Context, dir string, args ...string) error {
+	cmd := newGitCommand(ctx, dir, args...)
 	cmd.Stdout = os.Stderr // progress to stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
 func (g *GitStore) gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	if dir != "" {
-		cmd.Dir = dir
-	}
+	cmd := newGitCommand(ctx, dir, args...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -3,6 +3,7 @@ package signing
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -246,29 +247,117 @@ func RejectSymlinkIfExists(path string) error {
 	return nil
 }
 
-func newGitCommand(ctx context.Context, dir string, args ...string) *exec.Cmd {
+func newGitCommand(ctx context.Context, dir string, args ...string) (*exec.Cmd, error) {
+	environment := gitEnvironmentWithoutRepositorySelectors(os.Environ(), runtime.GOOS)
+	coreSSHCommandConfigured := false
+	if gitCommandMayUseSSH(args) && !hasGitSSHEnvironmentOverride(environment, runtime.GOOS) {
+		var err error
+		coreSSHCommandConfigured, err = hasConfiguredGitSSHCommand(ctx, dir, environment, runtime.GOOS)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
-	cmd.Env = gitCommandEnvironment(os.Environ())
-	return cmd
+	cmd.Env = gitCommandEnvironmentWithConfig(environment, runtime.GOOS, coreSSHCommandConfigured)
+	return cmd, nil
+}
+
+var gitRepositorySelectorEnvironmentKeys = []string{
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_IMPLICIT_WORK_TREE",
+	"GIT_GRAFT_FILE",
+	"GIT_INDEX_FILE",
+	"GIT_NO_REPLACE_OBJECTS",
+	"GIT_REPLACE_REF_BASE",
+	"GIT_PREFIX",
+	"GIT_INTERNAL_SUPER_PREFIX",
+	"GIT_SHALLOW_FILE",
+	"GIT_COMMON_DIR",
+}
+
+func gitEnvironmentWithoutRepositorySelectors(environment []string, goos string) []string {
+	caseInsensitive := goos == "windows"
+	for _, key := range gitRepositorySelectorEnvironmentKeys {
+		environment = removeCommandEnvironmentValue(environment, key, caseInsensitive)
+	}
+	return environment
 }
 
 func gitCommandEnvironment(environment []string) []string {
-	return gitCommandEnvironmentForGOOS(environment, runtime.GOOS)
+	return gitCommandEnvironmentWithConfig(environment, runtime.GOOS, false)
 }
 
 func gitCommandEnvironmentForGOOS(environment []string, goos string) []string {
+	return gitCommandEnvironmentWithConfig(environment, goos, false)
+}
+
+func gitCommandEnvironmentWithConfig(environment []string, goos string, coreSSHCommandConfigured bool) []string {
 	caseInsensitive := goos == "windows"
 	environment = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0", caseInsensitive)
 
 	sshCommand, ok := commandEnvironmentValue(environment, "GIT_SSH_COMMAND", caseInsensitive)
-	if !ok || strings.TrimSpace(sshCommand) == "" {
-		sshCommand = "ssh -o BatchMode=yes"
+	if ok && strings.TrimSpace(sshCommand) != "" {
+		// A caller-provided command may contain shell quoting or invoke a wrapper.
+		// Preserve it verbatim instead of trying to append or rewrite SSH options.
+		return replaceCommandEnvironmentValue(environment, "GIT_SSH_COMMAND", sshCommand, caseInsensitive)
 	}
+	environment = removeCommandEnvironmentValue(environment, "GIT_SSH_COMMAND", caseInsensitive)
 
-	// A caller-provided command may contain shell quoting or invoke a wrapper.
-	// Preserve it verbatim instead of trying to append or rewrite SSH options.
-	return replaceCommandEnvironmentValue(environment, "GIT_SSH_COMMAND", sshCommand, caseInsensitive)
+	gitSSH, ok := commandEnvironmentValue(environment, "GIT_SSH", caseInsensitive)
+	if ok && strings.TrimSpace(gitSSH) != "" {
+		return environment
+	}
+	environment = removeCommandEnvironmentValue(environment, "GIT_SSH", caseInsensitive)
+
+	if coreSSHCommandConfigured {
+		return environment
+	}
+	return replaceCommandEnvironmentValue(environment, "GIT_SSH_COMMAND", "ssh -o BatchMode=yes", caseInsensitive)
+}
+
+func hasGitSSHEnvironmentOverride(environment []string, goos string) bool {
+	caseInsensitive := goos == "windows"
+	for _, key := range []string{"GIT_SSH_COMMAND", "GIT_SSH"} {
+		value, ok := commandEnvironmentValue(environment, key, caseInsensitive)
+		if ok && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func gitCommandMayUseSSH(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "clone", "fetch", "ls-remote", "pull", "push", "submodule":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasConfiguredGitSSHCommand(ctx context.Context, dir string, environment []string, goos string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "config", "--get", "core.sshCommand")
+	cmd.Dir = dir
+	cmd.Env = replaceCommandEnvironmentValue(environment, "GIT_TERMINAL_PROMPT", "0", goos == "windows")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("check Git core.sshCommand: %w", err)
+	}
+	return strings.TrimSpace(stdout.String()) != "", nil
 }
 
 func commandEnvironmentValue(environment []string, key string, caseInsensitive bool) (string, bool) {
@@ -291,6 +380,17 @@ func replaceCommandEnvironmentValue(environment []string, key, value string, cas
 	return append(updated, key+"="+value)
 }
 
+func removeCommandEnvironmentValue(environment []string, key string, caseInsensitive bool) []string {
+	updated := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		if _, ok := commandEnvironmentEntryValue(entry, key, caseInsensitive); ok {
+			continue
+		}
+		updated = append(updated, entry)
+	}
+	return updated
+}
+
 func commandEnvironmentEntryValue(entry, key string, caseInsensitive bool) (string, bool) {
 	entryKey, value, ok := strings.Cut(entry, "=")
 	if !ok {
@@ -303,17 +403,23 @@ func commandEnvironmentEntryValue(entry, key string, caseInsensitive bool) (stri
 }
 
 func (g *GitStore) gitRun(ctx context.Context, dir string, args ...string) error {
-	cmd := newGitCommand(ctx, dir, args...)
+	cmd, err := newGitCommand(ctx, dir, args...)
+	if err != nil {
+		return err
+	}
 	cmd.Stdout = os.Stderr // progress to stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
 func (g *GitStore) gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := newGitCommand(ctx, dir, args...)
+	cmd, err := newGitCommand(ctx, dir, args...)
+	if err != nil {
+		return "", err
+	}
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
+	err = cmd.Run()
 	return stdout.String(), err
 }

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -3,7 +3,9 @@ package signing
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -271,6 +273,9 @@ func TestGitStoreGitHelpersUseNonInteractiveExecutables(t *testing.T) {
 
 	writeTestExecutable(t, filepath.Join(binDir, "git"), `#!/bin/sh
 set -eu
+if [ "${1-}" = "config" ] && [ "${2-}" = "--get" ] && [ "${3-}" = "core.sshCommand" ]; then
+  exit 1
+fi
 printf '%s|%s\n' "${GIT_TERMINAL_PROMPT-}" "${GIT_SSH_COMMAND-}" >> "$ASC_FAKE_GIT_CAPTURE"
 sh -c "$GIT_SSH_COMMAND \"\$@\"" asc-fake-git "$@"
 if [ "${1-}" = "status" ]; then
@@ -327,9 +332,15 @@ set -eu
 func TestNewGitCommandUsesNonInteractiveEnvironment(t *testing.T) {
 	t.Setenv("GIT_TERMINAL_PROMPT", "1")
 	t.Setenv("GIT_SSH_COMMAND", " ")
+	t.Setenv("GIT_SSH", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
 
 	dir := t.TempDir()
-	cmd := newGitCommand(context.Background(), dir, "status", "--porcelain")
+	cmd, err := newGitCommand(context.Background(), dir, "status", "--porcelain")
+	if err != nil {
+		t.Fatalf("newGitCommand: %v", err)
+	}
 
 	if cmd.Dir != dir {
 		t.Fatalf("newGitCommand() dir = %q, want %q", cmd.Dir, dir)
@@ -339,6 +350,230 @@ func TestNewGitCommandUsesNonInteractiveEnvironment(t *testing.T) {
 	}
 	if got := commandEnvironmentValues(cmd.Env, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
 		t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
+	}
+}
+
+func TestNewGitCommandPreservesGitSSHTransport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable scripts require a POSIX shell")
+	}
+
+	transportCapture := filepath.Join(t.TempDir(), "transport-args.txt")
+	transport := filepath.Join(t.TempDir(), "team-ssh")
+	writeTestExecutable(t, transport, `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "$ASC_FAKE_SSH_CAPTURE"
+exit 17
+`)
+
+	t.Setenv("ASC_FAKE_SSH_CAPTURE", transportCapture)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
+	t.Setenv("GIT_SSH_COMMAND", "")
+	t.Setenv("GIT_SSH", transport)
+	t.Setenv("GIT_SSH_VARIANT", "ssh")
+
+	cmd, err := newGitCommand(context.Background(), "", "ls-remote", "ssh://git@127.0.0.1:1/repository")
+	if err != nil {
+		t.Fatalf("newGitCommand: %v", err)
+	}
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected fake SSH transport failure")
+	}
+	if _, err := os.Stat(transportCapture); err != nil {
+		t.Fatalf("expected inherited GIT_SSH transport to run: %v", err)
+	}
+}
+
+func TestNewGitCommandPreservesConfiguredSSHTransport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable scripts require a POSIX shell")
+	}
+
+	tests := []struct {
+		name      string
+		configure func(t *testing.T, transport string) string
+	}{
+		{
+			name: "global config",
+			configure: func(t *testing.T, transport string) string {
+				configPath := filepath.Join(t.TempDir(), "gitconfig")
+				configureGitSSHCommand(t, configPath, transport)
+				t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+				return t.TempDir()
+			},
+		},
+		{
+			name: "repository config",
+			configure: func(t *testing.T, transport string) string {
+				t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
+				repositoryDir := t.TempDir()
+				runTestGit(t, "init", "--quiet", repositoryDir)
+				runTestGit(t, "-C", repositoryDir, "config", "core.sshCommand", transport)
+				return repositoryDir
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			standaloneEnvironment := standaloneTestGitEnvironment(t)
+			sentinelRepository := filepath.Join(t.TempDir(), "sentinel")
+			runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
+			transportCapture := filepath.Join(t.TempDir(), "transport-args.txt")
+			transport := filepath.Join(t.TempDir(), "configured-ssh")
+			writeTestExecutable(t, transport, `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "$ASC_FAKE_SSH_CAPTURE"
+exit 17
+`)
+
+			t.Setenv("ASC_FAKE_SSH_CAPTURE", transportCapture)
+			t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+			t.Setenv("GIT_SSH_COMMAND", "")
+			t.Setenv("GIT_SSH", "")
+			t.Setenv("GIT_SSH_VARIANT", "ssh")
+			t.Setenv("GIT_DIR", filepath.Join(sentinelRepository, ".git"))
+			t.Setenv("GIT_WORK_TREE", sentinelRepository)
+			t.Setenv("GIT_COMMON_DIR", filepath.Join(sentinelRepository, ".git"))
+			dir := tt.configure(t, transport)
+
+			cmd, err := newGitCommand(context.Background(), dir, "ls-remote", "ssh://git@127.0.0.1:1/repository")
+			if err != nil {
+				t.Fatalf("newGitCommand: %v", err)
+			}
+			if err := cmd.Run(); err == nil {
+				t.Fatal("expected fake SSH transport failure")
+			}
+			if _, err := os.Stat(transportCapture); err != nil {
+				t.Fatalf("expected configured SSH transport to run: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewGitCommandDefaultsForBlankConfiguredSSHCommand(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "gitconfig")
+	configureGitSSHCommand(t, configPath, "")
+
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+	t.Setenv("GIT_SSH_COMMAND", "")
+	t.Setenv("GIT_SSH", "")
+
+	cmd, err := newGitCommand(context.Background(), t.TempDir(), "clone", "source", "destination")
+	if err != nil {
+		t.Fatalf("newGitCommand: %v", err)
+	}
+	if got := commandEnvironmentValues(cmd.Env, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
+		t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
+	}
+}
+
+func TestNewGitCommandFailsClosedWhenSSHConfigLookupFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable scripts require a POSIX shell")
+	}
+
+	binDir := t.TempDir()
+	mainCommandCapture := filepath.Join(t.TempDir(), "main-command.txt")
+	writeTestExecutable(t, filepath.Join(binDir, "git"), `#!/bin/sh
+set -eu
+if [ "${1-}" = "config" ] && [ "${2-}" = "--get" ] && [ "${3-}" = "core.sshCommand" ]; then
+  printf 'invalid git configuration\n' >&2
+  exit 2
+fi
+printf 'invoked\n' > "$ASC_FAKE_GIT_CAPTURE"
+`)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ASC_FAKE_GIT_CAPTURE", mainCommandCapture)
+	t.Setenv("GIT_SSH_COMMAND", "")
+	t.Setenv("GIT_SSH", "")
+
+	cmd, err := newGitCommand(context.Background(), "", "clone", "source", "destination")
+	if err == nil {
+		t.Fatalf("newGitCommand() = %v, want SSH config lookup error", cmd)
+	}
+	if !strings.Contains(err.Error(), "core.sshCommand") {
+		t.Fatalf("newGitCommand() error = %q, want core.sshCommand context", err)
+	}
+	if _, statErr := os.Stat(mainCommandCapture); !os.IsNotExist(statErr) {
+		t.Fatalf("network-capable Git command ran after lookup failure: %v", statErr)
+	}
+}
+
+func TestNewGitCommandIgnoresInheritedRepositorySelectors(t *testing.T) {
+	sentinelRepository := filepath.Join(t.TempDir(), "sentinel")
+	targetRepository := filepath.Join(t.TempDir(), "target")
+	standaloneEnvironment := standaloneTestGitEnvironment(t)
+	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
+	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", targetRepository)
+
+	globalConfig := filepath.Join(t.TempDir(), "global-config")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+	t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(t.TempDir(), "missing-system-config"))
+	t.Setenv("GIT_DIR", filepath.Join(sentinelRepository, ".git"))
+	t.Setenv("GIT_WORK_TREE", sentinelRepository)
+	t.Setenv("GIT_COMMON_DIR", filepath.Join(sentinelRepository, ".git"))
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(sentinelRepository, ".git", "index"))
+	t.Setenv("GIT_OBJECT_DIRECTORY", filepath.Join(sentinelRepository, ".git", "objects"))
+	t.Setenv("GIT_SSH", "/opt/team/bin/ssh-wrapper")
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+
+	cmd, err := newGitCommand(context.Background(), targetRepository, "config", "core.testMarker", "target-command")
+	if err != nil {
+		t.Fatalf("newGitCommand: %v", err)
+	}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run Git command: %v", err)
+	}
+
+	targetValue, targetConfigured := standaloneTestGitConfigValue(t, standaloneEnvironment, targetRepository, "core.testMarker")
+	if !targetConfigured || targetValue != "target-command" {
+		t.Errorf("target core.testMarker = %q, configured = %t; want target-command in target repository", targetValue, targetConfigured)
+	}
+	sentinelValue, sentinelConfigured := standaloneTestGitConfigValue(t, standaloneEnvironment, sentinelRepository, "core.testMarker")
+	if sentinelConfigured {
+		t.Errorf("sentinel core.testMarker = %q; inherited repository selectors redirected Git", sentinelValue)
+	}
+	if got := commandEnvironmentValues(cmd.Env, "GIT_DIR"); len(got) != 0 {
+		t.Errorf("GIT_DIR values = %v, want none", got)
+	}
+	if got := commandEnvironmentValues(cmd.Env, "GIT_CONFIG_GLOBAL"); len(got) != 1 || got[0] != globalConfig {
+		t.Errorf("GIT_CONFIG_GLOBAL values = %v, want [%s]", got, globalConfig)
+	}
+	if got := commandEnvironmentValues(cmd.Env, "GIT_SSH"); len(got) != 1 || got[0] != "/opt/team/bin/ssh-wrapper" {
+		t.Errorf("GIT_SSH values = %v, want preserved transport", got)
+	}
+	if got := commandEnvironmentValues(cmd.Env, "GIT_TERMINAL_PROMPT"); len(got) != 1 || got[0] != "0" {
+		t.Errorf("GIT_TERMINAL_PROMPT values = %v, want [0]", got)
+	}
+}
+
+func TestRunTestGitIsolatesRepositoryEnvironment(t *testing.T) {
+	sentinelRepository := filepath.Join(t.TempDir(), "sentinel")
+	targetRepository := filepath.Join(t.TempDir(), "target")
+	standaloneEnvironment := standaloneTestGitEnvironment(t)
+	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
+	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", targetRepository)
+
+	t.Setenv("GIT_DIR", filepath.Join(sentinelRepository, ".git"))
+	t.Setenv("GIT_WORK_TREE", sentinelRepository)
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-global-config"))
+	t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(t.TempDir(), "missing-system-config"))
+	t.Setenv("HOME", t.TempDir())
+	runTestGit(t, "-C", targetRepository, "config", "core.sshCommand", "target-command")
+
+	targetValue, targetConfigured := standaloneTestGitConfigValue(t, standaloneEnvironment, targetRepository, "core.sshCommand")
+	if !targetConfigured || targetValue != "target-command" {
+		t.Errorf("target core.sshCommand = %q, configured = %t; want target-command in target repository", targetValue, targetConfigured)
+	}
+	sentinelValue, sentinelConfigured := standaloneTestGitConfigValue(t, standaloneEnvironment, sentinelRepository, "core.sshCommand")
+	if sentinelConfigured {
+		t.Fatalf("sentinel core.sshCommand = %q; inherited repository selectors escaped test isolation", sentinelValue)
 	}
 }
 
@@ -377,6 +612,23 @@ func TestGitCommandEnvironmentPreservesCustomSSHCommand(t *testing.T) {
 				t.Fatalf("GIT_SSH_COMMAND values = %v, want [%s]", got, tt.sshCommand)
 			}
 		})
+	}
+}
+
+func TestGitCommandEnvironmentPreservesGitSSH(t *testing.T) {
+	environment := gitCommandEnvironment([]string{
+		"PATH=/usr/bin",
+		"GIT_TERMINAL_PROMPT=1",
+		"GIT_SSH_COMMAND= \t",
+		"GIT_SSH=/opt/team/bin/ssh-wrapper",
+	})
+	want := []string{
+		"PATH=/usr/bin",
+		"GIT_SSH=/opt/team/bin/ssh-wrapper",
+		"GIT_TERMINAL_PROMPT=0",
+	}
+	if !slices.Equal(environment, want) {
+		t.Fatalf("gitCommandEnvironment() = %v, want %v", environment, want)
 	}
 }
 
@@ -425,6 +677,42 @@ func TestGitCommandEnvironmentForWindowsMatchesKeysCaseInsensitively(t *testing.
 	}
 }
 
+func TestGitCommandEnvironmentForWindowsPreservesGitSSH(t *testing.T) {
+	environment := gitCommandEnvironmentForGOOS([]string{
+		"PATH=C:\\Windows\\System32",
+		"git_terminal_prompt=1",
+		"git_ssh_command= ",
+		`git_ssh=C:\tools\team-ssh.exe`,
+	}, "windows")
+	want := []string{
+		"PATH=C:\\Windows\\System32",
+		`git_ssh=C:\tools\team-ssh.exe`,
+		"GIT_TERMINAL_PROMPT=0",
+	}
+	if !slices.Equal(environment, want) {
+		t.Fatalf("gitCommandEnvironmentForGOOS() = %v, want %v", environment, want)
+	}
+}
+
+func TestGitEnvironmentWithoutRepositorySelectorsMatchesWindowsKeysCaseInsensitively(t *testing.T) {
+	environment := gitEnvironmentWithoutRepositorySelectors([]string{
+		"PATH=C:\\Windows\\System32",
+		`git_dir=C:\sensitive\repo\.git`,
+		`Git_Work_Tree=C:\sensitive\repo`,
+		`GIT_COMMON_DIR=C:\sensitive\repo\.git`,
+		`GIT_CONFIG_GLOBAL=C:\config\gitconfig`,
+		`GIT_SSH=C:\tools\team-ssh.exe`,
+	}, "windows")
+	want := []string{
+		"PATH=C:\\Windows\\System32",
+		`GIT_CONFIG_GLOBAL=C:\config\gitconfig`,
+		`GIT_SSH=C:\tools\team-ssh.exe`,
+	}
+	if !slices.Equal(environment, want) {
+		t.Fatalf("gitEnvironmentWithoutRepositorySelectors() = %v, want %v", environment, want)
+	}
+}
+
 func TestGitCommandEnvironmentForPOSIXKeepsKeysCaseSensitive(t *testing.T) {
 	environment := gitCommandEnvironmentForGOOS([]string{
 		"PATH=/usr/bin",
@@ -459,4 +747,57 @@ func writeTestExecutable(t *testing.T, path, contents string) {
 	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
 		t.Fatalf("write executable %s: %v", path, err)
 	}
+}
+
+func configureGitSSHCommand(t *testing.T, configPath, command string) {
+	t.Helper()
+	runTestGit(t, "config", "--file", configPath, "core.sshCommand", command)
+}
+
+func runTestGit(t *testing.T, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = t.TempDir()
+	cmd.Env = standaloneTestGitEnvironment(t)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
+	}
+}
+
+func standaloneTestGitEnvironment(t *testing.T) []string {
+	t.Helper()
+	return []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=" + filepath.Join(t.TempDir(), "missing-global-config"),
+		"GIT_CONFIG_SYSTEM=" + filepath.Join(t.TempDir(), "missing-system-config"),
+	}
+}
+
+func runStandaloneTestGit(t *testing.T, environment []string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = t.TempDir()
+	cmd.Env = environment
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("standalone git %s: %v: %s", strings.Join(args, " "), err, output)
+	}
+}
+
+func standaloneTestGitConfigValue(t *testing.T, environment []string, repository, key string) (string, bool) {
+	t.Helper()
+	cmd := exec.Command("git", "--git-dir", filepath.Join(repository, ".git"), "config", "--get", key)
+	cmd.Dir = t.TempDir()
+	cmd.Env = environment
+	output, err := cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(output)), true
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+		return "", false
+	}
+	t.Fatalf("standalone git config --get %s: %v", key, err)
+	return "", false
 }

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -329,179 +329,84 @@ set -eu
 	}
 }
 
-func TestNewGitCommandUsesNonInteractiveEnvironment(t *testing.T) {
-	t.Setenv("GIT_TERMINAL_PROMPT", "1")
-	t.Setenv("GIT_SSH_COMMAND", " ")
-	t.Setenv("GIT_SSH", "")
-	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
-	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
-
-	dir := t.TempDir()
-	cmd, err := newGitCommand(context.Background(), dir, "status", "--porcelain")
-	if err != nil {
-		t.Fatalf("newGitCommand: %v", err)
-	}
-
-	if cmd.Dir != dir {
-		t.Fatalf("newGitCommand() dir = %q, want %q", cmd.Dir, dir)
-	}
-	if got := commandEnvironmentValues(cmd.Env, "GIT_TERMINAL_PROMPT"); len(got) != 1 || got[0] != "0" {
-		t.Fatalf("GIT_TERMINAL_PROMPT values = %v, want [0]", got)
-	}
-	if got := commandEnvironmentValues(cmd.Env, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
-		t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
-	}
-}
-
-func TestNewGitCommandPreservesGitSSHTransport(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake executable scripts require a POSIX shell")
-	}
-
-	transportCapture := filepath.Join(t.TempDir(), "transport-args.txt")
-	transport := filepath.Join(t.TempDir(), "team-ssh")
-	writeTestExecutable(t, transport, `#!/bin/sh
-set -eu
-printf '%s\n' "$@" > "$ASC_FAKE_SSH_CAPTURE"
-exit 17
-`)
-
-	t.Setenv("ASC_FAKE_SSH_CAPTURE", transportCapture)
-	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
-	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
-	t.Setenv("GIT_SSH_COMMAND", "")
-	t.Setenv("GIT_SSH", transport)
-	t.Setenv("GIT_SSH_VARIANT", "ssh")
-
-	cmd, err := newGitCommand(context.Background(), "", "ls-remote", "ssh://git@127.0.0.1:1/repository")
-	if err != nil {
-		t.Fatalf("newGitCommand: %v", err)
-	}
-	if err := cmd.Run(); err == nil {
-		t.Fatal("expected fake SSH transport failure")
-	}
-	if _, err := os.Stat(transportCapture); err != nil {
-		t.Fatalf("expected inherited GIT_SSH transport to run: %v", err)
-	}
-}
-
-func TestNewGitCommandPreservesConfiguredSSHTransport(t *testing.T) {
+func TestNewGitCommandSSHSelection(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake executable scripts require a POSIX shell")
 	}
 
 	tests := []struct {
-		name      string
-		clone     bool
-		configure func(t *testing.T, transport string) string
+		name        string
+		setup       string
+		clone       bool
+		wantDefault bool
 	}{
-		{
-			name:  "global config for clone",
-			clone: true,
-			configure: func(t *testing.T, transport string) string {
-				configPath := filepath.Join(t.TempDir(), "gitconfig")
-				configureGitSSHCommand(t, configPath, transport)
-				t.Setenv("GIT_CONFIG_GLOBAL", configPath)
-				return t.TempDir()
-			},
-		},
-		{
-			name:  "unconditional global include for clone",
-			clone: true,
-			configure: func(t *testing.T, transport string) string {
-				includedConfig := filepath.Join(t.TempDir(), "included-gitconfig")
-				configureGitSSHCommand(t, includedConfig, transport)
-				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
-				runTestGit(t, "config", "--file", globalConfig, "include.path", includedConfig)
-				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
-				return t.TempDir()
-			},
-		},
-		{
-			name:  "command config for clone",
-			clone: true,
-			configure: func(t *testing.T, transport string) string {
-				t.Setenv("GIT_CONFIG_COUNT", "1")
-				t.Setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
-				t.Setenv("GIT_CONFIG_VALUE_0", transport)
-				t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
-				return t.TempDir()
-			},
-		},
-		{
-			name: "repository config",
-			configure: func(t *testing.T, transport string) string {
-				t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
-				repositoryDir := t.TempDir()
-				runTestGit(t, "init", "--quiet", repositoryDir)
-				runTestGit(t, "-C", repositoryDir, "config", "core.sshCommand", transport)
-				return repositoryDir
-			},
-		},
+		{name: "explicit GIT_SSH_COMMAND", setup: "environment-command", clone: true},
+		{name: "inherited GIT_SSH", setup: "environment-ssh", clone: true},
+		{name: "global config for clone", setup: "global", clone: true},
+		{name: "unconditional global include for clone", setup: "include", clone: true},
+		{name: "command config for clone", setup: "command", clone: true},
+		{name: "repository config for ls-remote", setup: "repository"},
+		{name: "clone ignores local repository config", setup: "local", clone: true, wantDefault: true},
+		{name: "clone ignores gitdir conditional config", setup: "conditional", clone: true, wantDefault: true},
+		{name: "blank command config overrides global config", setup: "blank-command", clone: true, wantDefault: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			standaloneEnvironment := standaloneTestGitEnvironment(t)
-			sentinelRepository := filepath.Join(t.TempDir(), "sentinel")
-			runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
-			transportCapture := filepath.Join(t.TempDir(), "transport-args.txt")
-			transport := filepath.Join(t.TempDir(), "configured-ssh")
-			writeTestExecutable(t, transport, `#!/bin/sh
+			callerRepository := t.TempDir()
+			runTestGit(t, "init", "--quiet", callerRepository)
+
+			configuredCapture := filepath.Join(t.TempDir(), "configured-transport.txt")
+			configuredTransport := filepath.Join(t.TempDir(), "configured-ssh")
+			writeTestExecutable(t, configuredTransport, `#!/bin/sh
 set -eu
-printf '%s\n' "$@" > "$ASC_FAKE_SSH_CAPTURE"
+printf '%s\n' "$@" > "$ASC_CONFIGURED_SSH_CAPTURE"
+exit 17
+`)
+			binDir := t.TempDir()
+			defaultCapture := filepath.Join(t.TempDir(), "default-transport.txt")
+			writeTestExecutable(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "$ASC_DEFAULT_SSH_CAPTURE"
 exit 17
 `)
 
-			t.Setenv("ASC_FAKE_SSH_CAPTURE", transportCapture)
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("ASC_CONFIGURED_SSH_CAPTURE", configuredCapture)
+			t.Setenv("ASC_DEFAULT_SSH_CAPTURE", defaultCapture)
 			t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+			t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-global-config"))
+			t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(t.TempDir(), "missing-system-config"))
+			t.Setenv("GIT_CONFIG_COUNT", "0")
 			t.Setenv("GIT_SSH_COMMAND", "")
 			t.Setenv("GIT_SSH", "")
 			t.Setenv("GIT_SSH_VARIANT", "ssh")
-			t.Setenv("GIT_DIR", filepath.Join(sentinelRepository, ".git"))
-			t.Setenv("GIT_WORK_TREE", sentinelRepository)
-			t.Setenv("GIT_COMMON_DIR", filepath.Join(sentinelRepository, ".git"))
-			dir := tt.configure(t, transport)
 
-			args := []string{"ls-remote", "ssh://git@127.0.0.1:1/repository"}
-			if tt.clone {
-				args = []string{"clone", "ssh://git@127.0.0.1:1/repository", filepath.Join(t.TempDir(), "clone")}
-			}
-			cmd, err := newGitCommand(context.Background(), dir, args...)
-			if err != nil {
-				t.Fatalf("newGitCommand: %v", err)
-			}
-			if err := cmd.Run(); err == nil {
-				t.Fatal("expected fake SSH transport failure")
-			}
-			if _, err := os.Stat(transportCapture); err != nil {
-				t.Fatalf("expected configured SSH transport to run: %v", err)
-			}
-		})
-	}
-}
-
-func TestNewGitCommandCloneIgnoresCallerScopedSSHCommands(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake executable scripts require a POSIX shell")
-	}
-
-	tests := []struct {
-		name      string
-		configure func(t *testing.T, callerRepository, transport string) string
-	}{
-		{
-			name: "local repository config",
-			configure: func(t *testing.T, callerRepository, transport string) string {
-				runTestGit(t, "-C", callerRepository, "config", "core.sshCommand", transport)
-				return filepath.Join(t.TempDir(), "missing-gitconfig")
-			},
-		},
-		{
-			name: "gitdir conditional global config",
-			configure: func(t *testing.T, callerRepository, transport string) string {
+			switch tt.setup {
+			case "environment-command":
+				t.Setenv("GIT_SSH_COMMAND", configuredTransport+` --identity 'release key'`)
+			case "environment-ssh":
+				t.Setenv("GIT_SSH", configuredTransport)
+			case "global":
+				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
+				runTestGit(t, "config", "--file", globalConfig, "core.sshCommand", configuredTransport)
+				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+			case "include":
 				includedConfig := filepath.Join(t.TempDir(), "included-gitconfig")
-				configureGitSSHCommand(t, includedConfig, transport)
+				runTestGit(t, "config", "--file", includedConfig, "core.sshCommand", configuredTransport)
+				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
+				runTestGit(t, "config", "--file", globalConfig, "include.path", includedConfig)
+				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+			case "command":
+				t.Setenv("GIT_CONFIG_COUNT", "1")
+				t.Setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
+				t.Setenv("GIT_CONFIG_VALUE_0", configuredTransport)
+			case "repository", "local":
+				runTestGit(t, "-C", callerRepository, "config", "core.sshCommand", configuredTransport)
+			case "conditional":
+				includedConfig := filepath.Join(t.TempDir(), "included-gitconfig")
+				runTestGit(t, "config", "--file", includedConfig, "core.sshCommand", configuredTransport)
 				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
 				resolvedCallerRepository, err := filepath.EvalSymlinks(callerRepository)
 				if err != nil {
@@ -509,144 +414,52 @@ func TestNewGitCommandCloneIgnoresCallerScopedSSHCommands(t *testing.T) {
 				}
 				conditionKey := "includeIf.gitdir:" + filepath.ToSlash(resolvedCallerRepository) + "/.path"
 				runTestGit(t, "config", "--file", globalConfig, conditionKey, includedConfig)
-
-				cmd := exec.Command("git", "config", "--get", "core.sshCommand")
-				cmd.Dir = callerRepository
-				cmd.Env = replaceCommandEnvironmentValue(
-					standaloneTestGitEnvironment(t),
-					"GIT_CONFIG_GLOBAL",
-					globalConfig,
-					false,
+				preconditionEnvironment := replaceCommandEnvironmentValue(
+					standaloneTestGitEnvironment(t), "GIT_CONFIG_GLOBAL", globalConfig, false,
 				)
-				output, err := cmd.Output()
-				if err != nil {
-					t.Fatalf("verify gitdir conditional config: %v", err)
+				got := strings.TrimSpace(runTestGitOutput(
+					t, preconditionEnvironment, callerRepository, "config", "--get", "core.sshCommand",
+				))
+				if got != configuredTransport {
+					t.Fatalf("conditional core.sshCommand = %q, want %q", got, configuredTransport)
 				}
-				if got := strings.TrimSpace(string(output)); got != transport {
-					t.Fatalf("conditional core.sshCommand = %q, want %q", got, transport)
-				}
-				return globalConfig
-			},
-		},
-	}
+				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+			case "blank-command":
+				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
+				runTestGit(t, "config", "--file", globalConfig, "core.sshCommand", configuredTransport)
+				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+				t.Setenv("GIT_CONFIG_COUNT", "1")
+				t.Setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
+				t.Setenv("GIT_CONFIG_VALUE_0", "")
+			default:
+				t.Fatalf("unknown test setup %q", tt.setup)
+			}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			callerRepository := t.TempDir()
-			runTestGit(t, "init", "--quiet", callerRepository)
-			callerTransportCapture := filepath.Join(t.TempDir(), "caller-transport.txt")
-			callerTransport := filepath.Join(t.TempDir(), "caller-ssh")
-			writeTestExecutable(t, callerTransport, `#!/bin/sh
-set -eu
-printf 'caller\n' > "$ASC_CALLER_SSH_CAPTURE"
-exit 17
-`)
-			globalConfig := tt.configure(t, callerRepository, callerTransport)
-
-			binDir := t.TempDir()
-			defaultTransportCapture := filepath.Join(t.TempDir(), "default-transport.txt")
-			writeTestExecutable(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
-set -eu
-printf '%s\n' "$@" > "$ASC_FAKE_SSH_CAPTURE"
-exit 17
-`)
-
-			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-			t.Setenv("ASC_CALLER_SSH_CAPTURE", callerTransportCapture)
-			t.Setenv("ASC_FAKE_SSH_CAPTURE", defaultTransportCapture)
-			t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
-			t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
-			t.Setenv("GIT_SSH_COMMAND", "")
-			t.Setenv("GIT_SSH", "")
-			t.Setenv("GIT_SSH_VARIANT", "ssh")
-
-			destination := filepath.Join(t.TempDir(), "clone")
-			cmd, err := newGitCommand(context.Background(), callerRepository, "clone", "ssh://git@127.0.0.1:1/repository", destination)
+			args := []string{"ls-remote", "ssh://git@127.0.0.1:1/repository"}
+			if tt.clone {
+				args = []string{"clone", "ssh://git@127.0.0.1:1/repository", filepath.Join(t.TempDir(), "clone")}
+			}
+			cmd, err := newGitCommand(context.Background(), callerRepository, args...)
 			if err != nil {
 				t.Fatalf("newGitCommand: %v", err)
 			}
 			if err := cmd.Run(); err == nil {
 				t.Fatal("expected fake SSH transport failure")
 			}
-			defaultArguments, err := os.ReadFile(defaultTransportCapture)
+
+			selectedCapture, unselectedCapture := configuredCapture, defaultCapture
+			if tt.wantDefault {
+				selectedCapture, unselectedCapture = defaultCapture, configuredCapture
+			}
+			selectedArguments, err := os.ReadFile(selectedCapture)
 			if err != nil {
-				t.Fatalf("read default SSH transport arguments: %v", err)
+				t.Fatalf("read selected SSH transport arguments: %v", err)
 			}
-			if !strings.Contains(string(defaultArguments), "-o\nBatchMode=yes\n") {
-				t.Fatalf("default SSH transport arguments = %q, want BatchMode=yes", defaultArguments)
+			if tt.wantDefault && !strings.Contains(string(selectedArguments), "-o\nBatchMode=yes\n") {
+				t.Fatalf("default SSH transport arguments = %q, want BatchMode=yes", selectedArguments)
 			}
-			if _, err := os.Stat(callerTransportCapture); !os.IsNotExist(err) {
-				t.Fatalf("caller-scoped core.sshCommand unexpectedly ran during clone: %v", err)
-			}
-		})
-	}
-}
-
-func TestNewGitCommandDefaultsForBlankConfiguredSSHCommand(t *testing.T) {
-	configPath := filepath.Join(t.TempDir(), "gitconfig")
-	configureGitSSHCommand(t, configPath, "")
-
-	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
-	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
-	t.Setenv("GIT_SSH_COMMAND", "")
-	t.Setenv("GIT_SSH", "")
-
-	cmd, err := newGitCommand(context.Background(), t.TempDir(), "clone", "source", "destination")
-	if err != nil {
-		t.Fatalf("newGitCommand: %v", err)
-	}
-	if got := commandEnvironmentValues(cmd.Env, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
-		t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
-	}
-}
-
-func TestConfiguredGitSSHCommandFromScopedOutput(t *testing.T) {
-	tests := []struct {
-		name                    string
-		output                  string
-		includeRepositoryConfig bool
-		want                    bool
-		wantErr                 bool
-	}{
-		{
-			name:   "clone ignores caller repository config",
-			output: "local\x00ssh local\x00",
-		},
-		{
-			name:   "clone preserves global config before local override",
-			output: "global\x00ssh global\x00local\x00 \x00",
-			want:   true,
-		},
-		{
-			name:   "clone honors blank command policy over global config",
-			output: "global\x00ssh global\x00command\x00 \x00",
-		},
-		{
-			name:                    "repository command honors blank local override",
-			output:                  "global\x00ssh global\x00local\x00 \x00",
-			includeRepositoryConfig: true,
-		},
-		{
-			name:                    "repository command preserves local config",
-			output:                  "global\x00 \x00local\x00ssh local\x00",
-			includeRepositoryConfig: true,
-			want:                    true,
-		},
-		{
-			name:    "malformed scoped output",
-			output:  "global\x00ssh\x00local\x00",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := configuredGitSSHCommandFromScopedOutput([]byte(tt.output), tt.includeRepositoryConfig)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("configuredGitSSHCommandFromScopedOutput() error = %v, wantErr %t", err, tt.wantErr)
-			}
-			if got != tt.want {
-				t.Fatalf("configuredGitSSHCommandFromScopedOutput() = %t, want %t", got, tt.want)
+			if _, err := os.Stat(unselectedCapture); !os.IsNotExist(err) {
+				t.Fatalf("unselected SSH transport unexpectedly ran: %v", err)
 			}
 		})
 	}
@@ -689,8 +502,8 @@ func TestNewGitCommandIgnoresInheritedRepositorySelectors(t *testing.T) {
 	sentinelRepository := filepath.Join(t.TempDir(), "sentinel")
 	targetRepository := filepath.Join(t.TempDir(), "target")
 	standaloneEnvironment := standaloneTestGitEnvironment(t)
-	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
-	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", targetRepository)
+	runTestGitWithEnvironment(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
+	runTestGitWithEnvironment(t, standaloneEnvironment, "init", "--quiet", targetRepository)
 
 	globalConfig := filepath.Join(t.TempDir(), "global-config")
 	t.Setenv("HOME", t.TempDir())
@@ -721,17 +534,8 @@ func TestNewGitCommandIgnoresInheritedRepositorySelectors(t *testing.T) {
 	if sentinelConfigured {
 		t.Errorf("sentinel core.testMarker = %q; inherited repository selectors redirected Git", sentinelValue)
 	}
-	if got := commandEnvironmentValues(cmd.Env, "GIT_DIR"); len(got) != 0 {
-		t.Errorf("GIT_DIR values = %v, want none", got)
-	}
-	if got := commandEnvironmentValues(cmd.Env, "GIT_CONFIG_GLOBAL"); len(got) != 1 || got[0] != globalConfig {
-		t.Errorf("GIT_CONFIG_GLOBAL values = %v, want [%s]", got, globalConfig)
-	}
-	if got := commandEnvironmentValues(cmd.Env, "GIT_SSH"); len(got) != 1 || got[0] != "/opt/team/bin/ssh-wrapper" {
-		t.Errorf("GIT_SSH values = %v, want preserved transport", got)
-	}
-	if got := commandEnvironmentValues(cmd.Env, "GIT_TERMINAL_PROMPT"); len(got) != 1 || got[0] != "0" {
-		t.Errorf("GIT_TERMINAL_PROMPT values = %v, want [0]", got)
+	if _, ok := commandEnvironmentValue(cmd.Env, "GIT_DIR", false); ok {
+		t.Error("GIT_DIR unexpectedly remained in command environment")
 	}
 }
 
@@ -739,8 +543,8 @@ func TestRunTestGitIsolatesRepositoryEnvironment(t *testing.T) {
 	sentinelRepository := filepath.Join(t.TempDir(), "sentinel")
 	targetRepository := filepath.Join(t.TempDir(), "target")
 	standaloneEnvironment := standaloneTestGitEnvironment(t)
-	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
-	runStandaloneTestGit(t, standaloneEnvironment, "init", "--quiet", targetRepository)
+	runTestGitWithEnvironment(t, standaloneEnvironment, "init", "--quiet", sentinelRepository)
+	runTestGitWithEnvironment(t, standaloneEnvironment, "init", "--quiet", targetRepository)
 
 	t.Setenv("GIT_DIR", filepath.Join(sentinelRepository, ".git"))
 	t.Setenv("GIT_WORK_TREE", sentinelRepository)
@@ -759,120 +563,110 @@ func TestRunTestGitIsolatesRepositoryEnvironment(t *testing.T) {
 	}
 }
 
-func TestGitCommandEnvironmentPreservesCustomSSHCommand(t *testing.T) {
+func TestGitCommandEnvironmentSelection(t *testing.T) {
+	customCommand := `team-ssh-wrapper --identity '/tmp/release key' -o BatchMode=no`
 	tests := []struct {
-		name       string
-		sshCommand string
+		name                     string
+		goos                     string
+		environment              []string
+		coreSSHCommandConfigured bool
+		want                     []string
 	}{
 		{
-			name:       "quoted identity path with batch mode",
-			sshCommand: `ssh -i '/tmp/team key' -o BatchMode=yes`,
-		},
-		{
-			name:       "wrapper command",
-			sshCommand: `team-ssh-wrapper --identity 'release key'`,
-		},
-		{
-			name:       "explicit interactive override",
-			sshCommand: `ssh -o BatchMode=no`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			environment := gitCommandEnvironmentWithConfig([]string{
+			name: "preserves explicit command byte for byte",
+			goos: "linux",
+			environment: []string{
 				"PATH=/usr/bin",
 				"GIT_TERMINAL_PROMPT=1",
 				"GIT_TERMINAL_PROMPT=true",
-				"GIT_SSH_COMMAND=" + tt.sshCommand,
-			}, runtime.GOOS, false)
-
-			if got := commandEnvironmentValues(environment, "GIT_TERMINAL_PROMPT"); len(got) != 1 || got[0] != "0" {
-				t.Fatalf("GIT_TERMINAL_PROMPT values = %v, want [0]", got)
-			}
-			if got := commandEnvironmentValues(environment, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != tt.sshCommand {
-				t.Fatalf("GIT_SSH_COMMAND values = %v, want [%s]", got, tt.sshCommand)
-			}
-		})
-	}
-}
-
-func TestGitCommandEnvironmentPreservesGitSSH(t *testing.T) {
-	environment := gitCommandEnvironmentWithConfig([]string{
-		"PATH=/usr/bin",
-		"GIT_TERMINAL_PROMPT=1",
-		"GIT_SSH_COMMAND= \t",
-		"GIT_SSH=/opt/team/bin/ssh-wrapper",
-	}, runtime.GOOS, false)
-	want := []string{
-		"PATH=/usr/bin",
-		"GIT_SSH=/opt/team/bin/ssh-wrapper",
-		"GIT_TERMINAL_PROMPT=0",
-	}
-	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
-	}
-}
-
-func TestGitCommandEnvironmentDefaultsMissingOrBlankSSHCommand(t *testing.T) {
-	tests := []struct {
-		name        string
-		environment []string
-	}{
+				"GIT_SSH_COMMAND=" + customCommand,
+			},
+			want: []string{"PATH=/usr/bin", "GIT_TERMINAL_PROMPT=0", "GIT_SSH_COMMAND=" + customCommand},
+		},
 		{
-			name:        "missing",
+			name: "preserves GIT_SSH after blank command",
+			goos: "linux",
+			environment: []string{
+				"PATH=/usr/bin",
+				"GIT_TERMINAL_PROMPT=1",
+				"GIT_SSH_COMMAND= \t",
+				"GIT_SSH=/opt/team/bin/ssh-wrapper",
+			},
+			want: []string{"PATH=/usr/bin", "GIT_SSH=/opt/team/bin/ssh-wrapper", "GIT_TERMINAL_PROMPT=0"},
+		},
+		{
+			name:        "defaults missing SSH settings",
+			goos:        "linux",
 			environment: []string{"PATH=/usr/bin"},
+			want:        []string{"PATH=/usr/bin", "GIT_TERMINAL_PROMPT=0", "GIT_SSH_COMMAND=ssh -o BatchMode=yes"},
 		},
 		{
-			name:        "empty",
-			environment: []string{"PATH=/usr/bin", "GIT_SSH_COMMAND="},
+			name:        "defaults blank SSH settings",
+			goos:        "linux",
+			environment: []string{"PATH=/usr/bin", "GIT_SSH_COMMAND= \t", "GIT_SSH= "},
+			want:        []string{"PATH=/usr/bin", "GIT_TERMINAL_PROMPT=0", "GIT_SSH_COMMAND=ssh -o BatchMode=yes"},
 		},
 		{
-			name:        "whitespace",
-			environment: []string{"PATH=/usr/bin", "GIT_SSH_COMMAND= \t"},
+			name:                     "configured core command suppresses default",
+			goos:                     "linux",
+			environment:              []string{"PATH=/usr/bin"},
+			coreSSHCommandConfigured: true,
+			want:                     []string{"PATH=/usr/bin", "GIT_TERMINAL_PROMPT=0"},
+		},
+		{
+			name: "Windows matches command keys case insensitively",
+			goos: "windows",
+			environment: []string{
+				"PATH=C:\\Windows\\System32",
+				"git_terminal_prompt=1",
+				`git_ssh_command=team-ssh-wrapper --identity 'release key'`,
+			},
+			want: []string{
+				"PATH=C:\\Windows\\System32",
+				"GIT_TERMINAL_PROMPT=0",
+				`GIT_SSH_COMMAND=team-ssh-wrapper --identity 'release key'`,
+			},
+		},
+		{
+			name: "Windows preserves mixed-case GIT_SSH",
+			goos: "windows",
+			environment: []string{
+				"PATH=C:\\Windows\\System32",
+				"git_terminal_prompt=1",
+				"git_ssh_command= ",
+				`git_ssh=C:\tools\team-ssh.exe`,
+			},
+			want: []string{
+				"PATH=C:\\Windows\\System32",
+				`git_ssh=C:\tools\team-ssh.exe`,
+				"GIT_TERMINAL_PROMPT=0",
+			},
+		},
+		{
+			name: "POSIX keeps differently cased keys",
+			goos: "linux",
+			environment: []string{
+				"PATH=/usr/bin",
+				"git_terminal_prompt=1",
+				"git_ssh_command=team-ssh-wrapper",
+			},
+			want: []string{
+				"PATH=/usr/bin",
+				"git_terminal_prompt=1",
+				"git_ssh_command=team-ssh-wrapper",
+				"GIT_TERMINAL_PROMPT=0",
+				"GIT_SSH_COMMAND=ssh -o BatchMode=yes",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			environment := gitCommandEnvironmentWithConfig(tt.environment, runtime.GOOS, false)
-			if got := commandEnvironmentValues(environment, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
-				t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
+			got := gitCommandEnvironmentWithConfig(tt.environment, tt.goos, tt.coreSSHCommandConfigured)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestGitCommandEnvironmentForWindowsMatchesKeysCaseInsensitively(t *testing.T) {
-	environment := gitCommandEnvironmentWithConfig([]string{
-		"PATH=C:\\Windows\\System32",
-		"git_terminal_prompt=1",
-		`git_ssh_command=team-ssh-wrapper --identity 'release key'`,
-	}, "windows", false)
-	want := []string{
-		"PATH=C:\\Windows\\System32",
-		"GIT_TERMINAL_PROMPT=0",
-		`GIT_SSH_COMMAND=team-ssh-wrapper --identity 'release key'`,
-	}
-	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
-	}
-}
-
-func TestGitCommandEnvironmentForWindowsPreservesGitSSH(t *testing.T) {
-	environment := gitCommandEnvironmentWithConfig([]string{
-		"PATH=C:\\Windows\\System32",
-		"git_terminal_prompt=1",
-		"git_ssh_command= ",
-		`git_ssh=C:\tools\team-ssh.exe`,
-	}, "windows", false)
-	want := []string{
-		"PATH=C:\\Windows\\System32",
-		`git_ssh=C:\tools\team-ssh.exe`,
-		"GIT_TERMINAL_PROMPT=0",
-	}
-	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
 	}
 }
 
@@ -895,35 +689,6 @@ func TestGitEnvironmentWithoutRepositorySelectorsMatchesWindowsKeysCaseInsensiti
 	}
 }
 
-func TestGitCommandEnvironmentForPOSIXKeepsKeysCaseSensitive(t *testing.T) {
-	environment := gitCommandEnvironmentWithConfig([]string{
-		"PATH=/usr/bin",
-		"git_terminal_prompt=1",
-		"git_ssh_command=team-ssh-wrapper",
-	}, "linux", false)
-	want := []string{
-		"PATH=/usr/bin",
-		"git_terminal_prompt=1",
-		"git_ssh_command=team-ssh-wrapper",
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_SSH_COMMAND=ssh -o BatchMode=yes",
-	}
-	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
-	}
-}
-
-func commandEnvironmentValues(environment []string, key string) []string {
-	prefix := key + "="
-	var values []string
-	for _, entry := range environment {
-		if strings.HasPrefix(entry, prefix) {
-			values = append(values, strings.TrimPrefix(entry, prefix))
-		}
-	}
-	return values
-}
-
 func writeTestExecutable(t *testing.T, path, contents string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
@@ -931,19 +696,9 @@ func writeTestExecutable(t *testing.T, path, contents string) {
 	}
 }
 
-func configureGitSSHCommand(t *testing.T, configPath, command string) {
-	t.Helper()
-	runTestGit(t, "config", "--file", configPath, "core.sshCommand", command)
-}
-
 func runTestGit(t *testing.T, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = t.TempDir()
-	cmd.Env = standaloneTestGitEnvironment(t)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
-	}
+	runTestGitWithEnvironment(t, standaloneTestGitEnvironment(t), args...)
 }
 
 func standaloneTestGitEnvironment(t *testing.T) []string {
@@ -957,14 +712,21 @@ func standaloneTestGitEnvironment(t *testing.T) []string {
 	}
 }
 
-func runStandaloneTestGit(t *testing.T, environment []string, args ...string) {
+func runTestGitWithEnvironment(t *testing.T, environment []string, args ...string) {
+	t.Helper()
+	runTestGitOutput(t, environment, t.TempDir(), args...)
+}
+
+func runTestGitOutput(t *testing.T, environment []string, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
-	cmd.Dir = t.TempDir()
+	cmd.Dir = dir
 	cmd.Env = environment
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("standalone git %s: %v: %s", strings.Join(args, " "), err, output)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
 	}
+	return string(output)
 }
 
 func standaloneTestGitConfigValue(t *testing.T, environment []string, repository, key string) (string, bool) {

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -480,8 +480,10 @@ exit 17
 				if capture == selectedCapture {
 					continue
 				}
-				if _, err := os.Stat(capture); !os.IsNotExist(err) {
-					t.Fatalf("unselected SSH transport unexpectedly ran: %v", err)
+				if _, err := os.Stat(capture); err == nil {
+					t.Fatalf("unselected SSH transport %q unexpectedly ran", capture)
+				} else if !os.IsNotExist(err) {
+					t.Fatalf("stat unselected SSH transport %q: %v", capture, err)
 				}
 			}
 		})
@@ -740,16 +742,35 @@ func runTestGitWithEnvironment(t *testing.T, environment []string, args ...strin
 	runTestGitOutput(t, environment, t.TempDir(), args...)
 }
 
+func TestRunTestGitOutputSeparatesStandardError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable scripts require a POSIX shell")
+	}
+
+	binDir := t.TempDir()
+	writeTestExecutable(t, filepath.Join(binDir, "git"), `#!/bin/sh
+printf 'configured transport\n'
+printf 'warning: diagnostic only\n' >&2
+`)
+	t.Setenv("PATH", binDir)
+	environment := replaceCommandEnvironmentValue(standaloneTestGitEnvironment(t), "PATH", binDir, false)
+	if got := runTestGitOutput(t, environment, t.TempDir(), "config", "--get", "core.sshCommand"); got != "configured transport\n" {
+		t.Fatalf("runTestGitOutput() = %q, want stdout only", got)
+	}
+}
+
 func runTestGitOutput(t *testing.T, environment []string, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = environment
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, stderr.String())
 	}
-	return string(output)
+	return stdout.String()
 }
 
 func standaloneTestGitConfigValue(t *testing.T, environment []string, repository, key string) (string, bool) {

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -273,7 +273,7 @@ func TestGitStoreGitHelpersUseNonInteractiveExecutables(t *testing.T) {
 
 	writeTestExecutable(t, filepath.Join(binDir, "git"), `#!/bin/sh
 set -eu
-if [ "${1-}" = "config" ] && [ "${2-}" = "--get" ] && [ "${3-}" = "core.sshCommand" ]; then
+if [ "${1-}" = "config" ]; then
   exit 1
 fi
 printf '%s|%s\n' "${GIT_TERMINAL_PROMPT-}" "${GIT_SSH_COMMAND-}" >> "$ASC_FAKE_GIT_CAPTURE"
@@ -392,10 +392,12 @@ func TestNewGitCommandPreservesConfiguredSSHTransport(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		clone     bool
 		configure func(t *testing.T, transport string) string
 	}{
 		{
-			name: "global config",
+			name:  "global config for clone",
+			clone: true,
 			configure: func(t *testing.T, transport string) string {
 				configPath := filepath.Join(t.TempDir(), "gitconfig")
 				configureGitSSHCommand(t, configPath, transport)
@@ -438,7 +440,11 @@ exit 17
 			t.Setenv("GIT_COMMON_DIR", filepath.Join(sentinelRepository, ".git"))
 			dir := tt.configure(t, transport)
 
-			cmd, err := newGitCommand(context.Background(), dir, "ls-remote", "ssh://git@127.0.0.1:1/repository")
+			args := []string{"ls-remote", "ssh://git@127.0.0.1:1/repository"}
+			if tt.clone {
+				args = []string{"clone", "ssh://git@127.0.0.1:1/repository", filepath.Join(t.TempDir(), "clone")}
+			}
+			cmd, err := newGitCommand(context.Background(), dir, args...)
 			if err != nil {
 				t.Fatalf("newGitCommand: %v", err)
 			}
@@ -449,6 +455,59 @@ exit 17
 				t.Fatalf("expected configured SSH transport to run: %v", err)
 			}
 		})
+	}
+}
+
+func TestNewGitCommandCloneIgnoresCallerRepositorySSHCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable scripts require a POSIX shell")
+	}
+
+	callerRepository := t.TempDir()
+	runTestGit(t, "init", "--quiet", callerRepository)
+	localTransportCapture := filepath.Join(t.TempDir(), "local-transport.txt")
+	localTransport := filepath.Join(t.TempDir(), "local-ssh")
+	writeTestExecutable(t, localTransport, `#!/bin/sh
+set -eu
+printf 'local\n' > "$ASC_LOCAL_SSH_CAPTURE"
+exit 17
+`)
+	runTestGit(t, "-C", callerRepository, "config", "core.sshCommand", localTransport)
+
+	binDir := t.TempDir()
+	defaultTransportCapture := filepath.Join(t.TempDir(), "default-transport.txt")
+	writeTestExecutable(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "$ASC_FAKE_SSH_CAPTURE"
+exit 17
+`)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ASC_LOCAL_SSH_CAPTURE", localTransportCapture)
+	t.Setenv("ASC_FAKE_SSH_CAPTURE", defaultTransportCapture)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
+	t.Setenv("GIT_SSH_COMMAND", "")
+	t.Setenv("GIT_SSH", "")
+	t.Setenv("GIT_SSH_VARIANT", "ssh")
+
+	destination := filepath.Join(t.TempDir(), "clone")
+	cmd, err := newGitCommand(context.Background(), callerRepository, "clone", "ssh://git@127.0.0.1:1/repository", destination)
+	if err != nil {
+		t.Fatalf("newGitCommand: %v", err)
+	}
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected fake SSH transport failure")
+	}
+	defaultArguments, err := os.ReadFile(defaultTransportCapture)
+	if err != nil {
+		t.Fatalf("read default SSH transport arguments: %v", err)
+	}
+	if !strings.Contains(string(defaultArguments), "-o\nBatchMode=yes\n") {
+		t.Fatalf("default SSH transport arguments = %q, want BatchMode=yes", defaultArguments)
+	}
+	if _, err := os.Stat(localTransportCapture); !os.IsNotExist(err) {
+		t.Fatalf("caller repository core.sshCommand unexpectedly ran during clone: %v", err)
 	}
 }
 
@@ -470,6 +529,58 @@ func TestNewGitCommandDefaultsForBlankConfiguredSSHCommand(t *testing.T) {
 	}
 }
 
+func TestConfiguredGitSSHCommandFromScopedOutput(t *testing.T) {
+	tests := []struct {
+		name                    string
+		output                  string
+		includeRepositoryConfig bool
+		want                    bool
+		wantErr                 bool
+	}{
+		{
+			name:   "clone ignores caller repository config",
+			output: "local\x00ssh local\x00",
+		},
+		{
+			name:   "clone preserves global config before local override",
+			output: "global\x00ssh global\x00local\x00 \x00",
+			want:   true,
+		},
+		{
+			name:   "clone honors blank command policy over global config",
+			output: "global\x00ssh global\x00command\x00 \x00",
+		},
+		{
+			name:                    "repository command honors blank local override",
+			output:                  "global\x00ssh global\x00local\x00 \x00",
+			includeRepositoryConfig: true,
+		},
+		{
+			name:                    "repository command preserves local config",
+			output:                  "global\x00 \x00local\x00ssh local\x00",
+			includeRepositoryConfig: true,
+			want:                    true,
+		},
+		{
+			name:    "malformed scoped output",
+			output:  "global\x00ssh\x00local\x00",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := configuredGitSSHCommandFromScopedOutput([]byte(tt.output), tt.includeRepositoryConfig)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("configuredGitSSHCommandFromScopedOutput() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("configuredGitSSHCommandFromScopedOutput() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewGitCommandFailsClosedWhenSSHConfigLookupFails(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake executable scripts require a POSIX shell")
@@ -479,7 +590,7 @@ func TestNewGitCommandFailsClosedWhenSSHConfigLookupFails(t *testing.T) {
 	mainCommandCapture := filepath.Join(t.TempDir(), "main-command.txt")
 	writeTestExecutable(t, filepath.Join(binDir, "git"), `#!/bin/sh
 set -eu
-if [ "${1-}" = "config" ] && [ "${2-}" = "--get" ] && [ "${3-}" = "core.sshCommand" ]; then
+if [ "${1-}" = "config" ]; then
   printf 'invalid git configuration\n' >&2
   exit 2
 fi

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -405,6 +406,40 @@ func TestGitCommandEnvironmentDefaultsMissingOrBlankSSHCommand(t *testing.T) {
 				t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
 			}
 		})
+	}
+}
+
+func TestGitCommandEnvironmentForWindowsMatchesKeysCaseInsensitively(t *testing.T) {
+	environment := gitCommandEnvironmentForGOOS([]string{
+		"PATH=C:\\Windows\\System32",
+		"git_terminal_prompt=1",
+		`git_ssh_command=team-ssh-wrapper --identity 'release key'`,
+	}, "windows")
+	want := []string{
+		"PATH=C:\\Windows\\System32",
+		"GIT_TERMINAL_PROMPT=0",
+		`GIT_SSH_COMMAND=team-ssh-wrapper --identity 'release key'`,
+	}
+	if !slices.Equal(environment, want) {
+		t.Fatalf("gitCommandEnvironmentForGOOS() = %v, want %v", environment, want)
+	}
+}
+
+func TestGitCommandEnvironmentForPOSIXKeepsKeysCaseSensitive(t *testing.T) {
+	environment := gitCommandEnvironmentForGOOS([]string{
+		"PATH=/usr/bin",
+		"git_terminal_prompt=1",
+		"git_ssh_command=team-ssh-wrapper",
+	}, "linux")
+	want := []string{
+		"PATH=/usr/bin",
+		"git_terminal_prompt=1",
+		"git_ssh_command=team-ssh-wrapper",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_SSH_COMMAND=ssh -o BatchMode=yes",
+	}
+	if !slices.Equal(environment, want) {
+		t.Fatalf("gitCommandEnvironmentForGOOS() = %v, want %v", environment, want)
 	}
 }
 

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -709,12 +709,12 @@ func TestGitCommandEnvironmentPreservesCustomSSHCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			environment := gitCommandEnvironment([]string{
+			environment := gitCommandEnvironmentWithConfig([]string{
 				"PATH=/usr/bin",
 				"GIT_TERMINAL_PROMPT=1",
 				"GIT_TERMINAL_PROMPT=true",
 				"GIT_SSH_COMMAND=" + tt.sshCommand,
-			})
+			}, runtime.GOOS, false)
 
 			if got := commandEnvironmentValues(environment, "GIT_TERMINAL_PROMPT"); len(got) != 1 || got[0] != "0" {
 				t.Fatalf("GIT_TERMINAL_PROMPT values = %v, want [0]", got)
@@ -727,19 +727,19 @@ func TestGitCommandEnvironmentPreservesCustomSSHCommand(t *testing.T) {
 }
 
 func TestGitCommandEnvironmentPreservesGitSSH(t *testing.T) {
-	environment := gitCommandEnvironment([]string{
+	environment := gitCommandEnvironmentWithConfig([]string{
 		"PATH=/usr/bin",
 		"GIT_TERMINAL_PROMPT=1",
 		"GIT_SSH_COMMAND= \t",
 		"GIT_SSH=/opt/team/bin/ssh-wrapper",
-	})
+	}, runtime.GOOS, false)
 	want := []string{
 		"PATH=/usr/bin",
 		"GIT_SSH=/opt/team/bin/ssh-wrapper",
 		"GIT_TERMINAL_PROMPT=0",
 	}
 	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironment() = %v, want %v", environment, want)
+		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
 	}
 }
 
@@ -764,7 +764,7 @@ func TestGitCommandEnvironmentDefaultsMissingOrBlankSSHCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			environment := gitCommandEnvironment(tt.environment)
+			environment := gitCommandEnvironmentWithConfig(tt.environment, runtime.GOOS, false)
 			if got := commandEnvironmentValues(environment, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
 				t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
 			}
@@ -773,35 +773,35 @@ func TestGitCommandEnvironmentDefaultsMissingOrBlankSSHCommand(t *testing.T) {
 }
 
 func TestGitCommandEnvironmentForWindowsMatchesKeysCaseInsensitively(t *testing.T) {
-	environment := gitCommandEnvironmentForGOOS([]string{
+	environment := gitCommandEnvironmentWithConfig([]string{
 		"PATH=C:\\Windows\\System32",
 		"git_terminal_prompt=1",
 		`git_ssh_command=team-ssh-wrapper --identity 'release key'`,
-	}, "windows")
+	}, "windows", false)
 	want := []string{
 		"PATH=C:\\Windows\\System32",
 		"GIT_TERMINAL_PROMPT=0",
 		`GIT_SSH_COMMAND=team-ssh-wrapper --identity 'release key'`,
 	}
 	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironmentForGOOS() = %v, want %v", environment, want)
+		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
 	}
 }
 
 func TestGitCommandEnvironmentForWindowsPreservesGitSSH(t *testing.T) {
-	environment := gitCommandEnvironmentForGOOS([]string{
+	environment := gitCommandEnvironmentWithConfig([]string{
 		"PATH=C:\\Windows\\System32",
 		"git_terminal_prompt=1",
 		"git_ssh_command= ",
 		`git_ssh=C:\tools\team-ssh.exe`,
-	}, "windows")
+	}, "windows", false)
 	want := []string{
 		"PATH=C:\\Windows\\System32",
 		`git_ssh=C:\tools\team-ssh.exe`,
 		"GIT_TERMINAL_PROMPT=0",
 	}
 	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironmentForGOOS() = %v, want %v", environment, want)
+		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
 	}
 }
 
@@ -825,11 +825,11 @@ func TestGitEnvironmentWithoutRepositorySelectorsMatchesWindowsKeysCaseInsensiti
 }
 
 func TestGitCommandEnvironmentForPOSIXKeepsKeysCaseSensitive(t *testing.T) {
-	environment := gitCommandEnvironmentForGOOS([]string{
+	environment := gitCommandEnvironmentWithConfig([]string{
 		"PATH=/usr/bin",
 		"git_terminal_prompt=1",
 		"git_ssh_command=team-ssh-wrapper",
-	}, "linux")
+	}, "linux", false)
 	want := []string{
 		"PATH=/usr/bin",
 		"git_terminal_prompt=1",
@@ -838,7 +838,7 @@ func TestGitCommandEnvironmentForPOSIXKeepsKeysCaseSensitive(t *testing.T) {
 		"GIT_SSH_COMMAND=ssh -o BatchMode=yes",
 	}
 	if !slices.Equal(environment, want) {
-		t.Fatalf("gitCommandEnvironmentForGOOS() = %v, want %v", environment, want)
+		t.Fatalf("gitCommandEnvironmentWithConfig() = %v, want %v", environment, want)
 	}
 }
 

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -406,6 +406,29 @@ func TestNewGitCommandPreservesConfiguredSSHTransport(t *testing.T) {
 			},
 		},
 		{
+			name:  "unconditional global include for clone",
+			clone: true,
+			configure: func(t *testing.T, transport string) string {
+				includedConfig := filepath.Join(t.TempDir(), "included-gitconfig")
+				configureGitSSHCommand(t, includedConfig, transport)
+				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
+				runTestGit(t, "config", "--file", globalConfig, "include.path", includedConfig)
+				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+				return t.TempDir()
+			},
+		},
+		{
+			name:  "command config for clone",
+			clone: true,
+			configure: func(t *testing.T, transport string) string {
+				t.Setenv("GIT_CONFIG_COUNT", "1")
+				t.Setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
+				t.Setenv("GIT_CONFIG_VALUE_0", transport)
+				t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
+				return t.TempDir()
+			},
+		},
+		{
 			name: "repository config",
 			configure: func(t *testing.T, transport string) string {
 				t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
@@ -458,56 +481,104 @@ exit 17
 	}
 }
 
-func TestNewGitCommandCloneIgnoresCallerRepositorySSHCommand(t *testing.T) {
+func TestNewGitCommandCloneIgnoresCallerScopedSSHCommands(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake executable scripts require a POSIX shell")
 	}
 
-	callerRepository := t.TempDir()
-	runTestGit(t, "init", "--quiet", callerRepository)
-	localTransportCapture := filepath.Join(t.TempDir(), "local-transport.txt")
-	localTransport := filepath.Join(t.TempDir(), "local-ssh")
-	writeTestExecutable(t, localTransport, `#!/bin/sh
+	tests := []struct {
+		name      string
+		configure func(t *testing.T, callerRepository, transport string) string
+	}{
+		{
+			name: "local repository config",
+			configure: func(t *testing.T, callerRepository, transport string) string {
+				runTestGit(t, "-C", callerRepository, "config", "core.sshCommand", transport)
+				return filepath.Join(t.TempDir(), "missing-gitconfig")
+			},
+		},
+		{
+			name: "gitdir conditional global config",
+			configure: func(t *testing.T, callerRepository, transport string) string {
+				includedConfig := filepath.Join(t.TempDir(), "included-gitconfig")
+				configureGitSSHCommand(t, includedConfig, transport)
+				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
+				resolvedCallerRepository, err := filepath.EvalSymlinks(callerRepository)
+				if err != nil {
+					t.Fatalf("resolve caller repository: %v", err)
+				}
+				conditionKey := "includeIf.gitdir:" + filepath.ToSlash(resolvedCallerRepository) + "/.path"
+				runTestGit(t, "config", "--file", globalConfig, conditionKey, includedConfig)
+
+				cmd := exec.Command("git", "config", "--get", "core.sshCommand")
+				cmd.Dir = callerRepository
+				cmd.Env = replaceCommandEnvironmentValue(
+					standaloneTestGitEnvironment(t),
+					"GIT_CONFIG_GLOBAL",
+					globalConfig,
+					false,
+				)
+				output, err := cmd.Output()
+				if err != nil {
+					t.Fatalf("verify gitdir conditional config: %v", err)
+				}
+				if got := strings.TrimSpace(string(output)); got != transport {
+					t.Fatalf("conditional core.sshCommand = %q, want %q", got, transport)
+				}
+				return globalConfig
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callerRepository := t.TempDir()
+			runTestGit(t, "init", "--quiet", callerRepository)
+			callerTransportCapture := filepath.Join(t.TempDir(), "caller-transport.txt")
+			callerTransport := filepath.Join(t.TempDir(), "caller-ssh")
+			writeTestExecutable(t, callerTransport, `#!/bin/sh
 set -eu
-printf 'local\n' > "$ASC_LOCAL_SSH_CAPTURE"
+printf 'caller\n' > "$ASC_CALLER_SSH_CAPTURE"
 exit 17
 `)
-	runTestGit(t, "-C", callerRepository, "config", "core.sshCommand", localTransport)
+			globalConfig := tt.configure(t, callerRepository, callerTransport)
 
-	binDir := t.TempDir()
-	defaultTransportCapture := filepath.Join(t.TempDir(), "default-transport.txt")
-	writeTestExecutable(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
+			binDir := t.TempDir()
+			defaultTransportCapture := filepath.Join(t.TempDir(), "default-transport.txt")
+			writeTestExecutable(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
 set -eu
 printf '%s\n' "$@" > "$ASC_FAKE_SSH_CAPTURE"
 exit 17
 `)
 
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("ASC_LOCAL_SSH_CAPTURE", localTransportCapture)
-	t.Setenv("ASC_FAKE_SSH_CAPTURE", defaultTransportCapture)
-	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
-	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-gitconfig"))
-	t.Setenv("GIT_SSH_COMMAND", "")
-	t.Setenv("GIT_SSH", "")
-	t.Setenv("GIT_SSH_VARIANT", "ssh")
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("ASC_CALLER_SSH_CAPTURE", callerTransportCapture)
+			t.Setenv("ASC_FAKE_SSH_CAPTURE", defaultTransportCapture)
+			t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+			t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+			t.Setenv("GIT_SSH_COMMAND", "")
+			t.Setenv("GIT_SSH", "")
+			t.Setenv("GIT_SSH_VARIANT", "ssh")
 
-	destination := filepath.Join(t.TempDir(), "clone")
-	cmd, err := newGitCommand(context.Background(), callerRepository, "clone", "ssh://git@127.0.0.1:1/repository", destination)
-	if err != nil {
-		t.Fatalf("newGitCommand: %v", err)
-	}
-	if err := cmd.Run(); err == nil {
-		t.Fatal("expected fake SSH transport failure")
-	}
-	defaultArguments, err := os.ReadFile(defaultTransportCapture)
-	if err != nil {
-		t.Fatalf("read default SSH transport arguments: %v", err)
-	}
-	if !strings.Contains(string(defaultArguments), "-o\nBatchMode=yes\n") {
-		t.Fatalf("default SSH transport arguments = %q, want BatchMode=yes", defaultArguments)
-	}
-	if _, err := os.Stat(localTransportCapture); !os.IsNotExist(err) {
-		t.Fatalf("caller repository core.sshCommand unexpectedly ran during clone: %v", err)
+			destination := filepath.Join(t.TempDir(), "clone")
+			cmd, err := newGitCommand(context.Background(), callerRepository, "clone", "ssh://git@127.0.0.1:1/repository", destination)
+			if err != nil {
+				t.Fatalf("newGitCommand: %v", err)
+			}
+			if err := cmd.Run(); err == nil {
+				t.Fatal("expected fake SSH transport failure")
+			}
+			defaultArguments, err := os.ReadFile(defaultTransportCapture)
+			if err != nil {
+				t.Fatalf("read default SSH transport arguments: %v", err)
+			}
+			if !strings.Contains(string(defaultArguments), "-o\nBatchMode=yes\n") {
+				t.Fatalf("default SSH transport arguments = %q, want BatchMode=yes", defaultArguments)
+			}
+			if _, err := os.Stat(callerTransportCapture); !os.IsNotExist(err) {
+				t.Fatalf("caller-scoped core.sshCommand unexpectedly ran during clone: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -2,8 +2,10 @@ package signing
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -254,5 +256,172 @@ func TestGitStoreListEncryptedFilesSkipsGitDirAndSymlinks(t *testing.T) {
 	}
 	if gotSet["linked-dir/child"] {
 		t.Fatalf("did not expect symlinked directory contents in list, got %v", got)
+	}
+}
+
+func TestGitStoreGitHelpersUseNonInteractiveExecutables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable scripts require a POSIX shell")
+	}
+
+	binDir := t.TempDir()
+	gitCapture := filepath.Join(t.TempDir(), "git-env.txt")
+	sshCapture := filepath.Join(t.TempDir(), "ssh-args.txt")
+
+	writeTestExecutable(t, filepath.Join(binDir, "git"), `#!/bin/sh
+set -eu
+printf '%s|%s\n' "${GIT_TERMINAL_PROMPT-}" "${GIT_SSH_COMMAND-}" >> "$ASC_FAKE_GIT_CAPTURE"
+sh -c "$GIT_SSH_COMMAND \"\$@\"" asc-fake-git "$@"
+if [ "${1-}" = "status" ]; then
+  printf 'clean\n'
+fi
+`)
+	writeTestExecutable(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
+set -eu
+{
+  printf '%s\n' '--call--'
+  for arg in "$@"; do
+    printf '%s\n' "$arg"
+  done
+} >> "$ASC_FAKE_SSH_CAPTURE"
+`)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ASC_FAKE_GIT_CAPTURE", gitCapture)
+	t.Setenv("ASC_FAKE_SSH_CAPTURE", sshCapture)
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GIT_SSH_COMMAND", "")
+
+	store := &GitStore{}
+	if err := store.gitRun(context.Background(), "", "clone", "source", "destination"); err != nil {
+		t.Fatalf("gitRun: %v", err)
+	}
+	output, err := store.gitOutput(context.Background(), "", "status", "--porcelain")
+	if err != nil {
+		t.Fatalf("gitOutput: %v", err)
+	}
+	if output != "clean\n" {
+		t.Fatalf("gitOutput() = %q, want %q", output, "clean\n")
+	}
+
+	gitEnvironment, err := os.ReadFile(gitCapture)
+	if err != nil {
+		t.Fatalf("read fake git environment: %v", err)
+	}
+	if got, want := string(gitEnvironment), "0|ssh -o BatchMode=yes\n0|ssh -o BatchMode=yes\n"; got != want {
+		t.Fatalf("fake git environment = %q, want %q", got, want)
+	}
+
+	sshArguments, err := os.ReadFile(sshCapture)
+	if err != nil {
+		t.Fatalf("read fake ssh arguments: %v", err)
+	}
+	wantCalls := "--call--\n-o\nBatchMode=yes\nclone\nsource\ndestination\n" +
+		"--call--\n-o\nBatchMode=yes\nstatus\n--porcelain\n"
+	if got := string(sshArguments); got != wantCalls {
+		t.Fatalf("fake ssh arguments = %q, want %q", got, wantCalls)
+	}
+}
+
+func TestNewGitCommandUsesNonInteractiveEnvironment(t *testing.T) {
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GIT_SSH_COMMAND", " ")
+
+	dir := t.TempDir()
+	cmd := newGitCommand(context.Background(), dir, "status", "--porcelain")
+
+	if cmd.Dir != dir {
+		t.Fatalf("newGitCommand() dir = %q, want %q", cmd.Dir, dir)
+	}
+	if got := commandEnvironmentValues(cmd.Env, "GIT_TERMINAL_PROMPT"); len(got) != 1 || got[0] != "0" {
+		t.Fatalf("GIT_TERMINAL_PROMPT values = %v, want [0]", got)
+	}
+	if got := commandEnvironmentValues(cmd.Env, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
+		t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
+	}
+}
+
+func TestGitCommandEnvironmentPreservesCustomSSHCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		sshCommand string
+	}{
+		{
+			name:       "quoted identity path with batch mode",
+			sshCommand: `ssh -i '/tmp/team key' -o BatchMode=yes`,
+		},
+		{
+			name:       "wrapper command",
+			sshCommand: `team-ssh-wrapper --identity 'release key'`,
+		},
+		{
+			name:       "explicit interactive override",
+			sshCommand: `ssh -o BatchMode=no`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			environment := gitCommandEnvironment([]string{
+				"PATH=/usr/bin",
+				"GIT_TERMINAL_PROMPT=1",
+				"GIT_TERMINAL_PROMPT=true",
+				"GIT_SSH_COMMAND=" + tt.sshCommand,
+			})
+
+			if got := commandEnvironmentValues(environment, "GIT_TERMINAL_PROMPT"); len(got) != 1 || got[0] != "0" {
+				t.Fatalf("GIT_TERMINAL_PROMPT values = %v, want [0]", got)
+			}
+			if got := commandEnvironmentValues(environment, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != tt.sshCommand {
+				t.Fatalf("GIT_SSH_COMMAND values = %v, want [%s]", got, tt.sshCommand)
+			}
+		})
+	}
+}
+
+func TestGitCommandEnvironmentDefaultsMissingOrBlankSSHCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment []string
+	}{
+		{
+			name:        "missing",
+			environment: []string{"PATH=/usr/bin"},
+		},
+		{
+			name:        "empty",
+			environment: []string{"PATH=/usr/bin", "GIT_SSH_COMMAND="},
+		},
+		{
+			name:        "whitespace",
+			environment: []string{"PATH=/usr/bin", "GIT_SSH_COMMAND= \t"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			environment := gitCommandEnvironment(tt.environment)
+			if got := commandEnvironmentValues(environment, "GIT_SSH_COMMAND"); len(got) != 1 || got[0] != "ssh -o BatchMode=yes" {
+				t.Fatalf("GIT_SSH_COMMAND values = %v, want [ssh -o BatchMode=yes]", got)
+			}
+		})
+	}
+}
+
+func commandEnvironmentValues(environment []string, key string) []string {
+	prefix := key + "="
+	var values []string
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) {
+			values = append(values, strings.TrimPrefix(entry, prefix))
+		}
+	}
+	return values
+}
+
+func writeTestExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
 	}
 }

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -335,13 +335,14 @@ func TestNewGitCommandSSHSelection(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		setup       string
-		clone       bool
-		wantDefault bool
+		name              string
+		setup             string
+		clone             bool
+		wantDefault       bool
+		wantLowerPriority bool
 	}{
-		{name: "explicit GIT_SSH_COMMAND", setup: "environment-command", clone: true},
-		{name: "inherited GIT_SSH", setup: "environment-ssh", clone: true},
+		{name: "GIT_SSH_COMMAND overrides GIT_SSH and core config", setup: "command-precedence", clone: true},
+		{name: "GIT_SSH and core config suppress default injection", setup: "ssh-and-core", clone: true, wantLowerPriority: true},
 		{name: "global config for clone", setup: "global", clone: true},
 		{name: "unconditional global include for clone", setup: "include", clone: true},
 		{name: "command config for clone", setup: "command", clone: true},
@@ -363,6 +364,13 @@ set -eu
 printf '%s\n' "$@" > "$ASC_CONFIGURED_SSH_CAPTURE"
 exit 17
 `)
+			lowerPriorityCapture := filepath.Join(t.TempDir(), "lower-priority-transport.txt")
+			lowerPriorityTransport := filepath.Join(t.TempDir(), "lower-priority-ssh")
+			writeTestExecutable(t, lowerPriorityTransport, `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "$ASC_LOWER_PRIORITY_SSH_CAPTURE"
+exit 17
+`)
 			binDir := t.TempDir()
 			defaultCapture := filepath.Join(t.TempDir(), "default-transport.txt")
 			writeTestExecutable(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
@@ -374,6 +382,7 @@ exit 17
 			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			t.Setenv("HOME", t.TempDir())
 			t.Setenv("ASC_CONFIGURED_SSH_CAPTURE", configuredCapture)
+			t.Setenv("ASC_LOWER_PRIORITY_SSH_CAPTURE", lowerPriorityCapture)
 			t.Setenv("ASC_DEFAULT_SSH_CAPTURE", defaultCapture)
 			t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 			t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "missing-global-config"))
@@ -384,9 +393,16 @@ exit 17
 			t.Setenv("GIT_SSH_VARIANT", "ssh")
 
 			switch tt.setup {
-			case "environment-command":
+			case "command-precedence":
+				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
+				runTestGit(t, "config", "--file", globalConfig, "core.sshCommand", lowerPriorityTransport)
+				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+				t.Setenv("GIT_SSH", lowerPriorityTransport)
 				t.Setenv("GIT_SSH_COMMAND", configuredTransport+` --identity 'release key'`)
-			case "environment-ssh":
+			case "ssh-and-core":
+				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
+				runTestGit(t, "config", "--file", globalConfig, "core.sshCommand", lowerPriorityTransport)
+				t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
 				t.Setenv("GIT_SSH", configuredTransport)
 			case "global":
 				globalConfig := filepath.Join(t.TempDir(), "global-gitconfig")
@@ -447,9 +463,11 @@ exit 17
 				t.Fatal("expected fake SSH transport failure")
 			}
 
-			selectedCapture, unselectedCapture := configuredCapture, defaultCapture
+			selectedCapture := configuredCapture
 			if tt.wantDefault {
-				selectedCapture, unselectedCapture = defaultCapture, configuredCapture
+				selectedCapture = defaultCapture
+			} else if tt.wantLowerPriority {
+				selectedCapture = lowerPriorityCapture
 			}
 			selectedArguments, err := os.ReadFile(selectedCapture)
 			if err != nil {
@@ -458,8 +476,13 @@ exit 17
 			if tt.wantDefault && !strings.Contains(string(selectedArguments), "-o\nBatchMode=yes\n") {
 				t.Fatalf("default SSH transport arguments = %q, want BatchMode=yes", selectedArguments)
 			}
-			if _, err := os.Stat(unselectedCapture); !os.IsNotExist(err) {
-				t.Fatalf("unselected SSH transport unexpectedly ran: %v", err)
+			for _, capture := range []string{configuredCapture, lowerPriorityCapture, defaultCapture} {
+				if capture == selectedCapture {
+					continue
+				}
+				if _, err := os.Stat(capture); !os.IsNotExist(err) {
+					t.Fatalf("unselected SSH transport unexpectedly ran: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- disable terminal credential prompts for signing repository Git subprocesses
- default SSH operations to BatchMode while preserving explicit custom SSH commands byte-for-byte
- cover both shared Git helpers with constructor assertions and fake Git/SSH executable tests

## Compatibility

Signing sync now expects credentials to be available without a terminal prompt, such as through a credential helper or ssh-agent. Nonblank caller transport settings in `GIT_SSH_COMMAND`, `GIT_SSH`, and effective `core.sshCommand` are preserved, and Git's native precedence remains unchanged.

## Testing

- focused signing regression tests, 10 consecutive runs
- focused signing regression tests with the race detector
- built CLI local-repository pull and deterministic SSH failure checks
- read-only disposable-app and bundle lookup
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788934357&installation_model_id=10418&pr_number=1945&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1945&signature=02ed757671404e639bb355eb290d6c2c12861166c993ccb8f254482494ed45bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git operations now run non-interactively, preventing unexpected prompts during signing workflows.
  * SSH-based Git operations use batch mode by default while preserving valid custom SSH settings.
  * Git commands handle missing, blank, or invalid SSH configuration more reliably.
  * Repository-specific environment settings are isolated consistently across operating systems.

* **Tests**
  * Added coverage for non-interactive execution, SSH configuration precedence, error handling, environment isolation, and platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->