### PR TITLE
fix(builds): use highest processed build number

### DIFF
--- a/internal/cli/builds/builds_latest.go
+++ b/internal/cli/builds/builds_latest.go
@@ -37,6 +37,10 @@ func BuildsNextBuildNumberCommand() *ffcli.Command {
 This command compares the latest processed build and in-flight build uploads,
 then returns the next build number that should be safe to use.
 
+latestProcessedBuildNumber reports the most recently uploaded matching build.
+latestObservedBuildNumber and nextBuildNumber use the highest numeric matching
+build number across processed builds and build uploads.
+
 Examples:
   asc builds next-build-number --app "123456789"
   asc builds next-build-number --app "123456789" --version "1.2.3" --platform IOS

--- a/internal/cli/builds/builds_latest.go
+++ b/internal/cli/builds/builds_latest.go
@@ -37,9 +37,12 @@ func BuildsNextBuildNumberCommand() *ffcli.Command {
 This command compares the latest processed build and in-flight build uploads,
 then returns the next build number that should be safe to use.
 
-latestProcessedBuildNumber reports the most recently uploaded matching build.
-latestObservedBuildNumber and nextBuildNumber use the highest numeric matching
-build number across processed builds and build uploads.
+latestProcessedBuildNumber reports the most recently uploaded matching build
+when its number is positive; zero-style placeholders are reported as null.
+latestObservedBuildNumber and nextBuildNumber use the highest positive numeric
+build number across processed builds and build uploads. If only zero-style
+placeholders remain, all latest fields are null, sourcesConsidered is empty,
+and nextBuildNumber uses --initial-build-number.
 
 Examples:
   asc builds next-build-number --app "123456789"

--- a/internal/cli/cmdtest/builds_next_number_processed_max_test.go
+++ b/internal/cli/cmdtest/builds_next_number_processed_max_test.go
@@ -5,10 +5,112 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"path/filepath"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+const (
+	processedBuildsQuery       = "filter%5Bapp%5D=100000001&limit=200&sort=-uploadedDate"
+	processedBuildUploadsQuery = "filter%5Bstate%5D=AWAITING_UPLOAD%2CPROCESSING%2CCOMPLETE&limit=200"
+)
+
+type processedMaximumRequestStep struct {
+	path         string
+	rawQuery     string
+	responseBody string
+}
+
+type processedMaximumRequestRecorder struct {
+	t     *testing.T
+	mu    sync.Mutex
+	steps []processedMaximumRequestStep
+	next  int
+}
+
+func (r *processedMaximumRequestRecorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.next >= len(r.steps) {
+		r.t.Errorf("unexpected extra request: %s %s", req.Method, req.URL.RequestURI())
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+		return
+	}
+
+	step := r.steps[r.next]
+	r.next++
+	if req.Method != http.MethodGet {
+		r.t.Errorf("request %d method = %s, want GET", r.next, req.Method)
+	}
+	if req.URL.EscapedPath() != step.path {
+		r.t.Errorf("request %d path = %q, want %q", r.next, req.URL.EscapedPath(), step.path)
+	}
+	if req.URL.RawQuery != step.rawQuery {
+		r.t.Errorf("request %d query = %q, want %q", r.next, req.URL.RawQuery, step.rawQuery)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, step.responseBody)
+}
+
+func (r *processedMaximumRequestRecorder) requireComplete() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.next != len(r.steps) {
+		r.t.Errorf("requests = %d, want %d in exact order", r.next, len(r.steps))
+	}
+}
+
+func setProcessedMaximumTestClient(t *testing.T, steps []processedMaximumRequestStep) {
+	t.Helper()
+	setupAuth(t)
+
+	recorder := &processedMaximumRequestRecorder{t: t, steps: steps}
+	server := httptest.NewServer(recorder)
+	t.Cleanup(func() {
+		server.Close()
+		recorder.requireComplete()
+	})
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Scheme + "://" + req.URL.Host; got != asc.BaseURL {
+			t.Fatalf("request origin = %s, want %s", got, asc.BaseURL)
+		}
+		authorization := req.Header.Get("Authorization")
+		token, ok := strings.CutPrefix(authorization, "Bearer ")
+		if !ok || strings.TrimSpace(token) == "" {
+			t.Fatalf("Authorization = %q, want nonempty Bearer token", authorization)
+		}
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
+}
 
 type processedMaximumOutput struct {
 	LatestProcessedBuildNumber *string  `json:"latestProcessedBuildNumber"`
@@ -106,31 +208,18 @@ func TestBuildsNextBuildNumberUsesHighestProcessedNumber(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			setupAuth(t)
-			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-
-			originalTransport := http.DefaultTransport
-			t.Cleanup(func() { http.DefaultTransport = originalTransport })
-			buildRequests := 0
-			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				switch {
-				case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
-					buildRequests++
-					query := req.URL.Query()
-					if query.Get("filter[app]") != "100000001" || query.Get("sort") != "-uploadedDate" {
-						t.Fatalf("unexpected builds query: %s", req.URL.RawQuery)
-					}
-					body := test.chronologicalBody
-					if buildRequests > 1 && test.maximumBody != "" {
-						body = test.maximumBody
-					}
-					return jsonHTTPResponse(http.StatusOK, body), nil
-				case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
-					return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
-				default:
-					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-					return nil, nil
-				}
+			maximumBody := test.maximumBody
+			if maximumBody == "" {
+				maximumBody = test.chronologicalBody
+			}
+			setProcessedMaximumTestClient(t, []processedMaximumRequestStep{
+				{path: "/v1/builds", rawQuery: processedBuildsQuery, responseBody: test.chronologicalBody},
+				{path: "/v1/builds", rawQuery: processedBuildsQuery, responseBody: maximumBody},
+				{
+					path:         "/v1/apps/100000001/buildUploads",
+					rawQuery:     processedBuildUploadsQuery,
+					responseBody: `{"data":[],"links":{"next":""}}`,
+				},
 			})
 
 			stdout, stderr, runErr := runProcessedMaximumCommand(t)
@@ -149,37 +238,27 @@ func TestBuildsNextBuildNumberUsesHighestProcessedNumber(t *testing.T) {
 			if len(output.SourcesConsidered) != 1 || output.SourcesConsidered[0] != "processed_builds" {
 				t.Fatalf("sourcesConsidered = %v, want [processed_builds]", output.SourcesConsidered)
 			}
-			if buildRequests != 2 {
-				t.Fatalf("build requests = %d, want 2 chronological and maximum reads", buildRequests)
-			}
 		})
 	}
 }
 
 func TestBuildsNextBuildNumberScansEveryProcessedPageForMaximum(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 	const page2 = "https://api.appstoreconnect.apple.com/v1/builds?cursor=page-2"
 	const page3 = "https://api.appstoreconnect.apple.com/v1/builds?cursor=page-3"
-	page3Requests := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case req.URL.String() == page2:
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-old-40","attributes":{"version":"40","uploadedDate":"2026-02-02T00:00:00Z"}}],"links":{"next":"`+page3+`"}}`), nil
-		case req.URL.String() == page3:
-			page3Requests++
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-old-100","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}],"links":{"next":""}}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}}],"links":{"next":"`+page2+`"}}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
-			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
-		}
+	firstPageBody := `{"data":[{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}}],"links":{"next":"` + page2 + `"}}`
+	secondPageBody := `{"data":[{"type":"builds","id":"build-old-40","attributes":{"version":"40","uploadedDate":"2026-02-02T00:00:00Z"}}],"links":{"next":"` + page3 + `"}}`
+	thirdPageBody := `{"data":[{"type":"builds","id":"build-old-100","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}],"links":{"next":""}}`
+	setProcessedMaximumTestClient(t, []processedMaximumRequestStep{
+		{path: "/v1/builds", rawQuery: processedBuildsQuery, responseBody: firstPageBody},
+		{path: "/v1/builds", rawQuery: "cursor=page-2", responseBody: secondPageBody},
+		{path: "/v1/builds", rawQuery: processedBuildsQuery, responseBody: firstPageBody},
+		{path: "/v1/builds", rawQuery: "cursor=page-2", responseBody: secondPageBody},
+		{path: "/v1/builds", rawQuery: "cursor=page-3", responseBody: thirdPageBody},
+		{
+			path:         "/v1/apps/100000001/buildUploads",
+			rawQuery:     processedBuildUploadsQuery,
+			responseBody: `{"data":[],"links":{"next":""}}`,
+		},
 	})
 
 	stdout, stderr, runErr := runProcessedMaximumCommand(t)
@@ -195,32 +274,16 @@ func TestBuildsNextBuildNumberScansEveryProcessedPageForMaximum(t *testing.T) {
 	if output.NextBuildNumber != "101" {
 		t.Fatalf("nextBuildNumber = %q, want 101", output.NextBuildNumber)
 	}
-	if page3Requests != 1 {
-		t.Fatalf("page 3 requests = %d, want 1", page3Requests)
-	}
 }
 
 func TestBuildsNextBuildNumberRejectsMalformedOlderProcessedNumber(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	uploadRequests := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
-			return jsonHTTPResponse(http.StatusOK, `{"data":[
+	responseBody := `{"data":[
 				{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}},
 				{"type":"builds","id":"build-old-bad","attributes":{"version":"not-a-number","uploadedDate":"2026-02-02T00:00:00Z"}}
-			]}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
-			uploadRequests++
-			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
-		}
+			]}`
+	setProcessedMaximumTestClient(t, []processedMaximumRequestStep{
+		{path: "/v1/builds", rawQuery: processedBuildsQuery, responseBody: responseBody},
+		{path: "/v1/builds", rawQuery: processedBuildsQuery, responseBody: responseBody},
 	})
 
 	stdout, _, runErr := runProcessedMaximumCommand(t)
@@ -232,8 +295,5 @@ func TestBuildsNextBuildNumberRejectsMalformedOlderProcessedNumber(t *testing.T)
 	}
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
-	}
-	if uploadRequests != 0 {
-		t.Fatalf("upload requests = %d, want 0 after processed history failure", uploadRequests)
 	}
 }

--- a/internal/cli/cmdtest/builds_next_number_processed_max_test.go
+++ b/internal/cli/cmdtest/builds_next_number_processed_max_test.go
@@ -194,6 +194,32 @@ func TestBuildsNextBuildNumberUsesHighestProcessedNumber(t *testing.T) {
 			wantNext:          "101",
 		},
 		{
+			name: "latest zero placeholder",
+			chronologicalBody: `{"data":[
+				{"type":"builds","id":"build-new-zero","attributes":{"version":"0","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-100","attributes":{"version":"100","uploadedDate":"2026-02-02T00:00:00Z"}}
+			]}`,
+			wantObserved: "100",
+			wantNext:     "101",
+		},
+		{
+			name: "latest zero-style placeholder",
+			chronologicalBody: `{"data":[
+				{"type":"builds","id":"build-new-zero-dot","attributes":{"version":"0.1","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-100","attributes":{"version":"100","uploadedDate":"2026-02-02T00:00:00Z"}}
+			]}`,
+			wantObserved: "100",
+			wantNext:     "101",
+		},
+		{
+			name: "only non-positive placeholders",
+			chronologicalBody: `{"data":[
+				{"type":"builds","id":"build-new-zero","attributes":{"version":"0","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-zero-dot","attributes":{"version":"0.1","uploadedDate":"2026-02-02T00:00:00Z"}}
+			]}`,
+			wantNext: "1",
+		},
+		{
 			name: "older non-positive placeholders",
 			chronologicalBody: `{"data":[
 				{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}},
@@ -230,12 +256,28 @@ func TestBuildsNextBuildNumberUsesHighestProcessedNumber(t *testing.T) {
 				t.Fatalf("stderr = %q, want empty", stderr)
 			}
 			output := decodeProcessedMaximumOutput(t, stdout)
-			requireProcessedMaximumValue(t, "latestProcessedBuildNumber", output.LatestProcessedBuildNumber, test.wantLatest)
-			requireProcessedMaximumValue(t, "latestObservedBuildNumber", output.LatestObservedBuildNumber, test.wantObserved)
+			if test.wantLatest == "" {
+				if output.LatestProcessedBuildNumber != nil {
+					t.Fatalf("latestProcessedBuildNumber = %q, want nil for non-positive placeholder", *output.LatestProcessedBuildNumber)
+				}
+			} else {
+				requireProcessedMaximumValue(t, "latestProcessedBuildNumber", output.LatestProcessedBuildNumber, test.wantLatest)
+			}
+			if test.wantObserved == "" {
+				if output.LatestObservedBuildNumber != nil {
+					t.Fatalf("latestObservedBuildNumber = %q, want nil without a positive build number", *output.LatestObservedBuildNumber)
+				}
+			} else {
+				requireProcessedMaximumValue(t, "latestObservedBuildNumber", output.LatestObservedBuildNumber, test.wantObserved)
+			}
 			if output.NextBuildNumber != test.wantNext {
 				t.Fatalf("nextBuildNumber = %q, want %q", output.NextBuildNumber, test.wantNext)
 			}
-			if len(output.SourcesConsidered) != 1 || output.SourcesConsidered[0] != "processed_builds" {
+			if test.wantObserved == "" {
+				if len(output.SourcesConsidered) != 0 {
+					t.Fatalf("sourcesConsidered = %v, want empty without a positive build number", output.SourcesConsidered)
+				}
+			} else if len(output.SourcesConsidered) != 1 || output.SourcesConsidered[0] != "processed_builds" {
 				t.Fatalf("sourcesConsidered = %v, want [processed_builds]", output.SourcesConsidered)
 			}
 		})
@@ -292,6 +334,27 @@ func TestBuildsNextBuildNumberRejectsMalformedOlderProcessedNumber(t *testing.T)
 	}
 	if !strings.Contains(runErr.Error(), `processed build build-old-bad build number "not-a-number" is not numeric`) {
 		t.Fatalf("run error = %v, want malformed processed build context", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+}
+
+func TestBuildsNextBuildNumberRejectsMalformedLatestProcessedNumber(t *testing.T) {
+	responseBody := `{"data":[
+				{"type":"builds","id":"build-new-bad","attributes":{"version":"not-a-number","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-50","attributes":{"version":"50","uploadedDate":"2026-02-02T00:00:00Z"}}
+			]}`
+	setProcessedMaximumTestClient(t, []processedMaximumRequestStep{
+		{path: "/v1/builds", rawQuery: processedBuildsQuery, responseBody: responseBody},
+	})
+
+	stdout, _, runErr := runProcessedMaximumCommand(t)
+	if runErr == nil {
+		t.Fatal("expected malformed latest processed build number error")
+	}
+	if !strings.Contains(runErr.Error(), `processed build build-new-bad build number "not-a-number" is not numeric`) {
+		t.Fatalf("run error = %v, want malformed latest processed build context", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)

--- a/internal/cli/cmdtest/builds_next_number_processed_max_test.go
+++ b/internal/cli/cmdtest/builds_next_number_processed_max_test.go
@@ -1,0 +1,239 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type processedMaximumOutput struct {
+	LatestProcessedBuildNumber *string  `json:"latestProcessedBuildNumber"`
+	LatestUploadBuildNumber    *string  `json:"latestUploadBuildNumber"`
+	LatestObservedBuildNumber  *string  `json:"latestObservedBuildNumber"`
+	NextBuildNumber            string   `json:"nextBuildNumber"`
+	SourcesConsidered          []string `json:"sourcesConsidered"`
+}
+
+func runProcessedMaximumCommand(t *testing.T) (string, string, error) {
+	t.Helper()
+
+	root := RootCommand("test")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "next-build-number", "--app", "100000001", "--output", "json"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func decodeProcessedMaximumOutput(t *testing.T, stdout string) processedMaximumOutput {
+	t.Helper()
+
+	var output processedMaximumOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v; stdout=%s", err, stdout)
+	}
+	return output
+}
+
+func requireProcessedMaximumValue(t *testing.T, label string, got *string, want string) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s = nil, want %q", label, want)
+	}
+	if *got != want {
+		t.Fatalf("%s = %q, want %q", label, *got, want)
+	}
+}
+
+func TestBuildsNextBuildNumberUsesHighestProcessedNumber(t *testing.T) {
+	tests := []struct {
+		name              string
+		chronologicalBody string
+		maximumBody       string
+		wantLatest        string
+		wantObserved      string
+		wantNext          string
+	}{
+		{
+			name: "older numeric maximum",
+			chronologicalBody: `{"data":[
+				{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-51","attributes":{"version":"51","uploadedDate":"2026-02-02T00:00:00Z"}},
+				{"type":"builds","id":"build-old-100","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}
+			]}`,
+			wantLatest:   "50",
+			wantObserved: "100",
+			wantNext:     "101",
+		},
+		{
+			name: "dotted numeric maximum",
+			chronologicalBody: `{"data":[
+				{"type":"builds","id":"build-new-1-9","attributes":{"version":"1.9","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-1-10","attributes":{"version":"1.10","uploadedDate":"2026-02-02T00:00:00Z"}}
+			]}`,
+			wantLatest:   "1.9",
+			wantObserved: "1.10",
+			wantNext:     "1.11",
+		},
+		{
+			name:              "chronological seed survives lower second read",
+			chronologicalBody: `{"data":[{"type":"builds","id":"build-new-100","attributes":{"version":"100","uploadedDate":"2026-02-03T00:00:00Z"}}]}`,
+			maximumBody:       `{"data":[{"type":"builds","id":"build-old-50","attributes":{"version":"50","uploadedDate":"2026-02-02T00:00:00Z"}}]}`,
+			wantLatest:        "100",
+			wantObserved:      "100",
+			wantNext:          "101",
+		},
+		{
+			name: "older non-positive placeholders",
+			chronologicalBody: `{"data":[
+				{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-zero","attributes":{"version":"0","uploadedDate":"2026-02-02T00:00:00Z"}},
+				{"type":"builds","id":"build-old-zero-dot","attributes":{"version":"0.1","uploadedDate":"2026-02-01T00:00:00Z"}}
+			]}`,
+			wantLatest:   "50",
+			wantObserved: "50",
+			wantNext:     "51",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			originalTransport := http.DefaultTransport
+			t.Cleanup(func() { http.DefaultTransport = originalTransport })
+			buildRequests := 0
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
+					buildRequests++
+					query := req.URL.Query()
+					if query.Get("filter[app]") != "100000001" || query.Get("sort") != "-uploadedDate" {
+						t.Fatalf("unexpected builds query: %s", req.URL.RawQuery)
+					}
+					body := test.chronologicalBody
+					if buildRequests > 1 && test.maximumBody != "" {
+						body = test.maximumBody
+					}
+					return jsonHTTPResponse(http.StatusOK, body), nil
+				case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+				default:
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+					return nil, nil
+				}
+			})
+
+			stdout, stderr, runErr := runProcessedMaximumCommand(t)
+			if runErr != nil {
+				t.Fatalf("run: %v", runErr)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+			output := decodeProcessedMaximumOutput(t, stdout)
+			requireProcessedMaximumValue(t, "latestProcessedBuildNumber", output.LatestProcessedBuildNumber, test.wantLatest)
+			requireProcessedMaximumValue(t, "latestObservedBuildNumber", output.LatestObservedBuildNumber, test.wantObserved)
+			if output.NextBuildNumber != test.wantNext {
+				t.Fatalf("nextBuildNumber = %q, want %q", output.NextBuildNumber, test.wantNext)
+			}
+			if len(output.SourcesConsidered) != 1 || output.SourcesConsidered[0] != "processed_builds" {
+				t.Fatalf("sourcesConsidered = %v, want [processed_builds]", output.SourcesConsidered)
+			}
+			if buildRequests != 2 {
+				t.Fatalf("build requests = %d, want 2 chronological and maximum reads", buildRequests)
+			}
+		})
+	}
+}
+
+func TestBuildsNextBuildNumberScansEveryProcessedPageForMaximum(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	const page2 = "https://api.appstoreconnect.apple.com/v1/builds?cursor=page-2"
+	const page3 = "https://api.appstoreconnect.apple.com/v1/builds?cursor=page-3"
+	page3Requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.URL.String() == page2:
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-old-40","attributes":{"version":"40","uploadedDate":"2026-02-02T00:00:00Z"}}],"links":{"next":"`+page3+`"}}`), nil
+		case req.URL.String() == page3:
+			page3Requests++
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-old-100","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}}],"links":{"next":"`+page2+`"}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, runErr := runProcessedMaximumCommand(t)
+	if runErr != nil {
+		t.Fatalf("run: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	output := decodeProcessedMaximumOutput(t, stdout)
+	requireProcessedMaximumValue(t, "latestProcessedBuildNumber", output.LatestProcessedBuildNumber, "50")
+	requireProcessedMaximumValue(t, "latestObservedBuildNumber", output.LatestObservedBuildNumber, "100")
+	if output.NextBuildNumber != "101" {
+		t.Fatalf("nextBuildNumber = %q, want 101", output.NextBuildNumber)
+	}
+	if page3Requests != 1 {
+		t.Fatalf("page 3 requests = %d, want 1", page3Requests)
+	}
+}
+
+func TestBuildsNextBuildNumberRejectsMalformedOlderProcessedNumber(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	uploadRequests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[
+				{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-03T00:00:00Z"}},
+				{"type":"builds","id":"build-old-bad","attributes":{"version":"not-a-number","uploadedDate":"2026-02-02T00:00:00Z"}}
+			]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
+			uploadRequests++
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, _, runErr := runProcessedMaximumCommand(t)
+	if runErr == nil {
+		t.Fatal("expected malformed processed build number error")
+	}
+	if !strings.Contains(runErr.Error(), `processed build build-old-bad build number "not-a-number" is not numeric`) {
+		t.Fatalf("run error = %v, want malformed processed build context", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if uploadRequests != 0 {
+		t.Fatalf("upload requests = %d, want 0 after processed history failure", uploadRequests)
+	}
+}

--- a/internal/cli/cmdtest/builds_next_number_test.go
+++ b/internal/cli/cmdtest/builds_next_number_test.go
@@ -727,7 +727,10 @@ func TestBuildsNextBuildNumberHelpExplainsChronologicalAndNumericValues(t *testi
 	usage := usageForCommand(t, "builds", "next-build-number")
 	for _, want := range []string{
 		"latestProcessedBuildNumber reports the most recently uploaded matching build",
-		"latestObservedBuildNumber and nextBuildNumber use the highest numeric matching",
+		"zero-style placeholders are reported as null",
+		"latestObservedBuildNumber and nextBuildNumber use the highest positive numeric",
+		"sourcesConsidered is empty",
+		"nextBuildNumber uses --initial-build-number",
 	} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("expected next-build-number help to contain %q, got %q", want, usage)

--- a/internal/cli/cmdtest/builds_next_number_test.go
+++ b/internal/cli/cmdtest/builds_next_number_test.go
@@ -252,6 +252,8 @@ func TestBuildsNextBuildNumberWithFiltersUsesCanonicalQueryShape(t *testing.T) {
 		http.DefaultTransport = originalTransport
 	})
 
+	chronologicalBuildRequests := 0
+	maximumBuildRequests := 0
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/preReleaseVersions":
@@ -287,10 +289,20 @@ func TestBuildsNextBuildNumberWithFiltersUsesCanonicalQueryShape(t *testing.T) {
 			if query.Get("sort") != "-uploadedDate" {
 				t.Fatalf("expected sort=-uploadedDate, got %q", query.Get("sort"))
 			}
-			if query.Get("limit") != "1" {
-				t.Fatalf("expected limit=1, got %q", query.Get("limit"))
+			switch query.Get("limit") {
+			case "1":
+				chronologicalBuildRequests++
+				return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-02T00:00:00Z"}}]}`), nil
+			case "200":
+				maximumBuildRequests++
+				return jsonHTTPResponse(http.StatusOK, `{"data":[
+					{"type":"builds","id":"build-new-50","attributes":{"version":"50","uploadedDate":"2026-02-02T00:00:00Z"}},
+					{"type":"builds","id":"build-old-100","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}
+				]}`), nil
+			default:
+				t.Fatalf("expected limit=1 or limit=200, got %q", query.Get("limit"))
+				return nil, nil
 			}
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"builds","id":"build-1","attributes":{"version":"100","uploadedDate":"2026-02-01T00:00:00Z"}}]}`), nil
 
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/100000001/buildUploads":
 			query := req.URL.Query()
@@ -303,7 +315,7 @@ func TestBuildsNextBuildNumberWithFiltersUsesCanonicalQueryShape(t *testing.T) {
 			if query.Get("filter[platform]") != "IOS" {
 				t.Fatalf("expected filter[platform]=IOS, got %q", query.Get("filter[platform]"))
 			}
-			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleVersion":"101"}}],"links":{"next":""}}`), nil
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleVersion":"90"}}],"links":{"next":""}}`), nil
 
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
@@ -337,19 +349,26 @@ func TestBuildsNextBuildNumberWithFiltersUsesCanonicalQueryShape(t *testing.T) {
 	var out struct {
 		LatestProcessedBuildNumber *string `json:"latestProcessedBuildNumber"`
 		LatestUploadBuildNumber    *string `json:"latestUploadBuildNumber"`
+		LatestObservedBuildNumber  *string `json:"latestObservedBuildNumber"`
 		NextBuildNumber            string  `json:"nextBuildNumber"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
 		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
 	}
-	if out.LatestProcessedBuildNumber == nil || *out.LatestProcessedBuildNumber != "100" {
-		t.Fatalf("expected latestProcessedBuildNumber=100, got %v", out.LatestProcessedBuildNumber)
+	if out.LatestProcessedBuildNumber == nil || *out.LatestProcessedBuildNumber != "50" {
+		t.Fatalf("expected latestProcessedBuildNumber=50, got %v", out.LatestProcessedBuildNumber)
 	}
-	if out.LatestUploadBuildNumber == nil || *out.LatestUploadBuildNumber != "101" {
-		t.Fatalf("expected latestUploadBuildNumber=101, got %v", out.LatestUploadBuildNumber)
+	if out.LatestUploadBuildNumber == nil || *out.LatestUploadBuildNumber != "90" {
+		t.Fatalf("expected latestUploadBuildNumber=90, got %v", out.LatestUploadBuildNumber)
 	}
-	if out.NextBuildNumber != "102" {
-		t.Fatalf("expected nextBuildNumber=102, got %q", out.NextBuildNumber)
+	if out.LatestObservedBuildNumber == nil || *out.LatestObservedBuildNumber != "100" {
+		t.Fatalf("expected latestObservedBuildNumber=100, got %v", out.LatestObservedBuildNumber)
+	}
+	if out.NextBuildNumber != "101" {
+		t.Fatalf("expected nextBuildNumber=101, got %q", out.NextBuildNumber)
+	}
+	if chronologicalBuildRequests != 1 || maximumBuildRequests != 1 {
+		t.Fatalf("build requests = chronological:%d maximum:%d, want 1 each", chronologicalBuildRequests, maximumBuildRequests)
 	}
 }
 
@@ -701,5 +720,17 @@ func TestBuildsHelpShowsNextBuildNumberAndHidesLatestAlias(t *testing.T) {
 	}
 	if strings.Contains(usage, "\n  latest\t") || strings.Contains(usage, "\n  latest ") {
 		t.Fatalf("expected deprecated latest alias to stay hidden from builds help, got %q", usage)
+	}
+}
+
+func TestBuildsNextBuildNumberHelpExplainsChronologicalAndNumericValues(t *testing.T) {
+	usage := usageForCommand(t, "builds", "next-build-number")
+	for _, want := range []string{
+		"latestProcessedBuildNumber reports the most recently uploaded matching build",
+		"latestObservedBuildNumber and nextBuildNumber use the highest numeric matching",
+	} {
+		if !strings.Contains(usage, want) {
+			t.Fatalf("expected next-build-number help to contain %q, got %q", want, usage)
+		}
 	}
 }

--- a/internal/cli/shared/build_numbers.go
+++ b/internal/cli/shared/build_numbers.go
@@ -97,14 +97,17 @@ func ResolveNextBuildNumber(ctx context.Context, client *asc.Client, opts NextBu
 	var latestProcessedValue buildNumber
 	hasLatestProcessed := false
 	if selection.LatestBuild != nil {
-		parsed, err := parseBuildNumber(selection.LatestBuild.Data.Attributes.Version, fmt.Sprintf("processed build %s", selection.LatestBuild.Data.ID))
-		if err != nil {
-			return nil, err
+		latestVersion := selection.LatestBuild.Data.Attributes.Version
+		if !isNonPositiveNumericBuildNumber(latestVersion) {
+			parsed, err := parseBuildNumber(latestVersion, fmt.Sprintf("processed build %s", selection.LatestBuild.Data.ID))
+			if err != nil {
+				return nil, err
+			}
+			latestProcessedValue = parsed
+			value := parsed.String()
+			latestProcessedNumber = &value
+			hasLatestProcessed = true
 		}
-		latestProcessedValue = parsed
-		value := parsed.String()
-		latestProcessedNumber = &value
-		hasLatestProcessed = true
 	}
 
 	highestProcessedValue := latestProcessedValue

--- a/internal/cli/shared/build_numbers.go
+++ b/internal/cli/shared/build_numbers.go
@@ -23,10 +23,12 @@ type LatestBuildSelectionOptions struct {
 }
 
 type latestBuildSelectionResult struct {
-	ResolvedAppID      string
-	NormalizedVersion  string
-	NormalizedPlatform string
-	LatestBuild        *asc.BuildResponse
+	ResolvedAppID        string
+	NormalizedVersion    string
+	NormalizedPlatform   string
+	HasPreReleaseFilters bool
+	PreReleaseVersionIDs []string
+	LatestBuild          *asc.BuildResponse
 }
 
 // NextBuildNumberOptions configures next build number calculation.
@@ -75,8 +77,8 @@ func NormalizeLatestBuildSelectionOptions(appID, version, platform, processingSt
 	}, nil
 }
 
-// ResolveNextBuildNumber compares the latest processed build and the latest
-// in-flight build upload, then returns the next safe build number.
+// ResolveNextBuildNumber compares the highest observed processed build and
+// in-flight build upload numbers, then returns the next safe build number.
 func ResolveNextBuildNumber(ctx context.Context, client *asc.Client, opts NextBuildNumberOptions) (*asc.BuildsNextBuildNumberResult, error) {
 	if opts.InitialBuildNumber < 1 {
 		return nil, UsageError("--initial-build-number must be >= 1")
@@ -93,7 +95,7 @@ func ResolveNextBuildNumber(ctx context.Context, client *asc.Client, opts NextBu
 	sourcesConsidered := make([]string, 0, 2)
 
 	var latestProcessedValue buildNumber
-	hasProcessed := false
+	hasLatestProcessed := false
 	if selection.LatestBuild != nil {
 		parsed, err := parseBuildNumber(selection.LatestBuild.Data.Attributes.Version, fmt.Sprintf("processed build %s", selection.LatestBuild.Data.ID))
 		if err != nil {
@@ -102,7 +104,27 @@ func ResolveNextBuildNumber(ctx context.Context, client *asc.Client, opts NextBu
 		latestProcessedValue = parsed
 		value := parsed.String()
 		latestProcessedNumber = &value
+		hasLatestProcessed = true
+	}
+
+	highestProcessedValue := latestProcessedValue
+	highestProcessedNumber := latestProcessedNumber
+	hasProcessed := hasLatestProcessed
+	scannedProcessedValue, scannedProcessedNumber, hasScannedProcessed, err := findHighestProcessedBuildNumber(
+		ctx,
+		client,
+		selection,
+		opts.LatestBuildSelectionOptions,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if hasScannedProcessed && (!hasProcessed || scannedProcessedValue.Compare(highestProcessedValue) > 0) {
+		highestProcessedValue = scannedProcessedValue
+		highestProcessedNumber = scannedProcessedNumber
 		hasProcessed = true
+	}
+	if hasProcessed {
 		sourcesConsidered = append(sourcesConsidered, "processed_builds")
 	}
 
@@ -123,9 +145,9 @@ func ResolveNextBuildNumber(ctx context.Context, client *asc.Client, opts NextBu
 	var latestObservedValue buildNumber
 	hasObserved := false
 	if hasProcessed {
-		latestObservedValue = latestProcessedValue
+		latestObservedValue = highestProcessedValue
 		hasObserved = true
-		latestObservedNumber = latestProcessedNumber
+		latestObservedNumber = highestProcessedNumber
 	}
 	if hasUpload && (!hasObserved || latestUploadValue.Compare(latestObservedValue) > 0) {
 		latestObservedValue = latestUploadValue
@@ -271,11 +293,80 @@ func resolveLatestBuildSelection(ctx context.Context, client *asc.Client, opts L
 	}
 
 	return &latestBuildSelectionResult{
-		ResolvedAppID:      resolvedAppID,
-		NormalizedVersion:  opts.Version,
-		NormalizedPlatform: opts.Platform,
-		LatestBuild:        latestBuild,
+		ResolvedAppID:        resolvedAppID,
+		NormalizedVersion:    opts.Version,
+		NormalizedPlatform:   opts.Platform,
+		HasPreReleaseFilters: hasPreReleaseFilters,
+		PreReleaseVersionIDs: append([]string(nil), preReleaseVersionIDs...),
+		LatestBuild:          latestBuild,
 	}, nil
+}
+
+func findHighestProcessedBuildNumber(
+	ctx context.Context,
+	client *asc.Client,
+	selection *latestBuildSelectionResult,
+	opts LatestBuildSelectionOptions,
+) (buildNumber, *string, bool, error) {
+	if selection.HasPreReleaseFilters && len(selection.PreReleaseVersionIDs) == 0 {
+		return buildNumber{}, nil, false, nil
+	}
+
+	buildOpts := []asc.BuildsOption{
+		asc.WithBuildsSort("-uploadedDate"),
+		asc.WithBuildsLimit(200),
+	}
+	if len(selection.PreReleaseVersionIDs) > 0 {
+		buildOpts = append(buildOpts, asc.WithBuildsPreReleaseVersions(selection.PreReleaseVersionIDs))
+	}
+	if len(opts.ProcessingStateValues) > 0 {
+		buildOpts = append(buildOpts, asc.WithBuildsProcessingStates(opts.ProcessingStateValues))
+	}
+	if opts.ExcludeExpired {
+		buildOpts = append(buildOpts, asc.WithBuildsExpired(false))
+	}
+
+	builds, err := client.GetBuilds(ctx, selection.ResolvedAppID, buildOpts...)
+	if err != nil {
+		return buildNumber{}, nil, false, fmt.Errorf("failed to fetch processed build history: %w", err)
+	}
+
+	var highestValue buildNumber
+	var highestNumber *string
+	hasBuild := false
+	processPage := func(page *asc.BuildsResponse) error {
+		for _, build := range page.Data {
+			if isNonPositiveNumericBuildNumber(build.Attributes.Version) {
+				continue
+			}
+			parsed, err := parseBuildNumber(build.Attributes.Version, fmt.Sprintf("processed build %s", build.ID))
+			if err != nil {
+				return err
+			}
+			if !hasBuild || parsed.Compare(highestValue) > 0 {
+				highestValue = parsed
+				value := parsed.String()
+				highestNumber = &value
+				hasBuild = true
+			}
+		}
+		return nil
+	}
+
+	err = asc.PaginateEach(ctx, builds, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetBuilds(ctx, selection.ResolvedAppID, asc.WithBuildsNextURL(nextURL))
+	}, func(page asc.PaginatedResponse) error {
+		resp, ok := page.(*asc.BuildsResponse)
+		if !ok {
+			return fmt.Errorf("unexpected builds page type %T", page)
+		}
+		return processPage(resp)
+	})
+	if err != nil {
+		return buildNumber{}, nil, false, fmt.Errorf("failed to paginate processed build history: %w", err)
+	}
+
+	return highestValue, highestNumber, hasBuild, nil
 }
 
 // FindPreReleaseVersionIDs returns the exact-matching pre-release version IDs

--- a/internal/cli/shared/build_numbers_test.go
+++ b/internal/cli/shared/build_numbers_test.go
@@ -57,6 +57,36 @@ func TestBuildNumberNextIncrementsLastSegment(t *testing.T) {
 	}
 }
 
+func TestBuildNumberCompareUsesNumericComponents(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  int
+	}{
+		{name: "dotted numeric order", left: "1.10", right: "1.9", want: 1},
+		{name: "missing trailing zero is equal", left: "1.2", right: "1.2.0", want: 0},
+		{name: "first component wins", left: "10", right: "9.99", want: 1},
+		{name: "lower component", left: "2.3.3", right: "2.3.4", want: -1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			left, err := parseBuildNumber(test.left, "left")
+			if err != nil {
+				t.Fatalf("parse left: %v", err)
+			}
+			right, err := parseBuildNumber(test.right, "right")
+			if err != nil {
+				t.Fatalf("parse right: %v", err)
+			}
+			if got := left.Compare(right); got != test.want {
+				t.Fatalf("Compare(%q, %q) = %d, want %d", test.left, test.right, got, test.want)
+			}
+		})
+	}
+}
+
 func TestParseBuildTimestamp(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- keep `latestProcessedBuildNumber` tied to the most recently uploaded matching build
- compute `latestObservedBuildNumber` and `nextBuildNumber` from the highest numeric processed build across every matching page
- preserve zero-placeholder handling, fail closed on malformed positive candidates, and leave ordinary latest-build consumers unchanged

## Validation

- `make format`
- `make generate-command-docs`
- focused behavior and race tests
- builds, Xcode, publish, and latest-build consumer tests
- `make build`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- read-only disposable-app verification for build lists, upload lists, JSON/table/Markdown output, and invalid-input exit behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788949780&installation_model_id=10418&pr_number=1960&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1960&signature=c3019de1863b0577ad65ba15a6cb011758ee4b99226334d7917a48d4d2e5825d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `next-build-number` calculations by considering the highest numeric value across all matching processed builds and uploads.
  * Added support for scanning paginated build history and applying version filters accurately.
  * Added clearer help text distinguishing chronological latest builds from highest numeric build numbers.
  * Documented handling for empty sources, zero-style placeholders, and fallback to the initial build number.

* **Bug Fixes**
  * Improved handling of dotted and non-positive build numbers, with clearer errors for malformed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->