### PR TITLE
refactor(analytics)!: remove deprecated compatibility surfaces

### DIFF
--- a/commands/analytics.mdx
+++ b/commands/analytics.mdx
@@ -120,8 +120,6 @@ asc analytics requests --app "123456789"
 * `--paginate` - Fetch all pages automatically
 * `--next` - Pagination URL from previous response
 
-The released `--state` flag remains accepted as a deprecated compatibility surface, but App Store Connect does not support state filtering. It fails before authentication with migration guidance to `--access-type ONGOING` or `--access-type ONE_TIME_SNAPSHOT`.
-
 **Examples:**
 
 ```bash  theme={null}
@@ -142,8 +140,6 @@ asc analytics requests --app "123456789" --paginate
 
 Retrieve available analytics reports and instances for a request.
 
-`asc analytics get` still works as a deprecated compatibility alias, but `asc analytics view` is the canonical command.
-
 ```bash  theme={null}
 asc analytics view --request-id "REQUEST_ID"
 ```
@@ -161,8 +157,6 @@ asc analytics view --request-id "REQUEST_ID"
 * `--limit` - Results per page (1-200)
 * `--paginate` - Fetch all reports (recommended with `--processing-date`)
 * `--next` - Pagination URL
-
-`--date` remains available as a deprecated compatibility flag. It warns and preserves the previous local match against either `reportDate` or `processingDate`; new automation should use `--processing-date` for Apple's server-side filter.
 
 **Examples:**
 

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -7,9 +7,7 @@ Quirks and tips for specific App Store Connect API endpoints.
 - Although Apple's current Sales Reports documentation describes `YYYY-MM-DD` for non-daily dates, the live endpoint requires `YYYY-MM` for monthly reports and `YYYY` for yearly reports. The CLI accepts either form and reduces full monthly or yearly dates to those live period identifiers before the request.
 - Vendor number comes from Sales and Trends → Reports URL (`vendorNumber=...`)
 - Sales Reports validates the complete report type/subtype/frequency/version tuple against Apple's endpoint table. Although the current table lists `SUBSCRIPTION` `1_3`, live verification in PR #1842 proved `1_4` succeeds and is required by some accounts, so both are accepted and `1_4` remains the default.
-- `asc analytics requests --state` is a deprecated compatibility flag. Apple rejects `filter[state]`; the CLI now fails before HTTP and directs callers to the supported `--access-type` filter.
 - Use `--paginate` with `asc analytics view --processing-date` to search every report page; the CLI forwards the value as `filter[processingDate]` when fetching instances
-- `asc analytics view --date` is a deprecated compatibility flag. It preserves the previous local match against either `reportDate` or `processingDate` and warns callers to migrate to the explicit server-side `--processing-date` filter.
 - Use `--granularity "DAILY,WEEKLY,MONTHLY"` with `asc analytics view` to filter instances by one or more documented granularities
 - Long analytics runs may require raising `ASC_TIMEOUT`
 

--- a/internal/asc/analytics.go
+++ b/internal/asc/analytics.go
@@ -65,16 +65,6 @@ const (
 	AnalyticsAccessTypeOneTimeSnapshot AnalyticsAccessType = "ONE_TIME_SNAPSHOT"
 )
 
-// AnalyticsReportRequestState is retained for source compatibility with older
-// responses; current App Store Connect responses do not expose this attribute.
-type AnalyticsReportRequestState string
-
-const (
-	AnalyticsReportRequestStateProcessing AnalyticsReportRequestState = "PROCESSING"
-	AnalyticsReportRequestStateCompleted  AnalyticsReportRequestState = "COMPLETED"
-	AnalyticsReportRequestStateFailed     AnalyticsReportRequestState = "FAILED"
-)
-
 // SalesReportParams describes sales report query parameters.
 type SalesReportParams struct {
 	VendorNumber  string
@@ -93,12 +83,8 @@ type ReportDownload struct {
 
 // AnalyticsReportRequestAttributes describes analytics report request data.
 type AnalyticsReportRequestAttributes struct {
-	AccessType AnalyticsAccessType `json:"accessType,omitempty"`
-	// Legacy compatibility: current App Store Connect responses omit this field.
-	State AnalyticsReportRequestState `json:"state,omitempty"`
-	// Legacy compatibility: current App Store Connect responses omit this field.
-	CreatedDate            string `json:"createdDate,omitempty"`
-	StoppedDueToInactivity *bool  `json:"stoppedDueToInactivity,omitempty"`
+	AccessType             AnalyticsAccessType `json:"accessType,omitempty"`
+	StoppedDueToInactivity *bool               `json:"stoppedDueToInactivity,omitempty"`
 }
 
 // AnalyticsReportRequestRelationships describes request relationships.
@@ -213,8 +199,7 @@ type AnalyticsReportRequestReportsLinkagesResponse = LinkagesResponse
 
 type analyticsReportRequestsQuery struct {
 	listQuery
-	accessType         AnalyticsAccessType
-	deprecatedStateSet bool
+	accessType AnalyticsAccessType
 }
 
 type analyticsReportsQuery struct {
@@ -266,15 +251,6 @@ func WithAnalyticsReportRequestsNextURL(next string) AnalyticsReportRequestsOpti
 func WithAnalyticsReportRequestsAccessType(accessType AnalyticsAccessType) AnalyticsReportRequestsOption {
 	return func(q *analyticsReportRequestsQuery) {
 		q.accessType = AnalyticsAccessType(strings.TrimSpace(string(accessType)))
-	}
-}
-
-// WithAnalyticsReportRequestsState is retained for source compatibility.
-// Deprecated: App Store Connect does not support state filtering. Use
-// WithAnalyticsReportRequestsAccessType instead.
-func WithAnalyticsReportRequestsState(_ string) AnalyticsReportRequestsOption {
-	return func(q *analyticsReportRequestsQuery) {
-		q.deprecatedStateSet = true
 	}
 }
 
@@ -454,10 +430,6 @@ func (c *Client) GetAnalyticsReportRequests(ctx context.Context, appID string, o
 	for _, opt := range opts {
 		opt(query)
 	}
-	if query.deprecatedStateSet {
-		return nil, fmt.Errorf("analyticsReportRequests: state filtering is unsupported by App Store Connect; use WithAnalyticsReportRequestsAccessType")
-	}
-
 	path := "/v1/analyticsReportRequests"
 	if strings.TrimSpace(appID) != "" {
 		path = fmt.Sprintf("/v1/apps/%s/analyticsReportRequests", strings.TrimSpace(appID))

--- a/internal/asc/analytics_output.go
+++ b/internal/asc/analytics_output.go
@@ -22,8 +22,6 @@ type AnalyticsReportRequestResult struct {
 	RequestID              string `json:"requestId"`
 	AppID                  string `json:"appId"`
 	AccessType             string `json:"accessType"`
-	State                  string `json:"state,omitempty"`       // Deprecated: retained for output compatibility.
-	CreatedDate            string `json:"createdDate,omitempty"` // Deprecated: retained for output compatibility.
 	StoppedDueToInactivity *bool  `json:"stoppedDueToInactivity,omitempty"`
 }
 
@@ -32,8 +30,6 @@ type AnalyticsReportRequestReuseResult struct {
 	RequestID              string `json:"requestId"`
 	AppID                  string `json:"appId"`
 	AccessType             string `json:"accessType"`
-	State                  string `json:"state,omitempty"`       // Deprecated: retained for output compatibility.
-	CreatedDate            string `json:"createdDate,omitempty"` // Deprecated: retained for output compatibility.
 	StoppedDueToInactivity *bool  `json:"stoppedDueToInactivity,omitempty"`
 	Created                bool   `json:"created"`
 }
@@ -110,19 +106,17 @@ func salesReportResultRows(result *SalesReportResult) ([]string, [][]string) {
 }
 
 func analyticsReportRequestResultRows(result *AnalyticsReportRequestResult) ([]string, [][]string) {
-	headers := []string{"Request ID", "App ID", "Access Type", "State", "Created Date", "Stopped Due To Inactivity"}
-	rows := [][]string{{result.RequestID, result.AppID, result.AccessType, result.State, result.CreatedDate, formatAnalyticsOptionalBool(result.StoppedDueToInactivity)}}
+	headers := []string{"Request ID", "App ID", "Access Type", "Stopped Due To Inactivity"}
+	rows := [][]string{{result.RequestID, result.AppID, result.AccessType, formatAnalyticsOptionalBool(result.StoppedDueToInactivity)}}
 	return headers, rows
 }
 
 func analyticsReportRequestReuseResultRows(result *AnalyticsReportRequestReuseResult) ([]string, [][]string) {
-	headers := []string{"Request ID", "App ID", "Access Type", "State", "Created Date", "Stopped Due To Inactivity", "Created"}
+	headers := []string{"Request ID", "App ID", "Access Type", "Stopped Due To Inactivity", "Created"}
 	rows := [][]string{{
 		result.RequestID,
 		result.AppID,
 		result.AccessType,
-		result.State,
-		result.CreatedDate,
 		formatAnalyticsOptionalBool(result.StoppedDueToInactivity),
 		fmt.Sprintf("%t", result.Created),
 	}}
@@ -136,7 +130,7 @@ func analyticsReportRequestDeleteResultRows(result *AnalyticsReportRequestDelete
 }
 
 func analyticsReportRequestsRows(resp *AnalyticsReportRequestsResponse) ([]string, [][]string) {
-	headers := []string{"ID", "Access Type", "State", "Created Date", "Stopped Due To Inactivity", "App ID"}
+	headers := []string{"ID", "Access Type", "Stopped Due To Inactivity", "App ID"}
 	rows := make([][]string, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		appID := ""
@@ -146,8 +140,6 @@ func analyticsReportRequestsRows(resp *AnalyticsReportRequestsResponse) ([]strin
 		rows = append(rows, []string{
 			item.ID,
 			string(item.Attributes.AccessType),
-			string(item.Attributes.State),
-			item.Attributes.CreatedDate,
 			formatAnalyticsOptionalBool(item.Attributes.StoppedDueToInactivity),
 			appID,
 		})

--- a/internal/asc/analytics_output_test.go
+++ b/internal/asc/analytics_output_test.go
@@ -1,0 +1,103 @@
+package asc
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAnalyticsReportRequestOutputUsesCurrentSchema(t *testing.T) {
+	var response AnalyticsReportRequestResponse
+	if err := json.Unmarshal([]byte(`{
+		"data": {
+			"type": "analyticsReportRequests",
+			"id": "request-1",
+			"attributes": {
+				"accessType": "ONGOING",
+				"state": "PROCESSING",
+				"createdDate": "2026-08-10T00:00:00Z",
+				"stoppedDueToInactivity": false
+			}
+		}
+	}`), &response); err != nil {
+		t.Fatalf("unmarshal analytics request: %v", err)
+	}
+
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal analytics request: %v", err)
+	}
+	for _, removed := range []string{`"state"`, `"createdDate"`} {
+		if strings.Contains(string(encoded), removed) {
+			t.Fatalf("current analytics request output contains removed field %s: %s", removed, encoded)
+		}
+	}
+	for _, retained := range []string{`"accessType":"ONGOING"`, `"stoppedDueToInactivity":false`} {
+		if !strings.Contains(string(encoded), retained) {
+			t.Fatalf("current analytics request output is missing %s: %s", retained, encoded)
+		}
+	}
+
+	falseValue := false
+	tests := []struct {
+		name        string
+		render      func() ([]string, [][]string)
+		wantHeaders []string
+		wantRow     []string
+	}{
+		{
+			name: "created request",
+			render: func() ([]string, [][]string) {
+				return analyticsReportRequestResultRows(&AnalyticsReportRequestResult{
+					RequestID:              "request-1",
+					AppID:                  "app-1",
+					AccessType:             "ONGOING",
+					StoppedDueToInactivity: &falseValue,
+				})
+			},
+			wantHeaders: []string{"Request ID", "App ID", "Access Type", "Stopped Due To Inactivity"},
+			wantRow:     []string{"request-1", "app-1", "ONGOING", "false"},
+		},
+		{
+			name: "reused request",
+			render: func() ([]string, [][]string) {
+				return analyticsReportRequestReuseResultRows(&AnalyticsReportRequestReuseResult{
+					RequestID:              "request-1",
+					AppID:                  "app-1",
+					AccessType:             "ONGOING",
+					StoppedDueToInactivity: &falseValue,
+					Created:                false,
+				})
+			},
+			wantHeaders: []string{"Request ID", "App ID", "Access Type", "Stopped Due To Inactivity", "Created"},
+			wantRow:     []string{"request-1", "app-1", "ONGOING", "false", "false"},
+		},
+		{
+			name: "request list",
+			render: func() ([]string, [][]string) {
+				return analyticsReportRequestsRows(&AnalyticsReportRequestsResponse{Data: []AnalyticsReportRequestResource{{
+					ID: "request-1",
+					Attributes: AnalyticsReportRequestAttributes{
+						AccessType:             AnalyticsAccessTypeOngoing,
+						StoppedDueToInactivity: &falseValue,
+					},
+				}}})
+			},
+			wantHeaders: []string{"ID", "Access Type", "Stopped Due To Inactivity", "App ID"},
+			wantRow:     []string{"request-1", "ONGOING", "false", ""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers, rows := test.render()
+			if !reflect.DeepEqual(headers, test.wantHeaders) {
+				t.Fatalf("headers = %#v, want %#v", headers, test.wantHeaders)
+			}
+			if len(rows) != 1 || !reflect.DeepEqual(rows[0], test.wantRow) {
+				t.Fatalf("rows = %#v, want %#v", rows, [][]string{test.wantRow})
+			}
+		})
+	}
+}

--- a/internal/asc/analytics_test.go
+++ b/internal/asc/analytics_test.go
@@ -129,7 +129,7 @@ func TestGetSalesReport_ErrorResponse(t *testing.T) {
 }
 
 func TestCreateAnalyticsReportRequest_SendsRequest(t *testing.T) {
-	response := jsonResponse(http.StatusCreated, `{"data":{"type":"analyticsReportRequests","id":"req-1","attributes":{"accessType":"ONGOING","state":"PROCESSING"}}}`)
+	response := jsonResponse(http.StatusCreated, `{"data":{"type":"analyticsReportRequests","id":"req-1","attributes":{"accessType":"ONGOING","stoppedDueToInactivity":false}}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
@@ -184,48 +184,6 @@ func TestGetAnalyticsReportRequests_WithAccessTypeFilter(t *testing.T) {
 		WithAnalyticsReportRequestsAccessType(AnalyticsAccessTypeOngoing),
 	); err != nil {
 		t.Fatalf("GetAnalyticsReportRequests() error: %v", err)
-	}
-}
-
-func TestGetAnalyticsReportRequests_DeprecatedStateFailsBeforeHTTP(t *testing.T) {
-	requestCount := 0
-	client := newTestClient(t, func(_ *http.Request) {
-		requestCount++
-	}, jsonResponse(http.StatusOK, `{"data":[]}`))
-
-	_, err := client.GetAnalyticsReportRequests(
-		context.Background(),
-		"app-1",
-		WithAnalyticsReportRequestsState("COMPLETED"),
-	)
-	if err == nil ||
-		!strings.Contains(err.Error(), "state filtering is unsupported") ||
-		!strings.Contains(err.Error(), "use WithAnalyticsReportRequestsAccessType") {
-		t.Fatalf("expected migration error, got %v", err)
-	}
-	if requestCount != 0 {
-		t.Fatalf("request count = %d, want 0", requestCount)
-	}
-}
-
-func TestGetAnalyticsReportRequests_EmptyDeprecatedStateFailsBeforeHTTP(t *testing.T) {
-	requestCount := 0
-	client := newTestClient(t, func(_ *http.Request) {
-		requestCount++
-	}, jsonResponse(http.StatusOK, `{"data":[]}`))
-
-	_, err := client.GetAnalyticsReportRequests(
-		context.Background(),
-		"app-1",
-		WithAnalyticsReportRequestsState(""),
-	)
-	if err == nil ||
-		!strings.Contains(err.Error(), "state filtering is unsupported") ||
-		!strings.Contains(err.Error(), "use WithAnalyticsReportRequestsAccessType") {
-		t.Fatalf("expected migration error, got %v", err)
-	}
-	if requestCount != 0 {
-		t.Fatalf("request count = %d, want 0", requestCount)
 	}
 }
 

--- a/internal/cli/analytics/analytics.go
+++ b/internal/cli/analytics/analytics.go
@@ -33,7 +33,7 @@ Examples:
 			AnalyticsSalesCommand(),
 			AnalyticsRequestCommand(),
 			AnalyticsRequestsCommand(),
-			AnalyticsGetCommand(),
+			AnalyticsViewCommand(),
 			AnalyticsReportsCommand(),
 			AnalyticsInstancesCommand(),
 			AnalyticsSegmentsCommand(),

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -274,28 +274,6 @@ func normalizeAnalyticsProcessingDateFilter(value string) (string, error) {
 	return parsed.Format("2006-01-02"), nil
 }
 
-func normalizeAnalyticsDateFilter(value string) (string, error) {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return "", nil
-	}
-	parsed, err := time.Parse("2006-01-02", trimmed)
-	if err != nil {
-		return "", fmt.Errorf("--date must be in YYYY-MM-DD format")
-	}
-	return parsed.Format("2006-01-02"), nil
-}
-
-func matchAnalyticsInstanceDate(attrs asc.AnalyticsReportInstanceAttributes, date string) bool {
-	if strings.TrimSpace(date) == "" {
-		return true
-	}
-	if strings.HasPrefix(attrs.ReportDate, date) {
-		return true
-	}
-	return strings.HasPrefix(attrs.ProcessingDate, date)
-}
-
 func normalizeAnalyticsGranularities(value string) ([]string, error) {
 	parts := strings.Split(value, ",")
 	seen := make(map[string]struct{}, len(parts))

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -77,8 +77,6 @@ Examples:
 				RequestID:              response.Data.ID,
 				AppID:                  resolvedAppID,
 				AccessType:             string(normalizedAccessType),
-				State:                  string(response.Data.Attributes.State),
-				CreatedDate:            response.Data.Attributes.CreatedDate,
 				StoppedDueToInactivity: response.Data.Attributes.StoppedDueToInactivity,
 			}
 
@@ -94,12 +92,10 @@ func AnalyticsRequestsCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	requestID := fs.String("request-id", "", "Filter by request ID")
 	accessType := fs.String("access-type", "", "Filter by access type: ONGOING, ONE_TIME_SNAPSHOT")
-	fs.String("state", "", "Deprecated analytics request state filter")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
-	shared.HideFlagFromHelp(fs.Lookup("state"))
 
 	return &ffcli.Command{
 		Name:       "requests",
@@ -122,15 +118,6 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) > 0 {
 				return flag.ErrHelp
-			}
-			stateFlagUsed := false
-			fs.Visit(func(parsed *flag.Flag) {
-				if parsed.Name == "state" {
-					stateFlagUsed = true
-				}
-			})
-			if stateFlagUsed {
-				return shared.UsageError("analytics requests: --state is deprecated and unsupported by App Store Connect; use --access-type ONGOING or --access-type ONE_TIME_SNAPSHOT")
 			}
 			if *limit != 0 && (*limit < 1 || *limit > analyticsMaxLimit) {
 				return fmt.Errorf("analytics requests: --limit must be between 1 and 200")
@@ -305,8 +292,6 @@ func analyticsReportRequestReuseResult(appID string, request asc.AnalyticsReport
 		RequestID:              request.ID,
 		AppID:                  appID,
 		AccessType:             string(request.Attributes.AccessType),
-		State:                  string(request.Attributes.State),
-		CreatedDate:            request.Attributes.CreatedDate,
 		StoppedDueToInactivity: request.Attributes.StoppedDueToInactivity,
 		Created:                created,
 	}
@@ -366,15 +351,13 @@ Examples:
 	}
 }
 
-// AnalyticsGetCommand retrieves analytics reports and instances for a request.
-func AnalyticsGetCommand() *ffcli.Command {
+// AnalyticsViewCommand retrieves analytics reports and instances for a request.
+func AnalyticsViewCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("view", flag.ExitOnError)
 
 	requestID := fs.String("request-id", "", "Analytics report request ID")
 	instanceID := fs.String("instance-id", "", "Filter by specific instance ID")
 	processingDate := fs.String("processing-date", "", "Filter instances by processing date (YYYY-MM-DD)")
-	legacyDate := fs.String("date", "", "DEPRECATED: filter instances by report or processing date (YYYY-MM-DD); use --processing-date")
-	shared.HideFlagFromHelp(fs.Lookup("date"))
 	granularity := fs.String("granularity", "", "Filter instances by granularity (comma-separated: DAILY, WEEKLY, MONTHLY)")
 	includeSegments := fs.Bool("include-segments", false, "Include report segments with download URLs")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
@@ -390,8 +373,6 @@ func AnalyticsGetCommand() *ffcli.Command {
 
 The --processing-date and --granularity filters are sent to App Store Connect
 when fetching report instances. Granularity accepts DAILY, WEEKLY, and MONTHLY.
-The deprecated --date compatibility flag retains its previous local matching
-against either reportDate or processingDate.
 
 Examples:
   asc analytics view --request-id "REQUEST_ID"
@@ -402,23 +383,15 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			var processingDateProvided, legacyDateProvided, granularityProvided bool
+			var processingDateProvided, granularityProvided bool
 			fs.Visit(func(item *flag.Flag) {
 				switch item.Name {
 				case "processing-date":
 					processingDateProvided = true
-				case "date":
-					legacyDateProvided = true
 				case "granularity":
 					granularityProvided = true
 				}
 			})
-			if legacyDateProvided {
-				fmt.Fprintln(os.Stderr, "Warning: `--date` is deprecated. Use `--processing-date`.")
-				if processingDateProvided {
-					return shared.UsageError("--date conflicts with --processing-date; use only --processing-date")
-				}
-			}
 			if strings.TrimSpace(*requestID) == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --request-id is required")
 				return shared.MissingRequiredUsageError()
@@ -448,15 +421,6 @@ Examples:
 				}
 				processingDateFilter = normalized
 			}
-			var legacyDateFilter string
-			if legacyDateProvided {
-				normalized, normalizeErr := normalizeAnalyticsDateFilter(*legacyDate)
-				if normalizeErr != nil {
-					return shared.UsageErrorf("analytics view: %v", normalizeErr)
-				}
-				legacyDateFilter = normalized
-			}
-
 			var granularities []string
 			if granularityProvided {
 				normalized, normalizeErr := normalizeAnalyticsGranularities(*granularity)
@@ -508,10 +472,6 @@ Examples:
 					if strings.TrimSpace(*instanceID) != "" && instance.ID != strings.TrimSpace(*instanceID) {
 						continue
 					}
-					if legacyDateFilter != "" && !matchAnalyticsInstanceDate(instance.Attributes, legacyDateFilter) {
-						continue
-					}
-
 					instanceResult := asc.AnalyticsReportGetInstance{
 						ID:             instance.ID,
 						ReportDate:     instance.Attributes.ReportDate,
@@ -548,7 +508,7 @@ Examples:
 					continue
 				}
 
-				if (processingDateFilter != "" || legacyDateFilter != "") && len(reportResult.Instances) == 0 {
+				if processingDateFilter != "" && len(reportResult.Instances) == 0 {
 					continue
 				}
 				result.Data = append(result.Data, reportResult)
@@ -557,17 +517,11 @@ Examples:
 			if strings.TrimSpace(*instanceID) != "" && !foundInstance {
 				return fmt.Errorf("analytics view: instance %q not found for request %q", strings.TrimSpace(*instanceID), strings.TrimSpace(*requestID))
 			}
-			dateFilterValue := processingDateFilter
-			dateFilterLabel := "processing date"
-			if legacyDateFilter != "" {
-				dateFilterValue = legacyDateFilter
-				dateFilterLabel = "date"
-			}
-			if dateFilterValue != "" && len(result.Data) == 0 {
+			if processingDateFilter != "" && len(result.Data) == 0 {
 				if strings.TrimSpace(*next) == "" && !*paginate {
-					return fmt.Errorf("analytics view: no instances found for %s %q in the first page of reports (use --paginate or --next)", dateFilterLabel, dateFilterValue)
+					return fmt.Errorf("analytics view: no instances found for processing date %q in the first page of reports (use --paginate or --next)", processingDateFilter)
 				}
-				return fmt.Errorf("analytics view: no instances found for %s %q", dateFilterLabel, dateFilterValue)
+				return fmt.Errorf("analytics view: no instances found for processing date %q", processingDateFilter)
 			}
 
 			return shared.PrintOutput(result, *output.Output, *output.Pretty)

--- a/internal/cli/analytics/analytics_test.go
+++ b/internal/cli/analytics/analytics_test.go
@@ -10,17 +10,29 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestAnalyticsViewProcessingDateFlagLifecycle(t *testing.T) {
-	cmd := AnalyticsGetCommand()
+	root := AnalyticsCommand()
+	viewIndex := -1
+	for index, subcommand := range root.Subcommands {
+		if subcommand.Name == "get" {
+			t.Fatal("removed analytics get compatibility command is still registered")
+		}
+		if subcommand.Name == "view" {
+			viewIndex = index
+		}
+	}
+	if viewIndex == -1 {
+		t.Fatal("canonical analytics view command is not registered")
+	}
+	cmd := root.Subcommands[viewIndex]
 	if cmd.FlagSet.Lookup("processing-date") == nil {
 		t.Fatal("canonical --processing-date flag is not registered")
 	}
-	if cmd.FlagSet.Lookup("date") == nil {
-		t.Fatal("deprecated --date compatibility flag is not registered")
+	if cmd.FlagSet.Lookup("date") != nil {
+		t.Fatal("removed --date compatibility flag is still registered")
 	}
 
 	visible := make(map[string]bool)
@@ -30,22 +42,18 @@ func TestAnalyticsViewProcessingDateFlagLifecycle(t *testing.T) {
 	if !visible["processing-date"] {
 		t.Fatal("canonical --processing-date flag is hidden from help")
 	}
-	if visible["date"] {
-		t.Fatal("deprecated --date flag should be hidden from canonical help")
-	}
 
 	usage := cmd.UsageFunc(cmd)
 	for _, want := range []string{
 		"The --processing-date and --granularity filters are sent to App Store Connect",
-		"The deprecated --date compatibility flag retains its previous local matching",
 		`--processing-date "2024-01-20"`,
 	} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("analytics view help does not contain %q:\n%s", want, usage)
 		}
 	}
-	if strings.Contains(usage, `--date "2024-01-20"`) {
-		t.Fatalf("analytics view help still teaches deprecated --date:\n%s", usage)
+	if strings.Contains(usage, "deprecated") || strings.Contains(usage, "--date compatibility") {
+		t.Fatalf("analytics view help still describes removed compatibility behavior:\n%s", usage)
 	}
 }
 
@@ -65,13 +73,8 @@ func TestAnalyticsRequestsAccessTypeFlagLifecycle(t *testing.T) {
 	if !strings.Contains(usage, `--access-type ONGOING`) {
 		t.Fatalf("analytics requests help does not teach --access-type:\n%s", usage)
 	}
-	if cmd.FlagSet.Lookup("state") == nil {
-		t.Fatal("deprecated --state compatibility flag is not registered")
-	}
-	for _, item := range shared.VisibleHelpFlags(cmd.FlagSet) {
-		if item.Name == "state" {
-			t.Fatal("deprecated --state flag should be hidden from canonical help")
-		}
+	if cmd.FlagSet.Lookup("state") != nil {
+		t.Fatal("removed --state compatibility flag is still registered")
 	}
 }
 
@@ -89,46 +92,6 @@ func TestAnalyticsRequestsRejectsInvalidAccessType(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "--access-type must be ONGOING or ONE_TIME_SNAPSHOT") {
 		t.Fatalf("expected access type validation error, got %q", stderr)
-	}
-}
-
-func TestAnalyticsRequestsDeprecatedStateFailsBeforeAuth(t *testing.T) {
-	tests := []struct {
-		name      string
-		stateArgs []string
-	}{
-		{name: "legacy value", stateArgs: []string{"--state", "COMPLETED"}},
-		{name: "equals empty", stateArgs: []string{"--state="}},
-		{name: "separate empty", stateArgs: []string{"--state", ""}},
-		{name: "whitespace", stateArgs: []string{"--state", " \t "}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			clientFactoryCalls := 0
-			restoreClient := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
-				clientFactoryCalls++
-				return nil, errors.New("client construction should not be attempted")
-			})
-			t.Cleanup(restoreClient)
-
-			args := []string{"analytics", "requests", "--app", "app-1"}
-			args = append(args, tt.stateArgs...)
-			stdout, stderr, err := runAnalyticsCommand(t, args)
-			if !errors.Is(err, flag.ErrHelp) {
-				t.Fatalf("expected usage error, got %v", err)
-			}
-			if stdout != "" {
-				t.Fatalf("expected empty stdout, got %q", stdout)
-			}
-			if !strings.Contains(stderr, "--state is deprecated and unsupported by App Store Connect") ||
-				!strings.Contains(stderr, "use --access-type ONGOING or --access-type ONE_TIME_SNAPSHOT") {
-				t.Fatalf("expected migration guidance, got %q", stderr)
-			}
-			if clientFactoryCalls != 0 {
-				t.Fatalf("client factory calls = %d, want 0", clientFactoryCalls)
-			}
-		})
 	}
 }
 
@@ -377,7 +340,7 @@ func TestAnalyticsRequestsValidationErrors(t *testing.T) {
 	}
 }
 
-func TestAnalyticsGetValidationErrors(t *testing.T) {
+func TestAnalyticsViewValidationErrors(t *testing.T) {
 	stdout, stderr, err := runAnalyticsCommand(t, []string{"analytics", "view"})
 	if !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected ErrHelp, got %v", err)

--- a/internal/cli/cmdtest/analytics_next_validation_test.go
+++ b/internal/cli/cmdtest/analytics_next_validation_test.go
@@ -263,7 +263,7 @@ func TestAnalyticsReportsRelationshipsPaginateFromNextWithoutReportID(t *testing
 	)
 }
 
-func TestAnalyticsGetRejectsInvalidNextURL(t *testing.T) {
+func TestAnalyticsViewRejectsInvalidNextURL(t *testing.T) {
 	runAnalyticsInvalidNextURLCases(
 		t,
 		[]string{"analytics", "view"},
@@ -271,7 +271,7 @@ func TestAnalyticsGetRejectsInvalidNextURL(t *testing.T) {
 	)
 }
 
-func TestAnalyticsGetPaginateFromNextWithoutRequestID(t *testing.T) {
+func TestAnalyticsViewPaginateFromNextWithoutRequestID(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 

--- a/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
+++ b/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
@@ -121,8 +121,8 @@ func TestAnalyticsRequestReuseExistingUsesExistingRequest(t *testing.T) {
 		}
 
 		body := `{"data":[` +
-			`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}},` +
-			`{"type":"analyticsReportRequests","id":"req-existing","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
+			`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","stoppedDueToInactivity":false}},` +
+			`{"type":"analyticsReportRequests","id":"req-existing","attributes":{"accessType":"ONGOING","stoppedDueToInactivity":false}}` +
 			`],"links":{"next":""}}`
 		return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 	}))
@@ -175,7 +175,7 @@ func TestAnalyticsRequestReuseExistingUsesExistingRequestFromLaterPage(t *testin
 				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
 			}
 			body := `{"data":[` +
-				`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}}` +
+				`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","stoppedDueToInactivity":false}}` +
 				`],"links":{"next":"/v1/apps/app-1/analyticsReportRequests?cursor=2"}}`
 			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 		case 2:
@@ -189,7 +189,7 @@ func TestAnalyticsRequestReuseExistingUsesExistingRequestFromLaterPage(t *testin
 				t.Fatalf("expected cursor=2, got %q", req.URL.Query().Get("cursor"))
 			}
 			body := `{"data":[` +
-				`{"type":"analyticsReportRequests","id":"req-existing-page-2","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
+				`{"type":"analyticsReportRequests","id":"req-existing-page-2","attributes":{"accessType":"ONGOING","stoppedDueToInactivity":false}}` +
 				`],"links":{"next":""}}`
 			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 		default:
@@ -246,7 +246,7 @@ func TestAnalyticsRequestReuseExistingUsesExistingRequestFromFirstPageWithMultip
 				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
 			}
 			body := `{"data":[` +
-				`{"type":"analyticsReportRequests","id":"req-existing-page-1","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-01T00:00:00Z"}}` +
+				`{"type":"analyticsReportRequests","id":"req-existing-page-1","attributes":{"accessType":"ONGOING","stoppedDueToInactivity":false}}` +
 				`],"links":{"next":"/v1/apps/app-1/analyticsReportRequests?cursor=2"}}`
 			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 		case 2:
@@ -260,7 +260,7 @@ func TestAnalyticsRequestReuseExistingUsesExistingRequestFromFirstPageWithMultip
 				t.Fatalf("expected cursor=2, got %q", req.URL.Query().Get("cursor"))
 			}
 			body := `{"data":[` +
-				`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","state":"COMPLETED"}}` +
+				`{"type":"analyticsReportRequests","id":"req-snapshot","attributes":{"accessType":"ONE_TIME_SNAPSHOT","stoppedDueToInactivity":false}}` +
 				`],"links":{"next":""}}`
 			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 		default:
@@ -348,7 +348,7 @@ func TestAnalyticsRequestReuseExistingCreatesMissingRequest(t *testing.T) {
 			if payload.Data.Attributes.AccessType != "ONGOING" || payload.Data.Relationships.App.Data.ID != "app-1" {
 				t.Fatalf("unexpected create payload: %#v", payload)
 			}
-			response := `{"data":{"type":"analyticsReportRequests","id":"req-created","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-02T00:00:00Z"}}}`
+			response := `{"data":{"type":"analyticsReportRequests","id":"req-created","attributes":{"accessType":"ONGOING","stoppedDueToInactivity":false}}}`
 			return analyticsReuseExistingJSONResponse(http.StatusCreated, response), nil
 		default:
 			t.Fatalf("unexpected extra request %d: %s %s", count, req.Method, req.URL.String())
@@ -387,6 +387,11 @@ func TestAnalyticsRequestReuseExistingCreatesMissingRequest(t *testing.T) {
 	if result["created"] != true {
 		t.Fatalf("expected created=true, got %#v", result["created"])
 	}
+	for _, removed := range []string{"state", "createdDate"} {
+		if _, ok := result[removed]; ok {
+			t.Fatalf("removed output field %q is still present: %#v", removed, result)
+		}
+	}
 }
 
 func TestAnalyticsRequestReuseExistingRefetchesAfterCreateConflict(t *testing.T) {
@@ -421,7 +426,7 @@ func TestAnalyticsRequestReuseExistingRefetchesAfterCreateConflict(t *testing.T)
 				t.Fatalf("expected analytics requests path, got %s", req.URL.Path)
 			}
 			body := `{"data":[` +
-				`{"type":"analyticsReportRequests","id":"req-created-by-race","attributes":{"accessType":"ONGOING","state":"PROCESSING","createdDate":"2026-05-03T00:00:00Z"}}` +
+				`{"type":"analyticsReportRequests","id":"req-created-by-race","attributes":{"accessType":"ONGOING","stoppedDueToInactivity":false}}` +
 				`],"links":{"next":""}}`
 			return analyticsReuseExistingJSONResponse(http.StatusOK, body), nil
 		default:

--- a/internal/cli/cmdtest/analytics_view_filters_test.go
+++ b/internal/cli/cmdtest/analytics_view_filters_test.go
@@ -3,8 +3,6 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -14,83 +12,6 @@ import (
 )
 
 const analyticsViewRequestID = "11111111-1111-1111-1111-111111111111"
-
-func TestAnalyticsViewDeprecatedDatePreservesReportDateMatching(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
-	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requestCount++
-		switch requestCount {
-		case 1:
-			if req.Method != http.MethodGet || req.URL.Path != "/v1/analyticsReportRequests/"+analyticsViewRequestID+"/reports" {
-				t.Fatalf("unexpected reports request: %s %s", req.Method, req.URL.String())
-			}
-			return analyticsViewJSONResponse(`{
-				"data":[{
-					"type":"analyticsReports",
-					"id":"report-1",
-					"attributes":{"name":"App Sessions","reportType":"STANDARD","category":"APP_USAGE","granularity":"DAILY"}
-				}],
-				"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/11111111-1111-1111-1111-111111111111/reports"}
-			}`), nil
-		case 2:
-			if req.Method != http.MethodGet || req.URL.Path != "/v1/analyticsReports/report-1/instances" {
-				t.Fatalf("unexpected instances request: %s %s", req.Method, req.URL.String())
-			}
-			if req.URL.Query().Has("filter[processingDate]") {
-				t.Fatalf("deprecated --date must not become a processing-date API filter: %s", req.URL.String())
-			}
-			return analyticsViewJSONResponse(`{
-				"data":[{
-					"type":"analyticsReportInstances",
-					"id":"instance-1",
-					"attributes":{"reportDate":"2024-01-20","processingDate":"2024-01-21","granularity":"DAILY","version":"1.0"}
-				}],
-				"links":{}
-			}`), nil
-		default:
-			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
-			return nil, nil
-		}
-	})
-
-	stdout, stderr := runAnalyticsViewForOutput(
-		t,
-		"--request-id", analyticsViewRequestID,
-		"--date", "2024-01-20",
-		"--output", "json",
-	)
-	const warning = "Warning: `--date` is deprecated. Use `--processing-date`.\n"
-	if stderr != warning {
-		t.Fatalf("stderr = %q, want %q", stderr, warning)
-	}
-	assertAnalyticsViewJSONEqual(t, stdout, `{
-		"requestId":"11111111-1111-1111-1111-111111111111",
-		"data":[{
-			"id":"report-1",
-			"reportType":"STANDARD",
-			"name":"App Sessions",
-			"category":"APP_USAGE",
-			"granularity":"DAILY",
-			"instances":[{
-				"id":"instance-1",
-				"reportDate":"2024-01-20",
-				"processingDate":"2024-01-21",
-				"granularity":"DAILY",
-				"version":"1.0"
-			}]
-		}],
-		"links":{"self":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/11111111-1111-1111-1111-111111111111/reports"}
-	}`)
-	if requestCount != 2 {
-		t.Fatalf("expected 2 requests, got %d", requestCount)
-	}
-}
 
 func TestAnalyticsViewProcessingDateForwardsFilter(t *testing.T) {
 	setupAuth(t)
@@ -272,32 +193,6 @@ func TestAnalyticsViewFiltersPaginateAndPreserveOutput(t *testing.T) {
 	}`)
 	if requestCount != 5 {
 		t.Fatalf("expected 5 requests, got %d", requestCount)
-	}
-}
-
-func TestAnalyticsViewDeprecatedDateConflictsWithProcessingDate(t *testing.T) {
-	stdout, stderr, err := runCommand(t, []string{
-		"analytics", "view",
-		"--request-id", analyticsViewRequestID,
-		"--processing-date", "2024-01-20",
-		"--date", "2024-01-21",
-	})
-	if err == nil {
-		t.Fatal("expected conflicting date flags to fail")
-	}
-	if !errors.Is(err, flag.ErrHelp) {
-		t.Fatalf("error = %v, want usage error", err)
-	}
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
-	}
-	const warning = "Warning: `--date` is deprecated. Use `--processing-date`."
-	if !strings.Contains(stderr, warning) {
-		t.Fatalf("stderr = %q, want warning %q", stderr, warning)
-	}
-	const conflict = "Error: --date conflicts with --processing-date; use only --processing-date"
-	if !strings.Contains(stderr, conflict) {
-		t.Fatalf("stderr = %q, want conflict %q", stderr, conflict)
 	}
 }
 

--- a/internal/cli/cmdtest/insights_test.go
+++ b/internal/cli/cmdtest/insights_test.go
@@ -664,7 +664,7 @@ func TestInsightsWeeklyAnalyticsNestedForbiddenReturnsUnavailable(t *testing.T) 
 		case "/v1/apps/app-1/analyticsReportRequests":
 			return insightsJSONResponse(`{
 				"data":[
-					{"type":"analyticsReportRequests","id":"req-1","attributes":{"state":"COMPLETED","createdDate":"2026-02-16T10:00:00Z"}}
+					{"type":"analyticsReportRequests","id":"req-1","attributes":{"accessType":"ONGOING","stoppedDueToInactivity":false}}
 				],
 				"links":{"next":""}
 			}`), nil


### PR DESCRIPTION
## Summary

- remove the deprecated analytics requests state flag and its unsupported client option
- remove the deprecated analytics view date flag and its local fallback matching
- remove the stale analytics get constructor name and false documentation claim while retaining analytics view
- align analytics report-request models and JSON/table/Markdown output with Apple's current accessType and stoppedDueToInactivity schema

## Breaking changes for 4.0

- replace analytics requests --state with --access-type
- replace analytics view --date with --processing-date
- use analytics view; analytics get is not a registered command
- stop consuming state and createdDate from analytics report-request output

The analytics sales --date flag is unrelated and remains supported.

## Validation

- focused RED/GREEN analytics tests, repeated 10 times
- focused race tests
- rebuilt-binary command-tree, help, and removed-flag exit checks
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test

No App Store Connect state was mutated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/App-Store-Connect-CLI/pr/1964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788965014&installation_model_id=10418&pr_number=1964&repository=rorkai%2FApp-Store-Connect-CLI&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2FApp-Store-Connect-CLI%2Fpull%2F1964&signature=47a3ff0214efdd84bf30a092228d298aa14e83debb3b2f60fb3a072547677300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Replaced the deprecated Analytics `get` command with `view`.
  * Removed support for the deprecated `--state` and `--date` options.
  * Analytics request results no longer display state or creation-date fields.

* **Documentation**
  * Updated Analytics documentation to describe supported processing-date filtering and remove deprecated compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->