### PR TITLE
fix(web): clarify SMS fallback during login

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -70,8 +70,8 @@ Available commands:
 During an interactive trusted-device challenge, `asc` shows a phone-code
 fallback hint when Apple reports a registered phone number. Enter an incorrect
 trusted-device code once; Apple then delivers the phone verification code by
-its configured method (including SMS) and `asc` prompts again. Automated flows using
-`--two-factor-code-command` are unchanged.
+its configured method (including SMS) and `asc` prompts again. Automated flows
+rerun the configured `--two-factor-code-command` after phone fallback.
 
 ### `asc web api-keys`
 

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -67,6 +67,12 @@ Available commands:
 * `asc web auth capabilities` - inspect web-visible capability metadata
 * `asc web auth logout` - clear the cached web session
 
+During an interactive trusted-device challenge, `asc` shows an SMS fallback
+hint when Apple reports a registered phone number. Enter an incorrect
+trusted-device code once; Apple then sends an SMS and `asc` prompts again for
+the phone verification code. Automated flows using
+`--two-factor-code-command` are unchanged.
+
 ### `asc web api-keys`
 
 Team API key creation through an Apple Account web session.

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -67,10 +67,10 @@ Available commands:
 * `asc web auth capabilities` - inspect web-visible capability metadata
 * `asc web auth logout` - clear the cached web session
 
-During an interactive trusted-device challenge, `asc` shows an SMS fallback
-hint when Apple reports a registered phone number. Enter an incorrect
-trusted-device code once; Apple then sends an SMS and `asc` prompts again for
-the phone verification code. Automated flows using
+During an interactive trusted-device challenge, `asc` shows a phone-code
+fallback hint when Apple reports a registered phone number. Enter an incorrect
+trusted-device code once; Apple then delivers the phone verification code by
+its configured method (including SMS) and `asc` prompts again. Automated flows using
 `--two-factor-code-command` are unchanged.
 
 ### `asc web api-keys`

--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -207,8 +207,16 @@ func TestWebAuthLoginExposesDeprecatedTwoFactorAliasWithoutPlaintextPasswordFlag
 	if cmd.FlagSet.Lookup("two-factor-code-command") == nil {
 		t.Fatal("expected --two-factor-code-command flag on web auth login")
 	}
-	if !strings.Contains(cmd.LongHelp, "enter an incorrect trusted-device code once") {
-		t.Fatalf("expected SMS fallback guidance in web auth login help, got %q", cmd.LongHelp)
+	for _, phrase := range []string{
+		"Phone-code fallback (including SMS):",
+		"interactive: if Apple offers a registered phone fallback",
+		"enter an incorrect trusted-device code once",
+		"Apple then delivers a phone verification code and asc prompts again",
+		"automated: asc reruns the configured 2FA code command after phone fallback",
+	} {
+		if !strings.Contains(cmd.LongHelp, phrase) {
+			t.Fatalf("expected %q in web auth login help, got %q", phrase, cmd.LongHelp)
+		}
 	}
 }
 

--- a/internal/cli/cmdtest/web_commands_test.go
+++ b/internal/cli/cmdtest/web_commands_test.go
@@ -207,6 +207,9 @@ func TestWebAuthLoginExposesDeprecatedTwoFactorAliasWithoutPlaintextPasswordFlag
 	if cmd.FlagSet.Lookup("two-factor-code-command") == nil {
 		t.Fatal("expected --two-factor-code-command flag on web auth login")
 	}
+	if !strings.Contains(cmd.LongHelp, "enter an incorrect trusted-device code once") {
+		t.Fatalf("expected SMS fallback guidance in web auth login help, got %q", cmd.LongHelp)
+	}
 }
 
 func TestWebAppsCreateExposesDeprecatedTwoFactorAlias(t *testing.T) {

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -947,8 +947,9 @@ Two-factor input options:
   - --two-factor-code (deprecated compatibility alias when the code is already known)
 
 Phone-code fallback (including SMS):
-  - if Apple offers a registered phone fallback, enter an incorrect trusted-device code once
+  - interactive: if Apple offers a registered phone fallback, enter an incorrect trusted-device code once
   - Apple then delivers a phone verification code and asc prompts again
+  - automated: asc reruns the configured 2FA code command after phone fallback
 
 Provider selection:
   - --public-provider-id selects the public App Store Connect provider/team ID

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -505,6 +505,17 @@ func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, apple
 			}
 			_, _ = fmt.Fprintln(twoFactorStatusWriter, "Trusted-device verification was rejected. Enter the phone verification code that was just sent.")
 		}
+		writeInitialSMSFallbackGuidance := func() {
+			if challenge == nil || !challenge.PhoneFallbackAvailable || twoFactorStatusWriter == nil {
+				return
+			}
+			destination := strings.TrimSpace(challenge.Destination)
+			if destination != "" {
+				_, _ = fmt.Fprintf(twoFactorStatusWriter, "Need an SMS code? Enter an incorrect trusted-device code once; Apple will then send a verification code to %s.\n", destination)
+				return
+			}
+			_, _ = fmt.Fprintln(twoFactorStatusWriter, "Need an SMS code? Enter an incorrect trusted-device code once; Apple will then send a verification code to your registered phone number.")
+		}
 		readCode := func() (string, error) {
 			if command != "" {
 				return readTwoFactorCodeFromCommandFn(ctx, command)
@@ -512,6 +523,9 @@ func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, apple
 			return promptTwoFactorCodeFn()
 		}
 		if code == "" {
+			if command == "" {
+				writeInitialSMSFallbackGuidance()
+			}
 			if challenge != nil && challenge.IsPhoneMethod() {
 				challenge, prepErr = ensureTwoFactorCodeRequestedFn(ctx, session)
 				if prepErr != nil {
@@ -931,6 +945,10 @@ Two-factor input options:
   - --two-factor-code-command
   - %s environment variable (recommended for automation)
   - --two-factor-code (deprecated compatibility alias when the code is already known)
+
+SMS fallback:
+  - if Apple offers a registered phone fallback, enter an incorrect trusted-device code once
+  - Apple then sends an SMS and asc prompts again for the phone verification code
 
 Provider selection:
   - --public-provider-id selects the public App Store Connect provider/team ID

--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -505,16 +505,16 @@ func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, apple
 			}
 			_, _ = fmt.Fprintln(twoFactorStatusWriter, "Trusted-device verification was rejected. Enter the phone verification code that was just sent.")
 		}
-		writeInitialSMSFallbackGuidance := func() {
+		writeInitialPhoneFallbackGuidance := func() {
 			if challenge == nil || !challenge.PhoneFallbackAvailable || twoFactorStatusWriter == nil {
 				return
 			}
 			destination := strings.TrimSpace(challenge.Destination)
 			if destination != "" {
-				_, _ = fmt.Fprintf(twoFactorStatusWriter, "Need an SMS code? Enter an incorrect trusted-device code once; Apple will then send a verification code to %s.\n", destination)
+				_, _ = fmt.Fprintf(twoFactorStatusWriter, "Need a phone verification code? Enter an incorrect trusted-device code once; Apple will then deliver a verification code to %s.\n", destination)
 				return
 			}
-			_, _ = fmt.Fprintln(twoFactorStatusWriter, "Need an SMS code? Enter an incorrect trusted-device code once; Apple will then send a verification code to your registered phone number.")
+			_, _ = fmt.Fprintln(twoFactorStatusWriter, "Need a phone verification code? Enter an incorrect trusted-device code once; Apple will then deliver a verification code to your registered phone number.")
 		}
 		readCode := func() (string, error) {
 			if command != "" {
@@ -524,7 +524,7 @@ func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, apple
 		}
 		if code == "" {
 			if command == "" {
-				writeInitialSMSFallbackGuidance()
+				writeInitialPhoneFallbackGuidance()
 			}
 			if challenge != nil && challenge.IsPhoneMethod() {
 				challenge, prepErr = ensureTwoFactorCodeRequestedFn(ctx, session)
@@ -946,9 +946,9 @@ Two-factor input options:
   - %s environment variable (recommended for automation)
   - --two-factor-code (deprecated compatibility alias when the code is already known)
 
-SMS fallback:
+Phone-code fallback (including SMS):
   - if Apple offers a registered phone fallback, enter an incorrect trusted-device code once
-  - Apple then sends an SMS and asc prompts again for the phone verification code
+  - Apple then delivers a phone verification code and asc prompts again
 
 Provider selection:
   - --public-provider-id selects the public App Store Connect provider/team ID

--- a/internal/cli/web/web_auth_test.go
+++ b/internal/cli/web/web_auth_test.go
@@ -1038,6 +1038,9 @@ func TestLoginWithOptionalTwoFactorRepromptsAfterFallbackPhoneRequest(t *testing
 		return nil, nil
 	}
 	promptTwoFactorCodeFn = func() (string, error) {
+		if promptCalls == 0 && !strings.Contains(statusOutput.String(), "Need a phone verification code?") {
+			t.Fatalf("expected phone fallback guidance before the first prompt, got %q", statusOutput.String())
+		}
 		promptCalls++
 		switch promptCalls {
 		case 1:

--- a/internal/cli/web/web_auth_test.go
+++ b/internal/cli/web/web_auth_test.go
@@ -1027,7 +1027,11 @@ func TestLoginWithOptionalTwoFactorRepromptsAfterFallbackPhoneRequest(t *testing
 		return &webcore.AuthSession{}, &webcore.TwoFactorRequiredError{}
 	}
 	prepareTwoFactorChallengeFn = func(ctx context.Context, session *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
-		return &webcore.TwoFactorChallenge{Method: "trusted-device"}, nil
+		return &webcore.TwoFactorChallenge{
+			Method:                 "trusted-device",
+			Destination:            "+1 (•••) •••-••66",
+			PhoneFallbackAvailable: true,
+		}, nil
 	}
 	ensureTwoFactorCodeRequestedFn = func(ctx context.Context, session *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
 		t.Fatal("did not expect upfront phone-code request for trusted-device challenge")
@@ -1070,10 +1074,19 @@ func TestLoginWithOptionalTwoFactorRepromptsAfterFallbackPhoneRequest(t *testing
 	if got, want := submitted, []string{"111111", "222222"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected submitted codes %v, got %v", want, got)
 	}
-	if output := statusOutput.String(); !strings.Contains(output, "Verification code sent to +1 (•••) •••-••66.") {
+	output := statusOutput.String()
+	guidanceIndex := strings.Index(output, "Need an SMS code? Enter an incorrect trusted-device code once; Apple will then send a verification code to +1 (•••) •••-••66.")
+	if guidanceIndex < 0 {
+		t.Fatalf("expected initial SMS fallback guidance, got %q", output)
+	}
+	deliveryIndex := strings.Index(output, "Verification code sent to +1 (•••) •••-••66.")
+	if deliveryIndex < 0 {
 		t.Fatalf("expected fallback delivery notice, got %q", output)
 	}
-	if output := statusOutput.String(); !strings.Contains(output, "Trusted-device verification was rejected. Enter the phone verification code that was just sent.") {
+	if guidanceIndex > deliveryIndex {
+		t.Fatalf("expected SMS fallback guidance before delivery notice, got %q", output)
+	}
+	if !strings.Contains(output, "Trusted-device verification was rejected. Enter the phone verification code that was just sent.") {
 		t.Fatalf("expected fallback phone prompt guidance, got %q", output)
 	}
 }
@@ -1104,7 +1117,11 @@ func TestLoginWithOptionalTwoFactorRerunsCommandAfterFallbackPhoneRequest(t *tes
 		return &webcore.AuthSession{}, &webcore.TwoFactorRequiredError{}
 	}
 	prepareTwoFactorChallengeFn = func(ctx context.Context, session *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
-		return &webcore.TwoFactorChallenge{Method: "trusted-device"}, nil
+		return &webcore.TwoFactorChallenge{
+			Method:                 "trusted-device",
+			Destination:            "+1 (•••) •••-••66",
+			PhoneFallbackAvailable: true,
+		}, nil
 	}
 	ensureTwoFactorCodeRequestedFn = func(ctx context.Context, session *webcore.AuthSession) (*webcore.TwoFactorChallenge, error) {
 		t.Fatal("did not expect upfront phone-code request for trusted-device challenge")
@@ -1155,6 +1172,9 @@ func TestLoginWithOptionalTwoFactorRerunsCommandAfterFallbackPhoneRequest(t *tes
 	}
 	if output := statusOutput.String(); !strings.Contains(output, "Trusted-device verification was rejected. Re-running the configured 2FA code command for the phone verification code.") {
 		t.Fatalf("expected fallback command guidance, got %q", output)
+	}
+	if output := statusOutput.String(); strings.Contains(output, "Need an SMS code?") {
+		t.Fatalf("did not expect interactive SMS guidance for configured command, got %q", output)
 	}
 }
 

--- a/internal/cli/web/web_auth_test.go
+++ b/internal/cli/web/web_auth_test.go
@@ -1075,16 +1075,19 @@ func TestLoginWithOptionalTwoFactorRepromptsAfterFallbackPhoneRequest(t *testing
 		t.Fatalf("expected submitted codes %v, got %v", want, got)
 	}
 	output := statusOutput.String()
-	guidanceIndex := strings.Index(output, "Need an SMS code? Enter an incorrect trusted-device code once; Apple will then send a verification code to +1 (•••) •••-••66.")
+	guidanceIndex := strings.Index(output, "Need a phone verification code? Enter an incorrect trusted-device code once; Apple will then deliver a verification code to +1 (•••) •••-••66.")
 	if guidanceIndex < 0 {
-		t.Fatalf("expected initial SMS fallback guidance, got %q", output)
+		t.Fatalf("expected initial phone fallback guidance, got %q", output)
+	}
+	if strings.Contains(output, "SMS") {
+		t.Fatalf("expected delivery-neutral guidance for voice-capable phone fallbacks, got %q", output)
 	}
 	deliveryIndex := strings.Index(output, "Verification code sent to +1 (•••) •••-••66.")
 	if deliveryIndex < 0 {
 		t.Fatalf("expected fallback delivery notice, got %q", output)
 	}
 	if guidanceIndex > deliveryIndex {
-		t.Fatalf("expected SMS fallback guidance before delivery notice, got %q", output)
+		t.Fatalf("expected phone fallback guidance before delivery notice, got %q", output)
 	}
 	if !strings.Contains(output, "Trusted-device verification was rejected. Enter the phone verification code that was just sent.") {
 		t.Fatalf("expected fallback phone prompt guidance, got %q", output)
@@ -1173,8 +1176,8 @@ func TestLoginWithOptionalTwoFactorRerunsCommandAfterFallbackPhoneRequest(t *tes
 	if output := statusOutput.String(); !strings.Contains(output, "Trusted-device verification was rejected. Re-running the configured 2FA code command for the phone verification code.") {
 		t.Fatalf("expected fallback command guidance, got %q", output)
 	}
-	if output := statusOutput.String(); strings.Contains(output, "Need an SMS code?") {
-		t.Fatalf("did not expect interactive SMS guidance for configured command, got %q", output)
+	if output := statusOutput.String(); strings.Contains(output, "Need a phone verification code?") {
+		t.Fatalf("did not expect interactive phone fallback guidance for configured command, got %q", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- show an interactive stderr hint before the trusted-device prompt when Apple reports a registered phone fallback
- explain the existing incorrect-code → SMS → phone-code prompt sequence in `asc web auth login --help` and the web command guide
- keep configured `--two-factor-code-command` automation, flags, stdout, and exit behavior unchanged

Fixes #1976

## Verification

- RED: focused runtime and help-contract tests failed before implementation
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/web -run 'TestLoginWithOptionalTwoFactor(RepromptsAfterFallbackPhoneRequest|RerunsCommandAfterFallbackPhoneRequest)$' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestWebAuthLoginExposesDeprecatedTwoFactorAliasWithoutPlaintextPasswordFlag$' -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/web ./internal/web ./internal/appleauth ./internal/cli/cmdtest -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built `/tmp/asc` and verified `ASC_BYPASS_KEYCHAIN=1 /tmp/asc web auth login --help`

No Apple state was mutated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for interactive two-factor authentication when a trusted-device challenge supports SMS fallback.
  * When Apple reports a registered phone number, the CLI displays the destination and explains that entering an incorrect trusted-device code triggers SMS verification.
  * Automated authentication flows rerun the configured two-factor code command after SMS fallback.

* **Documentation**
  * Updated web authentication help and documentation to describe the trusted-device and SMS fallback process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->