### PR TITLE
fix(validate): check copyright acquisition years

### DIFF
--- a/internal/cli/cmdtest/validate_test.go
+++ b/internal/cli/cmdtest/validate_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/validate"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
@@ -378,6 +379,58 @@ func TestValidateVersionAndVersionIDMutuallyExclusive(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "mutually exclusive") {
 		t.Fatalf("expected mutually exclusive error, got %q", stderr)
+	}
+}
+
+func TestValidateReportsCopyrightWithoutLeadingAcquisitionYear(t *testing.T) {
+	fixture := validValidateFixture()
+	fixture.version = strings.Replace(fixture.version, `"copyright":"2026 Test Company"`, `"copyright":"Example Inc."`, 1)
+
+	client := newValidateTestClient(t, fixture)
+	restore := validate.SetClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	defer restore()
+
+	root := RootCommand("1.2.3")
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %T: %v", runErr, runErr)
+	}
+	if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitError {
+		t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitError)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var report validation.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("failed to parse JSON output: %v; stdout=%q", err, stdout)
+	}
+
+	var matches []validation.CheckResult
+	for _, check := range report.Checks {
+		if check.ID == "legal.format.copyright_year" {
+			matches = append(matches, check)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one copyright-year check, got %d: %+v", len(matches), report.Checks)
+	}
+	if report.Summary.Errors != 1 || report.Summary.Blocking != 1 {
+		t.Fatalf("expected one blocking error, got %+v", report.Summary)
+	}
+	check := matches[0]
+	if check.Severity != validation.SeverityError || check.Field != "copyright" || check.ResourceType != "appStoreVersion" {
+		t.Fatalf("unexpected copyright-year check: %+v", check)
 	}
 }
 

--- a/internal/validation/legal.go
+++ b/internal/validation/legal.go
@@ -3,13 +3,16 @@ package validation
 import (
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const AppleStandardEULAURL = "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/"
 
 var (
 	descriptionURLPattern = regexp.MustCompile(`(?i)https?://[^\s]+`)
+	copyrightYearPattern  = regexp.MustCompile(`^([0-9]{4})$`)
 	termsKeywordPattern   = regexp.MustCompile(`(?i)\bterms of use\b|\bterms\b|\beula\b`)
 	termsURLPattern       = regexp.MustCompile(`(^|[^a-z0-9])(terms?|eula|tos|termsofservice)([^a-z0-9]|$)`)
 )
@@ -26,6 +29,15 @@ func legalChecks(copyright string, hasActiveMonetization bool, hasReviewRelevant
 			ResourceType: "appStoreVersion",
 			Message:      "copyright is required",
 			Remediation:  "Set copyright via: asc versions update --version-id VERSION_ID --copyright \"2026 Your Company\"",
+		})
+	} else if !hasValidLeadingCopyrightYear(copyright, time.Now().Year()) {
+		checks = append(checks, CheckResult{
+			ID:           "legal.format.copyright_year",
+			Severity:     SeverityError,
+			Field:        "copyright",
+			ResourceType: "appStoreVersion",
+			Message:      "copyright must start with the four-digit year the rights were obtained",
+			Remediation:  "Use a current or past year followed by the rights owner, for example: \"2020 Your Company\"",
 		})
 	}
 
@@ -122,6 +134,21 @@ func legalChecks(copyright string, hasActiveMonetization bool, hasReviewRelevant
 	}
 
 	return checks
+}
+
+func hasValidLeadingCopyrightYear(value string, currentYear int) bool {
+	fields := strings.Fields(strings.TrimSpace(value))
+	if len(fields) == 0 {
+		return false
+	}
+
+	match := copyrightYearPattern.FindStringSubmatch(fields[0])
+	if len(match) != 2 {
+		return false
+	}
+
+	year, err := strconv.Atoi(match[1])
+	return err == nil && year > 0 && year <= currentYear
 }
 
 // HasTermsOfUseLink reports whether a description includes a functional Terms of Use / EULA link.

--- a/internal/validation/legal_test.go
+++ b/internal/validation/legal_test.go
@@ -5,24 +5,11 @@ import (
 )
 
 func TestLegalChecks_CopyrightEmpty(t *testing.T) {
-	checks := legalChecks(
-		"", false, false,
-		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
-		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
-	)
-	if !hasCheckID(checks, "legal.required.copyright") {
-		t.Fatal("expected copyright required check")
-	}
-}
-
-func TestLegalChecks_CopyrightWhitespaceOnly(t *testing.T) {
-	checks := legalChecks(
-		"   ", false, false,
-		[]VersionLocalization{{Locale: "en-US", SupportURL: "https://example.com"}},
-		[]AppInfoLocalization{{Locale: "en-US", PrivacyPolicyURL: "https://example.com/privacy"}},
-	)
-	if !hasCheckID(checks, "legal.required.copyright") {
-		t.Fatal("expected copyright required check for whitespace-only")
+	for _, value := range []string{"", "   "} {
+		checks := legalChecks(value, false, false, nil, nil)
+		if len(checks) != 1 || checks[0].ID != "legal.required.copyright" {
+			t.Fatalf("copyright checks for %q = %+v, want only legal.required.copyright", value, checks)
+		}
 	}
 }
 
@@ -34,6 +21,36 @@ func TestLegalChecks_CopyrightPresent(t *testing.T) {
 	)
 	if hasCheckID(checks, "legal.required.copyright") {
 		t.Fatal("did not expect copyright check when copyright is set")
+	}
+}
+
+func TestHasValidLeadingCopyrightYear(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "past year", value: "2016 Acme", want: true},
+		{name: "current year", value: "2026 Acme", want: true},
+		{name: "past year before 1900", value: "1899 Acme", want: true},
+		{name: "surrounding whitespace", value: "  2026 Acme  ", want: true},
+		{name: "unicode whitespace", value: "\u00a02026\tAcme\u00a0", want: true},
+		{name: "year without owner grammar", value: "2026", want: true},
+		{name: "year zero", value: "0000 Acme", want: false},
+		{name: "missing year", value: "Acme", want: false},
+		{name: "year is not leading", value: "Acme 2026", want: false},
+		{name: "year joined to owner", value: "2026会社", want: false},
+		{name: "five digit prefix", value: "20260 Acme", want: false},
+		{name: "non ASCII digits", value: "２０２６ Acme", want: false},
+		{name: "future year", value: "2027 Acme", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := hasValidLeadingCopyrightYear(test.value, 2026); got != test.want {
+				t.Fatalf("hasValidLeadingCopyrightYear(%q, 2026) = %v, want %v", test.value, got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- require non-empty copyright metadata to start with a four-digit acquisition-year token
- accept current and past years while reporting missing, trailing, zero, or future years as a blocking readiness error
- preserve the existing required-only result for empty or whitespace-only copyright values

## Behavior

`asc validate` now reports `legal.format.copyright_year` when non-empty copyright metadata does not begin with a valid current-or-past year. The finding remains part of the existing JSON, table, or Markdown readiness report on stdout; a blocking report returns exit 1 with empty stderr.

The check deliberately validates only the leading year token. It accepts Unicode whitespace separators and does not add owner-name grammar.

## Compatibility

Existing current-year and historical-year values continue to pass. Empty values still produce only `legal.required.copyright`. This does not change `versions update`, request payloads, authentication, or App Store Connect mutations.

## Verification

- deterministic RED: `Example Inc.` previously produced no copyright finding
- focused validation and CLI regression tests, 10 consecutive runs
- focused race tests
- built CLI help and read-only validation against the disposable app
- read-only empty-value boundary: exit 1, JSON report on stdout, empty stderr, exactly one copyright finding (`legal.required.copyright`)
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788948234&installation_model_id=10418&pr_number=1959&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1959&signature=ad21559a5477ff720b20fdb61dd77df0db2f70b7a2b23b87f71e9583f05ce0a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copyright-year validation to legal checks.
  * Non-empty copyright statements must begin with a valid four-digit acquisition year that is no later than the current year.
* **Bug Fixes**
  * Validation now reports a blocking error for copyright statements missing a valid leading year.
  * Improved handling of empty, whitespace-only, Unicode, and invalid year values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->