### PR TITLE
fix(release): address staging correctness findings

### DIFF
--- a/internal/cli/release/metadata_deletes_test.go
+++ b/internal/cli/release/metadata_deletes_test.go
@@ -142,6 +142,9 @@ func TestExecuteStageDryRunRejectsPlannedDeletesWithoutAllowDeletes(t *testing.T
 	if !strings.Contains(err.Error(), "--allow-deletes") {
 		t.Fatalf("expected error naming --allow-deletes, got %v", err)
 	}
+	if errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("mid-pipeline plan failure was classified as invalid command usage: %v", err)
+	}
 	if result.Status != "error" || result.FailedStep != stepApplyMetadata {
 		t.Fatalf("expected apply_metadata failure, got status %q step %q", result.Status, result.FailedStep)
 	}

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -266,44 +266,55 @@ func TestExecuteStageExplainsLegacyReleaseRunCheckpoint(t *testing.T) {
 	originalClientFactory := releaseClientFactory
 	t.Cleanup(func() { releaseClientFactory = originalClientFactory })
 
-	clientCalled := false
-	releaseClientFactory = func() (*asc.Client, error) {
-		clientCalled = true
-		return nil, errors.New("client must not be created")
-	}
+	for _, test := range []struct {
+		name string
+		mode string
+	}{
+		{name: "mode-less checkpoint"},
+		{name: "explicit run mode", mode: "run"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clientCalled := false
+			releaseClientFactory = func() (*asc.Client, error) {
+				clientCalled = true
+				return nil, errors.New("client must not be created")
+			}
 
-	checkpointPath := filepath.Join(t.TempDir(), "legacy-run-checkpoint.json")
-	if err := saveCheckpoint(checkpointPath, runCheckpoint{
-		AppID:            "APP_123",
-		Version:          "2.4.0",
-		BuildID:          "BUILD_123",
-		CopyMetadataFrom: "2.3.2",
-		Platform:         "IOS",
-		Completed:        map[string]bool{},
-	}); err != nil {
-		t.Fatalf("save checkpoint: %v", err)
-	}
+			checkpointPath := filepath.Join(t.TempDir(), "legacy-run-checkpoint.json")
+			if err := saveCheckpoint(checkpointPath, runCheckpoint{
+				AppID:            "APP_123",
+				Version:          "2.4.0",
+				BuildID:          "BUILD_123",
+				CopyMetadataFrom: "2.3.2",
+				Platform:         "IOS",
+				Mode:             test.mode,
+				Completed:        map[string]bool{},
+			}); err != nil {
+				t.Fatalf("save checkpoint: %v", err)
+			}
 
-	_, err := executeStage(context.Background(), runOptions{
-		AppID:            "APP_123",
-		Version:          "2.4.0",
-		BuildID:          "BUILD_123",
-		CopyMetadataFrom: "2.3.2",
-		Platform:         "IOS",
-		Timeout:          releaseRunTimeout,
-		DryRun:           true,
-		CheckpointFile:   checkpointPath,
-	})
-	if err == nil {
-		t.Fatal("executeStage() error = nil, want legacy checkpoint mismatch")
-	}
-	for _, want := range []string{"asc release run", "removed in 4.0", "asc release stage", checkpointPath} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("executeStage() error = %q, want migration guidance containing %q", err, want)
-		}
-	}
-	if clientCalled {
-		t.Fatal("executeStage() created a client before rejecting the legacy checkpoint")
+			_, err := executeStage(context.Background(), runOptions{
+				AppID:            "APP_123",
+				Version:          "2.4.0",
+				BuildID:          "BUILD_123",
+				CopyMetadataFrom: "2.3.2",
+				Platform:         "IOS",
+				Timeout:          releaseRunTimeout,
+				DryRun:           true,
+				CheckpointFile:   checkpointPath,
+			})
+			if err == nil {
+				t.Fatal("executeStage() error = nil, want legacy checkpoint mismatch")
+			}
+			for _, want := range []string{"asc release run", "removed in 4.0", "asc release stage", checkpointPath} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("executeStage() error = %q, want migration guidance containing %q", err, want)
+				}
+			}
+			if clientCalled {
+				t.Fatal("executeStage() created a client before rejecting the legacy checkpoint")
+			}
+		})
 	}
 }
 

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -306,7 +306,7 @@ func TestExecuteStageExplainsLegacyReleaseRunCheckpoint(t *testing.T) {
 			if err == nil {
 				t.Fatal("executeStage() error = nil, want legacy checkpoint mismatch")
 			}
-			for _, want := range []string{"asc release run", "removed in 4.0", "asc release stage", checkpointPath} {
+			for _, want := range []string{"asc release run", "removed in 1.0", "asc release stage", checkpointPath} {
 				if !strings.Contains(err.Error(), want) {
 					t.Fatalf("executeStage() error = %q, want migration guidance containing %q", err, want)
 				}

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -262,6 +262,51 @@ func TestCheckpointModeMatches(t *testing.T) {
 	}
 }
 
+func TestExecuteStageExplainsLegacyReleaseRunCheckpoint(t *testing.T) {
+	originalClientFactory := releaseClientFactory
+	t.Cleanup(func() { releaseClientFactory = originalClientFactory })
+
+	clientCalled := false
+	releaseClientFactory = func() (*asc.Client, error) {
+		clientCalled = true
+		return nil, errors.New("client must not be created")
+	}
+
+	checkpointPath := filepath.Join(t.TempDir(), "legacy-run-checkpoint.json")
+	if err := saveCheckpoint(checkpointPath, runCheckpoint{
+		AppID:            "APP_123",
+		Version:          "2.4.0",
+		BuildID:          "BUILD_123",
+		CopyMetadataFrom: "2.3.2",
+		Platform:         "IOS",
+		Completed:        map[string]bool{},
+	}); err != nil {
+		t.Fatalf("save checkpoint: %v", err)
+	}
+
+	_, err := executeStage(context.Background(), runOptions{
+		AppID:            "APP_123",
+		Version:          "2.4.0",
+		BuildID:          "BUILD_123",
+		CopyMetadataFrom: "2.3.2",
+		Platform:         "IOS",
+		Timeout:          releaseRunTimeout,
+		DryRun:           true,
+		CheckpointFile:   checkpointPath,
+	})
+	if err == nil {
+		t.Fatal("executeStage() error = nil, want legacy checkpoint mismatch")
+	}
+	for _, want := range []string{"asc release run", "removed in 4.0", "asc release stage", checkpointPath} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("executeStage() error = %q, want migration guidance containing %q", err, want)
+		}
+	}
+	if clientCalled {
+		t.Fatal("executeStage() created a client before rejecting the legacy checkpoint")
+	}
+}
+
 func TestExecuteStageResumesPartialCheckpointAfterRemovingRoutingCoverage(t *testing.T) {
 	originalClientFactory := releaseClientFactory
 	originalCopyExecutor := metadataCopyExecutor

--- a/internal/cli/release/routing_coverage.go
+++ b/internal/cli/release/routing_coverage.go
@@ -192,6 +192,9 @@ func reportFailedRoutingCoverageReplacement(
 	if readErr == nil && current != nil && strings.TrimSpace(current.Data.ID) != "" {
 		details.CoverageID = strings.TrimSpace(current.Data.ID)
 		details.DeliveryState = routingCoverageDeliveryState(current)
+		if strings.EqualFold(details.CoverageID, previousCoverageID) {
+			details.PreviousCoverageID = ""
+		}
 		return details, cause
 	}
 	return details, fmt.Errorf(

--- a/internal/cli/release/routing_coverage_replace_failure_test.go
+++ b/internal/cli/release/routing_coverage_replace_failure_test.go
@@ -111,4 +111,7 @@ func TestApplyRoutingCoverageStepKeepsSurvivingCoverageWhenReplacementNeverDelet
 	if details.CoverageID != "COVERAGE_OLD" || details.DeliveryState != "COMPLETE" {
 		t.Fatalf("expected the surviving coverage to stay reported as current, got %#v", details)
 	}
+	if details.PreviousCoverageID != "" {
+		t.Fatalf("surviving coverage was also reported as previous: %#v", details)
+	}
 }

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -177,7 +177,14 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 	}
 	if existing != nil {
 		if !checkpointMatchesRunArguments(existing, opts) {
-			err := fmt.Errorf("checkpoint does not match current run arguments")
+			err := errors.New("checkpoint does not match current run arguments")
+			if isLegacyReleaseRunCheckpoint(existing.Mode, opts.Mode) {
+				err = fmt.Errorf(
+					"checkpoint mode %q belongs to the `asc release run` pipeline removed in 4.0; delete %q or pass a different --checkpoint-file to start a new `asc release stage` run",
+					strings.TrimSpace(existing.Mode),
+					opts.CheckpointFile,
+				)
+			}
 			result.Status = "error"
 			result.Error = err.Error()
 			return result, err
@@ -431,7 +438,7 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 					Message:     "metadata plan requires --allow-deletes",
 					Remediation: "Add the missing localizations to --metadata-dir, or rerun with --allow-deletes to apply the planned deletions.",
 					Details:     details,
-				}, fmt.Errorf("apply metadata: %w", shared.UsageError("--allow-deletes is required to apply delete operations"))
+				}, errors.New("apply metadata: --allow-deletes is required to apply delete operations")
 			}
 
 			changeCount := len(pushResult.Adds) + len(pushResult.Updates) + len(pushResult.Deletes)
@@ -691,9 +698,15 @@ func defaultStageCheckpointPath(appID, version, buildID, platform string) string
 
 // checkpointModeMatches reports whether an existing checkpoint was written by
 // the pipeline that is being resumed. A checkpoint without a mode was written
-// by the `release run` pipeline removed in 1.0, so it never matches.
+// by the `release run` pipeline removed in 4.0, so it never matches.
 func checkpointModeMatches(existingMode, desiredMode string) bool {
 	return strings.TrimSpace(existingMode) == strings.TrimSpace(desiredMode)
+}
+
+func isLegacyReleaseRunCheckpoint(existingMode, desiredMode string) bool {
+	existing := strings.TrimSpace(existingMode)
+	desired := strings.TrimSpace(desiredMode)
+	return desired == releaseModeStage && (existing == "" || existing == "run")
 }
 
 func checkpointMatchesRunArguments(existing *runCheckpoint, opts runOptions) bool {

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -180,7 +180,7 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 			err := errors.New("checkpoint does not match current run arguments")
 			if isLegacyReleaseRunCheckpoint(existing.Mode, opts.Mode) {
 				err = fmt.Errorf(
-					"checkpoint mode %q belongs to the `asc release run` pipeline removed in 4.0; delete %q or pass a different --checkpoint-file to start a new `asc release stage` run",
+					"checkpoint mode %q belongs to the `asc release run` pipeline removed in 1.0; delete %q or pass a different --checkpoint-file to start a new `asc release stage` run",
 					strings.TrimSpace(existing.Mode),
 					opts.CheckpointFile,
 				)
@@ -698,7 +698,7 @@ func defaultStageCheckpointPath(appID, version, buildID, platform string) string
 
 // checkpointModeMatches reports whether an existing checkpoint was written by
 // the pipeline that is being resumed. A checkpoint without a mode was written
-// by the `release run` pipeline removed in 4.0, so it never matches.
+// by the `release run` pipeline removed in 1.0, so it never matches.
 func checkpointModeMatches(existingMode, desiredMode string) bool {
 	return strings.TrimSpace(existingMode) == strings.TrimSpace(desiredMode)
 }

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -21,22 +21,42 @@ func readReleaseWorkflow() ([]byte, error) {
 	return repositoryRoot.ReadFile(filepath.Join(".github", "workflows", "release.yml"))
 }
 
-var releaseWorkflowJobPattern = regexp.MustCompile(`(?m)^  [A-Za-z0-9_-]+:\s*$`)
+var (
+	releaseWorkflowJobsPattern     = regexp.MustCompile(`(?m)^jobs:\s*$`)
+	releaseWorkflowTopLevelPattern = regexp.MustCompile(`(?m)^[A-Za-z0-9_-]+:\s*$`)
+	releaseWorkflowJobPattern      = regexp.MustCompile(`(?m)^  [A-Za-z0-9_-]+:\s*$`)
+)
+
+func releaseWorkflowJobsBlock(t *testing.T, workflow string) string {
+	t.Helper()
+
+	jobsMatch := releaseWorkflowJobsPattern.FindStringIndex(workflow)
+	if jobsMatch == nil {
+		t.Fatal("release workflow missing jobs mapping")
+	}
+
+	jobsBlock := workflow[jobsMatch[1]:]
+	if nextTopLevel := releaseWorkflowTopLevelPattern.FindStringIndex(jobsBlock); nextTopLevel != nil {
+		jobsBlock = jobsBlock[:nextTopLevel[0]]
+	}
+	return jobsBlock
+}
 
 func releaseWorkflowJobBlock(t *testing.T, workflow, jobName string) string {
 	t.Helper()
 
+	jobsBlock := releaseWorkflowJobsBlock(t, workflow)
 	jobHeader := "  " + jobName + ":"
-	jobMatches := releaseWorkflowJobPattern.FindAllStringIndex(workflow, -1)
+	jobMatches := releaseWorkflowJobPattern.FindAllStringIndex(jobsBlock, -1)
 	for index, match := range jobMatches {
-		if workflow[match[0]:match[1]] != jobHeader {
+		if jobsBlock[match[0]:match[1]] != jobHeader {
 			continue
 		}
-		end := len(workflow)
+		end := len(jobsBlock)
 		if index+1 < len(jobMatches) {
 			end = jobMatches[index+1][0]
 		}
-		return workflow[match[0]:end]
+		return jobsBlock[match[0]:end]
 	}
 
 	t.Fatalf("release workflow missing %s job", jobName)
@@ -44,10 +64,32 @@ func releaseWorkflowJobBlock(t *testing.T, workflow, jobName string) string {
 }
 
 func TestReleaseWorkflowJobBlockStopsAtNextJob(t *testing.T) {
-	workflow := "jobs:\n  winget:\n    name: Submit WinGet package\n  later:\n    if: always() && needs.publish.result == 'success'\n"
-	block := releaseWorkflowJobBlock(t, workflow, "winget")
-	if strings.Contains(block, "later") || strings.Contains(block, "needs.publish.result") {
-		t.Fatalf("winget block included a later job: %q", block)
+	tests := []struct {
+		name       string
+		workflow   string
+		unexpected []string
+	}{
+		{
+			name:       "next job",
+			workflow:   "jobs:\n  winget:\n    name: Submit WinGet package\n  later:\n    name: Later job\n",
+			unexpected: []string{"later"},
+		},
+		{
+			name:       "outside jobs mapping",
+			workflow:   "jobs:\n  winget:\n    name: Submit WinGet package\non:\n  workflow_dispatch:\n",
+			unexpected: []string{"on:", "workflow_dispatch"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			block := releaseWorkflowJobBlock(t, test.workflow, "winget")
+			for _, unexpected := range test.unexpected {
+				if strings.Contains(block, unexpected) {
+					t.Fatalf("winget block included content outside the job: %q", block)
+				}
+			}
+		})
 	}
 }
 
@@ -457,6 +499,7 @@ func TestReleaseWorkflowPublishesPackageManagersWhenBuildIsSkipped(t *testing.T)
 
 	workflow := string(data)
 	const publisherCondition = "\n    if: always() && needs.publish.result == 'success'\n"
+	const publisherNeeds = "\n    needs: publish\n"
 
 	for _, jobName := range []string{"homebrew", "winget"} {
 		jobBlock := releaseWorkflowJobBlock(t, workflow, jobName)
@@ -465,6 +508,9 @@ func TestReleaseWorkflowPublishesPackageManagersWhenBuildIsSkipped(t *testing.T)
 		// way or the already-published repair path silently ships nothing.
 		if !strings.Contains(jobBlock, publisherCondition) {
 			t.Errorf("%s job must contain the exact publisher condition %q", jobName, strings.TrimSpace(publisherCondition))
+		}
+		if !strings.Contains(jobBlock, publisherNeeds) {
+			t.Errorf("%s job must depend on publish", jobName)
 		}
 	}
 }

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -6,12 +6,53 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
+func readReleaseWorkflow() ([]byte, error) {
+	repositoryRoot, err := rootfs.New(".")
+	if err != nil {
+		return nil, err
+	}
+	return repositoryRoot.ReadFile(filepath.Join(".github", "workflows", "release.yml"))
+}
+
+var releaseWorkflowJobPattern = regexp.MustCompile(`(?m)^  [A-Za-z0-9_-]+:\s*$`)
+
+func releaseWorkflowJobBlock(t *testing.T, workflow, jobName string) string {
+	t.Helper()
+
+	jobHeader := "  " + jobName + ":"
+	jobMatches := releaseWorkflowJobPattern.FindAllStringIndex(workflow, -1)
+	for index, match := range jobMatches {
+		if workflow[match[0]:match[1]] != jobHeader {
+			continue
+		}
+		end := len(workflow)
+		if index+1 < len(jobMatches) {
+			end = jobMatches[index+1][0]
+		}
+		return workflow[match[0]:end]
+	}
+
+	t.Fatalf("release workflow missing %s job", jobName)
+	return ""
+}
+
+func TestReleaseWorkflowJobBlockStopsAtNextJob(t *testing.T) {
+	workflow := "jobs:\n  winget:\n    name: Submit WinGet package\n  later:\n    if: always() && needs.publish.result == 'success'\n"
+	block := releaseWorkflowJobBlock(t, workflow, "winget")
+	if strings.Contains(block, "later") || strings.Contains(block, "needs.publish.result") {
+		t.Fatalf("winget block included a later job: %q", block)
+	}
+}
+
 func TestReleaseWorkflowExportsHomebrewChecksumsBeforeFormulaGeneration(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -51,7 +92,7 @@ func TestReleaseWorkflowExportsHomebrewChecksumsBeforeFormulaGeneration(t *testi
 }
 
 func TestReleaseWorkflowTestsHomebrewFormulaUsingVersionStdout(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -69,7 +110,7 @@ func TestReleaseWorkflowTestsHomebrewFormulaUsingVersionStdout(t *testing.T) {
 }
 
 func TestReleaseWorkflowKeepsHistoricalGuardrailsInline(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -114,7 +155,7 @@ func TestReleaseRehearsalGuardrailsIncludeDocsValidatorSelfTest(t *testing.T) {
 }
 
 func TestReleaseWorkflowBuildsStrippedTrimmedBinaries(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -138,7 +179,7 @@ func TestReleaseWorkflowBuildsStrippedTrimmedBinaries(t *testing.T) {
 }
 
 func TestReleaseWorkflowDoesNotInterpolateDispatchInputIntoShell(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -158,7 +199,7 @@ func TestReleaseWorkflowDoesNotInterpolateDispatchInputIntoShell(t *testing.T) {
 }
 
 func TestReleaseWorkflowNotarizesMacOSBinariesBeforePublishing(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -205,7 +246,7 @@ func TestReleaseWorkflowNotarizesMacOSBinariesBeforePublishing(t *testing.T) {
 }
 
 func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -263,7 +304,7 @@ func TestReleaseWorkflowCanRepairExistingNotarizationWithoutReplacingAssets(t *t
 }
 
 func TestReleaseWorkflowCreatesPrivateKeyWithRestrictedModeInRunnerTemp(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -282,7 +323,7 @@ func TestReleaseWorkflowCreatesPrivateKeyWithRestrictedModeInRunnerTemp(t *testi
 }
 
 func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -316,7 +357,7 @@ func TestReleaseWorkflowReusesOneBuildArtifactForEveryPublisher(t *testing.T) {
 }
 
 func TestReleaseWorkflowUsesValidSecureReleaseSteps(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -334,7 +375,7 @@ func TestReleaseWorkflowUsesValidSecureReleaseSteps(t *testing.T) {
 }
 
 func TestReleaseWorkflowReusesArtifactsAcrossRerunAttempts(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -375,7 +416,7 @@ func TestReleaseWorkflowReusesArtifactsAcrossRerunAttempts(t *testing.T) {
 }
 
 func TestReleaseWorkflowRepairsPackageManagersWithoutRebuildingPublishedRelease(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -409,39 +450,27 @@ func TestReleaseWorkflowRepairsPackageManagersWithoutRebuildingPublishedRelease(
 }
 
 func TestReleaseWorkflowPublishesPackageManagersWhenBuildIsSkipped(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
 
 	workflow := string(data)
-	homebrewStart := strings.Index(workflow, "\n  homebrew:\n")
-	wingetStart := strings.Index(workflow, "\n  winget:\n")
-	if homebrewStart == -1 || wingetStart == -1 || homebrewStart >= wingetStart {
-		t.Fatal("release workflow must define homebrew before winget")
-	}
+	const publisherCondition = "\n    if: always() && needs.publish.result == 'success'\n"
 
-	for _, job := range []struct {
-		name  string
-		block string
-	}{
-		{name: "homebrew", block: workflow[homebrewStart:wingetStart]},
-		{name: "winget", block: workflow[wingetStart:]},
-	} {
+	for _, jobName := range []string{"homebrew", "winget"} {
+		jobBlock := releaseWorkflowJobBlock(t, workflow, jobName)
 		// publish escapes the skipped build with always(); GitHub propagates that skip
 		// down the whole needs chain, so every publisher must break the chain the same
 		// way or the already-published repair path silently ships nothing.
-		if !strings.Contains(job.block, "always()") {
-			t.Errorf("%s job must use always() so a skipped build does not skip package publication", job.name)
-		}
-		if !strings.Contains(job.block, "needs.publish.result == 'success'") {
-			t.Errorf("%s job must publish exactly when publish succeeded", job.name)
+		if !strings.Contains(jobBlock, publisherCondition) {
+			t.Errorf("%s job must contain the exact publisher condition %q", jobName, strings.TrimSpace(publisherCondition))
 		}
 	}
 }
 
 func TestVerifyReleaseAssetsRequiresExactChecksumCoverage(t *testing.T) {
-	workflowData, err := os.ReadFile(".github/workflows/release.yml")
+	workflowData, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -526,7 +555,7 @@ func TestVerifyReleaseAssetsRequiresExactChecksumCoverage(t *testing.T) {
 }
 
 func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -572,7 +601,7 @@ func TestReleaseWorkflowResumesDraftButNeverClobbersPublishedAssets(t *testing.T
 }
 
 func TestReleaseWorkflowGrantsArtifactReadPermissionToArtifactJobs(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -607,7 +636,7 @@ func TestReleaseWorkflowGrantsArtifactReadPermissionToArtifactJobs(t *testing.T)
 }
 
 func TestReleaseWorkflowSerializesTagAndDispatchForSameVersion(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -623,7 +652,7 @@ func TestReleaseWorkflowSerializesTagAndDispatchForSameVersion(t *testing.T) {
 }
 
 func TestReleaseWorkflowUsesCommitTimestampForBuildMetadata(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}
@@ -638,7 +667,7 @@ func TestReleaseWorkflowUsesCommitTimestampForBuildMetadata(t *testing.T) {
 }
 
 func TestReleaseWorkflowPushesWinGetBranchWithoutHistoryRewriteOrWorkflowScope(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
+	data, err := readReleaseWorkflow()
 	if err != nil {
 		t.Fatalf("read release workflow: %v", err)
 	}


### PR DESCRIPTION
## Summary

- keep failed routing-coverage replacements from reporting the surviving asset as both current and previous
- classify metadata dry-run planning failures as runtime failures instead of usage errors
- explain that mode-less checkpoints belong to the `asc release run` pipeline removed in 1.0 and point operators to a fresh `asc release stage` checkpoint
- read the release workflow through a repository-rooted `internal/rootfs.Root`
- bound Homebrew and WinGet assertions to their own job blocks and require the exact publisher condition

No public command, flag, output schema, or App Store Connect API contract changes.

## Verification

- RED/GREEN focused regressions for routing state, exit classification, and checkpoint guidance
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/release -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test . -count=1`
- built `/tmp/asc` and checked `release stage --help`
- built-binary legacy-checkpoint run returned exit 1, structured error JSON on stdout, and empty stderr
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

## Original discussions

- [surviving routing coverage state](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347813)
- [mid-pipeline failure classification](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347818)
- [legacy checkpoint guidance](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347826)
- [rooted workflow reads](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347863)
- [bounded publisher job assertions](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347874)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance when resuming releases from legacy checkpoints, including recovery instructions and checkpoint details.
  * Prevented failed coverage replacements from incorrectly reporting retained coverage as a previous asset.
  * Corrected dry-run metadata deletion errors so they are reported normally rather than as command-usage errors.
  * Updated release workflow validation to inspect job boundaries and checksum verification more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
