### PR TITLE
fix(background-assets): require checksum with file

### DIFF
--- a/internal/cli/backgroundassets/background_assets_test.go
+++ b/internal/cli/backgroundassets/background_assets_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -225,8 +224,8 @@ func TestBackgroundAssetsUploadFilesUpdateCommand_FileRequiresChecksumBeforeFile
 	if !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --file is used without --checksum, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "--file requires --checksum") {
-		t.Fatalf("expected file/checksum validation error, got %v", err)
+	if got, want := err.Error(), "--file requires --checksum"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
 	}
 	if clientFactoryCalled {
 		t.Fatal("client factory ran before --file/--checksum validation")

--- a/internal/cli/backgroundassets/background_assets_test.go
+++ b/internal/cli/backgroundassets/background_assets_test.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestBackgroundAssetsListCommand_MissingApp(t *testing.T) {
@@ -195,5 +200,35 @@ func TestBackgroundAssetsUploadFilesUpdateCommand_MissingUploaded(t *testing.T) 
 
 	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --uploaded is missing, got %v", err)
+	}
+}
+
+func TestBackgroundAssetsUploadFilesUpdateCommand_FileRequiresChecksumBeforeFileOrClientAccess(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "missing.zip")
+	clientFactoryCalled := false
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientFactoryCalled = true
+		return nil, errors.New("client factory must not run during flag validation")
+	})
+	defer restore()
+
+	cmd := BackgroundAssetsUploadFilesUpdateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--upload-file-id", "UPLOAD_ID",
+		"--uploaded", "true",
+		"--file", filePath,
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp when --file is used without --checksum, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "--file requires --checksum") {
+		t.Fatalf("expected file/checksum validation error, got %v", err)
+	}
+	if clientFactoryCalled {
+		t.Fatal("client factory ran before --file/--checksum validation")
 	}
 }

--- a/internal/cli/backgroundassets/background_assets_upload_files.go
+++ b/internal/cli/backgroundassets/background_assets_upload_files.go
@@ -280,7 +280,7 @@ func BackgroundAssetsUploadFilesUpdateCommand() *ffcli.Command {
 
 	uploadFileID := fs.String("upload-file-id", "", "Background asset upload file ID")
 	uploaded := fs.String("uploaded", "", "Mark upload as complete (true/false)")
-	filePath := fs.String("file", "", "Path to file for checksum verification")
+	filePath := fs.String("file", "", "Path to file for checksum verification (requires --checksum)")
 	checksum := fs.Bool("checksum", false, "Verify source file checksums before committing")
 	output := shared.BindOutputFlags(fs)
 
@@ -313,6 +313,9 @@ Examples:
 			}
 
 			pathValue := strings.TrimSpace(*filePath)
+			if pathValue != "" && !*checksum {
+				return shared.UsageError("--file requires --checksum")
+			}
 			if *checksum && pathValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --checksum requires --file")
 				return flag.ErrHelp

--- a/internal/cli/cmdtest/background_assets_upload_files_update_test.go
+++ b/internal/cli/cmdtest/background_assets_upload_files_update_test.go
@@ -1,0 +1,135 @@
+package cmdtest
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestBackgroundAssetsUploadFilesUpdatePreservesValidRequests(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		withChecksum bool
+	}{
+		{name: "uploaded only"},
+		{name: "paired file and checksum", withChecksum: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			args := []string{
+				"background-assets", "upload-files", "update",
+				"--upload-file-id", "UPLOAD_ID",
+				"--uploaded", "true",
+				"--output", "json",
+			}
+			fileContents := []byte("background asset")
+			checksum := md5.Sum(fileContents)
+			expectedHash := hex.EncodeToString(checksum[:])
+			if test.withChecksum {
+				filePath := filepath.Join(t.TempDir(), "asset.zip")
+				if err := os.WriteFile(filePath, fileContents, 0o600); err != nil {
+					t.Fatalf("write fixture: %v", err)
+				}
+				args = append(args, "--file", filePath, "--checksum")
+			}
+
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/backgroundAssetUploadFiles/UPLOAD_ID" && test.withChecksum:
+					_, _ = fmt.Fprintf(w, `{"data":{"type":"backgroundAssetUploadFiles","id":"UPLOAD_ID","attributes":{"sourceFileChecksums":{"file":{"hash":%q,"algorithm":"MD5"}}}}}`, expectedHash)
+				case req.Method == http.MethodPatch && req.URL.Path == "/v1/backgroundAssetUploadFiles/UPLOAD_ID":
+					var payload asc.BackgroundAssetUploadFileUpdateRequest
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Errorf("decode request: %v", err)
+						http.Error(w, "invalid request", http.StatusBadRequest)
+						return
+					}
+					assertBackgroundAssetUploadFileUpdatePayload(t, payload, test.withChecksum, expectedHash)
+					_, _ = io.WriteString(w, `{"data":{"type":"backgroundAssetUploadFiles","id":"UPLOAD_ID","attributes":{"uploaded":true}}}`)
+				default:
+					t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+				}
+			}))
+			t.Cleanup(server.Close)
+			installDefaultTransportForServer(t, server)
+
+			root := RootCommand("1.2.3")
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+			wantRequests := 1
+			if test.withChecksum {
+				wantRequests = 2
+			}
+			if requestCount != wantRequests {
+				t.Fatalf("request count = %d, want %d", requestCount, wantRequests)
+			}
+			assertBackgroundAssetUploadFileID(t, stdout, "UPLOAD_ID")
+		})
+	}
+}
+
+func assertBackgroundAssetUploadFileUpdatePayload(t *testing.T, payload asc.BackgroundAssetUploadFileUpdateRequest, wantChecksum bool, expectedHash string) {
+	t.Helper()
+
+	attrs := payload.Data.Attributes
+	if attrs == nil || attrs.Uploaded == nil || !*attrs.Uploaded {
+		t.Errorf("uploaded attribute = %#v, want true", attrs)
+		return
+	}
+	if !wantChecksum {
+		if attrs.SourceFileChecksums != nil {
+			t.Errorf("source file checksums = %#v, want omitted", attrs.SourceFileChecksums)
+		}
+		return
+	}
+	if attrs.SourceFileChecksums == nil || attrs.SourceFileChecksums.File == nil {
+		t.Errorf("source file checksums = %#v, want MD5 file checksum", attrs.SourceFileChecksums)
+		return
+	}
+	if got := attrs.SourceFileChecksums.File; got.Hash != expectedHash || got.Algorithm != asc.ChecksumAlgorithmMD5 {
+		t.Errorf("file checksum = %#v, want hash %q and MD5", got, expectedHash)
+	}
+}
+
+func assertBackgroundAssetUploadFileID(t *testing.T, output, want string) {
+	t.Helper()
+
+	var response struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		t.Fatalf("decode output: %v\noutput: %s", err, output)
+	}
+	if response.Data.ID != want {
+		t.Fatalf("output ID = %q, want %q", response.Data.ID, want)
+	}
+}

--- a/internal/cli/cmdtest/background_assets_upload_files_update_test.go
+++ b/internal/cli/cmdtest/background_assets_upload_files_update_test.go
@@ -11,9 +11,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestBackgroundAssetsUploadFilesUpdatePreservesValidRequests(t *testing.T) {
@@ -45,30 +47,54 @@ func TestBackgroundAssetsUploadFilesUpdatePreservesValidRequests(t *testing.T) {
 				args = append(args, "--file", filePath, "--checksum")
 			}
 
+			type expectedRequest struct {
+				method string
+				path   string
+			}
+			expectedRequests := []expectedRequest{}
+			if test.withChecksum {
+				expectedRequests = append(expectedRequests, expectedRequest{method: http.MethodGet, path: "/v1/backgroundAssetUploadFiles/UPLOAD_ID"})
+			}
+			expectedRequests = append(expectedRequests, expectedRequest{method: http.MethodPatch, path: "/v1/backgroundAssetUploadFiles/UPLOAD_ID"})
+
 			requestCount := 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				requestCount++
-				w.Header().Set("Content-Type", "application/json")
-
-				switch {
-				case req.Method == http.MethodGet && req.URL.Path == "/v1/backgroundAssetUploadFiles/UPLOAD_ID" && test.withChecksum:
-					_, _ = fmt.Fprintf(w, `{"data":{"type":"backgroundAssetUploadFiles","id":"UPLOAD_ID","attributes":{"sourceFileChecksums":{"file":{"hash":%q,"algorithm":"MD5"}}}}}`, expectedHash)
-				case req.Method == http.MethodPatch && req.URL.Path == "/v1/backgroundAssetUploadFiles/UPLOAD_ID":
-					var payload asc.BackgroundAssetUploadFileUpdateRequest
-					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-						t.Errorf("decode request: %v", err)
-						http.Error(w, "invalid request", http.StatusBadRequest)
-						return
-					}
-					assertBackgroundAssetUploadFileUpdatePayload(t, payload, test.withChecksum, expectedHash)
-					_, _ = io.WriteString(w, `{"data":{"type":"backgroundAssetUploadFiles","id":"UPLOAD_ID","attributes":{"uploaded":true}}}`)
-				default:
+				if requestCount >= len(expectedRequests) {
 					t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 					http.Error(w, "unexpected request", http.StatusBadRequest)
+					return
 				}
+				expected := expectedRequests[requestCount]
+				requestCount++
+				if req.Method != expected.method || req.URL.Path != expected.path {
+					t.Errorf("request %d = %s %s, want %s %s", requestCount, req.Method, req.URL.Path, expected.method, expected.path)
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+					return
+				}
+				if authorization := req.Header.Get("Authorization"); !strings.HasPrefix(authorization, "Bearer ") {
+					t.Errorf("request %d Authorization = %q, want Bearer token", requestCount, authorization)
+					http.Error(w, "missing authorization", http.StatusUnauthorized)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+
+				if req.Method == http.MethodGet {
+					_, _ = fmt.Fprintf(w, `{"data":{"type":"backgroundAssetUploadFiles","id":"UPLOAD_ID","attributes":{"sourceFileChecksums":{"file":{"hash":%q,"algorithm":"MD5"}}}}}`, expectedHash)
+					return
+				}
+
+				var payload asc.BackgroundAssetUploadFileUpdateRequest
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Errorf("decode request: %v", err)
+					http.Error(w, "invalid request", http.StatusBadRequest)
+					return
+				}
+				assertBackgroundAssetUploadFileUpdatePayload(t, payload, test.withChecksum, expectedHash)
+				_, _ = io.WriteString(w, `{"data":{"type":"backgroundAssetUploadFiles","id":"UPLOAD_ID","attributes":{"uploaded":true}}}`)
 			}))
 			t.Cleanup(server.Close)
-			installDefaultTransportForServer(t, server)
+			client := newReviewTestServerClient(t, server)
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) { return client, nil }))
 
 			root := RootCommand("1.2.3")
 			stdout, stderr := captureOutput(t, func() {
@@ -83,12 +109,8 @@ func TestBackgroundAssetsUploadFilesUpdatePreservesValidRequests(t *testing.T) {
 			if stderr != "" {
 				t.Fatalf("stderr = %q, want empty", stderr)
 			}
-			wantRequests := 1
-			if test.withChecksum {
-				wantRequests = 2
-			}
-			if requestCount != wantRequests {
-				t.Fatalf("request count = %d, want %d", requestCount, wantRequests)
+			if requestCount != len(expectedRequests) {
+				t.Fatalf("request count = %d, want %d", requestCount, len(expectedRequests))
 			}
 			assertBackgroundAssetUploadFileID(t, stdout, "UPLOAD_ID")
 		})


### PR DESCRIPTION
## Summary

- reject `--file` unless `--checksum` is enabled
- validate the flag pair before filesystem access, authentication, or network work
- clarify the long-form flag help while preserving both `--uploaded` alone and paired file/checksum updates

## Compatibility

`--file` without `--checksum` now exits with a usage error instead of accepting a path that is not used for checksum verification. Existing `--uploaded`-only updates and `--file` plus `--checksum` updates are unchanged.

## Verification

- focused invalid-pair test, 10 runs
- real-HTTP valid-request coverage, 10 runs
- focused race tests
- exact built-command exit 2, empty stdout, and pre-client validation proof
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

No live App Store Connect mutation was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788942356&installation_model_id=10418&pr_number=1950&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1950&signature=b663c02a59bd36c878cbfdd94320239462ca054dd867ef63b1edf2697bbaae9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The background asset upload update command now requires `--file` and `--checksum` together.
  * Invalid combinations are rejected before files are accessed or external services are contacted.
  * Upload-file updates support both uploaded-only requests and requests that include checksum information.
  * Successful updates display the upload-file ID in the output.

* **Tests**
  * Added coverage for validation, request payloads, checksum handling, responses, and command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->