### PR TITLE
Validate version view includes before authentication

### DIFF
--- a/internal/cli/cmdtest/versions_contract_test.go
+++ b/internal/cli/cmdtest/versions_contract_test.go
@@ -13,9 +13,13 @@ import (
 	"testing"
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 const releaseTypeValues = "MANUAL, AFTER_APPROVAL, SCHEDULED"
+
+const appStoreVersionIncludeValues = "ageRatingDeclaration, app, appStoreVersionLocalizations, build, appStoreVersionPhasedRelease, gameCenterAppVersion, routingAppCoverage, appStoreReviewDetail, appStoreVersionSubmission, appClipDefaultExperience, appStoreVersionExperiments, appStoreVersionExperimentsV2, alternativeDistributionPackage"
 
 func clearASCAuth(t *testing.T) {
 	t.Helper()
@@ -74,6 +78,58 @@ func TestVersionsViewSendsExactSupportedIncludeQuery(t *testing.T) {
 	}
 	if stderr != "" {
 		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestVersionsViewIncludeValidationBeforeClient(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name:       "unsupported include",
+			args:       []string{"versions", "view", "--version-id", "version-1", "--include", "invalid"},
+			wantStderr: "Error: versions view: --include must be one of: " + appStoreVersionIncludeValues + "\n",
+		},
+		{
+			name:       "include with include build",
+			args:       []string{"versions", "view", "--version-id", "version-1", "--include", "build", "--include-build"},
+			wantStderr: "Error: --include cannot be used with --include-build or --include-submission\n",
+		},
+		{
+			name:       "include with include submission",
+			args:       []string{"versions", "view", "--version-id", "version-1", "--include", "appStoreVersionSubmission", "--include-submission"},
+			wantStderr: "Error: --include cannot be used with --include-build or --include-submission\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearASCAuth(t)
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return nil, fmt.Errorf("client should not be created")
+			}))
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run(test.args, "test"); code != rootcmd.ExitUsage {
+					t.Errorf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Errorf("stdout = %q, want empty", stdout)
+			}
+			errorLine, _, _ := strings.Cut(stderr, "\n")
+			if got := errorLine + "\n"; got != test.wantStderr {
+				t.Errorf("stderr error line = %q, want %q; full stderr = %q", got, test.wantStderr, stderr)
+			}
+			if clientFactoryCalls != 0 {
+				t.Errorf("client factory calls = %d, want 0", clientFactoryCalls)
+			}
+		})
 	}
 }
 

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -173,6 +173,14 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 
+			includeValues, err := normalizeAppStoreVersionInclude(*include)
+			if err != nil {
+				return shared.UsageErrorf("versions view: %v", err)
+			}
+			if len(includeValues) > 0 && (*includeBuild || *includeSubmission) {
+				return shared.UsageError("--include cannot be used with --include-build or --include-submission")
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("versions view: %w", err)
@@ -181,16 +189,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			includeValues, err := normalizeAppStoreVersionInclude(*include)
-			if err != nil {
-				return fmt.Errorf("versions view: %w", err)
-			}
 			if len(includeValues) > 0 {
-				if *includeBuild || *includeSubmission {
-					fmt.Fprintln(os.Stderr, "Error: --include cannot be used with --include-build or --include-submission")
-					return flag.ErrHelp
-				}
-
 				apiIncludes, includeAgeRating := splitCompatAppStoreVersionIncludes(includeValues)
 				var versionResp *asc.AppStoreVersionResponse
 				if len(apiIncludes) > 0 {


### PR DESCRIPTION
## Summary
- validate versions view include values and conflicts before ASC client and authentication setup
- classify unsupported include values as usage errors
- preserve valid include query and output behavior

## Verification
- focused command tests repeated 10 times
- focused command tests under the race detector
- built binary invalid and conflict cases: exit 2, empty stdout, exact diagnostics
- built binary valid include case: successful read-only GET with matching response ID and type
- make build
- make format
- make generate-command-docs
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

No Apple state was changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788946126&installation_model_id=10418&pr_number=1955&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1955&signature=5d6d0e4a8a5b31cef637fa35fab2d72e25817469ec42e87160b569920a0c0f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the `versions view --include` option.
  * Unsupported include values now return clear usage errors.
  * Prevented conflicting use of `--include` with `--include-build` or `--include-submission`.
  * Validation occurs before connecting to the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->