### PR TITLE
test: harden review regression coverage

### DIFF
--- a/internal/cli/profiles/local_test.go
+++ b/internal/cli/profiles/local_test.go
@@ -177,7 +177,12 @@ func TestCaptureProfilesStderrRestoresAfterGoexit(t *testing.T) {
 	if os.Stderr != original {
 		t.Fatal("captureProfilesStderr did not restore os.Stderr after runtime.Goexit")
 	}
-	writer := <-writerCh
+	var writer *os.File
+	select {
+	case writer = <-writerCh:
+	case <-time.After(time.Second):
+		t.Fatal("captureProfilesStderr did not expose the redirected writer")
+	}
 	t.Cleanup(func() { _ = writer.Close() })
 	if _, err := writer.Write([]byte("probe")); err == nil {
 		t.Fatal("captureProfilesStderr did not close the pipe writer after runtime.Goexit")

--- a/internal/cli/profiles/local_test.go
+++ b/internal/cli/profiles/local_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -132,6 +133,11 @@ func captureProfilesStderr(t *testing.T, fn func()) string {
 	}
 	original := os.Stderr
 	os.Stderr = writer
+	cleanup := func() {
+		os.Stderr = original
+		_ = writer.Close()
+	}
+	defer cleanup()
 
 	captured := make(chan string, 1)
 	go func() {
@@ -143,9 +149,32 @@ func captureProfilesStderr(t *testing.T, fn func()) string {
 
 	fn()
 
-	os.Stderr = original
-	_ = writer.Close()
+	cleanup()
 	return <-captured
+}
+
+func TestCaptureProfilesStderrRestoresAfterGoexit(t *testing.T) {
+	original := os.Stderr
+	t.Cleanup(func() { os.Stderr = original })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		captureProfilesStderr(t, func() {
+			// testing.T.Fatal and testing.T.FailNow both terminate their
+			// goroutine with runtime.Goexit after running deferred cleanup.
+			runtime.Goexit()
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("captureProfilesStderr did not exit after runtime.Goexit")
+	}
+	if os.Stderr != original {
+		t.Fatal("captureProfilesStderr did not restore os.Stderr after runtime.Goexit")
+	}
 }
 
 func TestResolveProfilesInstallDirPreservesCancellation(t *testing.T) {

--- a/internal/cli/profiles/local_test.go
+++ b/internal/cli/profiles/local_test.go
@@ -157,10 +157,12 @@ func TestCaptureProfilesStderrRestoresAfterGoexit(t *testing.T) {
 	original := os.Stderr
 	t.Cleanup(func() { os.Stderr = original })
 
+	writerCh := make(chan *os.File, 1)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		captureProfilesStderr(t, func() {
+			writerCh <- os.Stderr
 			// testing.T.Fatal and testing.T.FailNow both terminate their
 			// goroutine with runtime.Goexit after running deferred cleanup.
 			runtime.Goexit()
@@ -174,6 +176,11 @@ func TestCaptureProfilesStderrRestoresAfterGoexit(t *testing.T) {
 	}
 	if os.Stderr != original {
 		t.Fatal("captureProfilesStderr did not restore os.Stderr after runtime.Goexit")
+	}
+	writer := <-writerCh
+	t.Cleanup(func() { _ = writer.Close() })
+	if _, err := writer.Write([]byte("probe")); err == nil {
+		t.Fatal("captureProfilesStderr did not close the pipe writer after runtime.Goexit")
 	}
 }
 

--- a/internal/cli/xcode/build_test.go
+++ b/internal/cli/xcode/build_test.go
@@ -189,6 +189,9 @@ func TestXcodeBuildRejectsExplicitlyEmptyOptionalValues(t *testing.T) {
 			if !errors.Is(runErr, flag.ErrHelp) {
 				t.Fatalf("Exec() error = %v, want usage error", runErr)
 			}
+			if runErr.Error() != test.want {
+				t.Fatalf("Exec() error = %q, want %q", runErr, test.want)
+			}
 			if stdout != "" {
 				t.Fatalf("stdout = %q, want empty", stdout)
 			}

--- a/internal/cli/xcode/xcode_test.go
+++ b/internal/cli/xcode/xcode_test.go
@@ -809,6 +809,9 @@ func TestXcodeArchiveRejectsExplicitlyEmptyConfiguration(t *testing.T) {
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("Exec() error = %v, want usage error", runErr)
 	}
+	if runErr.Error() != "--configuration must not be empty" {
+		t.Fatalf("Exec() error = %q, want %q", runErr, "--configuration must not be empty")
+	}
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
 	}

--- a/internal/validation/legal_test.go
+++ b/internal/validation/legal_test.go
@@ -1,7 +1,9 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
+	"time"
 )
 
 func TestLegalChecks_CopyrightEmpty(t *testing.T) {
@@ -25,12 +27,13 @@ func TestLegalChecks_CopyrightPresent(t *testing.T) {
 }
 
 func TestLegalChecks_CopyrightAcceptsAppStoreConnectFreeTextForms(t *testing.T) {
+	currentYear := time.Now().Year()
 	for _, value := range []string{
-		"© 2026 Acme Inc.",
-		"(c) 2026 Acme Inc.",
-		"Copyright 2026 Acme Inc.",
-		"2019-2026 Acme Inc.",
-		"2026, Acme Inc.",
+		fmt.Sprintf("© %d Acme Inc.", currentYear),
+		fmt.Sprintf("(c) %d Acme Inc.", currentYear),
+		fmt.Sprintf("Copyright %d Acme Inc.", currentYear),
+		fmt.Sprintf("2019-%d Acme Inc.", currentYear),
+		fmt.Sprintf("%d, Acme Inc.", currentYear),
 	} {
 		checks := legalChecks(value, false, false, nil, nil)
 		if hasCheckID(checks, "legal.format.copyright_year") {


### PR DESCRIPTION
## Summary

- restore `os.Stderr` and close the capture pipe when profile test callbacks terminate via `runtime.Goexit`, including the path used by `t.Fatal` and `t.FailNow`
- assert exact returned usage-error messages for explicitly empty Xcode build and archive configuration values
- derive accepted copyright free-text examples from the current year so the suite does not fail at a calendar boundary

## Original review discussions

- [profile stderr cleanup](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347804)
- [exact Xcode usage messages](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347840)
- [copyright calendar dependency](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347846)

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/profiles ./internal/cli/xcode ./internal/validation`
- 10 race-detector repetitions of the affected profile, Xcode, and validation tests
- `make format`
- `make check-docs`
- `make lint`
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- repository pre-commit hook, including its short test suite

No production behavior or Apple state is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened command-line validation tests to verify exact error messages for empty optional values and configuration arguments.
  * Added coverage ensuring stderr capture is restored correctly after early termination.
  * Updated copyright validation tests to use the current calendar year, keeping supported formats covered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->