### PR TITLE
Fix workflow output validation and documentation gaps

### DIFF
--- a/concepts/workflows.mdx
+++ b/concepts/workflows.mdx
@@ -430,6 +430,7 @@ There is no `exit_code` and no `success` field. Gate CI on `.status`, which is
 | `failed_step`    | string  | Step name (or generated key) that failed; omitted on success               |
 | `recoverable`    | boolean | Present when `--resume` can continue this run                              |
 | `terminal`       | boolean | Present when resume is refused; `terminal_reason` explains why             |
+| `terminal_reason` | string  | Reason resume is refused; present with `terminal`                           |
 | `run_id`         | string  | Resume handle; also the run-state file name                                |
 | `run_file`       | string  | Absolute path to the persisted run state                                   |
 | `resumed`        | boolean | Present when the run was started with `--resume`                           |

--- a/configuration/workflows.mdx
+++ b/configuration/workflows.mdx
@@ -174,7 +174,7 @@ Steps can be defined in two formats:
   Name of an environment variable that controls whether the step runs
 
   The step runs only when the variable has a truthy value such as `1`, `true`,
-  `yes`, or `on` (case-insensitive).
+  `yes`, `y`, or `on` (case-insensitive).
 </ParamField>
 
 <ParamField path="with" type="object">

--- a/internal/workflow/interpolate.go
+++ b/internal/workflow/interpolate.go
@@ -3,7 +3,9 @@ package workflow
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"regexp"
 	"slices"
@@ -146,8 +148,12 @@ func extractDeclaredOutputs(outputDecls map[string]string, stdout []byte) (map[s
 	if err := decoder.Decode(&payload); err != nil {
 		return nil, fmt.Errorf("extract outputs: parse command stdout as JSON: %w", err)
 	}
-	if decoder.More() {
-		return nil, fmt.Errorf("extract outputs: parse command stdout as JSON: invalid character after top-level value")
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = fmt.Errorf("unexpected trailing top-level value")
+		}
+		return nil, fmt.Errorf("extract outputs: parse command stdout as JSON: %w", err)
 	}
 
 	results := make(map[string]string, len(outputDecls))

--- a/internal/workflow/interpolate_test.go
+++ b/internal/workflow/interpolate_test.go
@@ -55,12 +55,14 @@ func TestExtractDeclaredOutputs_PreservesNestedAndContainerNumbers(t *testing.T)
 
 func TestExtractDeclaredOutputs_RejectsTrailingData(t *testing.T) {
 	tests := []struct {
-		name   string
-		stdout string
+		name    string
+		stdout  string
+		wantErr string
 	}{
-		{name: "text", stdout: `{"v":1} trailing`},
-		{name: "closing brace", stdout: `{"v":1}}`},
-		{name: "closing bracket", stdout: `{"v":1}]`},
+		{name: "text", stdout: `{"v":1} trailing`, wantErr: "parse command stdout as JSON"},
+		{name: "closing brace", stdout: `{"v":1}}`, wantErr: "parse command stdout as JSON"},
+		{name: "closing bracket", stdout: `{"v":1}]`, wantErr: "parse command stdout as JSON"},
+		{name: "second top-level value", stdout: `{"v":1} {"extra":2}`, wantErr: "unexpected trailing top-level value"},
 	}
 
 	for _, tc := range tests {
@@ -69,8 +71,8 @@ func TestExtractDeclaredOutputs_RejectsTrailingData(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected trailing data after the JSON value to be rejected")
 			}
-			if !strings.Contains(err.Error(), "parse command stdout as JSON") {
-				t.Fatalf("expected a JSON parse error, got %v", err)
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
 			}
 		})
 	}

--- a/internal/workflow/interpolate_test.go
+++ b/internal/workflow/interpolate_test.go
@@ -54,12 +54,25 @@ func TestExtractDeclaredOutputs_PreservesNestedAndContainerNumbers(t *testing.T)
 }
 
 func TestExtractDeclaredOutputs_RejectsTrailingData(t *testing.T) {
-	_, err := extractDeclaredOutputs(map[string]string{"V": "$.v"}, []byte(`{"v":1} trailing`))
-	if err == nil {
-		t.Fatal("expected trailing data after the JSON value to be rejected")
+	tests := []struct {
+		name   string
+		stdout string
+	}{
+		{name: "text", stdout: `{"v":1} trailing`},
+		{name: "closing brace", stdout: `{"v":1}}`},
+		{name: "closing bracket", stdout: `{"v":1}]`},
 	}
-	if !strings.Contains(err.Error(), "parse command stdout as JSON") {
-		t.Fatalf("expected a JSON parse error, got %v", err)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := extractDeclaredOutputs(map[string]string{"V": "$.v"}, []byte(tc.stdout))
+			if err == nil {
+				t.Fatal("expected trailing data after the JSON value to be rejected")
+			}
+			if !strings.Contains(err.Error(), "parse command stdout as JSON") {
+				t.Fatalf("expected a JSON parse error, got %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- document `terminal_reason` as a first-class workflow result field
- align every workflow `if` truthiness list with runtime support for `y`
- reject any data after the single declared-output JSON value by requiring a second decode to return `io.EOF`
- add regressions for trailing `}` and `]` tokens

## Original review findings

- [`terminal_reason` result schema](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347699) — verified valid; `RunResult` serialized the field while the result table only mentioned it indirectly. The table now has a dedicated string-field row.
- [Workflow `if` truthiness](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347709) — verified valid; runtime accepts `1`, `true`, `yes`, `y`, and `on`, while one `if` ParamField omitted `y`. The documentation is now consistent.
- [Trailing top-level JSON tokens](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347848) — verified valid; `Decoder.More()` returned false for trailing closing delimiters. Output extraction now decodes once more and accepts only `io.EOF`.

The already-merged PR threads now link back to this follow-up and are resolved.

## Verification

- RED: `TestExtractDeclaredOutputs_RejectsTrailingData` accepted both `{"v":1}}` and `{"v":1}]` before the implementation change
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/workflow -run "^TestExtractDeclaredOutputs_" -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/workflow -count=1`
- built binary: malformed declared-output JSON exits 1 with structured terminal failure output and `terminal_reason`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

No App Store Connect or Apple state was accessed or mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow JSON validation to reject trailing text, malformed delimiters, or extra JSON data.
  * Expanded validation coverage for malformed workflow output.

* **Documentation**
  * Documented why a terminal workflow run may refuse to resume.
  * Added `y` as a supported case-insensitive truthy value for conditional workflow steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
