### PR TITLE
fix(signing): deprecate --device without --create-missing

### DIFF
--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -36,9 +36,14 @@ This command:
 * `--output` - Output directory (default: `./signing`)
 * `--app` - App Store Connect app ID (validates bundle ID match)
 * `--certificate-type` - Filter specific certificate type (usually auto-inferred)
-* `--device` - Device IDs for development profiles (comma-separated)
+* `--device` - Device IDs for profiles created with `--create-missing` (comma-separated)
 * `--create-missing` - Create a new profile if none exists
 * `--format` - Output format for metadata: json, table, markdown (default: json)
+
+In 4.x, `signing fetch` and `signing sync push` still accept `--device` without
+`--create-missing` for compatibility, but print a deprecation warning and
+ignore the device IDs. Pair the flags now; 5.0.0 will reject the old
+combination.
 
 ## Profile Types
 

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -17,10 +17,13 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-// deviceRequiresCreateMissingMessage explains that device lists only reach App
-// Store Connect through profile creation; the API has no endpoint for adding
-// devices to an existing profile.
-const deviceRequiresCreateMissingMessage = "--device requires --create-missing (devices are only applied to profiles this command creates)"
+const deviceWithoutCreateMissingDeprecationWarning = "Warning: --device without --create-missing is deprecated and ignored because device IDs are only applied when creating a profile. Add --create-missing so they can be applied if a profile must be created. This combination will be rejected in 5.0.0."
+
+func warnDeviceWithoutCreateMissing(deviceIDs string, createMissing bool) {
+	if !createMissing && strings.TrimSpace(deviceIDs) != "" {
+		fmt.Fprintln(os.Stderr, deviceWithoutCreateMissingDeprecationWarning)
+	}
+}
 
 // SigningFetchCommand returns the signing fetch subcommand.
 func SigningFetchCommand() *ffcli.Command {
@@ -29,7 +32,7 @@ func SigningFetchCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (optional, or ASC_APP_ID env)")
 	bundleID := fs.String("bundle-id", "", "Bundle identifier (e.g., com.example.app) - required")
 	profileType := fs.String("profile-type", "", "Profile type: IOS_APP_STORE, IOS_APP_DEVELOPMENT, MAC_APP_STORE, etc. (required)")
-	deviceIDs := fs.String("device", "", "Device ID(s), comma-separated (requires --create-missing; required there for development profiles)")
+	deviceIDs := fs.String("device", "", "Device ID(s), comma-separated (required with --create-missing for development profiles; deprecated and ignored without it until 5.0.0)")
 	certType := fs.String("certificate-type", "", "Certificate type filter (optional)")
 	outputPath := fs.String("output", "./signing", "Output directory for signing files")
 	createMissing := fs.Bool("create-missing", false, "Create missing profiles")
@@ -46,7 +49,8 @@ and writes them to the output directory.
 
 With --create-missing, it will create a new profile if none exist for the
 specified configuration. Devices are only applied to profiles this command
-creates, so --device requires --create-missing.
+creates. In 4.x, passing --device without --create-missing prints a deprecation
+warning and ignores the device IDs; 5.0.0 will reject that combination.
 
 Examples:
   asc signing fetch --bundle-id com.example.app --profile-type IOS_APP_STORE --output ./signing
@@ -67,9 +71,7 @@ Examples:
 				return shared.MissingRequiredUsageError()
 			}
 			profType = strings.ToUpper(profType)
-			if !*createMissing && strings.TrimSpace(*deviceIDs) != "" {
-				return shared.UsageError(deviceRequiresCreateMissingMessage)
-			}
+			warnDeviceWithoutCreateMissing(*deviceIDs, *createMissing)
 			if *createMissing && isDevelopmentProfile(profType) && strings.TrimSpace(*deviceIDs) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --device is required for development profiles")
 				return shared.MissingRequiredUsageError()

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -110,11 +110,6 @@ func TestSigningFetchValidationErrors(t *testing.T) {
 			args:    []string{"signing", "fetch", "--bundle-id", "com.example.app", "--profile-type", "IOS_APP_DEVELOPMENT", "--create-missing"},
 			wantErr: "Error: --device is required for development profiles",
 		},
-		{
-			name:    "device without create-missing",
-			args:    []string{"signing", "fetch", "--bundle-id", "com.example.app", "--profile-type", "IOS_APP_DEVELOPMENT", "--device", "DEVICE1,DEVICE2"},
-			wantErr: "Error: --device requires --create-missing (devices are only applied to profiles this command creates)",
-		},
 	}
 
 	for _, test := range tests {
@@ -143,6 +138,46 @@ func TestSigningFetchValidationErrors(t *testing.T) {
 				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
 			}
 		})
+	}
+}
+
+func TestSigningFetchWarnsForDeviceWithoutCreateMissing(t *testing.T) {
+	clientCalls := 0
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientCalls++
+		return nil, errors.New("client reached after validation")
+	}))
+
+	cmd := SigningFetchCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.Parse([]string{
+		"--bundle-id", "com.example.app",
+		"--profile-type", "IOS_APP_DEVELOPMENT",
+		"--device", "DEVICE1,DEVICE2",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = cmd.Run(context.Background())
+	})
+
+	if runErr == nil || runErr.Error() != "signing fetch: client reached after validation" {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("deprecated input must not return a usage error: %v", runErr)
+	}
+	if clientCalls != 1 {
+		t.Fatalf("client factory calls = %d, want 1", clientCalls)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	wantWarning := "Warning: --device without --create-missing is deprecated and ignored because device IDs are only applied when creating a profile. Add --create-missing so they can be applied if a profile must be created. This combination will be rejected in 5.0.0.\n"
+	if stderr != wantWarning {
+		t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
 	}
 }
 
@@ -203,6 +238,12 @@ func TestSigningFetchHelpPairsDeviceWithCreateMissing(t *testing.T) {
 	}
 	if !strings.Contains(deviceFlag.Usage, "--create-missing") {
 		t.Fatalf("--device usage = %q, want it to name --create-missing", deviceFlag.Usage)
+	}
+	if !strings.Contains(deviceFlag.Usage, "deprecated") || !strings.Contains(deviceFlag.Usage, "5.0.0") {
+		t.Fatalf("--device usage = %q, want the transition and rejection release", deviceFlag.Usage)
+	}
+	if !strings.Contains(cmd.LongHelp, "warning and ignores the device IDs; 5.0.0 will reject") {
+		t.Fatalf("long help must describe the --device transition, got %q", cmd.LongHelp)
 	}
 
 	for _, line := range strings.Split(cmd.LongHelp, "\n") {

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -94,7 +94,7 @@ func syncPushCommand() *ffcli.Command {
 	password := fs.String("password", "", "Encryption password (or ASC_MATCH_PASSWORD env)")
 	branch := fs.String("branch", "main", "Git branch")
 	certType := fs.String("certificate-type", "", "Certificate type filter (optional)")
-	deviceIDs := fs.String("device", "", "Device ID(s), comma-separated (requires --create-missing; required there for development profiles)")
+	deviceIDs := fs.String("device", "", "Device ID(s), comma-separated (required with --create-missing for development profiles; deprecated and ignored without it until 5.0.0)")
 	createMissing := fs.Bool("create-missing", false, "Create missing profiles")
 	output := shared.BindOutputFlags(fs)
 
@@ -121,9 +121,7 @@ func syncPushCommand() *ffcli.Command {
 			if repo == "" {
 				return shared.UsageError("--repo is required")
 			}
-			if !*createMissing && strings.TrimSpace(*deviceIDs) != "" {
-				return shared.UsageError(deviceRequiresCreateMissingMessage)
-			}
+			warnDeviceWithoutCreateMissing(*deviceIDs, *createMissing)
 			if *createMissing && isDevelopmentProfile(profType) && strings.TrimSpace(*deviceIDs) == "" {
 				return shared.UsageError("--device is required for development profiles with --create-missing")
 			}

--- a/internal/cli/signing/signing_sync_test.go
+++ b/internal/cli/signing/signing_sync_test.go
@@ -25,6 +25,18 @@ func TestSigningSyncCommandLongHelpUsesOutputDirExample(t *testing.T) {
 	}
 }
 
+func TestSigningSyncPushHelpDocumentsDeviceTransition(t *testing.T) {
+	deviceFlag := syncPushCommand().FlagSet.Lookup("device")
+	if deviceFlag == nil {
+		t.Fatal("expected --device flag")
+	}
+	if !strings.Contains(deviceFlag.Usage, "--create-missing") ||
+		!strings.Contains(deviceFlag.Usage, "deprecated") ||
+		!strings.Contains(deviceFlag.Usage, "5.0.0") {
+		t.Fatalf("--device usage = %q, want the transition and rejection release", deviceFlag.Usage)
+	}
+}
+
 func TestSigningSyncPreparesRepositoryOnceInAssetOrder(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -109,14 +121,17 @@ func TestSigningSyncPreparesRepositoryOnceInAssetOrder(t *testing.T) {
 	}
 }
 
-func TestSigningSyncPushRejectsDeviceWithoutCreateMissing(t *testing.T) {
+func TestSigningSyncPushWarnsForDeviceWithoutCreateMissing(t *testing.T) {
+	clientCalls := 0
 	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
-		return nil, errors.New("App Store Connect client must not be created during flag validation")
+		clientCalls++
+		return nil, errors.New("client reached after validation")
 	}))
 
 	cmd := syncPushCommand()
 	cmd.FlagSet.SetOutput(io.Discard)
 
+	var runErr error
 	stdout, stderr := captureOutput(t, func() {
 		if err := cmd.Parse([]string{
 			"--bundle-id", "com.example.app",
@@ -127,18 +142,24 @@ func TestSigningSyncPushRejectsDeviceWithoutCreateMissing(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
-		err := cmd.Run(context.Background())
-		if !errors.Is(err, flag.ErrHelp) {
-			t.Fatalf("expected usage error, got %v", err)
-		}
+		runErr = cmd.Run(context.Background())
 	})
 
+	if runErr == nil || runErr.Error() != "signing sync push: client reached after validation" {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("deprecated input must not return a usage error: %v", runErr)
+	}
+	if clientCalls != 1 {
+		t.Fatalf("client factory calls = %d, want 1", clientCalls)
+	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	want := "Error: --device requires --create-missing (devices are only applied to profiles this command creates)"
-	if !strings.Contains(stderr, want) {
-		t.Fatalf("expected %q, got %q", want, stderr)
+	wantWarning := "Warning: --device without --create-missing is deprecated and ignored because device IDs are only applied when creating a profile. Add --create-missing so they can be applied if a profile must be created. This combination will be rejected in 5.0.0.\n"
+	if stderr != wantWarning {
+		t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
 	}
 }
 

--- a/migrate-to-4-0.mdx
+++ b/migrate-to-4-0.mdx
@@ -21,6 +21,33 @@ automation. The CLI is the source of truth.
 * Replacing remote screenshots or video previews now requires `--confirm`.
 * Many flags that were previously accepted and ignored now fail with a usage
   error before any API call.
+* `--device` without `--create-missing` is a temporary exception: 4.x warns and
+  continues to ignore the device IDs; 5.0.0 will reject the combination.
+
+## Deprecated signing flag combination
+
+In 3.7, `asc signing fetch` and `asc signing sync push` accepted `--device`
+without `--create-missing`, but those device IDs could only be sent to App Store
+Connect when the command created a profile. Otherwise the value was ignored.
+
+Version 4.x keeps that input working for one deprecation cycle. Both commands
+print a warning to stderr and continue with the same behavior. Add
+`--create-missing` anywhere you pass `--device` so the IDs can be applied if a
+profile must be created; 5.0.0 will reject the old combination with a usage
+error.
+
+```bash  theme={null}
+asc signing fetch --bundle-id "com.example.app" \
+  --profile-type IOS_APP_DEVELOPMENT \
+  --device "DEVICE_ID_1,DEVICE_ID_2" \
+  --create-missing
+
+asc signing sync push --bundle-id "com.example.app" \
+  --profile-type IOS_APP_DEVELOPMENT \
+  --repo "git@github.com:team/signing.git" \
+  --device "DEVICE_ID_1,DEVICE_ID_2" \
+  --create-missing
+```
 
 ## Removed commands
 
@@ -294,11 +321,11 @@ are all accepted.
 1. Search your repo for `--state`, `--date`, `review items view`, and
    `review items-get`, and replace them with the canonical forms above.
 2. Add `--confirm` to every `screenshots upload --replace` and
-   `video-previews upload --replace` invocation, and `--create-missing` to
-   every `signing fetch --device`.
+   `video-previews upload --replace` invocation. Pair every `--device` on
+   `signing fetch` or `signing sync push` with `--create-missing`.
 3. Re-check any script that pins a build number: compare
-   `asc builds next-build-number --app "APP_ID"` against 3.7 output for one app
-   before you rely on it.
+   `ASC_BYPASS_KEYCHAIN=1 asc builds next-build-number --app "APP_ID"` against
+   3.7 output for one app before you rely on it.
 4. On macOS runners, confirm which provisioning profile directory
    `asc profiles local list` reports before running `clean --confirm`.
 5. Re-run CI with the 4.0 binary and verify exit codes, stderr handling, and

--- a/migrate-to-4-0.mdx
+++ b/migrate-to-4-0.mdx
@@ -251,8 +251,9 @@ require `--confirm`. `--replace --dry-run` is unchanged and needs no
 
 ### Flags that were accepted and ignored
 
-* `asc signing fetch --device ...` and `asc signing sync push --device ...`
-  require `--create-missing`.
+* `asc signing fetch --device ...` and `asc signing sync push --device ...` are
+  the transition exception: 4.x warns and ignores the device IDs without
+  `--create-missing`; 5.0.0 will reject the combination.
 * `asc screenshots frame --watch` rejects `--device`, `--title`, `--subtitle`,
   `--bg-color`, `--title-color`, `--subtitle-color`, `--output-path`,
   `--output-dir`, and `--name`. Set them in the Koubou YAML config instead.


### PR DESCRIPTION
## Context

PR #1965 changed `--device` without `--create-missing` from accepted input in 3.7.0 to an immediate usage error in 4.0.0. That skipped the repository lifecycle for a stable flag combination.

Addresses [review thread 13](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347834) and [review thread 17](https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347851).

## Behavior

- `asc signing fetch` and `asc signing sync push` accept the old combination during 4.x.
- Each command prints one warning to stderr; device IDs stay ignored unless a profile must be created.
- Canonical invocations with `--create-missing` do not print the deprecation warning.
- Help and migration docs tell callers to pair the flags now. Version 5.0.0 will reject the old combination.

## Compatibility decision

Version 3.7.0 passed device IDs into the profile-creation path, but with `--create-missing=false` it could never create a profile, so the values had no effect. Keeping the input with a warning preserves that behavior for 4.x and gives scripts a visible migration path. Immediate rejection breaks stable input without a deprecation cycle; silent acceptance would keep hiding the ignored value.

No App Store Connect endpoint or request payload changed.

## Verification

- RED: focused fetch and sync tests first reproduced the exit-2 rejection.
- GREEN: both tests now require the exact warning, empty stdout, a non-usage error, and continued client construction.
- Built `/tmp/asc` checks: transitional invocations emitted one warning and reached isolated missing-auth handling with exit `3`; canonical invocations reached the same exit without a warning.
- `make build`
- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint` (zero issues; golangci-lint reported a stale deleted-worktree processor warning outside this branch)
- `ASC_BYPASS_KEYCHAIN=1 make test`

No live Apple calls or Apple-side mutations were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--device` should be used with `--create-missing`.
  * Documented the temporary 4.x behavior and planned rejection in 5.0.0.
  * Added updated signing examples and migration guidance.

* **Bug Fixes**
  * Signing fetch and sync push now warn and continue when `--device` is used without `--create-missing` in 4.x.
  * Device IDs are ignored in this deprecated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->