### PR TITLE
fix(game-center): reject non-finite matchmaking weights

### DIFF
--- a/internal/cli/cmdtest/game_center_matchmaking_weight_test.go
+++ b/internal/cli/cmdtest/game_center_matchmaking_weight_test.go
@@ -16,10 +16,20 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-func TestGameCenterMatchmakingRulesRejectNonFiniteWeightBeforeClient(t *testing.T) {
+func TestGameCenterMatchmakingRulesRejectInvalidWeightBeforeClient(t *testing.T) {
+	tests := []struct {
+		weight  string
+		message string
+	}{
+		{weight: "NaN", message: "--weight must be a finite number"},
+		{weight: "+Inf", message: "--weight must be a finite number"},
+		{weight: "-Inf", message: "--weight must be a finite number"},
+		{weight: "invalid", message: "--weight must be a number"},
+	}
+
 	for _, command := range []string{"create", "update"} {
-		for _, weight := range []string{"NaN", "+Inf", "-Inf"} {
-			t.Run(command+" "+weight, func(t *testing.T) {
+		for _, test := range tests {
+			t.Run(command+" "+test.weight, func(t *testing.T) {
 				clearASCAuth(t)
 				clientFactoryCalls := 0
 				t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
@@ -28,7 +38,7 @@ func TestGameCenterMatchmakingRulesRejectNonFiniteWeightBeforeClient(t *testing.
 				}))
 
 				stdout, stderr := captureOutput(t, func() {
-					if code := rootcmd.Run(gameCenterMatchmakingRuleArgs(command, weight), "test"); code != rootcmd.ExitUsage {
+					if code := rootcmd.Run(gameCenterMatchmakingRuleArgs(command, test.weight), "test"); code != rootcmd.ExitUsage {
 						t.Errorf("exit code = %d, want %d", code, rootcmd.ExitUsage)
 					}
 				})
@@ -37,7 +47,7 @@ func TestGameCenterMatchmakingRulesRejectNonFiniteWeightBeforeClient(t *testing.
 					t.Errorf("stdout = %q, want empty", stdout)
 				}
 				errorLine, _, _ := strings.Cut(stderr, "\n")
-				if got, want := errorLine+"\n", "Error: --weight must be a finite number\n"; got != want {
+				if got, want := errorLine+"\n", "Error: "+test.message+"\n"; got != want {
 					t.Errorf("stderr error line = %q, want %q; full stderr = %q", got, want, stderr)
 				}
 				if clientFactoryCalls != 0 {
@@ -57,6 +67,7 @@ func TestGameCenterMatchmakingRulesSendFiniteWeight(t *testing.T) {
 		path       string
 		statusCode int
 		wantBody   string
+		extraArgs  []string
 	}{
 		{
 			name:       "create negative weight",
@@ -76,6 +87,15 @@ func TestGameCenterMatchmakingRulesSendFiniteWeight(t *testing.T) {
 			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","attributes":{"referenceName":"Rule","description":"Match","type":"MATCH","expression":"true"},"relationships":{"ruleSet":{"data":{"type":"gameCenterMatchmakingRuleSets","id":"RULE_SET_ID"}}}}}`,
 		},
 		{
+			name:       "create positive weight",
+			command:    "create",
+			weight:     "0.5",
+			method:     http.MethodPost,
+			path:       "/v1/gameCenterMatchmakingRules",
+			statusCode: http.StatusCreated,
+			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","attributes":{"referenceName":"Rule","description":"Match","type":"MATCH","expression":"true","weight":0.5},"relationships":{"ruleSet":{"data":{"type":"gameCenterMatchmakingRuleSets","id":"RULE_SET_ID"}}}}}`,
+		},
+		{
 			name:       "update zero weight",
 			command:    "update",
 			weight:     "0",
@@ -92,6 +112,15 @@ func TestGameCenterMatchmakingRulesSendFiniteWeight(t *testing.T) {
 			path:       "/v1/gameCenterMatchmakingRules/RULE_ID",
 			statusCode: http.StatusOK,
 			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","id":"RULE_ID","attributes":{"weight":100}}}`,
+		},
+		{
+			name:       "update omitted weight",
+			command:    "update",
+			method:     http.MethodPatch,
+			path:       "/v1/gameCenterMatchmakingRules/RULE_ID",
+			statusCode: http.StatusOK,
+			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","id":"RULE_ID","attributes":{"description":"New match"}}}`,
+			extraArgs:  []string{"--description", "New match"},
 		},
 	}
 
@@ -130,7 +159,8 @@ func TestGameCenterMatchmakingRulesSendFiniteWeight(t *testing.T) {
 				return client, nil
 			}))
 
-			args := append(gameCenterMatchmakingRuleArgs(test.command, test.weight), "--output", "json")
+			args := append(gameCenterMatchmakingRuleArgs(test.command, test.weight), test.extraArgs...)
+			args = append(args, "--output", "json")
 			stdout, stderr := captureOutput(t, func() {
 				if code := rootcmd.Run(args, "test"); code != rootcmd.ExitSuccess {
 					t.Errorf("exit code = %d, want %d", code, rootcmd.ExitSuccess)

--- a/internal/cli/cmdtest/game_center_matchmaking_weight_test.go
+++ b/internal/cli/cmdtest/game_center_matchmaking_weight_test.go
@@ -1,0 +1,205 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestGameCenterMatchmakingRulesRejectNonFiniteWeightBeforeClient(t *testing.T) {
+	for _, command := range []string{"create", "update"} {
+		for _, weight := range []string{"NaN", "+Inf", "-Inf"} {
+			t.Run(command+" "+weight, func(t *testing.T) {
+				clearASCAuth(t)
+				clientFactoryCalls := 0
+				t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+					clientFactoryCalls++
+					return nil, fmt.Errorf("client should not be created")
+				}))
+
+				stdout, stderr := captureOutput(t, func() {
+					if code := rootcmd.Run(gameCenterMatchmakingRuleArgs(command, weight), "test"); code != rootcmd.ExitUsage {
+						t.Errorf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+					}
+				})
+
+				if stdout != "" {
+					t.Errorf("stdout = %q, want empty", stdout)
+				}
+				errorLine, _, _ := strings.Cut(stderr, "\n")
+				if got, want := errorLine+"\n", "Error: --weight must be a finite number\n"; got != want {
+					t.Errorf("stderr error line = %q, want %q; full stderr = %q", got, want, stderr)
+				}
+				if clientFactoryCalls != 0 {
+					t.Errorf("client factory calls = %d, want 0", clientFactoryCalls)
+				}
+			})
+		}
+	}
+}
+
+func TestGameCenterMatchmakingRulesSendFiniteWeight(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		weight     string
+		method     string
+		path       string
+		statusCode int
+		wantBody   string
+	}{
+		{
+			name:       "create negative weight",
+			command:    "create",
+			weight:     "-0.5",
+			method:     http.MethodPost,
+			path:       "/v1/gameCenterMatchmakingRules",
+			statusCode: http.StatusCreated,
+			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","attributes":{"referenceName":"Rule","description":"Match","type":"MATCH","expression":"true","weight":-0.5},"relationships":{"ruleSet":{"data":{"type":"gameCenterMatchmakingRuleSets","id":"RULE_SET_ID"}}}}}`,
+		},
+		{
+			name:       "create omitted weight",
+			command:    "create",
+			method:     http.MethodPost,
+			path:       "/v1/gameCenterMatchmakingRules",
+			statusCode: http.StatusCreated,
+			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","attributes":{"referenceName":"Rule","description":"Match","type":"MATCH","expression":"true"},"relationships":{"ruleSet":{"data":{"type":"gameCenterMatchmakingRuleSets","id":"RULE_SET_ID"}}}}}`,
+		},
+		{
+			name:       "update zero weight",
+			command:    "update",
+			weight:     "0",
+			method:     http.MethodPatch,
+			path:       "/v1/gameCenterMatchmakingRules/RULE_ID",
+			statusCode: http.StatusOK,
+			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","id":"RULE_ID","attributes":{"weight":0}}}`,
+		},
+		{
+			name:       "update exponent weight",
+			command:    "update",
+			weight:     "1e2",
+			method:     http.MethodPatch,
+			path:       "/v1/gameCenterMatchmakingRules/RULE_ID",
+			statusCode: http.StatusOK,
+			wantBody:   `{"data":{"type":"gameCenterMatchmakingRules","id":"RULE_ID","attributes":{"weight":100}}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requestCount++
+				if req.Method != test.method || req.URL.Path != test.path {
+					t.Errorf("request = %s %s, want %s %s", req.Method, req.URL.Path, test.method, test.path)
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+					return
+				}
+				if authorization := req.Header.Get("Authorization"); !strings.HasPrefix(authorization, "Bearer ") || authorization == "Bearer " {
+					t.Errorf("Authorization = %q, want non-empty bearer token", authorization)
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Errorf("read request body: %v", err)
+				} else if got := strings.TrimSpace(string(body)); got != test.wantBody {
+					t.Errorf("request body = %s, want %s", got, test.wantBody)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(test.statusCode)
+				_, _ = io.WriteString(w, `{"data":{"type":"gameCenterMatchmakingRules","id":"RULE_ID","attributes":{"referenceName":"Rule","description":"Match","type":"MATCH","expression":"true"}},"links":{}}`)
+			}))
+			t.Cleanup(server.Close)
+
+			client := newGameCenterMatchmakingTestClient(t, server)
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return client, nil
+			}))
+
+			args := append(gameCenterMatchmakingRuleArgs(test.command, test.weight), "--output", "json")
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run(args, "test"); code != rootcmd.ExitSuccess {
+					t.Errorf("exit code = %d, want %d", code, rootcmd.ExitSuccess)
+				}
+			})
+
+			if stderr != "" {
+				t.Errorf("stderr = %q, want empty", stderr)
+			}
+			var response asc.GameCenterMatchmakingRuleResponse
+			if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+				t.Fatalf("unmarshal stdout: %v; stdout=%q", err, stdout)
+			}
+			if response.Data.ID != "RULE_ID" || response.Data.Type != asc.ResourceTypeGameCenterMatchmakingRules {
+				t.Errorf("response data = %+v, want gameCenterMatchmakingRules RULE_ID", response.Data)
+			}
+			if clientFactoryCalls != 1 {
+				t.Errorf("client factory calls = %d, want 1", clientFactoryCalls)
+			}
+			if requestCount != 1 {
+				t.Errorf("request count = %d, want 1", requestCount)
+			}
+		})
+	}
+}
+
+func gameCenterMatchmakingRuleArgs(command, weight string) []string {
+	args := []string{"game-center", "matchmaking", "rules", command}
+	if command == "create" {
+		args = append(
+			args,
+			"--rule-set-id", "RULE_SET_ID",
+			"--reference-name", "Rule",
+			"--description", "Match",
+			"--type", "MATCH",
+			"--expression", "true",
+		)
+	} else {
+		args = append(args, "--id", "RULE_ID")
+	}
+	if weight != "" {
+		args = append(args, "--weight", weight)
+	}
+	return args
+}
+
+func newGameCenterMatchmakingTestClient(t *testing.T, server *httptest.Server) *asc.Client {
+	t.Helper()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Scheme != "https" || req.URL.Host != "api.appstoreconnect.apple.com" {
+			t.Errorf("request URL = %s, want official App Store Connect host", req.URL.String())
+		}
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client
+}

--- a/internal/cli/gamecenter/game_center_matchmaking.go
+++ b/internal/cli/gamecenter/game_center_matchmaking.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -885,7 +886,7 @@ func GameCenterMatchmakingRulesCreateCommand() *ffcli.Command {
 	description := fs.String("description", "", "Rule description")
 	ruleType := fs.String("type", "", "Rule type (COMPATIBLE, DISTANCE, MATCH, TEAM)")
 	expression := fs.String("expression", "", "Rule expression")
-	weight := fs.String("weight", "", "Rule weight (float)")
+	weight := fs.String("weight", "", "Rule weight (finite number)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -933,10 +934,9 @@ Examples:
 			}
 
 			if strings.TrimSpace(*weight) != "" {
-				val, err := strconv.ParseFloat(strings.TrimSpace(*weight), 64)
+				val, err := parseMatchmakingRuleWeight(*weight)
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Error: --weight must be a number")
-					return flag.ErrHelp
+					return shared.UsageError(err.Error())
 				}
 				attrs.Weight = &val
 			}
@@ -966,7 +966,7 @@ func GameCenterMatchmakingRulesUpdateCommand() *ffcli.Command {
 	ruleID := fs.String("id", "", "Matchmaking rule ID")
 	description := fs.String("description", "", "Rule description")
 	expression := fs.String("expression", "", "Rule expression")
-	weight := fs.String("weight", "", "Rule weight (float)")
+	weight := fs.String("weight", "", "Rule weight (finite number)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -1001,10 +1001,9 @@ Examples:
 				hasUpdate = true
 			}
 			if strings.TrimSpace(*weight) != "" {
-				val, err := strconv.ParseFloat(strings.TrimSpace(*weight), 64)
+				val, err := parseMatchmakingRuleWeight(*weight)
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Error: --weight must be a number")
-					return flag.ErrHelp
+					return shared.UsageError(err.Error())
 				}
 				attrs.Weight = &val
 				hasUpdate = true
@@ -1031,6 +1030,17 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func parseMatchmakingRuleWeight(value string) (float64, error) {
+	weight, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0, fmt.Errorf("--weight must be a number")
+	}
+	if math.IsNaN(weight) || math.IsInf(weight, 0) {
+		return 0, fmt.Errorf("--weight must be a finite number")
+	}
+	return weight, nil
 }
 
 // GameCenterMatchmakingRulesDeleteCommand returns the rules delete subcommand.


### PR DESCRIPTION
## Summary

- reject `NaN` and infinite matchmaking rule weights before client and authentication setup
- preserve finite and omitted weights for both create and update, including the existing nonnumeric diagnostic
- clarify the `--weight` help text

## Verification

- focused command tests repeated 10 times
- focused command tests under the race detector
- factory-injected real-client HTTP coverage for create and update
- exact built-binary invalid, finite, output, exit-code, and help checks
- `make build`
- `make generate-command-docs`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

No Apple state was changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788951232&installation_model_id=10418&pr_number=1962&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1962&signature=3a7ad4d311416521078d78f403614f6c1e5e12a1b00b8835d3b2bc53d0c442cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matchmaking rule creation and updates now reject invalid weights, including non-numeric, `NaN`, and infinite values.
  * Valid negative, zero, positive, exponent-form, and omitted weights continue to be accepted.
  * Invalid weight entries now return clearer usage errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->