### PR TITLE
Propagate structured output write failures

### DIFF
--- a/internal/asc/output_core.go
+++ b/internal/asc/output_core.go
@@ -19,12 +19,26 @@ func printPrettyRawJSON(data json.RawMessage) error {
 
 // PrintMarkdown prints data as Markdown table.
 func PrintMarkdown(data any) error {
-	return renderByRegistry(data, RenderMarkdown)
+	return printHumanOutput(data, renderMarkdown)
 }
 
 // PrintTable prints data as a formatted table.
 func PrintTable(data any) error {
-	return renderByRegistry(data, RenderTable)
+	return printHumanOutput(data, renderTable)
+}
+
+func printHumanOutput(data any, render func([]string, [][]string) error) error {
+	var renderErr error
+	dispatchErr := renderByRegistry(data, func(headers []string, rows [][]string) {
+		if renderErr != nil {
+			return
+		}
+		renderErr = render(headers, rows)
+	})
+	if dispatchErr != nil {
+		return dispatchErr
+	}
+	return renderErr
 }
 
 // PrintJSON prints data as minified JSON (best for AI agents).

--- a/internal/asc/output_test.go
+++ b/internal/asc/output_test.go
@@ -3,6 +3,7 @@ package asc
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -35,6 +36,95 @@ func captureStdout(t *testing.T, fn func() error) string {
 	}
 
 	return buf.String()
+}
+
+func withClosedStdout(t *testing.T, fn func() error) error {
+	t.Helper()
+
+	closed, err := os.CreateTemp(t.TempDir(), "closed-stdout-*")
+	if err != nil {
+		t.Fatalf("create closed stdout fixture: %v", err)
+	}
+	if err := closed.Close(); err != nil {
+		t.Fatalf("close stdout fixture: %v", err)
+	}
+
+	original := os.Stdout
+	os.Stdout = closed
+	defer func() {
+		os.Stdout = original
+	}()
+
+	return fn()
+}
+
+func TestPrintTableAndMarkdown_PropagateWriteErrors(t *testing.T) {
+	result := &ScreenshotSizesResult{Sizes: []ScreenshotSizeEntry{{
+		DisplayType: "APP_IPHONE_65",
+		Family:      "iPhone",
+		Dimensions:  []ScreenshotDimension{{Width: 1284, Height: 2778}},
+	}}}
+
+	renderers := []struct {
+		name string
+		fn   func(any) error
+	}{
+		{name: "table", fn: PrintTable},
+		{name: "markdown", fn: PrintMarkdown},
+	}
+
+	for _, renderer := range renderers {
+		renderer := renderer
+		t.Run(renderer.name, func(t *testing.T) {
+			err := withClosedStdout(t, func() error {
+				return renderer.fn(result)
+			})
+			if !errors.Is(err, os.ErrClosed) {
+				t.Fatalf("render error = %v, want a closed stdout error", err)
+			}
+		})
+	}
+}
+
+func TestPrintTable_DirectRendererPreservesFirstWriteError(t *testing.T) {
+	type multiTableOutput struct {
+		afterFirst func()
+	}
+
+	key := typeKey[multiTableOutput]()
+	cleanupRegistryTypes(t, key)
+	registerDirect(func(value *multiTableOutput, render func([]string, [][]string)) error {
+		render([]string{"First"}, [][]string{{"one"}})
+		value.afterFirst()
+		render([]string{"Second"}, [][]string{{"two"}})
+		return nil
+	})
+
+	closed, err := os.CreateTemp(t.TempDir(), "closed-first-render-*")
+	if err != nil {
+		t.Fatalf("create first render fixture: %v", err)
+	}
+	if err := closed.Close(); err != nil {
+		t.Fatalf("close first render fixture: %v", err)
+	}
+	writable, err := os.CreateTemp(t.TempDir(), "writable-second-render-*")
+	if err != nil {
+		t.Fatalf("create second render fixture: %v", err)
+	}
+	defer writable.Close()
+
+	original := os.Stdout
+	os.Stdout = closed
+	defer func() {
+		os.Stdout = original
+	}()
+
+	err = PrintTable(&multiTableOutput{afterFirst: func() {
+		os.Stdout = writable
+	}})
+	if !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("render error = %v, want the first closed stdout error", err)
+	}
 }
 
 func assertRenderedNonJSONContains(t *testing.T, render func(any) error, data any, want ...string) {

--- a/internal/asc/table_render.go
+++ b/internal/asc/table_render.go
@@ -1,6 +1,7 @@
 package asc
 
 import (
+	"io"
 	"os"
 
 	"github.com/olekukonko/tablewriter"
@@ -8,13 +9,40 @@ import (
 	"github.com/olekukonko/tablewriter/tw"
 )
 
+type renderErrorWriter struct {
+	writer io.Writer
+	err    error
+}
+
+func (w *renderErrorWriter) Write(data []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+
+	written, err := w.writer.Write(data)
+	if err != nil {
+		w.err = err
+		return written, err
+	}
+	if written != len(data) {
+		w.err = io.ErrShortWrite
+		return written, w.err
+	}
+	return written, nil
+}
+
 // RenderTable writes a bordered Unicode table to stdout.
 // Headers preserve their original casing and are center-aligned.
 // Data rows are left-aligned for readability.
 func RenderTable(headers []string, rows [][]string) {
+	_ = renderTable(headers, rows)
+}
+
+func renderTable(headers []string, rows [][]string) error {
 	safeHeaders, safeRows := sanitizeHumanTableData(headers, rows)
+	output := &renderErrorWriter{writer: os.Stdout}
 	table := tablewriter.NewTable(
-		os.Stdout,
+		output,
 		tablewriter.WithConfig(tablewriter.Config{
 			Header: tw.CellConfig{
 				Formatting: tw.CellFormatting{
@@ -28,17 +56,27 @@ func RenderTable(headers []string, rows [][]string) {
 		}),
 	)
 	table.Header(safeHeaders)
-	_ = table.Bulk(safeRows)
-	_ = table.Render()
+	if err := table.Bulk(safeRows); err != nil {
+		return err
+	}
+	if err := table.Render(); err != nil {
+		return err
+	}
+	return output.err
 }
 
 // RenderMarkdown writes a Markdown-formatted table to stdout.
 // Headers preserve their original casing. Data rows are left-aligned.
 // Pipe characters in cell values are escaped automatically by the renderer.
 func RenderMarkdown(headers []string, rows [][]string) {
+	_ = renderMarkdown(headers, rows)
+}
+
+func renderMarkdown(headers []string, rows [][]string) error {
 	safeHeaders, safeRows := sanitizeHumanTableData(headers, rows)
+	output := &renderErrorWriter{writer: os.Stdout}
 	table := tablewriter.NewTable(
-		os.Stdout,
+		output,
 		tablewriter.WithRenderer(renderer.NewMarkdown()),
 		tablewriter.WithConfig(tablewriter.Config{
 			Header: tw.CellConfig{
@@ -53,8 +91,13 @@ func RenderMarkdown(headers []string, rows [][]string) {
 		}),
 	)
 	table.Header(safeHeaders)
-	_ = table.Bulk(safeRows)
-	_ = table.Render()
+	if err := table.Bulk(safeRows); err != nil {
+		return err
+	}
+	if err := table.Render(); err != nil {
+		return err
+	}
+	return output.err
 }
 
 func sanitizeHumanTableData(headers []string, rows [][]string) ([]string, [][]string) {


### PR DESCRIPTION
## Summary
- return table and Markdown stdout write failures from registry-backed output commands
- retain the first writer failure even when the table renderer discards writer return values
- preserve successful output bytes and the exported renderer signatures

## Verification
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc -run '^(TestPrintTableAndMarkdown_PropagateWriteErrors|TestPrintTable_DirectRendererPreservesFirstWriteError)$' -count=20`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/asc -run '^(TestPrintTableAndMarkdown_PropagateWriteErrors|TestPrintTable_DirectRendererPreservesFirstWriteError)$' -count=10`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/asc ./internal/cli/shared ./internal/cli/assets -count=1`
- Windows amd64 package test compile and root build
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Behavior evidence
- the current-main binary exits successfully when table or Markdown stdout is unwritable; this branch exits nonzero with the underlying write error
- successful offline table and Markdown output remains byte-for-byte identical
- a read-only disposable-app list confirms the same nonzero behavior for API-backed table and Markdown output

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788936848&installation_model_id=10418&pr_number=1946&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1946&signature=b468c252d49c18ffe4f9c091bcec8491621f16d786ea279ab003fe7bb7a16933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating table and Markdown output.
  * Output write failures and incomplete writes are now reported instead of silently ignored.
  * Rendering errors are preserved and returned consistently, including when multiple output operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->