### PR TITLE
Preflight certificate request output paths

### DIFF
--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -411,6 +411,18 @@ func TestCertificatesCreateCommand_GenerateCSRWriteFailures(t *testing.T) {
 	}
 }
 
+func TestValidateCSRFileOutputPathRejectsWindowsSeparators(t *testing.T) {
+	windowsPathSeparator := func(character uint8) bool {
+		return character == '\\' || character == '/'
+	}
+
+	for _, path := range []string{"output/", `output\`} {
+		if _, err := validateCSRFileOutputPathWithSeparator(path, windowsPathSeparator); err == nil {
+			t.Fatalf("validateCSRFileOutputPathWithSeparator(%q) error = nil, want file-path error", path)
+		}
+	}
+}
+
 func TestCertificatesRevokeCommand_MissingID(t *testing.T) {
 	cmd := CertificatesRevokeCommand()
 

--- a/internal/cli/certificates/certificates_test.go
+++ b/internal/cli/certificates/certificates_test.go
@@ -423,6 +423,20 @@ func TestValidateCSRFileOutputPathRejectsWindowsSeparators(t *testing.T) {
 	}
 }
 
+func TestValidateCSRPairOutputPathsCleansAbsolutePaths(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "output")
+	csrOut := filepath.Join(dir, "discard") + string(filepath.Separator) + ".." + string(filepath.Separator) + "output" + string(filepath.Separator) + "request.csr"
+
+	err := validateCSRPairOutputPaths(keyOut, csrOut)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("validateCSRPairOutputPaths() error = %v, want flag.ErrHelp", err)
+	}
+	if err.Error() != "--key-out and --csr-out must not be nested paths" {
+		t.Fatalf("validateCSRPairOutputPaths() error = %q, want nested-path error", err)
+	}
+}
+
 func TestCertificatesRevokeCommand_MissingID(t *testing.T) {
 	cmd := CertificatesRevokeCommand()
 

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -154,8 +154,8 @@ func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, erro
 	if csrOutValue == "" {
 		return nil, nil, fmt.Errorf("--csr-out is required")
 	}
-	if filepath.Clean(keyOutValue) == filepath.Clean(csrOutValue) {
-		return nil, nil, shared.UsageError("--key-out and --csr-out must be different paths")
+	if err := validateCSRPairOutputPaths(keyOutValue, csrOutValue); err != nil {
+		return nil, nil, err
 	}
 
 	normalizedKeyType := strings.ToLower(strings.TrimSpace(opts.KeyType))
@@ -283,6 +283,31 @@ func renderCSRGenerateResult(result *csrGenerateResult, markdown bool) error {
 		}},
 	)
 	return nil
+}
+
+func validateCSRPairOutputPaths(keyOut string, csrOut string) error {
+	keyPath, err := filepath.Abs(keyOut)
+	if err != nil {
+		return fmt.Errorf("resolve --key-out: %w", err)
+	}
+	csrPath, err := filepath.Abs(csrOut)
+	if err != nil {
+		return fmt.Errorf("resolve --csr-out: %w", err)
+	}
+	if keyPath == csrPath {
+		return shared.UsageError("--key-out and --csr-out must be different paths")
+	}
+	if csrLexicalPathContains(keyPath, csrPath) || csrLexicalPathContains(csrPath, keyPath) {
+		return shared.UsageError("--key-out and --csr-out must not be nested paths")
+	}
+	return nil
+}
+
+func csrLexicalPathContains(parent string, child string) bool {
+	if !os.IsPathSeparator(parent[len(parent)-1]) {
+		parent += string(filepath.Separator)
+	}
+	return strings.HasPrefix(child, parent)
 }
 
 func preflightCSRFileWrite(path string, force bool) error {

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -180,18 +180,17 @@ func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, erro
 		subject.CommonName = "asc"
 	}
 
-	// Pre-check output paths to avoid leaving an orphaned key when CSR write fails.
-	// This is not atomic (TOCTOU), but it prevents the common confusing case.
-	if !opts.Force {
-		if _, err := os.Lstat(keyOutValue); err == nil {
-			return nil, nil, fmt.Errorf("write --key-out: output file already exists: %w", os.ErrExist)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("write --key-out: %w", err)
-		}
-		if _, err := os.Lstat(csrOutValue); err == nil {
-			return nil, nil, fmt.Errorf("write --csr-out: output file already exists: %w", os.ErrExist)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("write --csr-out: %w", err)
+	// Preflight both outputs before generating or replacing either file. This is
+	// not a cross-file transaction, but it catches deterministic path failures.
+	for _, output := range []struct {
+		flag string
+		path string
+	}{
+		{flag: "--key-out", path: keyOutValue},
+		{flag: "--csr-out", path: csrOutValue},
+	} {
+		if err := preflightCSRFileWrite(output.path, opts.Force); err != nil {
+			return nil, nil, fmt.Errorf("write %s: %w", output.flag, err)
 		}
 	}
 
@@ -286,16 +285,81 @@ func renderCSRGenerateResult(result *csrGenerateResult, markdown bool) error {
 	return nil
 }
 
-func writeFileBytesNoSymlink(path string, data []byte, perm os.FileMode, force bool) error {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
-		return fmt.Errorf("output path is required")
+func preflightCSRFileWrite(path string, force bool) error {
+	trimmed, err := validateCSRFileOutputPath(path)
+	if err != nil {
+		return err
 	}
-	if strings.HasSuffix(trimmed, string(filepath.Separator)) {
-		return fmt.Errorf("output path must be a file")
+	if err := preflightCSRParentDirectory(trimmed); err != nil {
+		return err
 	}
 
-	_, err := shared.SafeWriteFileNoSymlink(
+	info, err := os.Lstat(trimmed)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !force {
+		return fmt.Errorf("output file already exists: %w", os.ErrExist)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to overwrite symlink %q", trimmed)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("output path %q is a directory", trimmed)
+	}
+	return nil
+}
+
+func preflightCSRParentDirectory(path string) error {
+	for parent := filepath.Dir(path); ; parent = filepath.Dir(parent) {
+		info, err := os.Lstat(parent)
+		if errors.Is(err, os.ErrNotExist) {
+			if next := filepath.Dir(parent); next != parent {
+				continue
+			}
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			info, err = os.Stat(parent)
+			if err != nil {
+				return err
+			}
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%q is not a directory", parent)
+		}
+		return nil
+	}
+}
+
+func validateCSRFileOutputPath(path string) (string, error) {
+	return validateCSRFileOutputPathWithSeparator(path, os.IsPathSeparator)
+}
+
+func validateCSRFileOutputPathWithSeparator(path string, isPathSeparator func(uint8) bool) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("output path is required")
+	}
+	if isPathSeparator(trimmed[len(trimmed)-1]) {
+		return "", fmt.Errorf("output path must be a file")
+	}
+	return trimmed, nil
+}
+
+func writeFileBytesNoSymlink(path string, data []byte, perm os.FileMode, force bool) error {
+	trimmed, err := validateCSRFileOutputPath(path)
+	if err != nil {
+		return err
+	}
+
+	_, err = shared.SafeWriteFileNoSymlink(
 		trimmed,
 		perm,
 		force,

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -335,6 +335,9 @@ func preflightCSRFileWrite(path string, force bool) error {
 	if info.IsDir() {
 		return fmt.Errorf("output path %q is a directory", trimmed)
 	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("output path %q is not a regular file", trimmed)
+	}
 	return nil
 }
 

--- a/internal/cli/certificates/csr.go
+++ b/internal/cli/certificates/csr.go
@@ -114,7 +114,11 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --csr-out is required")
 				return shared.MissingRequiredUsageError()
 			}
-			if filepath.Clean(keyOutValue) == filepath.Clean(csrOutValue) {
+			samePath, err := csrOutputPathsEqual(keyOutValue, csrOutValue)
+			if err != nil {
+				return fmt.Errorf("certificates csr generate: %w", err)
+			}
+			if samePath {
 				return shared.UsageError("--key-out and --csr-out must be different paths")
 			}
 
@@ -154,7 +158,11 @@ func generateCSRFiles(opts csrGenerateOptions) (*csrGenerateResult, []byte, erro
 	if csrOutValue == "" {
 		return nil, nil, fmt.Errorf("--csr-out is required")
 	}
-	if filepath.Clean(keyOutValue) == filepath.Clean(csrOutValue) {
+	samePath, err := csrOutputPathsEqual(keyOutValue, csrOutValue)
+	if err != nil {
+		return nil, nil, err
+	}
+	if samePath {
 		return nil, nil, shared.UsageError("--key-out and --csr-out must be different paths")
 	}
 
@@ -283,6 +291,21 @@ func renderCSRGenerateResult(result *csrGenerateResult, markdown bool) error {
 		}},
 	)
 	return nil
+}
+
+// csrOutputPathsEqual reports whether both output flags name the same
+// destination under any lexical spelling, including mixed relative and
+// absolute forms of one path.
+func csrOutputPathsEqual(keyOut, csrOut string) (bool, error) {
+	keyAbsolute, err := filepath.Abs(keyOut)
+	if err != nil {
+		return false, fmt.Errorf("resolve --key-out: %w", err)
+	}
+	csrAbsolute, err := filepath.Abs(csrOut)
+	if err != nil {
+		return false, fmt.Errorf("resolve --csr-out: %w", err)
+	}
+	return keyAbsolute == csrAbsolute, nil
 }
 
 func preflightCSRFileWrite(path string, force bool) error {

--- a/internal/cli/cmdtest/certificates_csr_generate_nonregular_unix_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_nonregular_unix_test.go
@@ -63,4 +63,8 @@ func TestCertificatesCSRGenerate_ForceRejectsNamedPipeOutputsBeforeWriting(t *te
 	if !os.SameFile(originalKeyInfo, currentKeyInfo) {
 		t.Error("key inode changed before deterministic CSR destination failure")
 	}
+	keyContents, err := os.ReadFile(keyOut)
+	if err != nil || string(keyContents) != "original-private-key" {
+		t.Fatalf("ReadFile(keyOut) = (%q, %v), want original key", keyContents, err)
+	}
 }

--- a/internal/cli/cmdtest/certificates_csr_generate_nonregular_unix_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_nonregular_unix_test.go
@@ -1,0 +1,66 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCertificatesCSRGenerate_ForceRejectsNamedPipeOutputsBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "cert.key")
+	if err := os.WriteFile(keyOut, []byte("original-private-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(keyOut) error: %v", err)
+	}
+	originalKeyInfo, err := os.Stat(keyOut)
+	if err != nil {
+		t.Fatalf("Stat(keyOut) error: %v", err)
+	}
+	csrOut := filepath.Join(dir, "cert.csr")
+	if err := unix.Mkfifo(csrOut, 0o600); err != nil {
+		t.Skipf("mkfifo not supported: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"certificates", "csr", "generate",
+			"--key-out", keyOut,
+			"--csr-out", csrOut,
+			"--force",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil || !strings.Contains(runErr.Error(), "write --csr-out") ||
+		!strings.Contains(runErr.Error(), csrOut) ||
+		!strings.Contains(runErr.Error(), "is not a regular file") {
+		t.Fatalf("run error = %q, want owning flag, path, and non-regular rejection", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty output", stdout)
+	}
+	fifoInfo, err := os.Lstat(csrOut)
+	if err != nil || fifoInfo.Mode()&os.ModeNamedPipe == 0 {
+		t.Fatalf("Lstat(csrOut) = (%v, %v), want preserved named pipe", fifoInfo, err)
+	}
+	currentKeyInfo, err := os.Stat(keyOut)
+	if err != nil {
+		t.Fatalf("Stat(keyOut) after failure error: %v", err)
+	}
+	if !os.SameFile(originalKeyInfo, currentKeyInfo) {
+		t.Error("key inode changed before deterministic CSR destination failure")
+	}
+}

--- a/internal/cli/cmdtest/certificates_csr_generate_nonregular_unix_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_nonregular_unix_test.go
@@ -25,7 +25,7 @@ func TestCertificatesCSRGenerate_ForceRejectsNamedPipeOutputsBeforeWriting(t *te
 	}
 	csrOut := filepath.Join(dir, "cert.csr")
 	if err := unix.Mkfifo(csrOut, 0o600); err != nil {
-		t.Skipf("mkfifo not supported: %v", err)
+		t.Fatalf("Mkfifo(csrOut) error: %v", err)
 	}
 
 	root := RootCommand("1.2.3")

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -263,6 +263,96 @@ func TestCertificatesCSRGenerate_DoesNotOrphanKeyWhenCSROutExistsWithoutForce(t 
 	}
 }
 
+func TestCertificatesCSRGenerate_ValidatesLexicallyNestedOutputPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		keyParts   []string
+		csrParts   []string
+		force      bool
+		wantNested bool
+	}{
+		{
+			name:       "key output contains CSR output",
+			keyParts:   []string{"output"},
+			csrParts:   []string{"output", "request.csr"},
+			wantNested: true,
+		},
+		{
+			name:       "CSR output contains key output with force",
+			keyParts:   []string{"output", "private.key"},
+			csrParts:   []string{"output"},
+			force:      true,
+			wantNested: true,
+		},
+		{
+			name:     "sibling prefix remains valid",
+			keyParts: []string{"output"},
+			csrParts: []string{"output-extra", "request.csr"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			keyOut := filepath.Join(append([]string{dir}, test.keyParts...)...)
+			csrOut := filepath.Join(append([]string{dir}, test.csrParts...)...)
+			args := []string{
+				"certificates", "csr", "generate",
+				"--key-out", keyOut,
+				"--csr-out", csrOut,
+				"--output", "json",
+			}
+			if test.force {
+				args = append(args, "--force")
+			}
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if test.wantNested {
+				if !errors.Is(runErr, flag.ErrHelp) {
+					t.Errorf("run error = %v, want flag.ErrHelp", runErr)
+				}
+				if runErr == nil || !strings.Contains(runErr.Error(), "--key-out and --csr-out must not be nested paths") {
+					t.Errorf("run error = %v, want nested-path error", runErr)
+				}
+				if stdout != "" {
+					t.Errorf("stdout = %q, want empty output", stdout)
+				}
+				for _, path := range []string{keyOut, csrOut} {
+					if _, err := os.Lstat(path); err == nil {
+						t.Errorf("output artifact %q was created", path)
+					} else if !errors.Is(err, os.ErrNotExist) {
+						t.Errorf("Lstat(%q) error = %v, want not exist", path, err)
+					}
+				}
+				return
+			}
+
+			if runErr != nil {
+				t.Fatalf("run error: %v", runErr)
+			}
+			if stdout == "" {
+				t.Fatal("expected generated output")
+			}
+			for _, path := range []string{keyOut, csrOut} {
+				if info, err := os.Lstat(path); err != nil {
+					t.Fatalf("Lstat(%q) error: %v", path, err)
+				} else if !info.Mode().IsRegular() {
+					t.Fatalf("output %q mode = %v, want regular file", path, info.Mode())
+				}
+			}
+		})
+	}
+}
+
 func TestCertificatesCSRGenerate_ForcePreflightsCSRDestination(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -263,6 +263,55 @@ func TestCertificatesCSRGenerate_DoesNotOrphanKeyWhenCSROutExistsWithoutForce(t 
 	}
 }
 
+func TestCertificatesCSRGenerate_RejectsEquivalentSpellingsOfSameOutputPath(t *testing.T) {
+	dir := t.TempDir()
+	keyOut := filepath.Join(dir, "cert.key")
+	if err := os.WriteFile(keyOut, []byte("original-private-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(keyOut) error: %v", err)
+	}
+	t.Chdir(dir)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"certificates", "csr", "generate",
+			"--key-out", "cert.key",
+			"--csr-out", keyOut,
+			"--force",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("run error = %v, want usage error", runErr)
+	}
+	if !strings.Contains(stderr, "--key-out and --csr-out must be different paths") {
+		t.Fatalf("stderr = %q, want same-path usage error", stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty output", stdout)
+	}
+	keyContents, err := os.ReadFile(keyOut)
+	if err != nil {
+		t.Fatalf("ReadFile(keyOut) error: %v", err)
+	}
+	if string(keyContents) != "original-private-key" {
+		t.Errorf("key contents = %q, want original key", keyContents)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(dir) error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("unexpected output artifacts: %v", entries)
+	}
+}
+
 func TestCertificatesCSRGenerate_ForcePreflightsCSRDestination(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -290,6 +290,9 @@ func TestCertificatesCSRGenerate_RejectsEquivalentSpellingsOfSameOutputPath(t *t
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("run error = %v, want usage error", runErr)
 	}
+	if got, want := runErr.Error(), "--key-out and --csr-out must be different paths"; got != want {
+		t.Fatalf("run error = %q, want %q", got, want)
+	}
 	if !strings.Contains(stderr, "--key-out and --csr-out must be different paths") {
 		t.Fatalf("stderr = %q, want same-path usage error", stderr)
 	}

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -320,7 +320,7 @@ func TestCertificatesCSRGenerate_ValidatesLexicallyNestedOutputPaths(t *testing.
 				if !errors.Is(runErr, flag.ErrHelp) {
 					t.Errorf("run error = %v, want flag.ErrHelp", runErr)
 				}
-				if runErr == nil || !strings.Contains(runErr.Error(), "--key-out and --csr-out must not be nested paths") {
+				if runErr == nil || runErr.Error() != "certificates csr generate: --key-out and --csr-out must not be nested paths" {
 					t.Errorf("run error = %v, want nested-path error", runErr)
 				}
 				if stdout != "" {

--- a/internal/cli/cmdtest/certificates_csr_generate_test.go
+++ b/internal/cli/cmdtest/certificates_csr_generate_test.go
@@ -131,7 +131,8 @@ func TestCertificatesCSRGenerate_GeneratesKeyAndCSR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParsePKCS8PrivateKey() error: %v", err)
 	}
-	if _, ok := privAny.(*rsa.PrivateKey); !ok {
+	privateKey, ok := privAny.(*rsa.PrivateKey)
+	if !ok {
 		t.Fatalf("expected RSA private key, got %T", privAny)
 	}
 
@@ -150,6 +151,13 @@ func TestCertificatesCSRGenerate_GeneratesKeyAndCSR(t *testing.T) {
 	}
 	if err := csr.CheckSignature(); err != nil {
 		t.Fatalf("CSR signature invalid: %v", err)
+	}
+	csrPublicKey, ok := csr.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("expected RSA CSR public key, got %T", csr.PublicKey)
+	}
+	if privateKey.E != csrPublicKey.E || privateKey.N.Cmp(csrPublicKey.N) != 0 {
+		t.Fatal("generated private key does not match CSR public key")
 	}
 	if csr.Subject.CommonName != "ASC Signing" {
 		t.Fatalf("expected CSR CN ASC Signing, got %q", csr.Subject.CommonName)
@@ -252,6 +260,107 @@ func TestCertificatesCSRGenerate_DoesNotOrphanKeyWhenCSROutExistsWithoutForce(t 
 	}
 	if string(csrData) != "OLD-CSR" {
 		t.Fatalf("expected csr file unchanged, got %q", string(csrData))
+	}
+}
+
+func TestCertificatesCSRGenerate_ForcePreflightsCSRDestination(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string) string
+		want  string
+	}{
+		{
+			name: "parent is a file",
+			setup: func(t *testing.T, dir string) string {
+				parent := filepath.Join(dir, "blocked-parent")
+				if err := os.WriteFile(parent, []byte("not-a-directory"), 0o600); err != nil {
+					t.Fatalf("WriteFile(parent) error: %v", err)
+				}
+				return filepath.Join(parent, "cert.csr")
+			},
+			want: "not a directory",
+		},
+		{
+			name: "destination is a directory",
+			setup: func(t *testing.T, dir string) string {
+				destination := filepath.Join(dir, "cert.csr")
+				if err := os.Mkdir(destination, 0o700); err != nil {
+					t.Fatalf("Mkdir(destination) error: %v", err)
+				}
+				return destination
+			},
+			want: "directory",
+		},
+		{
+			name: "destination is a symlink",
+			setup: func(t *testing.T, dir string) string {
+				target := filepath.Join(dir, "target.csr")
+				if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+					t.Fatalf("WriteFile(target) error: %v", err)
+				}
+				destination := filepath.Join(dir, "cert.csr")
+				if err := os.Symlink(target, destination); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+				return destination
+			},
+			want: "symlink",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			keyOut := filepath.Join(dir, "cert.key")
+			if err := os.WriteFile(keyOut, []byte("original-private-key"), 0o600); err != nil {
+				t.Fatalf("WriteFile(keyOut) error: %v", err)
+			}
+			originalKeyInfo, err := os.Stat(keyOut)
+			if err != nil {
+				t.Fatalf("Stat(keyOut) error: %v", err)
+			}
+			csrOut := test.setup(t, dir)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"certificates", "csr", "generate",
+					"--key-out", keyOut,
+					"--csr-out", csrOut,
+					"--force",
+					"--output", "json",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil {
+				t.Fatal("expected CSR destination failure")
+			}
+			if !strings.Contains(runErr.Error(), "write --csr-out") || !strings.Contains(strings.ToLower(runErr.Error()), test.want) {
+				t.Fatalf("run error = %q, want CSR %q failure", runErr, test.want)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty output", stdout)
+			}
+			keyContents, err := os.ReadFile(keyOut)
+			if err != nil {
+				t.Fatalf("ReadFile(keyOut) error: %v", err)
+			}
+			if string(keyContents) != "original-private-key" {
+				t.Errorf("key contents = %q, want original key", keyContents)
+			}
+			currentKeyInfo, err := os.Stat(keyOut)
+			if err != nil {
+				t.Fatalf("Stat(keyOut) after failure error: %v", err)
+			}
+			if !os.SameFile(originalKeyInfo, currentKeyInfo) {
+				t.Error("key inode changed before deterministic CSR destination failure")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- preflight both certificate request output paths before generating or replacing either file
- reject invalid file-shaped paths, non-directory ancestors, directories, symlinks, special filesystem entries, and lexically nested output pairs before touching an existing key
- allow --force to replace existing regular files only; named pipes and other non-regular destinations are refused with the owning flag and path
- reject nested output pairs as usage errors (exit 2), while preserving sibling-prefix paths
- verify normal generation still produces a matching private key and certificate request

This is the intentionally narrow replacement for #1937. It prevents structural path failures that are knowable before writing. Pair comparison uses cleaned absolute lexical paths only; it intentionally does not attempt case or Unicode equivalence, symlink aliases, or bind-mount aliases. It also does not claim cross-file atomicity or rollback for later permission, quota, read-only filesystem, rename, concurrent-path, sync, close, or crash failures; the existing key-first write order remains unchanged.

## Verification

- focused certificate and command tests, including 10 repeated runs
- focused race tests
- Linux and Windows test-binary and CLI cross-compiles
- built-binary matrix for non-directory parents, directory outputs, symlink outputs, named-pipe outputs, nested paths in both directions, equivalent relative and absolute paths, sibling-prefix paths, and matching generated keys and certificate requests
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

No live App Store Connect mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSR output-path validation for Unix and Windows separators.
  * Detects equivalent, identical, or nested output paths to prevent key and CSR conflicts.
  * Validates destinations before key generation, preventing partial output for invalid, blocked, directory, symlink, or named-pipe destinations.
  * Improved `--force` handling while preserving existing key files when CSR generation fails.
  * Ensured generated CSRs contain a public key matching the retained private key.
  * Valid CSR and key outputs continue to generate successfully in supported locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->