### PR TITLE
Resolve local profile directory from active Xcode

### DIFF
--- a/cmd/profiles_local_default_test.go
+++ b/cmd/profiles_local_default_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestProfilesLocalDefaultDiscoveryFailuresAreRuntimeErrors(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("active Xcode profile directory is macOS-specific")
+	}
+
+	binDir := t.TempDir()
+	xcodebuildPath := filepath.Join(binDir, "xcodebuild")
+	script := "#!/bin/sh\nprintf 'xcode-select: active developer directory is a command line tools instance\\n' >&2\nexit 1\n"
+	if err := os.WriteFile(xcodebuildPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake xcodebuild: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	tests := []struct {
+		name    string
+		args    []string
+		context string
+	}{
+		{name: "install", args: []string{"profiles", "local", "install", "--path", filepath.Join(t.TempDir(), "profile.mobileprovision"), "--output", "json"}, context: "profiles local install"},
+		{name: "list", args: []string{"profiles", "local", "list", "--output", "json"}, context: "profiles local list"},
+		{name: "clean", args: []string{"profiles", "local", "clean", "--expired", "--dry-run", "--output", "json"}, context: "profiles local clean"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resetReportFlags(t)
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "test"); code != ExitError {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitError)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			for _, want := range []string{
+				"Error: " + test.context + ": resolve install directory:",
+				"xcodebuild -version failed",
+				"active developer directory is a command line tools instance",
+			} {
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("stderr missing %q: %q", want, stderr)
+				}
+			}
+			if strings.Contains(stderr, "Usage:") {
+				t.Fatalf("runtime discovery error must not print usage: %q", stderr)
+			}
+		})
+	}
+}

--- a/commands/profiles.mdx
+++ b/commands/profiles.mdx
@@ -249,7 +249,7 @@ Manage profiles on your local machine:
 asc profiles local list
 
 # Remove expired profiles
-asc profiles local clean
+asc profiles local clean --expired --confirm
 
 # Get UUID of a profile file
 asc profiles inspect --path "./profile.mobileprovision" --output json | jq -r '.uuid'

--- a/commands/profiles.mdx
+++ b/commands/profiles.mdx
@@ -172,8 +172,8 @@ asc profiles download --id "PROFILE_ID" \
 
 The downloaded `.mobileprovision` file can be:
 
-* Installed in Xcode (drag and drop)
-* Copied to `~/Library/MobileDevice/Provisioning Profiles/`
+* Installed with `asc profiles local install --path "./profile.mobileprovision"`
+* Opened with Xcode
 * Used in CI/CD pipelines
 
 ## Inspect Profile
@@ -201,13 +201,19 @@ This command reads local disk only. It decodes the signed provisioning profile p
 ### Install Profile
 
 ```bash  theme={null}
-# Copy to standard location
-mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-cp profile.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
+# Install into the active Xcode's provisioning profile directory
+asc profiles local install --path "./profile.mobileprovision"
 
 # Or open with Xcode
 open profile.mobileprovision
 ```
+
+On macOS, the default directory follows the active Xcode selected by `DEVELOPER_DIR` or `xcode-select`:
+
+* Xcode 16 or newer: `~/Library/Developer/Xcode/UserData/Provisioning Profiles`
+* Xcode 15 or older: `~/Library/MobileDevice/Provisioning Profiles`
+
+Pass `--install-dir` to choose a directory explicitly or when no full Xcode is active. Xcode 16 and newer can still load previously downloaded profiles from the older directory, but `profiles local` operates on one directory per invocation. Use an explicit `--install-dir "$HOME/Library/MobileDevice/Provisioning Profiles"` when you need to inspect or clean that compatibility store.
 
 ## Delete Profile
 
@@ -246,7 +252,7 @@ asc profiles local list
 asc profiles local clean
 
 # Get UUID of a profile file
-asc profiles local install --path ./profile.mobileprovision
+asc profiles inspect --path "./profile.mobileprovision" --output json | jq -r '.uuid'
 ```
 
 ## Complete Example Workflows
@@ -273,8 +279,8 @@ asc profiles download --id "PROFILE_ID" \
   --output "./signing/appstore.mobileprovision"
 
 # 5. Install profile
-cp ./signing/appstore.mobileprovision \
-  ~/Library/MobileDevice/Provisioning\ Profiles/
+asc profiles local install \
+  --path "./signing/appstore.mobileprovision"
 ```
 
 ### Create Development Profile
@@ -300,8 +306,7 @@ asc profiles create --name "Example Development" \
 # 4. Download and install
 asc profiles download --id "PROFILE_ID" \
   --output "./dev.mobileprovision"
-cp ./dev.mobileprovision \
-  ~/Library/MobileDevice/Provisioning\ Profiles/
+asc profiles local install --path "./dev.mobileprovision"
 ```
 
 ### Update Profile with New Device
@@ -369,15 +374,11 @@ set -e
 asc profiles download --id "$PROFILE_ID" \
   --output "./build.mobileprovision"
 
-# Create provisioning profiles directory
-mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-
 # Install profile
-cp ./build.mobileprovision \
-  ~/Library/MobileDevice/Provisioning\ Profiles/
+asc profiles local install --path "./build.mobileprovision"
 
 # Get profile UUID for Xcode
-PROFILE_UUID=$(asc profiles local install --path ./build.mobileprovision)
+PROFILE_UUID=$(asc profiles inspect --path "./build.mobileprovision" --output json | jq -r '.uuid')
 echo "PROFILE_UUID=$PROFILE_UUID" >> $GITHUB_ENV
 ```
 
@@ -457,11 +458,11 @@ Profiles must be installed in the correct location:
 
 ```bash  theme={null}
 # Check installed profiles
-ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
+asc profiles local list --output table
 
 # Re-install profile
 asc profiles download --id "PROFILE_ID" --output ./profile.mobileprovision
-cp ./profile.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/
+asc profiles local install --path "./profile.mobileprovision"
 
 # Restart Xcode
 ```

--- a/internal/cli/cmdtest/profiles_local_test.go
+++ b/internal/cli/cmdtest/profiles_local_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -293,6 +294,84 @@ type localListResult struct {
 	Items      []localProfileItem `json:"items"`
 
 	SkippedItems []localSkippedItem `json:"skippedItems"`
+}
+
+func TestProfilesLocalDefaultFollowsActiveXcodeWithoutCombiningStores(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("active Xcode profile directory is macOS-specific")
+	}
+
+	binDir := t.TempDir()
+	xcodebuildPath := filepath.Join(binDir, "xcodebuild")
+	if err := os.WriteFile(xcodebuildPath, []byte("#!/bin/sh\nprintf 'Xcode 16.0\\nBuild version 16A1\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write fake xcodebuild: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	modernDir := filepath.Join(homeDir, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles")
+	legacyDir := filepath.Join(homeDir, "Library", "MobileDevice", "Provisioning Profiles")
+	if err := os.MkdirAll(modernDir, 0o755); err != nil {
+		t.Fatalf("create modern profile directory: %v", err)
+	}
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("create legacy profile directory: %v", err)
+	}
+
+	modernUUID := "00000000-0000-0000-0000-000000000016"
+	legacyUUID := "00000000-0000-0000-0000-000000000015"
+	modernPath := filepath.Join(modernDir, modernUUID+".mobileprovision")
+	legacyPath := filepath.Join(legacyDir, legacyUUID+".mobileprovision")
+	expiresAt := time.Now().Add(-24 * time.Hour)
+	if err := os.WriteFile(modernPath, buildMobileprovision(t, modernUUID, "Modern Profile", expiresAt), 0o600); err != nil {
+		t.Fatalf("write modern profile: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, buildMobileprovision(t, legacyUUID, "Legacy Profile", expiresAt), 0o600); err != nil {
+		t.Fatalf("write legacy profile: %v", err)
+	}
+
+	run := func(args []string) (string, string, error) {
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+		var runErr error
+		stdout, stderr := captureOutput(t, func() {
+			if err := root.Parse(args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			runErr = root.Run(context.Background())
+		})
+		return stdout, stderr, runErr
+	}
+
+	stdout, stderr, err := run([]string{"profiles", "local", "list", "--output", "json"})
+	if err != nil {
+		t.Fatalf("default list error = %v, stderr = %q", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty list stderr, got %q", stderr)
+	}
+	var list localListResult
+	if err := json.Unmarshal([]byte(stdout), &list); err != nil {
+		t.Fatalf("decode list JSON: %v (stdout=%q)", err, stdout)
+	}
+	if list.InstallDir != modernDir || list.Listed != 1 || len(list.Items) != 1 || list.Items[0].UUID != modernUUID {
+		t.Fatalf("default list combined or selected the wrong store: %+v", list)
+	}
+
+	_, stderr, err = run([]string{"profiles", "local", "clean", "--expired", "--confirm", "--output", "json"})
+	if err != nil {
+		t.Fatalf("default clean error = %v, stderr = %q", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty clean stderr, got %q", stderr)
+	}
+	if _, err := os.Stat(modernPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("modern profile must be deleted, stat error = %v", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy profile must remain outside the selected store: %v", err)
+	}
 }
 
 func TestProfilesLocal_InstallListCleanExpired(t *testing.T) {

--- a/internal/cli/profiles/local.go
+++ b/internal/cli/profiles/local.go
@@ -18,11 +18,25 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	xcodecore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 )
+
+const profilesLocalDirectoryHelp = `On macOS, the default directory follows the active Xcode:
+  Xcode 16 or newer: ~/Library/Developer/Xcode/UserData/Provisioning Profiles
+  Xcode 15 or older: ~/Library/MobileDevice/Provisioning Profiles
+
+Use --install-dir to choose a directory explicitly or when no full Xcode is active.`
 
 // profileUUIDValidationRegex ensures the UUID from a provisioning profile is safe to use
 // as a filename component (prevents absolute paths / path traversal).
 var profileUUIDValidationRegex = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+var (
+	errProfilesInstallDirRequired = errors.New("--install-dir is required on non-macOS platforms")
+	profilesRuntimeGOOS           = runtime.GOOS
+	profilesUserHomeDirFn         = os.UserHomeDir
+	activeXcodeMajorVersionFn     = xcodecore.ActiveXcodeMajorVersion
+)
 
 func isValidProfileUUID(uuid string) bool {
 	return profileUUIDValidationRegex.MatchString(uuid)
@@ -96,6 +110,8 @@ func ProfilesLocalCommand() *ffcli.Command {
 These commands operate on local disk state (Xcode's Provisioning Profiles directory),
 not on App Store Connect API profile resources.
 
+` + profilesLocalDirectoryHelp + `
+
 Examples:
   asc profiles local install --path "./profile.mobileprovision"
   asc profiles local list
@@ -120,7 +136,7 @@ func ProfilesLocalInstallCommand() *ffcli.Command {
 
 	sourcePath := fs.String("path", "", "Path to a .mobileprovision file to install")
 	profileID := fs.String("id", "", "Profile ID to download and install")
-	installDir := fs.String("install-dir", "", "Install directory (defaults to Xcode's Provisioning Profiles dir on macOS)")
+	installDir := fs.String("install-dir", "", "Directory to use (defaults by active Xcode version on macOS)")
 	force := fs.Bool("force", false, "Overwrite an existing installed profile with the same UUID")
 	output := shared.BindOutputFlags(fs)
 
@@ -130,8 +146,7 @@ func ProfilesLocalInstallCommand() *ffcli.Command {
 		ShortHelp:  "Install a provisioning profile locally.",
 		LongHelp: `Install a provisioning profile locally.
 
-By default, this installs into:
-  ~/Library/MobileDevice/Provisioning Profiles
+` + profilesLocalDirectoryHelp + `
 
 Examples:
   asc profiles local install --path "./profile.mobileprovision"
@@ -150,9 +165,9 @@ Examples:
 				return shared.UsageError("--path and --id are mutually exclusive")
 			}
 
-			resolvedInstallDir, err := resolveProfilesInstallDir(*installDir)
+			resolvedInstallDir, err := resolveProfilesInstallDirForCommand(ctx, *installDir, "profiles local install")
 			if err != nil {
-				return shared.UsageError(err.Error())
+				return err
 			}
 
 			var (
@@ -261,7 +276,7 @@ Examples:
 func ProfilesLocalListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
-	installDir := fs.String("install-dir", "", "Install directory (defaults to Xcode's Provisioning Profiles dir on macOS)")
+	installDir := fs.String("install-dir", "", "Directory to use (defaults by active Xcode version on macOS)")
 	bundleID := fs.String("bundle-id", "", "Filter by bundle ID")
 	teamID := fs.String("team-id", "", "Filter by team ID")
 	expiredOnly := fs.Bool("expired", false, "Show only expired profiles")
@@ -273,6 +288,8 @@ func ProfilesLocalListCommand() *ffcli.Command {
 		ShortHelp:  "List locally installed provisioning profiles.",
 		LongHelp: `List locally installed provisioning profiles.
 
+` + profilesLocalDirectoryHelp + `
+
 Examples:
   asc profiles local list
   asc profiles local list --expired
@@ -280,9 +297,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			resolvedInstallDir, err := resolveProfilesInstallDir(*installDir)
+			resolvedInstallDir, err := resolveProfilesInstallDirForCommand(ctx, *installDir, "profiles local list")
 			if err != nil {
-				return shared.UsageError(err.Error())
+				return err
 			}
 
 			scanned, skipped, err := scanLocalProfiles(resolvedInstallDir, time.Now())
@@ -340,7 +357,7 @@ Examples:
 func ProfilesLocalCleanCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("clean", flag.ExitOnError)
 
-	installDir := fs.String("install-dir", "", "Install directory (defaults to Xcode's Provisioning Profiles dir on macOS)")
+	installDir := fs.String("install-dir", "", "Directory to use (defaults by active Xcode version on macOS)")
 	expiredOnly := fs.Bool("expired", false, "Delete expired profiles")
 	dryRun := fs.Bool("dry-run", false, "Show deletion plan without deleting")
 	confirm := fs.Bool("confirm", false, "Confirm deletion")
@@ -351,6 +368,8 @@ func ProfilesLocalCleanCommand() *ffcli.Command {
 		ShortUsage: "asc profiles local clean --expired --dry-run | asc profiles local clean --expired --confirm",
 		ShortHelp:  "Clean up locally installed provisioning profiles.",
 		LongHelp: `Clean up locally installed provisioning profiles.
+
+` + profilesLocalDirectoryHelp + `
 
 Examples:
   asc profiles local clean --expired --dry-run
@@ -367,9 +386,9 @@ Examples:
 				return shared.UsageError("at least one clean mode is required (e.g. --expired)")
 			}
 
-			resolvedInstallDir, err := resolveProfilesInstallDir(*installDir)
+			resolvedInstallDir, err := resolveProfilesInstallDirForCommand(ctx, *installDir, "profiles local clean")
 			if err != nil {
-				return shared.UsageError(err.Error())
+				return err
 			}
 
 			now := time.Now()
@@ -442,17 +461,40 @@ Examples:
 	}
 }
 
-func resolveProfilesInstallDir(value string) (string, error) {
+func resolveProfilesInstallDirForCommand(ctx context.Context, value, commandName string) (string, error) {
+	installDir, err := resolveProfilesInstallDir(ctx, value)
+	if err == nil {
+		return installDir, nil
+	}
+	if errors.Is(err, errProfilesInstallDirRequired) {
+		return "", shared.UsageError(err.Error())
+	}
+	return "", fmt.Errorf("%s: resolve install directory: %w", commandName, err)
+}
+
+func resolveProfilesInstallDir(ctx context.Context, value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed != "" {
 		return filepath.Clean(trimmed), nil
 	}
-	if runtime.GOOS != "darwin" {
-		return "", fmt.Errorf("--install-dir is required on non-macOS platforms")
+	if profilesRuntimeGOOS != "darwin" {
+		return "", errProfilesInstallDirRequired
 	}
-	home, err := os.UserHomeDir()
+
+	major, err := activeXcodeMajorVersionFn(ctx)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("determine active Xcode version: %w", err)
+	}
+	if major < 1 {
+		return "", fmt.Errorf("determine active Xcode version: invalid major version %d", major)
+	}
+
+	home, err := profilesUserHomeDirFn()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	if major >= 16 {
+		return filepath.Join(home, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles"), nil
 	}
 	return filepath.Join(home, "Library", "MobileDevice", "Provisioning Profiles"), nil
 }

--- a/internal/cli/profiles/local_test.go
+++ b/internal/cli/profiles/local_test.go
@@ -1,9 +1,176 @@
 package profiles
 
 import (
+	"context"
+	"errors"
+	"flag"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestResolveProfilesInstallDirVersionBoundary(t *testing.T) {
+	originalGOOS := profilesRuntimeGOOS
+	originalHomeDir := profilesUserHomeDirFn
+	originalActiveVersion := activeXcodeMajorVersionFn
+	t.Cleanup(func() {
+		profilesRuntimeGOOS = originalGOOS
+		profilesUserHomeDirFn = originalHomeDir
+		activeXcodeMajorVersionFn = originalActiveVersion
+	})
+
+	profilesRuntimeGOOS = "darwin"
+	homeDir := t.TempDir()
+	profilesUserHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	tests := []struct {
+		major    int
+		relative string
+	}{
+		{major: 15, relative: filepath.Join("Library", "MobileDevice", "Provisioning Profiles")},
+		{major: 16, relative: filepath.Join("Library", "Developer", "Xcode", "UserData", "Provisioning Profiles")},
+		{major: 27, relative: filepath.Join("Library", "Developer", "Xcode", "UserData", "Provisioning Profiles")},
+	}
+
+	for _, test := range tests {
+		activeXcodeMajorVersionFn = func(context.Context) (int, error) { return test.major, nil }
+		got, err := resolveProfilesInstallDir(context.Background(), "")
+		if err != nil {
+			t.Fatalf("resolveProfilesInstallDir() for Xcode %d error = %v", test.major, err)
+		}
+		want := filepath.Join(homeDir, test.relative)
+		if got != want {
+			t.Fatalf("resolveProfilesInstallDir() for Xcode %d = %q, want %q", test.major, got, want)
+		}
+	}
+}
+
+func TestResolveProfilesInstallDirExplicitOverrideSkipsDiscovery(t *testing.T) {
+	originalGOOS := profilesRuntimeGOOS
+	originalHomeDir := profilesUserHomeDirFn
+	originalActiveVersion := activeXcodeMajorVersionFn
+	t.Cleanup(func() {
+		profilesRuntimeGOOS = originalGOOS
+		profilesUserHomeDirFn = originalHomeDir
+		activeXcodeMajorVersionFn = originalActiveVersion
+	})
+
+	profilesRuntimeGOOS = "linux"
+	profilesUserHomeDirFn = func() (string, error) { panic("home lookup must not run") }
+	activeXcodeMajorVersionFn = func(context.Context) (int, error) { panic("Xcode discovery must not run") }
+
+	input := filepath.Join(t.TempDir(), "nested", "..", "profiles")
+	got, err := resolveProfilesInstallDir(context.Background(), input)
+	if err != nil {
+		t.Fatalf("resolveProfilesInstallDir() error = %v", err)
+	}
+	if want := filepath.Clean(input); got != want {
+		t.Fatalf("resolveProfilesInstallDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveProfilesInstallDirFailsClosed(t *testing.T) {
+	originalGOOS := profilesRuntimeGOOS
+	originalActiveVersion := activeXcodeMajorVersionFn
+	t.Cleanup(func() {
+		profilesRuntimeGOOS = originalGOOS
+		activeXcodeMajorVersionFn = originalActiveVersion
+	})
+
+	profilesRuntimeGOOS = "darwin"
+	discoveryErr := errors.New("full Xcode is not active")
+	activeXcodeMajorVersionFn = func(context.Context) (int, error) { return 0, discoveryErr }
+
+	_, err := resolveProfilesInstallDir(context.Background(), "")
+	if !errors.Is(err, discoveryErr) {
+		t.Fatalf("resolveProfilesInstallDir() error = %v, want discovery error", err)
+	}
+	if errors.Is(err, errProfilesInstallDirRequired) {
+		t.Fatalf("active Xcode discovery error must not be classified as missing --install-dir: %v", err)
+	}
+}
+
+func TestResolveProfilesInstallDirPreservesCancellation(t *testing.T) {
+	originalGOOS := profilesRuntimeGOOS
+	originalActiveVersion := activeXcodeMajorVersionFn
+	t.Cleanup(func() {
+		profilesRuntimeGOOS = originalGOOS
+		activeXcodeMajorVersionFn = originalActiveVersion
+	})
+
+	profilesRuntimeGOOS = "darwin"
+	activeXcodeMajorVersionFn = func(ctx context.Context) (int, error) { return 0, ctx.Err() }
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := resolveProfilesInstallDir(ctx, "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("resolveProfilesInstallDir() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestResolveProfilesInstallDirHomeFailureIsRuntimeError(t *testing.T) {
+	originalGOOS := profilesRuntimeGOOS
+	originalHomeDir := profilesUserHomeDirFn
+	originalActiveVersion := activeXcodeMajorVersionFn
+	t.Cleanup(func() {
+		profilesRuntimeGOOS = originalGOOS
+		profilesUserHomeDirFn = originalHomeDir
+		activeXcodeMajorVersionFn = originalActiveVersion
+	})
+
+	profilesRuntimeGOOS = "darwin"
+	activeXcodeMajorVersionFn = func(context.Context) (int, error) { return 16, nil }
+	homeErr := errors.New("home unavailable")
+	profilesUserHomeDirFn = func() (string, error) { return "", homeErr }
+
+	_, err := resolveProfilesInstallDirForCommand(context.Background(), "", "profiles local list")
+	if !errors.Is(err, homeErr) {
+		t.Fatalf("resolveProfilesInstallDirForCommand() error = %v, want home error", err)
+	}
+	if errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("home failure must be a runtime error, got %v", err)
+	}
+	if !strings.HasPrefix(err.Error(), "profiles local list: resolve install directory:") {
+		t.Fatalf("unexpected command context: %v", err)
+	}
+}
+
+func TestResolveProfilesInstallDirNonMacRequiresOverride(t *testing.T) {
+	originalGOOS := profilesRuntimeGOOS
+	t.Cleanup(func() { profilesRuntimeGOOS = originalGOOS })
+	profilesRuntimeGOOS = "linux"
+
+	_, err := resolveProfilesInstallDir(context.Background(), "")
+	if !errors.Is(err, errProfilesInstallDirRequired) {
+		t.Fatalf("resolveProfilesInstallDir() error = %v, want --install-dir requirement", err)
+	}
+}
+
+func TestProfilesLocalHelpDocumentsVersionedDefaults(t *testing.T) {
+	commands := []struct {
+		name string
+		help string
+	}{
+		{name: "local", help: ProfilesLocalCommand().LongHelp},
+		{name: "install", help: ProfilesLocalInstallCommand().LongHelp},
+		{name: "list", help: ProfilesLocalListCommand().LongHelp},
+		{name: "clean", help: ProfilesLocalCleanCommand().LongHelp},
+	}
+
+	for _, command := range commands {
+		for _, want := range []string{
+			"Xcode 16 or newer: ~/Library/Developer/Xcode/UserData/Provisioning Profiles",
+			"Xcode 15 or older: ~/Library/MobileDevice/Provisioning Profiles",
+			"Use --install-dir",
+		} {
+			if !strings.Contains(command.help, want) {
+				t.Fatalf("%s help missing %q: %s", command.name, want, command.help)
+			}
+		}
+	}
+}
 
 func TestIsExpired(t *testing.T) {
 	t0 := time.Date(2026, 2, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/xcode/active_version.go
+++ b/internal/xcode/active_version.go
@@ -1,0 +1,64 @@
+package xcode
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const activeXcodeVersionDiagnosticLimit = 4 * 1024
+
+var activeXcodeVersionPattern = regexp.MustCompile(`(?m)^Xcode[\t ]+([0-9]+)(?:[.][0-9]+)*(?:[\t ].*)?$`)
+
+// ActiveXcodeMajorVersion returns the major version reported by the active
+// xcodebuild selected through DEVELOPER_DIR or xcode-select.
+func ActiveXcodeMajorVersion(ctx context.Context) (int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	cmd := commandContextFn(ctx, "xcodebuild", "-version")
+	var stdout bytes.Buffer
+	stderr := newTailBuffer(activeXcodeVersionDiagnosticLimit)
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+	if err := runXcodeCommand(cmd); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return 0, ctxErr
+		}
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return 0, fmt.Errorf("xcodebuild -version failed: %s: %w", detail, err)
+		}
+		return 0, fmt.Errorf("xcodebuild -version failed: %w", err)
+	}
+
+	return parseActiveXcodeMajorVersion(stdout.String())
+}
+
+func parseActiveXcodeMajorVersion(output string) (int, error) {
+	match := activeXcodeVersionPattern.FindStringSubmatch(output)
+	if len(match) != 2 {
+		detail := strings.TrimSpace(output)
+		if detail == "" {
+			detail = "empty output"
+		} else {
+			detail = truncateUTF8Prefix(detail, 256)
+		}
+		return 0, fmt.Errorf("parse active Xcode version: unexpected xcodebuild -version output: %q", detail)
+	}
+
+	major, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, fmt.Errorf("parse active Xcode major version %q: %w", match[1], err)
+	}
+	if major < 1 {
+		return 0, fmt.Errorf("parse active Xcode major version %q", match[1])
+	}
+	return major, nil
+}

--- a/internal/xcode/active_version_test.go
+++ b/internal/xcode/active_version_test.go
@@ -1,0 +1,77 @@
+package xcode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestParseActiveXcodeMajorVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    int
+		wantErr string
+	}{
+		{name: "Xcode 15", output: "Xcode 15.4\nBuild version 15F31d\n", want: 15},
+		{name: "Xcode 16", output: "Xcode 16.0\nBuild version 16A242d\n", want: 16},
+		{name: "Xcode beta", output: "Xcode 27.0 beta 4\nBuild version 27A5228h\n", want: 27},
+		{name: "warning before version", output: "warning\nXcode 16.2.1\nBuild version 16C5032a\n", want: 16},
+		{name: "empty", wantErr: `unexpected xcodebuild -version output: "empty output"`},
+		{name: "malformed", output: "Command Line Tools 16.0\n", wantErr: "unexpected xcodebuild -version output"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseActiveXcodeMajorVersion(test.output)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("parseActiveXcodeMajorVersion() error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseActiveXcodeMajorVersion() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("parseActiveXcodeMajorVersion() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestActiveXcodeMajorVersionIncludesCommandDiagnostic(t *testing.T) {
+	originalCommandContext := commandContextFn
+	t.Cleanup(func() { commandContextFn = originalCommandContext })
+	commandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestActiveXcodeVersionHelperProcess")
+		cmd.Env = append(os.Environ(), "GO_WANT_ACTIVE_XCODE_VERSION_HELPER=error")
+		return cmd
+	}
+
+	_, err := ActiveXcodeMajorVersion(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "active developer directory is a command line tools instance") {
+		t.Fatalf("ActiveXcodeMajorVersion() error = %v", err)
+	}
+}
+
+func TestActiveXcodeMajorVersionPreservesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ActiveXcodeMajorVersion(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ActiveXcodeMajorVersion() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestActiveXcodeVersionHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_ACTIVE_XCODE_VERSION_HELPER") != "error" {
+		return
+	}
+	_, _ = os.Stderr.WriteString("xcode-select: active developer directory is a command line tools instance\n")
+	os.Exit(1)
+}


### PR DESCRIPTION
## What changed

When `--install-dir` is omitted, `profiles local` now reads the major version from the selected `xcodebuild`:

- Xcode 16 or newer uses `~/Library/Developer/Xcode/UserData/Provisioning Profiles`.
- Xcode 15 or older keeps `~/Library/MobileDevice/Provisioning Profiles`.
- An explicit `--install-dir` bypasses Xcode discovery on every platform.
- A Mac without a usable full Xcode fails with exit 1 and an instruction to select Xcode or pass the directory.

`list` and `clean` still operate on one directory per invocation, so cleanup never expands across both stores. Help and the profile guide now document the version boundary and use `profiles local install` instead of hard-coded copy commands.

## Contract

[Apple's Xcode 16 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes) place downloaded profiles in the Xcode UserData directory while retaining support for previously downloaded profiles in the older location. [Apple Developer Technical Support](https://developer.apple.com/forums/thread/812538) also identifies UserData as the current build-time location.

The older store remains the default for Xcode 15 and stays available through `--install-dir`. The command does not merge inventories because duplicate profile UUIDs and cleanup across two roots would make the existing one-directory contract ambiguous.

## Verification

- Reproduced the old resolver selecting the legacy directory for a fake Xcode 16, then made that test pass.
- Covered the 15/16 boundary, explicit overrides, cancellation, malformed discovery, home lookup failure, and runtime exit classification.
- Proved with temporary profile fixtures that default `list` and confirmed `clean` select only the active store.
- Ran focused tests ten times and under the race detector, then ran format, docs, lint, and the full repository test suite.
- Built `/tmp/asc`; the current Xcode selection resolved to UserData, a CLT-only selection returned exit 1 with empty stdout, and an explicit directory still succeeded.

No App Store Connect request or profile mutation was needed for verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788939447&installation_model_id=10418&pr_number=1947&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1947&signature=7d1ff4c54b4a375abc09b0bcf7a1b95527a655483bb92c5d052589c4e872ea38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provisioning-profile commands now select the appropriate macOS directory based on the active Xcode version.
  * Added `--install-dir` support and guidance for custom installation locations.
  * Updated installation, listing, cleanup, CI examples, and troubleshooting documentation.
  * Non-macOS environments now require an explicit installation directory.

* **Bug Fixes**
  * Improved diagnostics when Xcode or profile-directory discovery fails.
  * Prevented profile listing and cleanup from combining unrelated installation directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->