### PR TITLE
fix(webhooks): resume pagination from continuation URLs

### DIFF
--- a/internal/cli/cmdtest/webhooks_next_validation_test.go
+++ b/internal/cli/cmdtest/webhooks_next_validation_test.go
@@ -103,7 +103,7 @@ func TestWebhooksListPaginateFromNext(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"webhooks", "list", "--app", "app-1", "--paginate", "--next", firstURL}); err != nil {
+		if err := root.Parse([]string{"webhooks", "list", "--paginate", "--next", firstURL}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/webhooks/webhooks.go
+++ b/internal/cli/webhooks/webhooks.go
@@ -103,10 +103,6 @@ Examples:
 			}
 
 			if *paginate {
-				if resolvedAppID == "" {
-					fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-					return shared.MissingRequiredUsageError()
-				}
 				paginateOpts := append(opts, asc.WithWebhooksLimit(webhooksMaxLimit))
 				firstPage, err := client.GetAppWebhooks(requestCtx, resolvedAppID, paginateOpts...)
 				if err != nil {


### PR DESCRIPTION
## Summary

- allow `asc webhooks list --paginate --next <url>` to resume without also requiring `--app`
- preserve the existing missing-selector and trusted continuation URL validation
- cover a two-page continuation flow through the real command client

## Behavior

Continuation-only pagination now follows the supplied page and every subsequent `links.next` URL. Invocations without either `--app` or `--next` still fail as usage errors, and ordinary app-scoped listing is unchanged.

## Testing

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run "^TestWebhooksListPaginateFromNext$" -count=10`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run "^TestWebhooksListPaginateFromNext$" -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/webhooks ./internal/asc`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run Webhook -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- rebuilt binary: missing both selectors exits 2 with empty stdout
- read-only continuation-only and app-scoped checks against the disposable app both returned the same successful page; no Apple state was changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788950587&installation_model_id=10418&pr_number=1961&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1961&signature=100a34497d3050155d43a4fdaeb73e874a67bf63ef091590f04c03a7bbb32885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed webhook list pagination so a valid `--next` URL can be used without repeating the app identifier.
  * Removed an unnecessary validation error when continuing pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->