### PR TITLE
fix(web): preserve Unicode in generated app names

### DIFF
--- a/internal/cli/web/web_apps.go
+++ b/internal/cli/web/web_apps.go
@@ -200,15 +200,17 @@ func formatAppNameWithSuffix(baseName, suffix string) string {
 		return ""
 	}
 	sep := " - "
-	maxBase := maxAppNameLen - len(sep) - len(suffix)
+	suffixRunes := []rune(suffix)
+	maxBase := maxAppNameLen - len([]rune(sep)) - len(suffixRunes)
 	if maxBase <= 0 {
-		if len(suffix) > maxAppNameLen {
-			return suffix[:maxAppNameLen]
+		if len(suffixRunes) > maxAppNameLen {
+			return string(suffixRunes[:maxAppNameLen])
 		}
 		return suffix
 	}
-	if len(baseName) > maxBase {
-		baseName = strings.TrimSpace(baseName[:maxBase])
+	baseNameRunes := []rune(baseName)
+	if len(baseNameRunes) > maxBase {
+		baseName = strings.TrimSpace(string(baseNameRunes[:maxBase]))
 		baseName = strings.TrimRight(baseName, "-")
 		baseName = strings.TrimSpace(baseName)
 	}

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -4,17 +4,123 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"os"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
+
+func TestFormatAppNameWithSuffixCountsCharacters(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseName string
+		suffix   string
+		want     string
+	}{
+		{
+			name:     "unicode at truncation boundary",
+			baseName: "12345678901234567890123🚀Launch",
+			suffix:   "app",
+			want:     "12345678901234567890123🚀 - app",
+		},
+		{
+			name:     "ascii behavior",
+			baseName: "123456789012345678901234567890123",
+			suffix:   "app",
+			want:     "123456789012345678901234 - app",
+		},
+		{
+			name:     "unicode suffix-only fallback",
+			baseName: "A",
+			suffix:   strings.Repeat("🚀", maxAppNameLen+1),
+			want:     strings.Repeat("🚀", maxAppNameLen),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatAppNameWithSuffix(tt.baseName, tt.suffix)
+			if !utf8.ValidString(got) {
+				t.Errorf("formatAppNameWithSuffix() returned invalid UTF-8: %q", got)
+			}
+			if gotRunes, wantRunes := utf8.RuneCountInString(got), utf8.RuneCountInString(tt.want); gotRunes != wantRunes {
+				t.Errorf("formatAppNameWithSuffix() rune count = %d, want %d", gotRunes, wantRunes)
+			}
+			if gotRunes := utf8.RuneCountInString(got); gotRunes > maxAppNameLen {
+				t.Errorf("formatAppNameWithSuffix() rune count = %d, limit %d", gotRunes, maxAppNameLen)
+			}
+			if got != tt.want {
+				t.Errorf("formatAppNameWithSuffix() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunAppsCreateAutoRenamePreservesUnicode(t *testing.T) {
+	origResolveAppCreateSession := resolveAppCreateSessionFn
+	t.Cleanup(func() {
+		resolveAppCreateSessionFn = origResolveAppCreateSession
+	})
+
+	const originalName = "12345678901234567890123🚀Launch"
+	const retryName = "12345678901234567890123🚀 - app"
+	var requestBodies []string
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		requestBodies = append(requestBodies, string(body))
+
+		status := http.StatusOK
+		responseBody := `{"data":{"id":"app-123","type":"apps","attributes":{}}}`
+		if len(requestBodies) == 1 {
+			status = http.StatusUnprocessableEntity
+			responseBody = `{"errors":[{"code":"ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE.DIFFERENT_ACCOUNT","detail":"The app name you entered is already being used."}]}`
+		}
+		return &http.Response{
+			StatusCode: status,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+			Request:    req,
+		}, nil
+	})
+
+	resolveAppCreateSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{Client: &http.Client{Transport: transport}}, "cache", nil
+	}
+
+	t.Setenv("ASC_WEB_MIN_REQUEST_INTERVAL", "0")
+	err := RunAppsCreate(context.Background(), AppsCreateRunOptions{
+		Name:                     originalName,
+		BundleID:                 "com.example.app",
+		SKU:                      "SKU123",
+		AppleID:                  "user@example.com",
+		Output:                   "json",
+		AutoRename:               true,
+		DisableBundleIDPreflight: true,
+	})
+	if err != nil {
+		t.Fatalf("RunAppsCreate returned error: %v", err)
+	}
+	if len(requestBodies) != 2 {
+		t.Fatalf("expected 2 create requests, got %d", len(requestBodies))
+	}
+	if !strings.Contains(requestBodies[0], `"name":"`+originalName+`"`) {
+		t.Errorf("initial serialized request did not preserve name: %s", requestBodies[0])
+	}
+	if !strings.Contains(requestBodies[1], `"name":"`+retryName+`"`) {
+		t.Errorf("retry serialized request did not preserve name: %s", requestBodies[1])
+	}
+}
 
 func TestAppCreateCanPromptInteractivelyUsesControllingTTYWhenStdinIsNotTerminal(t *testing.T) {
 	origOpenTTY := openTTYFn


### PR DESCRIPTION
## Summary
- count generated retry names by Unicode characters before applying the 30-character limit
- keep long suffix-only fallbacks valid UTF-8
- cover duplicate-name retries through the real web client serialization boundary

## Compatibility
- the initial create request, flags, help, output, errors, and exit codes are unchanged
- ASCII retry names retain their existing formatting
- verification used offline HTTP stubs; no App Store Connect mutation was performed

## Testing
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/web -run "TestFormatAppNameWithSuffixCountsCharacters|TestRunAppsCreateAutoRenamePreservesUnicode" -count=10`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/web -run "TestFormatAppNameWithSuffixCountsCharacters|TestRunAppsCreateAutoRenamePreservesUnicode" -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/web ./internal/web -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`
- compiled help and offline required-flag validation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788947363&installation_model_id=10418&pr_number=1958&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1958&signature=4c704609a9e3f79a116260a8dfc78f1f6ddc750cb82f0ac1ca54f0d7a85cd4d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app-name truncation for Unicode characters, preventing broken or invalid text.
  * Preserved Unicode names when automatically renaming apps after duplicate-name conflicts.
  * Maintained expected length limits and behavior for both Unicode and ASCII names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->