### PR TITLE
Fix migration reliability findings from 4.0 audit

### DIFF
--- a/internal/cli/cmdtest/migrate_import_test.go
+++ b/internal/cli/cmdtest/migrate_import_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1241,6 +1242,97 @@ func TestMigrateImportWarnsAboutLocalizationCreatedBeforeScreenshotFailure(t *te
 	}
 }
 
+func TestMigrateImportWarnsAboutEveryUnreportedScreenshotLocalization(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	root := t.TempDir()
+	fastlaneDir := filepath.Join(root, "fastlane")
+	if err := os.MkdirAll(filepath.Join(fastlaneDir, "metadata"), 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	for _, locale := range []string{"en-US", "fr-FR"} {
+		screenshotsDir := filepath.Join(fastlaneDir, "screenshots", locale)
+		if err := os.MkdirAll(screenshotsDir, 0o755); err != nil {
+			t.Fatalf("mkdir screenshots %s: %v", locale, err)
+		}
+		writePNGForMigrate(t, filepath.Join(screenshotsDir, "iphone_65_existing.png"), 1242, 2688)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var createdLocales []string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID":
+			return migrateJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"VERSION_ID","attributes":{"versionString":"1.0","platform":"IOS"},"relationships":{"app":{"data":{"type":"apps","id":"APP_ID"}}}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_ID/appStoreVersionLocalizations":
+			return migrateJSONResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appStoreVersionLocalizations":
+			var payload struct {
+				Data struct {
+					Attributes struct {
+						Locale string `json:"locale"`
+					} `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode localization request: %v", err)
+			}
+			createdLocales = append(createdLocales, payload.Data.Attributes.Locale)
+			localizationID := fmt.Sprintf("loc-%d", len(createdLocales))
+			body := fmt.Sprintf(`{"data":{"type":"appStoreVersionLocalizations","id":%q,"attributes":{"locale":%q}}}`, localizationID, payload.Data.Attributes.Locale)
+			return migrateJSONResponse(http.StatusCreated, body), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-1/appScreenshotSets":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshotSets","id":"set-1","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"shot-existing"}],"links":{}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appScreenshotSets/set-1/appScreenshots":
+			return migrateJSONResponse(http.StatusOK, `{"data":[{"type":"appScreenshots","id":"shot-existing","attributes":{"fileName":"iphone_65_existing.png"}}]}`), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appScreenshotSets/set-1/relationships/appScreenshots":
+			return migrateJSONResponse(http.StatusNoContent, ""), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersionLocalizations/loc-2/appScreenshotSets":
+			return migrateJSONResponse(http.StatusConflict, `{"errors":[{"status":"409","code":"STATE_ERROR","title":"Request failed","detail":"sets unavailable"}]}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	rootCmd := RootCommand("1.2.3")
+	rootCmd.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		if err := rootCmd.Parse([]string{
+			"migrate", "import",
+			"--app", "APP_ID",
+			"--version-id", "VERSION_ID",
+			"--fastlane-dir", fastlaneDir,
+			"--confirm",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = rootCmd.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected migrate import to fail after one screenshot locale completed")
+	}
+	if len(createdLocales) != 2 {
+		t.Fatalf("created locales = %v, want two screenshot-only locales", createdLocales)
+	}
+	wantWarning := fmt.Sprintf(`Warning: created localization %q before the failure; re-run import or remove it manually`, createdLocales[1])
+	if !strings.Contains(stderr, wantWarning) {
+		t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
+	}
+	if strings.Contains(stderr, fmt.Sprintf(`created localization %q before the failure`, createdLocales[0])) {
+		t.Fatalf("stderr = %q, completed locale %q must not be warned as unreported", stderr, createdLocales[0])
+	}
+}
+
 // TestMigrateImportPartialOmitsSkippedReviewInformationStage keeps
 // completedStages restricted to stages that changed App Store Connect.
 func TestMigrateImportPartialOmitsSkippedReviewInformationStage(t *testing.T) {
@@ -1434,8 +1526,10 @@ func TestMigrateImportUploadPhaseKeepsFullUploadBudget(t *testing.T) {
 	})
 
 	budgets := make(map[string]time.Duration)
+	var budgetsMu sync.Mutex
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		label := req.Method + " " + req.URL.Path
+		budgetsMu.Lock()
 		if deadline, ok := req.Context().Deadline(); ok {
 			if remaining := time.Until(deadline); remaining > budgets[label] {
 				budgets[label] = remaining
@@ -1443,6 +1537,7 @@ func TestMigrateImportUploadPhaseKeepsFullUploadBudget(t *testing.T) {
 		} else {
 			budgets[label] = -1
 		}
+		budgetsMu.Unlock()
 
 		if req.URL.Host == "upload.example.com" {
 			return &http.Response{

--- a/internal/cli/migrate/import_helpers.go
+++ b/internal/cli/migrate/import_helpers.go
@@ -533,14 +533,25 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 		plansByLocale[plan.Locale] = append(plansByLocale[plan.Locale], plan)
 	}
 
-	// A failure before the first result leaves the localizations this stage
-	// created out of every report, so name them on stderr instead of leaving
-	// empty localizations behind silently.
+	// A failure can leave a localization this stage created out of every result,
+	// so name each unreported localization on stderr instead of leaving it
+	// behind silently.
 	var createdLocales []string
 	defer func() {
-		if err != nil && len(results) == 0 {
-			warnCreatedScreenshotLocalizations(os.Stderr, createdLocales)
+		if err == nil {
+			return
 		}
+		reportedLocales := make(map[string]struct{}, len(results))
+		for _, result := range results {
+			reportedLocales[result.Locale] = struct{}{}
+		}
+		unreportedLocales := make([]string, 0, len(createdLocales))
+		for _, locale := range createdLocales {
+			if _, reported := reportedLocales[locale]; !reported {
+				unreportedLocales = append(unreportedLocales, locale)
+			}
+		}
+		warnCreatedScreenshotLocalizations(os.Stderr, unreportedLocales)
 	}()
 
 	results = make([]ScreenshotUploadResult, 0, len(plans))
@@ -697,8 +708,8 @@ func uploadScreenshots(ctx context.Context, client *asc.Client, versionID string
 }
 
 // warnCreatedScreenshotLocalizations names the localizations the screenshot
-// stage created before a failure that left no result to print, so the operator
-// can re-run the import or remove the empty localizations by hand.
+// stage created before a failure that left them without a result, so the
+// operator can re-run the import or remove the empty localizations by hand.
 func warnCreatedScreenshotLocalizations(w io.Writer, locales []string) {
 	// Locales are collected in map order, so sort them for a stable report.
 	ordered := append([]string(nil), locales...)

--- a/internal/cli/migrate/path_resolution.go
+++ b/internal/cli/migrate/path_resolution.go
@@ -83,14 +83,18 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 	if err != nil {
 		return importInputs{}, nil, err
 	}
+	skipScreenshots := opts.MetadataOnly || opts.SkipScreenshots || config.SkipScreenshots
 	var screenshots resolvedImportPath
 	if !opts.MetadataOnly {
-		screenshots, err = resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots", "screenshots_path", opts.AllowExternalScreenshots)
+		if skipScreenshots {
+			screenshots, err = resolveSkippedImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots", "screenshots_path")
+		} else {
+			screenshots, err = resolveImportPath(workDir, opts.FastlaneDir, deliverfilePath, opts.ScreenshotsDir, config.ScreenshotsPath, "screenshots", "screenshots_path", opts.AllowExternalScreenshots)
+		}
 		if err != nil {
 			return importInputs{}, nil, err
 		}
 	}
-	skipScreenshots := opts.MetadataOnly || opts.SkipScreenshots || config.SkipScreenshots
 
 	skipped := []SkippedItem{}
 	skipped = noteOverriddenConventionalDir(skipped, metadata)
@@ -113,6 +117,46 @@ func resolveImportInputs(opts importInputOptions) (importInputs, []SkippedItem, 
 	inputs.ScreenshotsSource = screenshots.source
 
 	return inputs, skipped, nil
+}
+
+// resolveSkippedImportPath selects the path that would have supplied
+// screenshots without touching it. A skipped stage still reports its selected
+// path, but missing, external, or symlinked paths must not fail an import that
+// will never open them.
+func resolveSkippedImportPath(workDir, fastlaneDir, deliverfilePath, explicitPath, deliverfilePathValue, defaultDir, directive string) (resolvedImportPath, error) {
+	if strings.TrimSpace(explicitPath) != "" {
+		return resolvedImportPath{path: explicitPath, source: pathSourceFlag, label: defaultDir}, nil
+	}
+	base := workDir
+	if strings.TrimSpace(fastlaneDir) != "" {
+		base = fastlaneDir
+	}
+	if deliverfilePath != "" {
+		base = filepath.Dir(deliverfilePath)
+	}
+	if strings.TrimSpace(deliverfilePathValue) != "" {
+		path := deliverfilePathValue
+		if !filepath.IsAbs(path) {
+			absoluteBase, err := filepath.Abs(base)
+			if err != nil {
+				return resolvedImportPath{}, err
+			}
+			path = filepath.Join(absoluteBase, path)
+		}
+		path = filepath.Clean(path)
+		return resolvedImportPath{
+			path:         path,
+			source:       pathSourceDeliverfile,
+			label:        defaultDir,
+			directive:    directive,
+			value:        deliverfilePathValue,
+			conventional: overriddenConventionalDir(base, defaultDir, path),
+		}, nil
+	}
+	if strings.TrimSpace(fastlaneDir) != "" {
+		return resolvedImportPath{path: filepath.Join(fastlaneDir, defaultDir), source: pathSourceFlag, label: defaultDir}, nil
+	}
+	return resolvedImportPath{path: filepath.Join(base, defaultDir), source: pathSourceDefault, label: defaultDir}, nil
 }
 
 // resolvedImportPath records where an import directory came from so callers can

--- a/internal/cli/migrate/path_resolution_test.go
+++ b/internal/cli/migrate/path_resolution_test.go
@@ -417,6 +417,71 @@ func TestResolveImportInputs_AllowsMissingFastlaneScreenshotsWhenDeliverfileSkip
 	}
 }
 
+func TestResolveImportInputsPreservesInvalidDeliverfileScreenshotsPathWhenFlagSkips(t *testing.T) {
+	root := t.TempDir()
+	fastlaneDir := filepath.Join(root, "fastlane")
+	if err := os.MkdirAll(filepath.Join(fastlaneDir, "metadata"), 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(fastlaneDir, "Deliverfile"),
+		[]byte("screenshots_path \"../outside\"\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write Deliverfile: %v", err)
+	}
+
+	inputs, _, err := resolveImportInputs(importInputOptions{
+		WorkDir:         root,
+		FastlaneDir:     fastlaneDir,
+		SkipScreenshots: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error = %v, want skipped path preserved without validation", err)
+	}
+	want := filepath.Join(root, "outside")
+	if inputs.ScreenshotsDir != want {
+		t.Fatalf("ScreenshotsDir = %q, want skipped Deliverfile path %q", inputs.ScreenshotsDir, want)
+	}
+	if inputs.ScreenshotsSource != pathSourceDeliverfile {
+		t.Fatalf("ScreenshotsSource = %q, want %q", inputs.ScreenshotsSource, pathSourceDeliverfile)
+	}
+}
+
+func TestResolveImportInputsPreservesSymlinkedScreenshotsPathWhenDeliverfileSkips(t *testing.T) {
+	root := t.TempDir()
+	fastlaneDir := filepath.Join(root, "fastlane")
+	if err := os.MkdirAll(filepath.Join(fastlaneDir, "metadata"), 0o755); err != nil {
+		t.Fatalf("mkdir metadata: %v", err)
+	}
+	external := t.TempDir()
+	screenshotsPath := filepath.Join(fastlaneDir, "screenshots")
+	if err := os.Symlink(external, screenshotsPath); err != nil {
+		t.Fatalf("symlink screenshots: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(fastlaneDir, "Deliverfile"),
+		[]byte("skip_screenshots true\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write Deliverfile: %v", err)
+	}
+
+	inputs, _, err := resolveImportInputs(importInputOptions{
+		WorkDir:     root,
+		FastlaneDir: fastlaneDir,
+	})
+	if err != nil {
+		t.Fatalf("resolveImportInputs() error = %v, want skipped symlink path preserved without validation", err)
+	}
+	if inputs.ScreenshotsDir != screenshotsPath {
+		t.Fatalf("ScreenshotsDir = %q, want skipped symlink path %q", inputs.ScreenshotsDir, screenshotsPath)
+	}
+	if !inputs.DeliverfileConfig.SkipScreenshots {
+		t.Fatalf("DeliverfileConfig = %+v, want skip_screenshots", inputs.DeliverfileConfig)
+	}
+}
+
 func TestResolveImportInputsPreservesWhitespaceInFastlanePath(t *testing.T) {
 	base := t.TempDir()
 	fastlaneDir := filepath.Join(base, " fastlane ")


### PR DESCRIPTION
## Summary

- protect the upload-budget test fixture when `RoundTrip` calls overlap
- warn for each screenshot-created localization that has no matching result after a partial failure
- retain the selected screenshot path when `--skip-screenshots` or Deliverfile `skip_screenshots` bypasses path validation

Non-skipped screenshot paths keep the existing containment, existence, and symlink checks. Warning output remains sorted.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/cmdtest -run '^TestMigrateImportUploadPhaseKeepsFullUploadBudget$' -count=1`
- built `/tmp/asc-migrate-review-findings` and checked both skipped-path cases with offline `migrate import --dry-run` runs

No App Store Connect requests were made.

## Review follow-up

- https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347769
- https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347780
- https://github.com/rorkai/App-Store-Connect-CLI/pull/1965#discussion_r3753347794

Follow-up to #1965.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot localization migration warnings so every created localization without a corresponding upload result is reported, including cases where other screenshots succeeded.
  * Completed locales are no longer incorrectly included in these warnings.
  * Skipped screenshots now preserve configured paths without triggering unnecessary path or symlink validation.
  * Screenshot path selection continues to honor explicit, Deliverfile, Fastlane, and default path settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->