### PR TITLE
fix(win-back-offers): support FREE_TRIAL creation via --territory

### DIFF
--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -11578,7 +11578,7 @@ func TestCreateWinBackOffer_SendsRequest(t *testing.T) {
 					Territory: Relationship{
 						Data: ResourceData{Type: ResourceTypeTerritories, ID: "USA"},
 					},
-					SubscriptionPricePoint: Relationship{
+					SubscriptionPricePoint: &Relationship{
 						Data: ResourceData{Type: ResourceTypeSubscriptionPricePoints, ID: "price-point-1"},
 					},
 				},

--- a/internal/asc/output_win_back_offers.go
+++ b/internal/asc/output_win_back_offers.go
@@ -63,7 +63,11 @@ func winBackOfferPriceRelationshipIDs(raw json.RawMessage) (string, string, erro
 	if err := json.Unmarshal(raw, &relationships); err != nil {
 		return "", "", fmt.Errorf("decode win-back offer price relationships: %w", err)
 	}
-	return relationships.Territory.Data.ID, relationships.SubscriptionPricePoint.Data.ID, nil
+	pricePointID := ""
+	if relationships.SubscriptionPricePoint != nil {
+		pricePointID = relationships.SubscriptionPricePoint.Data.ID
+	}
+	return relationships.Territory.Data.ID, pricePointID, nil
 }
 
 func formatIntegerRange(rangeValue *IntegerRange) string {

--- a/internal/asc/output_win_back_offers_test.go
+++ b/internal/asc/output_win_back_offers_test.go
@@ -1,0 +1,40 @@
+package asc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWinBackOfferPricesRowsHandlesFreeTrialEntriesWithoutPricePoint(t *testing.T) {
+	resp := &WinBackOfferPricesResponse{
+		Data: []Resource[WinBackOfferPriceAttributes]{
+			{
+				Type:          ResourceTypeWinBackOfferPrices,
+				ID:            "price-free",
+				Relationships: json.RawMessage(`{"territory":{"data":{"type":"territories","id":"USA"}}}`),
+			},
+			{
+				Type:          ResourceTypeWinBackOfferPrices,
+				ID:            "price-paid",
+				Relationships: json.RawMessage(`{"territory":{"data":{"type":"territories","id":"FRA"}},"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"price-point-1"}}}`),
+			},
+		},
+	}
+
+	headers, rows, err := winBackOfferPricesRows(resp)
+	if err != nil {
+		t.Fatalf("winBackOfferPricesRows() error: %v", err)
+	}
+	if len(headers) != 3 {
+		t.Fatalf("headers = %v, want 3 columns", headers)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %v, want 2 rows", rows)
+	}
+	if rows[0][0] != "price-free" || rows[0][1] != "USA" || rows[0][2] != "" {
+		t.Fatalf("free-trial row = %v, want empty price point", rows[0])
+	}
+	if rows[1][0] != "price-paid" || rows[1][1] != "FRA" || rows[1][2] != "price-point-1" {
+		t.Fatalf("paid row = %v", rows[1])
+	}
+}

--- a/internal/asc/win_back_offers.go
+++ b/internal/asc/win_back_offers.go
@@ -147,18 +147,22 @@ type WinBackOfferUpdateRequest struct {
 // WinBackOfferPriceAttributes describes a win-back offer price (attributes are empty).
 type WinBackOfferPriceAttributes struct{}
 
-// WinBackOfferPriceRelationships describes price relationships.
+// WinBackOfferPriceRelationships describes price relationships. The
+// subscriptionPricePoint relationship must be omitted for free offers
+// (FREE_TRIAL); the API rejects it with "subscriptionPricePoint should not
+// be set for free offers".
 type WinBackOfferPriceRelationships struct {
-	Territory              Relationship `json:"territory"`
-	SubscriptionPricePoint Relationship `json:"subscriptionPricePoint"`
+	Territory              Relationship  `json:"territory"`
+	SubscriptionPricePoint *Relationship `json:"subscriptionPricePoint,omitempty"`
 }
 
 // WinBackOfferPriceInlineCreate describes inline creation data for prices.
 // Win-back offer prices do not exist before the offer is created, so the
 // create request must inline them via the JSON:API `included` array with
-// temporary `${price-N}` IDs, each carrying territory and
-// subscriptionPricePoint relationships. Without the relationships the API
-// rejects the request with "Missing subscriptionPricePoint relationship".
+// temporary `${price-N}` IDs, each carrying a territory relationship plus,
+// for paid offer modes only, a subscriptionPricePoint relationship. Without
+// the relationships the API rejects paid requests with "Missing
+// subscriptionPricePoint relationship".
 type WinBackOfferPriceInlineCreate struct {
 	Type          ResourceType                    `json:"type"`
 	ID            string                          `json:"id,omitempty"`

--- a/internal/cli/cmdtest/win_back_offers_free_trial_test.go
+++ b/internal/cli/cmdtest/win_back_offers_free_trial_test.go
@@ -192,16 +192,24 @@ func newWinBackOfferTestClient(t *testing.T, server *httptest.Server) *asc.Clien
 }
 
 func TestWinBackOffersCreateFreeTrialRejectsPrice(t *testing.T) {
-	t.Setenv("ASC_APP_ID", "")
-	assertUsageExit(t, winBackFreeTrialCreateArgs(
-		"--territory", "USA",
-		"--price", "eyJzIjoiMTIzNCIsInQiOiJVU0EiLCJwIjoiMTAwOTkifQ",
-	), "--price is not supported when --offer-mode is FREE_TRIAL")
+	for _, value := range []string{
+		"eyJzIjoiMTIzNCIsInQiOiJVU0EiLCJwIjoiMTAwOTkifQ",
+		"",
+		",,",
+	} {
+		t.Run(fmt.Sprintf("price=%q", value), func(t *testing.T) {
+			t.Setenv("ASC_APP_ID", "")
+			assertWinBackOfferUsageBeforeClient(t, winBackFreeTrialCreateArgs(
+				"--territory", "USA",
+				"--price", value,
+			), "--price is not supported when --offer-mode is FREE_TRIAL")
+		})
+	}
 }
 
 func TestWinBackOffersCreateFreeTrialRequiresTerritory(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
-	assertUsageExit(t, winBackFreeTrialCreateArgs(),
+	assertWinBackOfferUsageBeforeClient(t, winBackFreeTrialCreateArgs(),
 		"--territory is required when --offer-mode is FREE_TRIAL")
 }
 
@@ -213,6 +221,14 @@ func TestWinBackOffersCreatePaidRejectsTerritory(t *testing.T) {
 			args[i] = "PAY_AS_YOU_GO"
 		}
 	}
-	assertUsageExit(t, args,
+	assertWinBackOfferUsageBeforeClient(t, args,
 		"--territory is only supported when --offer-mode is FREE_TRIAL")
+}
+
+func assertWinBackOfferUsageBeforeClient(t *testing.T, args []string, wantErr string) {
+	t.Helper()
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return nil, fmt.Errorf("unexpected client creation")
+	}))
+	assertUsageExit(t, args, wantErr)
 }

--- a/internal/cli/cmdtest/win_back_offers_free_trial_test.go
+++ b/internal/cli/cmdtest/win_back_offers_free_trial_test.go
@@ -1,0 +1,153 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// Regression coverage for https://github.com/rorkai/App-Store-Connect-CLI/issues/1948:
+// FREE_TRIAL win-back offers must be creatable without --price, because the
+// API rejects subscriptionPricePoint relationships on free offers.
+
+func winBackFreeTrialCreateArgs(extra ...string) []string {
+	args := []string{
+		"subscriptions", "offers", "win-back", "create",
+		"--subscription-id", "1234567890",
+		"--reference-name", "Yearly winback",
+		"--offer-id", "yearly_winback_1mo",
+		"--duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--period-count", "1",
+		"--eligibility-paid-months", "1",
+		"--eligibility-last-subscribed-min", "1",
+		"--eligibility-last-subscribed-max", "12",
+		"--start-date", "2026-08-11",
+		"--priority", "HIGH",
+	}
+	return append(args, extra...)
+}
+
+func TestWinBackOffersCreateFreeTrialSendsTerritoryOnlyPrices(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected POST request, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/winBackOffers" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		var payload struct {
+			Data struct {
+				Attributes struct {
+					OfferMode string `json:"offerMode"`
+				} `json:"attributes"`
+				Relationships struct {
+					Prices struct {
+						Data []struct {
+							Type string `json:"type"`
+							ID   string `json:"id"`
+						} `json:"data"`
+					} `json:"prices"`
+				} `json:"relationships"`
+			} `json:"data"`
+			Included []struct {
+				Type          string                     `json:"type"`
+				ID            string                     `json:"id"`
+				Relationships map[string]json.RawMessage `json:"relationships"`
+			} `json:"included"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if payload.Data.Attributes.OfferMode != "FREE_TRIAL" {
+			t.Fatalf("expected offerMode FREE_TRIAL, got %q", payload.Data.Attributes.OfferMode)
+		}
+		if got := len(payload.Data.Relationships.Prices.Data); got != 2 {
+			t.Fatalf("expected 2 price linkages, got %d", got)
+		}
+		if got := len(payload.Included); got != 2 {
+			t.Fatalf("expected 2 included prices, got %d", got)
+		}
+		wantTerritories := []string{"USA", "FRA"}
+		for i, included := range payload.Included {
+			if included.Type != "winBackOfferPrices" {
+				t.Fatalf("included[%d] type = %q, want winBackOfferPrices", i, included.Type)
+			}
+			if _, ok := included.Relationships["subscriptionPricePoint"]; ok {
+				t.Fatalf("included[%d] must not carry subscriptionPricePoint for FREE_TRIAL: %s", i, body)
+			}
+			var territory struct {
+				Data struct {
+					Type string `json:"type"`
+					ID   string `json:"id"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(included.Relationships["territory"], &territory); err != nil {
+				t.Fatalf("included[%d] territory decode error: %v", i, err)
+			}
+			if territory.Data.Type != "territories" || territory.Data.ID != wantTerritories[i] {
+				t.Fatalf("included[%d] territory = %+v, want %s", i, territory.Data, wantTerritories[i])
+			}
+		}
+		return jsonResponse(http.StatusCreated, `{"data":{"type":"winBackOffers","id":"offer-1","attributes":{"referenceName":"Yearly winback","offerId":"yearly_winback_1mo"}}}`)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(winBackFreeTrialCreateArgs("--territory", "US,France")); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if stdout == "" {
+		t.Fatal("expected JSON output")
+	}
+}
+
+func TestWinBackOffersCreateFreeTrialRejectsPrice(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	assertUsageExit(t, winBackFreeTrialCreateArgs(
+		"--territory", "USA",
+		"--price", "eyJzIjoiMTIzNCIsInQiOiJVU0EiLCJwIjoiMTAwOTkifQ",
+	), "--price is not supported when --offer-mode is FREE_TRIAL")
+}
+
+func TestWinBackOffersCreateFreeTrialRequiresTerritory(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	assertUsageExit(t, winBackFreeTrialCreateArgs(),
+		"--territory is required when --offer-mode is FREE_TRIAL")
+}
+
+func TestWinBackOffersCreatePaidRejectsTerritory(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	args := winBackFreeTrialCreateArgs("--territory", "USA")
+	for i, arg := range args {
+		if arg == "FREE_TRIAL" {
+			args[i] = "PAY_AS_YOU_GO"
+		}
+	}
+	assertUsageExit(t, args,
+		"--territory is only supported when --offer-mode is FREE_TRIAL")
+}

--- a/internal/cli/cmdtest/win_back_offers_free_trial_test.go
+++ b/internal/cli/cmdtest/win_back_offers_free_trial_test.go
@@ -1,11 +1,20 @@
 package cmdtest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 // Regression coverage for https://github.com/rorkai/App-Store-Connect-CLI/issues/1948:
@@ -34,77 +43,55 @@ func TestWinBackOffersCreateFreeTrialSendsTerritoryOnlyPrices(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	setupAuth(t)
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	requestBodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodPost {
-			t.Fatalf("expected POST request, got %s", req.Method)
+			t.Errorf("expected POST request, got %s", req.Method)
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
 		}
 		if req.URL.Path != "/v1/winBackOffers" {
-			t.Fatalf("unexpected path %q", req.URL.Path)
+			t.Errorf("unexpected path %q", req.URL.Path)
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		if req.URL.RawQuery != "" {
+			t.Errorf("unexpected query %q", req.URL.RawQuery)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+			return
+		}
+		authorization := req.Header.Get("Authorization")
+		token, ok := strings.CutPrefix(authorization, "Bearer ")
+		if !ok || strings.TrimSpace(token) == "" {
+			t.Errorf("Authorization = %q, want nonempty Bearer token", authorization)
+			http.Error(w, "missing authorization", http.StatusUnauthorized)
+			return
 		}
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			t.Fatalf("failed to read request body: %v", err)
+			t.Errorf("failed to read request body: %v", err)
+			http.Error(w, "failed to read body", http.StatusBadRequest)
+			return
 		}
-		var payload struct {
-			Data struct {
-				Attributes struct {
-					OfferMode string `json:"offerMode"`
-				} `json:"attributes"`
-				Relationships struct {
-					Prices struct {
-						Data []struct {
-							Type string `json:"type"`
-							ID   string `json:"id"`
-						} `json:"data"`
-					} `json:"prices"`
-				} `json:"relationships"`
-			} `json:"data"`
-			Included []struct {
-				Type          string                     `json:"type"`
-				ID            string                     `json:"id"`
-				Relationships map[string]json.RawMessage `json:"relationships"`
-			} `json:"included"`
+		select {
+		case requestBodies <- body:
+		default:
+			t.Errorf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected extra request", http.StatusBadRequest)
+			return
 		}
-		if err := json.Unmarshal(body, &payload); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
-		}
-		if payload.Data.Attributes.OfferMode != "FREE_TRIAL" {
-			t.Fatalf("expected offerMode FREE_TRIAL, got %q", payload.Data.Attributes.OfferMode)
-		}
-		if got := len(payload.Data.Relationships.Prices.Data); got != 2 {
-			t.Fatalf("expected 2 price linkages, got %d", got)
-		}
-		if got := len(payload.Included); got != 2 {
-			t.Fatalf("expected 2 included prices, got %d", got)
-		}
-		wantTerritories := []string{"USA", "FRA"}
-		for i, included := range payload.Included {
-			if included.Type != "winBackOfferPrices" {
-				t.Fatalf("included[%d] type = %q, want winBackOfferPrices", i, included.Type)
-			}
-			if _, ok := included.Relationships["subscriptionPricePoint"]; ok {
-				t.Fatalf("included[%d] must not carry subscriptionPricePoint for FREE_TRIAL: %s", i, body)
-			}
-			var territory struct {
-				Data struct {
-					Type string `json:"type"`
-					ID   string `json:"id"`
-				} `json:"data"`
-			}
-			if err := json.Unmarshal(included.Relationships["territory"], &territory); err != nil {
-				t.Fatalf("included[%d] territory decode error: %v", i, err)
-			}
-			if territory.Data.Type != "territories" || territory.Data.ID != wantTerritories[i] {
-				t.Fatalf("included[%d] territory = %+v, want %s", i, territory.Data, wantTerritories[i])
-			}
-		}
-		return jsonResponse(http.StatusCreated, `{"data":{"type":"winBackOffers","id":"offer-1","attributes":{"referenceName":"Yearly winback","offerId":"yearly_winback_1mo"}}}`)
-	})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"data":{"type":"winBackOffers","id":"offer-1","attributes":{"referenceName":"Yearly winback","offerId":"yearly_winback_1mo"}}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := newWinBackOfferTestClient(t, server)
+	clientFactoryCalls := 0
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientFactoryCalls++
+		return client, nil
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
@@ -121,9 +108,87 @@ func TestWinBackOffersCreateFreeTrialSendsTerritoryOnlyPrices(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if stdout == "" {
-		t.Fatal("expected JSON output")
+	var response asc.WinBackOfferResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("decode stdout JSON: %v; stdout=%q", err, stdout)
 	}
+	if response.Data.Type != asc.ResourceTypeWinBackOffers || response.Data.ID != "offer-1" {
+		t.Fatalf("response data = %+v, want winBackOffers offer-1", response.Data)
+	}
+	body := <-requestBodies
+	var payload asc.WinBackOfferCreateRequest
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode request body: %v; body=%s", err, body)
+	}
+	if payload.Data.Attributes.OfferMode != asc.SubscriptionOfferModeFreeTrial {
+		t.Fatalf("offerMode = %q, want FREE_TRIAL", payload.Data.Attributes.OfferMode)
+	}
+	if bytes.Contains(body, []byte(`"subscriptionPricePoint"`)) {
+		t.Fatalf("FREE_TRIAL payload must omit subscriptionPricePoint: %s", body)
+	}
+	if got := len(payload.Data.Relationships.Prices.Data); got != 2 {
+		t.Fatalf("price linkages = %d, want 2", got)
+	}
+	if got := len(payload.Included); got != 2 {
+		t.Fatalf("included prices = %d, want 2", got)
+	}
+	wantTerritories := []string{"USA", "FRA"}
+	for i, included := range payload.Included {
+		wantID := fmt.Sprintf("${price-%d}", i+1)
+		linkage := payload.Data.Relationships.Prices.Data[i]
+		if linkage.Type != asc.ResourceTypeWinBackOfferPrices || linkage.ID != wantID {
+			t.Fatalf("price linkage[%d] = %+v, want winBackOfferPrices %s", i, linkage, wantID)
+		}
+		if included.Type != asc.ResourceTypeWinBackOfferPrices || included.ID != wantID {
+			t.Fatalf("included[%d] = %s %s, want winBackOfferPrices %s", i, included.Type, included.ID, wantID)
+		}
+		if included.Relationships == nil {
+			t.Fatalf("included[%d] is missing relationships: %s", i, body)
+		}
+		if included.Relationships.SubscriptionPricePoint != nil {
+			t.Fatalf("included[%d] must not carry subscriptionPricePoint: %s", i, body)
+		}
+		territory := included.Relationships.Territory.Data
+		if territory.Type != asc.ResourceTypeTerritories || territory.ID != wantTerritories[i] {
+			t.Fatalf("included[%d] territory = %+v, want %s", i, territory, wantTerritories[i])
+		}
+	}
+	if clientFactoryCalls != 1 {
+		t.Fatalf("client factory calls = %d, want 1", clientFactoryCalls)
+	}
+	select {
+	case extra := <-requestBodies:
+		t.Fatalf("unexpected extra request body: %s", extra)
+	default:
+	}
+}
+
+func newWinBackOfferTestClient(t *testing.T, server *httptest.Server) *asc.Client {
+	t.Helper()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Scheme + "://" + req.URL.Host; got != asc.BaseURL {
+			t.Fatalf("request origin = %s, want %s", got, asc.BaseURL)
+		}
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		cloned.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	return client
 }
 
 func TestWinBackOffersCreateFreeTrialRejectsPrice(t *testing.T) {

--- a/internal/cli/winbackoffers/win_back_offers.go
+++ b/internal/cli/winbackoffers/win_back_offers.go
@@ -275,7 +275,8 @@ func WinBackOffersCreateCommand() *ffcli.Command {
 	endDate := fs.String("end-date", "", "End date (YYYY-MM-DD)")
 	priority := fs.String("priority", "", "Offer priority: "+strings.Join(winBackOfferPriorityValues, ", "))
 	promotionIntent := fs.String("promotion-intent", "", "Promotion intent: "+strings.Join(winBackOfferPromotionIntentValues, ", "))
-	priceIDs := fs.String("price", "", "Subscription price point ID(s), comma-separated")
+	priceIDs := fs.String("price", "", "Subscription price point ID(s), comma-separated (required for paid offer modes)")
+	territories := fs.String("territory", "", "Territories for FREE_TRIAL offers, comma-separated (accepts alpha-2, alpha-3, or exact English country names)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -284,8 +285,13 @@ func WinBackOffersCreateCommand() *ffcli.Command {
 		ShortHelp:  "Create a win-back offer.",
 		LongHelp: `Create a win-back offer.
 
+Paid offer modes (PAY_AS_YOU_GO, PAY_UP_FRONT) require --price with
+subscription price point IDs. FREE_TRIAL offers carry no price point, so
+they require --territory instead.
+
 Examples:
-  asc win-back-offers create --subscription-id "SUB_ID" --reference-name "spring-2026" --offer-id "OFFER-1" --duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --period-count 1 --eligibility-paid-months 6 --eligibility-last-subscribed-min 3 --eligibility-last-subscribed-max 12 --start-date "2026-02-01" --priority HIGH --price "SUBSCRIPTION_PRICE_POINT_ID"`,
+  asc win-back-offers create --subscription-id "SUB_ID" --reference-name "spring-2026" --offer-id "OFFER-1" --duration ONE_MONTH --offer-mode PAY_AS_YOU_GO --period-count 1 --eligibility-paid-months 6 --eligibility-last-subscribed-min 3 --eligibility-last-subscribed-max 12 --start-date "2026-02-01" --priority HIGH --price "SUBSCRIPTION_PRICE_POINT_ID"
+  asc win-back-offers create --subscription-id "SUB_ID" --reference-name "spring-2026" --offer-id "OFFER-2" --duration ONE_MONTH --offer-mode FREE_TRIAL --period-count 1 --eligibility-paid-months 6 --eligibility-last-subscribed-min 3 --eligibility-last-subscribed-max 12 --start-date "2026-02-01" --priority HIGH --territory "USA,FRA"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -381,10 +387,31 @@ Examples:
 				return fmt.Errorf("win-back-offers create: %w", err)
 			}
 
+			isFreeTrial := offerModeValue == asc.SubscriptionOfferModeFreeTrial
 			prices := shared.SplitCSV(*priceIDs)
-			if len(prices) == 0 {
-				fmt.Fprintln(os.Stderr, "Error: --price is required")
-				return shared.MissingRequiredUsageError()
+			var freeTrialTerritories []string
+			if isFreeTrial {
+				if len(prices) > 0 {
+					fmt.Fprintln(os.Stderr, "Error: --price is not supported when --offer-mode is FREE_TRIAL; use --territory to choose territories")
+					return shared.MissingRequiredUsageError()
+				}
+				freeTrialTerritories, err = shared.NormalizeASCTerritoryCSV(*territories)
+				if err != nil {
+					return shared.UsageError(fmt.Sprintf("win-back-offers create: %v", err))
+				}
+				if len(freeTrialTerritories) == 0 {
+					fmt.Fprintln(os.Stderr, "Error: --territory is required when --offer-mode is FREE_TRIAL")
+					return shared.MissingRequiredUsageError()
+				}
+			} else {
+				if strings.TrimSpace(*territories) != "" {
+					fmt.Fprintln(os.Stderr, "Error: --territory is only supported when --offer-mode is FREE_TRIAL")
+					return shared.MissingRequiredUsageError()
+				}
+				if len(prices) == 0 {
+					fmt.Fprintln(os.Stderr, "Error: --price is required")
+					return shared.MissingRequiredUsageError()
+				}
 			}
 
 			if eligibilityWaitMonths.set && eligibilityWaitMonths.value < 0 {
@@ -408,41 +435,58 @@ Examples:
 				promotionIntentValue = &intent
 			}
 
-			// Each --price value is a subscriptionPricePoint ID. Win-back
-			// offer prices don't exist before the offer does, so inline-create
-			// them in `included` with temp `${price-N}` IDs and territory +
-			// subscriptionPricePoint relationships (the territory is encoded
-			// inside the price point ID itself).
-			priceData := make([]asc.ResourceData, 0, len(prices))
-			includedPrices := make([]asc.WinBackOfferPriceInlineCreate, 0, len(prices))
-			for i, priceID := range prices {
-				territory, err := territoryFromPricePointID(priceID)
-				if err != nil {
-					return shared.UsageError(fmt.Sprintf("win-back-offers create: %v", err))
-				}
-				tempID := fmt.Sprintf("${price-%d}", i+1)
+			// Win-back offer prices don't exist before the offer does, so
+			// inline-create them in `included` with temp `${price-N}` IDs.
+			// Paid modes pair each entry with territory (decoded from the
+			// price point ID itself) + subscriptionPricePoint relationships;
+			// FREE_TRIAL entries carry only the territory because the API
+			// rejects price points on free offers.
+			var priceData []asc.ResourceData
+			var includedPrices []asc.WinBackOfferPriceInlineCreate
+			appendInlinePrice := func(relationships *asc.WinBackOfferPriceRelationships) {
+				tempID := fmt.Sprintf("${price-%d}", len(priceData)+1)
 				priceData = append(priceData, asc.ResourceData{
 					Type: asc.ResourceTypeWinBackOfferPrices,
 					ID:   tempID,
 				})
 				includedPrices = append(includedPrices, asc.WinBackOfferPriceInlineCreate{
-					Type: asc.ResourceTypeWinBackOfferPrices,
-					ID:   tempID,
-					Relationships: &asc.WinBackOfferPriceRelationships{
+					Type:          asc.ResourceTypeWinBackOfferPrices,
+					ID:            tempID,
+					Relationships: relationships,
+				})
+			}
+			if isFreeTrial {
+				for _, territory := range freeTrialTerritories {
+					appendInlinePrice(&asc.WinBackOfferPriceRelationships{
 						Territory: asc.Relationship{
 							Data: asc.ResourceData{
 								Type: asc.ResourceTypeTerritories,
 								ID:   territory,
 							},
 						},
-						SubscriptionPricePoint: asc.Relationship{
+					})
+				}
+			} else {
+				for _, priceID := range prices {
+					territory, err := territoryFromPricePointID(priceID)
+					if err != nil {
+						return shared.UsageError(fmt.Sprintf("win-back-offers create: %v", err))
+					}
+					appendInlinePrice(&asc.WinBackOfferPriceRelationships{
+						Territory: asc.Relationship{
+							Data: asc.ResourceData{
+								Type: asc.ResourceTypeTerritories,
+								ID:   territory,
+							},
+						},
+						SubscriptionPricePoint: &asc.Relationship{
 							Data: asc.ResourceData{
 								Type: asc.ResourceTypeSubscriptionPricePoints,
 								ID:   priceID,
 							},
 						},
-					},
-				})
+					})
+				}
 			}
 
 			var waitBetween *int

--- a/internal/cli/winbackoffers/win_back_offers.go
+++ b/internal/cli/winbackoffers/win_back_offers.go
@@ -388,10 +388,12 @@ Examples:
 			}
 
 			isFreeTrial := offerModeValue == asc.SubscriptionOfferModeFreeTrial
+			priceProvided := false
+			fs.Visit(func(f *flag.Flag) { priceProvided = priceProvided || f.Name == "price" })
 			prices := shared.SplitCSV(*priceIDs)
 			var freeTrialTerritories []string
 			if isFreeTrial {
-				if len(prices) > 0 {
+				if priceProvided {
 					fmt.Fprintln(os.Stderr, "Error: --price is not supported when --offer-mode is FREE_TRIAL; use --territory to choose territories")
 					return shared.MissingRequiredUsageError()
 				}

--- a/internal/cli/winbackoffers/win_back_offers_test.go
+++ b/internal/cli/winbackoffers/win_back_offers_test.go
@@ -11,11 +11,21 @@ func TestWinBackOffersCreateHelpDescribesPricePointIDs(t *testing.T) {
 	if priceFlag == nil {
 		t.Fatal("expected --price flag")
 	}
-	if got := priceFlag.Usage; got != "Subscription price point ID(s), comma-separated" {
+	if got := priceFlag.Usage; got != "Subscription price point ID(s), comma-separated (required for paid offer modes)" {
 		t.Fatalf("unexpected --price usage: %q", got)
 	}
 	if !strings.Contains(cmd.LongHelp, `--price "SUBSCRIPTION_PRICE_POINT_ID"`) {
 		t.Fatalf("expected long help to describe subscription price point IDs, got %q", cmd.LongHelp)
+	}
+	territoryFlag := cmd.FlagSet.Lookup("territory")
+	if territoryFlag == nil {
+		t.Fatal("expected --territory flag")
+	}
+	if !strings.Contains(territoryFlag.Usage, "FREE_TRIAL") {
+		t.Fatalf("unexpected --territory usage: %q", territoryFlag.Usage)
+	}
+	if !strings.Contains(cmd.LongHelp, `--offer-mode FREE_TRIAL`) || !strings.Contains(cmd.LongHelp, `--territory "USA,FRA"`) {
+		t.Fatalf("expected long help to include a FREE_TRIAL example, got %q", cmd.LongHelp)
 	}
 }
 


### PR DESCRIPTION
Fixes #1948.

## Problem

`FREE_TRIAL` win-back offers could not be created through the CLI. The command always required `--price`, while App Store Connect rejects `subscriptionPricePoint` relationships for free offers.

## Change

- add `--territory` for `FREE_TRIAL` offers, accepting alpha-2, alpha-3, or exact English territory names
- require `--territory` and reject `--price` for `FREE_TRIAL`
- keep `--price` required for `PAY_AS_YOU_GO` and `PAY_UP_FRONT`, rejecting `--territory` for those paid modes
- omit `subscriptionPricePoint` from free-trial inline price relationships
- render free-trial price rows safely when no price point relationship is present

```bash
asc subscriptions offers win-back create \
  --subscription-id "SUB_ID" \
  --reference-name "Yearly winback" \
  --offer-id "yearly_winback_1mo" \
  --duration ONE_MONTH \
  --offer-mode FREE_TRIAL \
  --period-count 1 \
  --eligibility-paid-months 1 \
  --eligibility-last-subscribed-min 1 \
  --eligibility-last-subscribed-max 12 \
  --start-date 2026-08-11 \
  --priority HIGH \
  --territory "USA,FRA"
```

## Compatibility

Previously successful paid invocations and payloads are unchanged. The new validation only rejects mismatched `--price`/`--territory` combinations that would otherwise be ignored or rejected by App Store Connect.

## Validation

- focused request, rendering, help, and usage tests repeated 10 times
- focused race tests
- compiled help and pre-auth invalid-combination checks
- real injected ASC client test proving the official host, Bearer authentication, one POST, normalized territories, territory-only inline entries, and structured output
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

No App Store Connect mutation was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788945365&installation_model_id=10418&pr_number=1954&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com/rorkai/App-Store-Connect-CLI%2Fpull%2F1954&signature=8112a56c4e9d74ff4abbeb7fc48a44cdeffaa372376f3e36e1acaf2ca6ce0644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating FREE_TRIAL win-back offers using territory-based pricing.
  * Paid offers require a price, while FREE_TRIAL offers use one or more territories instead.
  * Added validation for pricing and territory options.
  * Updated command help and examples for paid and free-trial workflows.

* **Bug Fixes**
  * Improved handling of free-trial entries without subscription price points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->