### PR TITLE
fix: align HTTP 422 exit code constant

### DIFF
--- a/cmd/exit_codes.go
+++ b/cmd/exit_codes.go
@@ -24,7 +24,7 @@ const (
 	ExitHTTPBadRequest    = 10       // 400
 	ExitHTTPUnauthorized  = ExitAuth // 401 (special case)
 	ExitHTTPForbidden     = ExitAuth // 403 (special case)
-	ExitHTTPUnprocessable = 22       // 422
+	ExitHTTPUnprocessable = 32       // 422
 
 	// HTTP 5xx range: 60 + (status - 500)
 	ExitHTTPInternalServer     = 60 // 500

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -129,6 +129,18 @@ func TestExitCodeConstants(t *testing.T) {
 	}
 }
 
+func TestExitHTTPUnprocessableMatchesRuntimeMapping(t *testing.T) {
+	const want = 10 + (http.StatusUnprocessableEntity - 400)
+
+	err := &asc.APIError{StatusCode: http.StatusUnprocessableEntity}
+	if got := ExitCodeFromError(err); got != want {
+		t.Fatalf("ExitCodeFromError(HTTP 422) = %d, want %d", got, want)
+	}
+	if ExitHTTPUnprocessable != want {
+		t.Fatalf("ExitHTTPUnprocessable = %d, want %d", ExitHTTPUnprocessable, want)
+	}
+}
+
 func TestAPIErrorCodeToExitCode(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/concepts/error-handling.mdx
+++ b/concepts/error-handling.mdx
@@ -39,7 +39,7 @@ The CLI maps HTTP status codes to exit codes:
 | 403 Forbidden     | `3`       | Authentication failure (special case)  |
 | 404 Not Found     | `4`       | Resource not found (special case)      |
 | 409 Conflict      | `5`       | Resource conflict (special case)       |
-| 422 Unprocessable | `22`      | Validation error                       |
+| 422 Unprocessable | `32`      | Validation error                       |
 
 #### 5xx Server Errors
 


### PR DESCRIPTION
## Summary
- align the exported HTTP 422 exit-code constant with the existing status mapper
- document the runtime HTTP 422 exit code
- add a regression test tying the constant to the runtime classification

## Compatibility
The process exit code for propagated HTTP 422 errors remains `32`; this corrects the exported constant and documentation without changing runtime mapping, stdout, or stderr.

## Verification
- RED: `ASC_BYPASS_KEYCHAIN=1 go test ./cmd -run "^TestExitHTTPUnprocessableMatchesRuntimeMapping$" -count=1` (`ExitHTTPUnprocessable = 22, want 32`)
- `ASC_BYPASS_KEYCHAIN=1 go test ./cmd -run "^(TestExitHTTPUnprocessableMatchesRuntimeMapping|TestExitCodeFromError_RetryExhaustedStatuses|TestExitCodeFromError_WebAPIStatus)$" -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run "^TestAppsSearchKeywordsSetAPIFailure$" -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788945219&installation_model_id=10418&pr_number=1953&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1953&signature=9f94f1077679ac59acc2868e647f2019e77adceaaded010adae12dfb12e38d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the process exit code returned for HTTP 422 (Unprocessable Content) errors.
  * Updated error-handling documentation to reflect the corrected mapping.

* **Tests**
  * Added regression coverage to ensure HTTP 422 errors consistently return the expected exit code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->