### PR TITLE
fix(signing): restore TTY-aware fetch output

### DIFF
--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -38,7 +38,7 @@ This command:
 * `--certificate-type` - Filter specific certificate type (usually auto-inferred)
 * `--device` - Device IDs for development profiles (comma-separated)
 * `--create-missing` - Create a new profile if none exists
-* `--format` - Output format for metadata: json, table, markdown (default: json)
+* `--format` - Output format for metadata: json, table, markdown. Defaults to table in terminals and minified JSON when piped or run in CI; an explicit value always wins.
 
 ## Profile Types
 

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -1269,8 +1269,8 @@ var (
 )
 
 // DefaultOutputFormat returns the default output format for CLI commands.
-// It checks ASC_DEFAULT_OUTPUT first. When unset, interactive terminals default
-// to table output and non-interactive contexts default to JSON.
+// It checks ASC_DEFAULT_OUTPUT first. When unset, local interactive terminals
+// default to table output while CI and non-interactive contexts default to JSON.
 // Valid ASC_DEFAULT_OUTPUT values are "json", "table", "markdown", and "md".
 func DefaultOutputFormat() string {
 	defaultOutputOnce.Do(func() {
@@ -1282,6 +1282,9 @@ func DefaultOutputFormat() string {
 func resolveDefaultOutput() string {
 	env := strings.TrimSpace(os.Getenv(defaultOutputEnvVar))
 	if env == "" {
+		if isCIEnvironment() {
+			return "json"
+		}
 		if isTerminal(int(os.Stdout.Fd())) {
 			return "table"
 		}
@@ -1295,6 +1298,27 @@ func resolveDefaultOutput() string {
 		fmt.Fprintf(os.Stderr, "Warning: invalid %s value %q (expected json, table, markdown, or md); using json\n", defaultOutputEnvVar, env)
 		return "json"
 	}
+}
+
+func isCIEnvironment() bool {
+	for _, key := range []string{
+		"CI",
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"CIRCLECI",
+		"BUILDKITE",
+		"BITRISE_IO",
+		"TF_BUILD",
+		"TRAVIS",
+		"APPVEYOR",
+	} {
+		switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+		case "1", "true", "yes", "y", "on":
+			return true
+		}
+	}
+	return strings.TrimSpace(os.Getenv("TEAMCITY_VERSION")) != "" ||
+		strings.TrimSpace(os.Getenv("JENKINS_URL")) != ""
 }
 
 // BindOutputFlagsWith registers a custom output-format flag and --pretty.

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -96,6 +96,25 @@ func setTerminalDetection(t *testing.T, detector func(fd int) bool) {
 	})
 }
 
+func clearCIEnvironment(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"CI",
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"CIRCLECI",
+		"BUILDKITE",
+		"BITRISE_IO",
+		"TF_BUILD",
+		"TRAVIS",
+		"APPVEYOR",
+		"TEAMCITY_VERSION",
+		"JENKINS_URL",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestDefaultOutputFormat_ReturnsJSON(t *testing.T) {
 	resetDefaultOutput(t)
 	setTerminalDetection(t, func(int) bool { return false })
@@ -118,11 +137,73 @@ func TestDefaultOutputFormat_UnsetReturnsJSON(t *testing.T) {
 func TestDefaultOutputFormat_UnsetReturnsTableWhenStdoutTTY(t *testing.T) {
 	resetDefaultOutput(t)
 	setTerminalDetection(t, func(int) bool { return true })
+	clearCIEnvironment(t)
 	t.Setenv("ASC_DEFAULT_OUTPUT", "")
 	os.Unsetenv("ASC_DEFAULT_OUTPUT")
 
 	if got := DefaultOutputFormat(); got != "table" {
 		t.Fatalf("expected table, got %q", got)
+	}
+}
+
+func TestDefaultOutputFormat_UnsetReturnsJSONWhenStdoutTTYInCI(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "generic", key: "CI", value: "true"},
+		{name: "GitHub Actions", key: "GITHUB_ACTIONS", value: "1"},
+		{name: "GitLab", key: "GITLAB_CI", value: "yes"},
+		{name: "CircleCI", key: "CIRCLECI", value: "on"},
+		{name: "Buildkite", key: "BUILDKITE", value: "y"},
+		{name: "Bitrise", key: "BITRISE_IO", value: "true"},
+		{name: "Azure Pipelines", key: "TF_BUILD", value: "true"},
+		{name: "Travis", key: "TRAVIS", value: "true"},
+		{name: "AppVeyor", key: "APPVEYOR", value: "true"},
+		{name: "TeamCity", key: "TEAMCITY_VERSION", value: "2026.1"},
+		{name: "Jenkins", key: "JENKINS_URL", value: "https://ci.example.test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDefaultOutput(t)
+			setTerminalDetection(t, func(int) bool { return true })
+			clearCIEnvironment(t)
+			t.Setenv("ASC_DEFAULT_OUTPUT", "")
+			os.Unsetenv("ASC_DEFAULT_OUTPUT")
+			t.Setenv(tt.key, tt.value)
+
+			if got := DefaultOutputFormat(); got != "json" {
+				t.Fatalf("DefaultOutputFormat() = %q, want json", got)
+			}
+		})
+	}
+}
+
+func TestDefaultOutputFormat_FalseCIMarkersKeepTTYTableDefault(t *testing.T) {
+	resetDefaultOutput(t)
+	setTerminalDetection(t, func(int) bool { return true })
+	clearCIEnvironment(t)
+	t.Setenv("ASC_DEFAULT_OUTPUT", "")
+	os.Unsetenv("ASC_DEFAULT_OUTPUT")
+	t.Setenv("CI", "false")
+	t.Setenv("GITHUB_ACTIONS", "0")
+
+	if got := DefaultOutputFormat(); got != "table" {
+		t.Fatalf("DefaultOutputFormat() = %q, want table", got)
+	}
+}
+
+func TestDefaultOutputFormat_ExplicitEnvOverridesCI(t *testing.T) {
+	resetDefaultOutput(t)
+	setTerminalDetection(t, func(int) bool { return true })
+	clearCIEnvironment(t)
+	t.Setenv("CI", "true")
+	t.Setenv("ASC_DEFAULT_OUTPUT", "table")
+
+	if got := DefaultOutputFormat(); got != "table" {
+		t.Fatalf("DefaultOutputFormat() = %q, want explicit table", got)
 	}
 }
 
@@ -310,6 +391,7 @@ func TestBindOutputFlagsUsesDefaultOutputFormat(t *testing.T) {
 func TestBindOutputFlagsUsesTTYAwareDefaultWhenEnvUnset(t *testing.T) {
 	resetDefaultOutput(t)
 	setTerminalDetection(t, func(int) bool { return true })
+	clearCIEnvironment(t)
 	t.Setenv("ASC_DEFAULT_OUTPUT", "")
 	os.Unsetenv("ASC_DEFAULT_OUTPUT")
 

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -33,7 +33,7 @@ func SigningFetchCommand() *ffcli.Command {
 	certType := fs.String("certificate-type", "", "Certificate type filter (optional)")
 	outputPath := fs.String("output", "./signing", "Output directory for signing files")
 	createMissing := fs.Bool("create-missing", false, "Create missing profiles")
-	output := shared.BindOutputFlagsWith(fs, "format", "json", "Output format for metadata: json (default), table, markdown")
+	output := shared.BindOutputFlagsWith(fs, "format", shared.DefaultOutputFormat(), "Output format for metadata: json, table, markdown")
 
 	return &ffcli.Command{
 		Name:       "fetch",

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -215,6 +215,40 @@ func TestSigningFetchHelpPairsDeviceWithCreateMissing(t *testing.T) {
 	}
 }
 
+func TestSigningFetchFormatUsesSharedOutputDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		defaultValue string
+	}{
+		{name: "resolved table default", defaultValue: "table"},
+		{name: "resolved JSON default", defaultValue: "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shared.ResetDefaultOutputFormat()
+			t.Cleanup(shared.ResetDefaultOutputFormat)
+			t.Setenv("ASC_DEFAULT_OUTPUT", tt.defaultValue)
+
+			cmd := SigningFetchCommand()
+			formatFlag := cmd.FlagSet.Lookup("format")
+			if formatFlag == nil {
+				t.Fatal("expected --format flag")
+			}
+			if got := formatFlag.Value.String(); got != tt.defaultValue {
+				t.Fatalf("default --format = %q, want %q", got, tt.defaultValue)
+			}
+
+			if err := cmd.FlagSet.Parse([]string{"--format", "markdown"}); err != nil {
+				t.Fatalf("parse explicit --format: %v", err)
+			}
+			if got := formatFlag.Value.String(); got != "markdown" {
+				t.Fatalf("explicit --format = %q, want markdown", got)
+			}
+		})
+	}
+}
+
 func TestSigningOutputPathsCoverProfileAndCertificateFiles(t *testing.T) {
 	dir := filepath.Join("tmp", "signing")
 	paths := signingOutputPaths(dir, "Created Profile", "profile-created", []asc.Resource[asc.CertificateAttributes]{


### PR DESCRIPTION
## Summary
- reuse the shared TTY-aware output resolver for `signing fetch --format`
- keep terminal output on table and piped or CI output on minified JSON
- preserve explicit `--format` overrides and document the behavior

Follow-up to [the CodeRabbit thread on #1973](https://github.com/rorkai/App-Store-Connect-CLI/pull/1973#discussion_r3759499298).

## Verification
- RED: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/signing -run ^TestSigningFetchFormatUsesSharedOutputDefault$ -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/signing -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 make build`
- built help under a PTY reports `--format ... (default: table)`
- built help with redirected stdout reports `--format ... (default: json)`

No Apple request or state mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The signing fetch command now automatically selects an appropriate output format for terminal, piped, and CI environments.
  * CI environments default to JSON output, while interactive terminals use table output where applicable.
  * Explicit `--format` values and configured output preferences continue to override automatic defaults.

* **Documentation**
  * Updated `--format` documentation to explain environment-specific defaults and override precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->