### PR TITLE
Fix output and help fidelity

### DIFF
--- a/guides/analytics-reports.mdx
+++ b/guides/analytics-reports.mdx
@@ -383,7 +383,7 @@ export ASC_VENDOR_NUMBER="YOUR_VENDOR_NUMBER"
 asc analytics view --request-id "REQUEST_ID"
 ```
 
-Retry `asc analytics view --request-id "REQUEST_ID" --paginate` until `data[].instances` is non-empty, then download.
+Retry `asc analytics view --request-id "REQUEST_ID" --paginate --output json` until `data[].instances` is non-empty, then download.
 
 ### "Failed to download report"
 

--- a/internal/asc/client_builds.go
+++ b/internal/asc/client_builds.go
@@ -245,22 +245,29 @@ type StateDetail struct {
 // across Description and Message so either field carries Apple's text.
 func (d *StateDetail) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Code        string `json:"code"`
-		Description string `json:"description"`
-		Message     string `json:"message"`
+		Code        *string `json:"code"`
+		Description *string `json:"description"`
+		Message     *string `json:"message"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	d.Code = raw.Code
-	d.Description = raw.Description
-	d.Message = raw.Message
-	if d.Description == "" {
-		d.Description = raw.Message
+	*d = StateDetail{}
+	if raw.Code != nil {
+		d.Code = *raw.Code
 	}
-	if d.Message == "" {
-		d.Message = raw.Description
+	if raw.Description != nil {
+		d.Description = *raw.Description
+	}
+	if raw.Message != nil {
+		d.Message = *raw.Message
+	}
+	if raw.Description == nil && raw.Message != nil {
+		d.Description = *raw.Message
+	}
+	if raw.Message == nil && raw.Description != nil {
+		d.Message = *raw.Description
 	}
 	return nil
 }

--- a/internal/asc/state_detail_test.go
+++ b/internal/asc/state_detail_test.go
@@ -74,6 +74,28 @@ func TestStateDetailDecodeMirrorsDescriptionIntoMessage(t *testing.T) {
 	}
 }
 
+func TestStateDetailDecodeResetsOmittedFieldsOnReusedReceiver(t *testing.T) {
+	detail := StateDetail{
+		Code:        "STALE_CODE",
+		Description: "stale description",
+		Message:     "stale message",
+	}
+
+	if err := json.Unmarshal([]byte(`{"code":"NEW_CODE"}`), &detail); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if detail.Code != "NEW_CODE" {
+		t.Fatalf("expected decoded code, got %q", detail.Code)
+	}
+	if detail.Description != "" {
+		t.Fatalf("expected omitted description to reset, got %q", detail.Description)
+	}
+	if detail.Message != "" {
+		t.Fatalf("expected omitted message to reset, got %q", detail.Message)
+	}
+}
+
 func TestStateDetailEncodeKeepsAppleWireFormat(t *testing.T) {
 	var detail StateDetail
 	if err := json.Unmarshal([]byte(`{"code":"CODE","description":"described"}`), &detail); err != nil {

--- a/internal/asc/state_detail_test.go
+++ b/internal/asc/state_detail_test.go
@@ -35,6 +35,20 @@ func TestStateDetailDecodeMirrorsDescriptionIntoMessage(t *testing.T) {
 			wantMessage:     "messaged",
 		},
 		{
+			name:            "explicit empty description is preserved",
+			payload:         `{"code":"CODE","description":"","message":"messaged"}`,
+			wantCode:        "CODE",
+			wantDescription: "",
+			wantMessage:     "messaged",
+		},
+		{
+			name:            "explicit empty message is preserved",
+			payload:         `{"code":"CODE","description":"described","message":""}`,
+			wantCode:        "CODE",
+			wantDescription: "described",
+			wantMessage:     "",
+		},
+		{
 			name:     "code only",
 			payload:  `{"code":"90062"}`,
 			wantCode: "90062",

--- a/internal/cli/assets/assets_previews.go
+++ b/internal/cli/assets/assets_previews.go
@@ -32,10 +32,6 @@ func AssetsPreviewsListCommand() *ffcli.Command {
 returned as data[].id by "asc localizations list --version VERSION_ID --output json".
 It is not the locale code such as en-US.
 
---replace deletes every existing preview in the target set before uploading and
-therefore requires --confirm. Use --replace --dry-run to preview the deletions
-without --confirm.
-
 Examples:
   asc localizations list --version "VERSION_ID" --output json --locale "en-US"
   asc video-previews list --version-localization "VERSION_LOCALIZATION_ID"`,

--- a/internal/cli/assets/assets_previews_test.go
+++ b/internal/cli/assets/assets_previews_test.go
@@ -14,6 +14,16 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
+func TestAssetsPreviewsListHelpOnlyDocumentsSupportedFlags(t *testing.T) {
+	cmd := AssetsPreviewsListCommand()
+
+	for _, unsupported := range []string{"--replace", "--confirm", "--dry-run"} {
+		if strings.Contains(cmd.LongHelp, unsupported) {
+			t.Errorf("list help must not document unsupported flag %s", unsupported)
+		}
+	}
+}
+
 func TestAssetsPreviewsUploadCommandRejectsSkipExistingWithReplace(t *testing.T) {
 	cmd := AssetsPreviewsUploadCommand()
 	cmd.FlagSet.SetOutput(io.Discard)


### PR DESCRIPTION
## Summary

- require JSON output in the analytics pending-request guide before referring to `data[].instances`
- preserve explicitly empty `description` and `message` values while keeping the existing `Description`/`Message` decode alias
- remove upload-only flags from `video-previews list` help

## Review threads addressed

- https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347712
- https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347746
- https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347755

## Compatibility

No command, flag, exit-code, or API request shape changes. `StateDetail.Message` remains excluded from JSON encoding; this only makes decoding distinguish an absent alias field from an explicitly empty one.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc .`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc video-previews list --help` (exit 0; no data stdout; help on stderr; unsupported upload flags absent)

No App Store Connect mutation or live Apple call was needed for these local output/help contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics troubleshooting retry commands now support requesting JSON output alongside pagination options.

* **Bug Fixes**
  * State details now preserve explicitly empty descriptions and messages correctly when processing responses.
  * Reused state details are reset properly, and related fields stay synchronized when only one is provided.

* **Documentation**
  * Updated assets preview list command help to show only supported options, removing misleading flag descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->