### PR TITLE
Fix iPad screenshot slot selection

### DIFF
--- a/internal/asc/screenshot_sizes_test.go
+++ b/internal/asc/screenshot_sizes_test.go
@@ -420,6 +420,67 @@ func TestScreenshotSizeEntryIncludesIPadPro129M5Dimensions(t *testing.T) {
 	}
 }
 
+func TestScreenshotSizeCatalogSeparatesIPad13AndLegacy129Dimensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		modernType string
+		legacyType string
+	}{
+		{
+			name:       "app screenshots",
+			modernType: "APP_IPAD_PRO_3GEN_129",
+			legacyType: "APP_IPAD_PRO_129",
+		},
+		{
+			name:       "iMessage screenshots",
+			modernType: "IMESSAGE_APP_IPAD_PRO_3GEN_129",
+			legacyType: "IMESSAGE_APP_IPAD_PRO_129",
+		},
+	}
+
+	sharedDimensions := []ScreenshotDimension{
+		{Width: 2048, Height: 2732},
+		{Width: 2732, Height: 2048},
+	}
+	modernOnlyDimensions := []ScreenshotDimension{
+		{Width: 2064, Height: 2752},
+		{Width: 2752, Height: 2064},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modern, ok := ScreenshotSizeEntryForDisplayType(test.modernType)
+			if !ok {
+				t.Fatalf("expected %s entry in screenshot size catalog", test.modernType)
+			}
+			legacy, ok := ScreenshotSizeEntryForDisplayType(test.legacyType)
+			if !ok {
+				t.Fatalf("expected %s entry in screenshot size catalog", test.legacyType)
+			}
+
+			for _, dim := range sharedDimensions {
+				if !containsScreenshotDimension(modern.Dimensions, dim) {
+					t.Fatalf("expected %s to include shared dimension %s", test.modernType, dim.String())
+				}
+				if !containsScreenshotDimension(legacy.Dimensions, dim) {
+					t.Fatalf("expected %s to include shared dimension %s", test.legacyType, dim.String())
+				}
+			}
+			for _, dim := range modernOnlyDimensions {
+				if !containsScreenshotDimension(modern.Dimensions, dim) {
+					t.Fatalf("expected %s to include modern dimension %s", test.modernType, dim.String())
+				}
+				if containsScreenshotDimension(legacy.Dimensions, dim) {
+					t.Fatalf("did not expect %s to include modern dimension %s", test.legacyType, dim.String())
+				}
+				if err := ValidateScreenshotDimensionsForSize("ipad-13.png", dim.Width, dim.Height, test.legacyType); err == nil {
+					t.Fatalf("expected %s to reject modern dimension %s", test.legacyType, dim.String())
+				}
+			}
+		})
+	}
+}
+
 func TestScreenshotSizeEntryIncludesMacDesktopDimensions(t *testing.T) {
 	entry, ok := ScreenshotSizeEntryForDisplayType("APP_DESKTOP")
 	if !ok {

--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -101,6 +101,64 @@ func TestMigrateImportDryRunPlan(t *testing.T) {
 	}
 }
 
+func TestMigrateImportDryRunClassifiesIPad13ScreenshotAsModernSlot(t *testing.T) {
+	root := t.TempDir()
+	metadataDir := filepath.Join(root, "metadata", "en-US")
+	if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	writeFile(t, filepath.Join(metadataDir, "description.txt"), "English description")
+
+	screenshotsDir := filepath.Join(root, "screenshots", "en-US")
+	if err := os.MkdirAll(screenshotsDir, 0o755); err != nil {
+		t.Fatalf("mkdir screenshots: %v", err)
+	}
+	writePNGForMigrate(t, filepath.Join(screenshotsDir, "iPad Pro 13-inch (M5)-1-main-screen.png"), 2064, 2752)
+
+	factoryCalls := 0
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		factoryCalls++
+		return nil, errors.New("client factory must not run during explicit-ID dry-run")
+	})
+	t.Cleanup(restore)
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", root,
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := rootCmd.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("client factory calls = %d, want zero", factoryCalls)
+	}
+
+	var result migrate.MigrateImportResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.ScreenshotPlan) != 1 {
+		t.Fatalf("expected 1 screenshot plan, got %d", len(result.ScreenshotPlan))
+	}
+	if got := result.ScreenshotPlan[0].DisplayType; got != "APP_IPAD_PRO_3GEN_129" {
+		t.Fatalf("display type = %q, want APP_IPAD_PRO_3GEN_129", got)
+	}
+}
+
 func TestMigrateImportDryRunReportsSkippedNonLocaleMetadataDirs(t *testing.T) {
 	root := t.TempDir()
 	metadataDir := filepath.Join(root, "metadata", "en-US")

--- a/internal/cli/migrate/screenshots.go
+++ b/internal/cli/migrate/screenshots.go
@@ -352,46 +352,46 @@ func readImageDimensions(path string) (int, int, error) {
 
 func inferDisplayTypeFromFilename(path string) string {
 	name := strings.ToLower(filepath.Base(path))
+	if strings.Contains(name, "app_ipad_pro_129") ||
+		(strings.Contains(name, "12.9") && strings.Contains(name, "2nd generation")) {
+		return "APP_IPAD_PRO_129"
+	}
+
 	replacements := map[string]string{
-		"ipad pro 13":      "APP_IPAD_PRO_129",
-		"ipad pro 13-inch": "APP_IPAD_PRO_129",
-		"ipad pro 13 inch": "APP_IPAD_PRO_129",
-		"iphone 6.9":       "APP_IPHONE_69",
-		"iphone6.9":        "APP_IPHONE_69",
-		"iphone 6.7":       "APP_IPHONE_67",
-		"iphone6.7":        "APP_IPHONE_67",
-		"iphone 6.5":       "APP_IPHONE_65",
-		"iphone6.5":        "APP_IPHONE_65",
-		"iphone 6.1":       "APP_IPHONE_61",
-		"iphone6.1":        "APP_IPHONE_61",
-		"iphone 5.8":       "APP_IPHONE_58",
-		"iphone5.8":        "APP_IPHONE_58",
-		"iphone 5.5":       "APP_IPHONE_55",
-		"iphone5.5":        "APP_IPHONE_55",
-		"iphone 4.7":       "APP_IPHONE_47",
-		"iphone4.7":        "APP_IPHONE_47",
-		"iphone 4.0":       "APP_IPHONE_40",
-		"iphone4.0":        "APP_IPHONE_40",
-		"iphone 3.5":       "APP_IPHONE_35",
-		"iphone3.5":        "APP_IPHONE_35",
-		"ipad 12.9":        "APP_IPAD_PRO_129",
-		"ipad12.9":         "APP_IPAD_PRO_129",
-		"ipad 11":          "APP_IPAD_PRO_3GEN_11",
-		"ipad11":           "APP_IPAD_PRO_3GEN_11",
-		"ipad 10.5":        "APP_IPAD_105",
-		"ipad10.5":         "APP_IPAD_105",
-		"ipad 9.7":         "APP_IPAD_97",
-		"ipad9.7":          "APP_IPAD_97",
-		"apple tv":         "APP_APPLE_TV",
-		"appletv":          "APP_APPLE_TV",
-		"vision pro":       "APP_APPLE_VISION_PRO",
-		"desktop":          "APP_DESKTOP",
-		"mac":              "APP_DESKTOP",
-		"watch ultra":      "APP_WATCH_ULTRA",
-		"watch series 10":  "APP_WATCH_SERIES_10",
-		"watch series 7":   "APP_WATCH_SERIES_7",
-		"watch series 4":   "APP_WATCH_SERIES_4",
-		"watch series 3":   "APP_WATCH_SERIES_3",
+		"iphone 6.9":      "APP_IPHONE_69",
+		"iphone6.9":       "APP_IPHONE_69",
+		"iphone 6.7":      "APP_IPHONE_67",
+		"iphone6.7":       "APP_IPHONE_67",
+		"iphone 6.5":      "APP_IPHONE_65",
+		"iphone6.5":       "APP_IPHONE_65",
+		"iphone 6.1":      "APP_IPHONE_61",
+		"iphone6.1":       "APP_IPHONE_61",
+		"iphone 5.8":      "APP_IPHONE_58",
+		"iphone5.8":       "APP_IPHONE_58",
+		"iphone 5.5":      "APP_IPHONE_55",
+		"iphone5.5":       "APP_IPHONE_55",
+		"iphone 4.7":      "APP_IPHONE_47",
+		"iphone4.7":       "APP_IPHONE_47",
+		"iphone 4.0":      "APP_IPHONE_40",
+		"iphone4.0":       "APP_IPHONE_40",
+		"iphone 3.5":      "APP_IPHONE_35",
+		"iphone3.5":       "APP_IPHONE_35",
+		"ipad 11":         "APP_IPAD_PRO_3GEN_11",
+		"ipad11":          "APP_IPAD_PRO_3GEN_11",
+		"ipad 10.5":       "APP_IPAD_105",
+		"ipad10.5":        "APP_IPAD_105",
+		"ipad 9.7":        "APP_IPAD_97",
+		"ipad9.7":         "APP_IPAD_97",
+		"apple tv":        "APP_APPLE_TV",
+		"appletv":         "APP_APPLE_TV",
+		"vision pro":      "APP_APPLE_VISION_PRO",
+		"desktop":         "APP_DESKTOP",
+		"mac":             "APP_DESKTOP",
+		"watch ultra":     "APP_WATCH_ULTRA",
+		"watch series 10": "APP_WATCH_SERIES_10",
+		"watch series 7":  "APP_WATCH_SERIES_7",
+		"watch series 4":  "APP_WATCH_SERIES_4",
+		"watch series 3":  "APP_WATCH_SERIES_3",
 	}
 	for key, value := range replacements {
 		if strings.Contains(name, key) {
@@ -438,9 +438,9 @@ func inferDisplayTypeFromDimensions(width, height int) string {
 	case maxDim == 960 && minDim == 640:
 		return "APP_IPHONE_35"
 	case maxDim == 2732 && minDim == 2048:
-		return "APP_IPAD_PRO_129"
+		return "APP_IPAD_PRO_3GEN_129"
 	case maxDim == 2752 && minDim == 2064:
-		return "APP_IPAD_PRO_129"
+		return "APP_IPAD_PRO_3GEN_129"
 	case maxDim == 2420 && minDim == 1668:
 		return "APP_IPAD_PRO_3GEN_11"
 	case maxDim == 2388 && minDim == 1668:

--- a/internal/cli/migrate/screenshots_test.go
+++ b/internal/cli/migrate/screenshots_test.go
@@ -273,17 +273,68 @@ func TestDiscoverScreenshotPlan_IgnoresEmptyLocaleDirectories(t *testing.T) {
 	}
 }
 
-func TestInferScreenshotDisplayType_FastlaneIPadPro13Filename(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "iPad Pro 13-inch (M5)-1-main-screen.png")
-	writePNG(t, path, 2064, 2752)
-
-	displayType, err := inferScreenshotDisplayType(path)
-	if err != nil {
-		t.Fatalf("inferScreenshotDisplayType() error: %v", err)
+func TestInferScreenshotDisplayType_IPadPro129GenerationDisambiguation(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		width  int
+		height int
+		want   string
+	}{
+		{
+			name:   "13 inch M5 filename",
+			path:   "iPad Pro 13-inch (M5)-1-main-screen.png",
+			width:  2064,
+			height: 2752,
+			want:   "APP_IPAD_PRO_3GEN_129",
+		},
+		{
+			name:   "modern 12.9 inch generation filename",
+			path:   "iPad Pro (12.9-inch) (6th generation)-1-main-screen.png",
+			width:  2048,
+			height: 2732,
+			want:   "APP_IPAD_PRO_3GEN_129",
+		},
+		{
+			name:   "unhinted 13 inch dimensions",
+			path:   "main-screen.png",
+			width:  2064,
+			height: 2752,
+			want:   "APP_IPAD_PRO_3GEN_129",
+		},
+		{
+			name:   "unhinted shared dimensions default modern",
+			path:   "main-screen.png",
+			width:  2048,
+			height: 2732,
+			want:   "APP_IPAD_PRO_3GEN_129",
+		},
+		{
+			name:   "explicit legacy display type",
+			path:   "APP_IPAD_PRO_129-1-main-screen.png",
+			width:  2048,
+			height: 2732,
+			want:   "APP_IPAD_PRO_129",
+		},
+		{
+			name:   "explicit second generation filename",
+			path:   "iPad Pro (12.9-inch) (2nd generation)-1-main-screen.png",
+			width:  2048,
+			height: 2732,
+			want:   "APP_IPAD_PRO_129",
+		},
 	}
-	if displayType != "APP_IPAD_PRO_129" {
-		t.Fatalf("expected APP_IPAD_PRO_129, got %q", displayType)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			displayType, err := inferScreenshotDisplayTypeFromDimensions(test.path, test.width, test.height)
+			if err != nil {
+				t.Fatalf("inferScreenshotDisplayTypeFromDimensions() error: %v", err)
+			}
+			if displayType != test.want {
+				t.Fatalf("display type = %q, want %q", displayType, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/screenshotcatalog/catalog.go
+++ b/internal/screenshotcatalog/catalog.go
@@ -80,11 +80,12 @@ var (
 	iphone40Dimensions = portraitLandscape(640, 1136)
 	iphone35Dimensions = portraitLandscape(640, 960)
 
-	ipadPro129Dimensions = combineDimensions(
+	ipadPro3Gen129Dimensions = combineDimensions(
 		portraitLandscape(2048, 2732),
 		portraitLandscape(2064, 2752),
 	)
-	ipadPro11Dimensions = combineDimensions(
+	ipadPro129Dimensions = portraitLandscape(2048, 2732)
+	ipadPro11Dimensions  = combineDimensions(
 		portraitLandscape(1488, 2266),
 		portraitLandscape(1668, 2388),
 		portraitLandscape(1668, 2420),
@@ -120,7 +121,7 @@ var registry = map[string][]Dimension{
 	"APP_IPHONE_47":                  iphone47Dimensions,
 	"APP_IPHONE_40":                  iphone40Dimensions,
 	"APP_IPHONE_35":                  iphone35Dimensions,
-	"APP_IPAD_PRO_3GEN_129":          ipadPro129Dimensions,
+	"APP_IPAD_PRO_3GEN_129":          ipadPro3Gen129Dimensions,
 	"APP_IPAD_PRO_3GEN_11":           ipadPro11Dimensions,
 	"APP_IPAD_PRO_129":               ipadPro129Dimensions,
 	"APP_IPAD_105":                   ipad105Dimensions,
@@ -141,7 +142,7 @@ var registry = map[string][]Dimension{
 	"IMESSAGE_APP_IPHONE_55":         iphone55Dimensions,
 	"IMESSAGE_APP_IPHONE_47":         iphone47Dimensions,
 	"IMESSAGE_APP_IPHONE_40":         iphone40Dimensions,
-	"IMESSAGE_APP_IPAD_PRO_3GEN_129": ipadPro129Dimensions,
+	"IMESSAGE_APP_IPAD_PRO_3GEN_129": ipadPro3Gen129Dimensions,
 	"IMESSAGE_APP_IPAD_PRO_3GEN_11":  ipadPro11Dimensions,
 	"IMESSAGE_APP_IPAD_PRO_129":      ipadPro129Dimensions,
 	"IMESSAGE_APP_IPAD_105":          ipad105Dimensions,


### PR DESCRIPTION
## Summary

- assign 13-inch iPad screenshots to APP_IPAD_PRO_3GEN_129 during migration
- retain the legacy slot for explicit legacy filename hints
- separate current and legacy iPad dimensions in the screenshot catalog

## Behavior

Unhinted 2048x2732 and 2064x2752 screenshots now default to APP_IPAD_PRO_3GEN_129. A filename containing APP_IPAD_PRO_129 or both 12.9 and 2nd generation still selects APP_IPAD_PRO_129. The legacy app and iMessage catalog entries no longer accept 2064x2752.

## Verification

- focused behavior tests repeated 10 times
- focused race-detector run
- built-binary offline migration dry-run and catalog boundary checks
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788946185&installation_model_id=10418&pr_number=1956&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1956&signature=99a9e5845af1b9076cb04ffce6a8600021fed0a1bfd9462ecf187517721d00ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iPad Pro screenshot classification across 12.9-inch and 13-inch generations.
  * Correctly distinguishes legacy 12.9-inch screenshots from modern-generation screenshots.
  * Added support for modern iPad Pro screenshot dimensions and orientations.
  * Updated app and iMessage screenshot validation to accept the appropriate dimensions for each device generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
