### PR TITLE
fix(review): disclose web-only doctor coverage

### DIFF
--- a/commands/review.mdx
+++ b/commands/review.mdx
@@ -66,6 +66,15 @@ asc review doctor --app "123456789" --version "1.2.3"
 asc review doctor --app "123456789" --version-id "VERSION_ID"
 ```
 
+`asc review doctor` checks submission readiness exposed by the public App Store
+Connect API. App Store Regulations and Permits declarations—including whether
+the app is a personal service—are managed on the App Store Connect website and
+are not checked. Doctor output reports this boundary under `coverageWarnings`
+in JSON and under **Coverage Warnings** in table and Markdown output. Coverage
+warnings do not change blocker counts or exit behavior. When no public-API
+blockers are found, the next action still directs you to verify these web-only
+declarations before submission.
+
 ***
 
 ### `asc review submissions-list`

--- a/internal/cli/reviews/review_overview.go
+++ b/internal/cli/reviews/review_overview.go
@@ -69,6 +69,14 @@ type reviewDoctorResult struct {
 	NextAction             string                   `json:"nextAction"`
 	BlockingChecks         []validation.CheckResult `json:"blockingChecks,omitempty"`
 	WarningChecks          []validation.CheckResult `json:"warningChecks,omitempty"`
+	CoverageWarnings       []reviewCoverageWarning  `json:"coverageWarnings"`
+}
+
+type reviewCoverageWarning struct {
+	ID          string `json:"id"`
+	Status      string `json:"status"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation"`
 }
 
 // ReviewStatusCommand returns an app-scoped review status command.
@@ -554,6 +562,7 @@ func buildReviewDoctorResult(snapshot reviewSnapshot, report validation.Report) 
 		NextAction:             "Create or select an App Store version before diagnosing review blockers.",
 		BlockingChecks:         make([]validation.CheckResult, 0),
 		WarningChecks:          make([]validation.CheckResult, 0),
+		CoverageWarnings:       reviewDoctorCoverageWarnings(),
 	}
 
 	if snapshot.Version == nil {
@@ -626,10 +635,21 @@ func buildReviewDoctorResult(snapshot reviewSnapshot, report validation.Report) 
 	case strings.EqualFold(strings.TrimSpace(snapshot.Version.State), "READY_FOR_SALE"):
 		result.NextAction = "No action needed."
 	default:
-		result.NextAction = "No submission blockers detected. Submit the version when ready."
+		result.NextAction = "No public-API submission blockers detected. Verify App Store Regulations and Permits in App Store Connect before submission."
 	}
 
 	return result
+}
+
+func reviewDoctorCoverageWarnings() []reviewCoverageWarning {
+	return []reviewCoverageWarning{
+		{
+			ID:          "review.coverage.app_store_regulations_and_permits",
+			Status:      "NOT_CHECKED",
+			Message:     "App Store Regulations and Permits declarations, including the personal-service declaration, are managed on the App Store Connect website and are not checked by asc review doctor.",
+			Remediation: "Verify App Store Regulations and Permits in App Store Connect before submission.",
+		},
+	}
 }
 
 func reviewPostCompleteAction(versionState string) string {
@@ -695,6 +715,12 @@ func renderReviewDoctor(result reviewDoctorResult, markdown bool) {
 		{"latestSubmissionId", shared.OrNA(reviewSubmissionField(result.LatestSubmission, func(s *reviewSubmissionContext) string { return s.ID }))},
 	}
 	shared.RenderSection("Current Review", []string{"field", "value"}, contextRows, markdown)
+
+	coverageRows := make([][]string, 0, len(result.CoverageWarnings))
+	for _, warning := range result.CoverageWarnings {
+		coverageRows = append(coverageRows, []string{warning.ID, warning.Status, warning.Message, warning.Remediation})
+	}
+	shared.RenderSection("Coverage Warnings", []string{"id", "status", "message", "remediation"}, coverageRows, markdown)
 
 	if len(result.BlockingChecks) > 0 {
 		blockerRows := make([][]string, 0, len(result.BlockingChecks))

--- a/internal/cli/reviews/review_overview_test.go
+++ b/internal/cli/reviews/review_overview_test.go
@@ -271,6 +271,7 @@ func TestRenderReviewDoctorDisclosesWebOnlyCoverage(t *testing.T) {
 				"review.coverage.app_store_regulations_and_permits",
 				"NOT_CHECKED",
 				"personal-service declaration",
+				"Verify App Store Regulations and Permits in App Store Connect before submission.",
 			} {
 				if !strings.Contains(strings.ToLower(output), strings.ToLower(want)) {
 					t.Fatalf("expected %q in output:\n%s", want, output)

--- a/internal/cli/reviews/review_overview_test.go
+++ b/internal/cli/reviews/review_overview_test.go
@@ -6,10 +6,12 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -181,6 +183,131 @@ func TestBuildReviewDoctorResultAddsRemovedItemsOnlyBlocker(t *testing.T) {
 	if result.Summary.Blocking != 1 || result.Summary.Errors != 1 {
 		t.Fatalf("expected summary to include synthetic blocker, got %+v", result.Summary)
 	}
+}
+
+func TestBuildReviewDoctorResultDisclosesWebOnlyCoverageWithoutChangingCheckSemantics(t *testing.T) {
+	snapshot := reviewSnapshot{
+		AppID: "123456789",
+		Version: &reviewVersionContext{
+			ID:       "ver-1",
+			Version:  "1.2.3",
+			Platform: "IOS",
+			State:    "PREPARE_FOR_SUBMISSION",
+		},
+	}
+
+	result := buildReviewDoctorResult(snapshot, validation.Report{})
+
+	if result.Summary != (validation.Summary{}) {
+		t.Fatalf("expected coverage warning not to change summary, got %+v", result.Summary)
+	}
+	if len(result.BlockingChecks) != 0 {
+		t.Fatalf("expected coverage warning not to add blockers, got %+v", result.BlockingChecks)
+	}
+	if len(result.WarningChecks) != 0 {
+		t.Fatalf("expected coverage warning not to add app-specific warning checks, got %+v", result.WarningChecks)
+	}
+	if result.NextAction != "No public-API submission blockers detected. Verify App Store Regulations and Permits in App Store Connect before submission." {
+		t.Fatalf("expected next action to disclose the public-API boundary, got %q", result.NextAction)
+	}
+
+	output, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal review doctor result: %v", err)
+	}
+	var payload struct {
+		CoverageWarnings []struct {
+			ID          string `json:"id"`
+			Status      string `json:"status"`
+			Message     string `json:"message"`
+			Remediation string `json:"remediation"`
+		} `json:"coverageWarnings"`
+	}
+	if err := json.Unmarshal(output, &payload); err != nil {
+		t.Fatalf("unmarshal review doctor result: %v", err)
+	}
+	if len(payload.CoverageWarnings) != 1 {
+		t.Fatalf("expected one coverage warning, got %s", output)
+	}
+	warning := payload.CoverageWarnings[0]
+	if warning.ID != "review.coverage.app_store_regulations_and_permits" {
+		t.Fatalf("unexpected coverage warning ID %q", warning.ID)
+	}
+	if warning.Status != "NOT_CHECKED" {
+		t.Fatalf("expected NOT_CHECKED status, got %q", warning.Status)
+	}
+	if !strings.Contains(warning.Message, "personal-service declaration") {
+		t.Fatalf("expected personal-service declaration disclosure, got %q", warning.Message)
+	}
+	if !strings.Contains(warning.Remediation, "App Store Connect") {
+		t.Fatalf("expected App Store Connect remediation, got %q", warning.Remediation)
+	}
+}
+
+func TestRenderReviewDoctorDisclosesWebOnlyCoverage(t *testing.T) {
+	result := buildReviewDoctorResult(reviewSnapshot{
+		AppID: "123456789",
+		Version: &reviewVersionContext{
+			ID:       "ver-1",
+			Version:  "1.2.3",
+			Platform: "IOS",
+			State:    "PREPARE_FOR_SUBMISSION",
+		},
+	}, validation.Report{})
+
+	for _, test := range []struct {
+		name     string
+		markdown bool
+	}{
+		{name: "table"},
+		{name: "markdown", markdown: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			output := captureReviewStdout(t, func() {
+				renderReviewDoctor(result, test.markdown)
+			})
+			for _, want := range []string{
+				"Coverage Warnings",
+				"review.coverage.app_store_regulations_and_permits",
+				"NOT_CHECKED",
+				"personal-service declaration",
+			} {
+				if !strings.Contains(strings.ToLower(output), strings.ToLower(want)) {
+					t.Fatalf("expected %q in output:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+func captureReviewStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	done := make(chan []byte, 1)
+	go func() {
+		output, _ := io.ReadAll(reader)
+		done <- output
+	}()
+
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	os.Stdout = oldStdout
+
+	return string(<-done)
 }
 
 func TestBuildReviewOverviewResultsExposeReviewDetailConfiguredState(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a structured `coverageWarnings` entry to `asc review doctor` JSON output for App Store Regulations and Permits
- render the same `NOT_CHECKED` warning in table and Markdown output
- qualify the clean-path next action as public-API-only and direct users to verify web-only declarations before submission
- document that the personal-service declaration cannot be inspected through the public App Store Connect API

The coverage warning is intentionally separate from `warningChecks`: it does not claim the declaration is missing, and it does not change blocker counts, warning counts, or exit behavior.

Fixes #1967

## Verification

- RED regression reproduced before implementation
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/reviews -run 'Test(BuildReviewDoctorResultDisclosesWebOnlyCoverageWithoutChangingCheckSemantics|RenderReviewDoctorDisclosesWebOnlyCoverage)$' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/reviews ./internal/cli/cmdtest -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built `/tmp/asc` and exercised JSON, table, and Markdown output against disposable app `6759231657`; all exited 0, wrote the coverage warning to stdout, and left stderr empty

Live verification was read-only. No Apple state was mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage warnings to `asc review doctor` for App Store Regulations and Permits declarations not checked by the command.
  * Coverage warnings now appear in a dedicated output section and JSON results.
  * Recommended next steps now direct you to verify these web-only declarations before submitting.

* **Documentation**
  * Clarified the command’s coverage boundaries.
  * Confirmed that coverage warnings do not affect blocker counts or exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->