### PR TITLE
apps wall: add Pebbles: Tax & Visa Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1036,6 +1036,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/22/a4/41/22a441e6-20c5-a464-2b0f-3db405633856/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Pebbles: Tax & Visa Tracker",
+    "link": "https://apps.apple.com/us/app/pebbles-tax-visa-tracker/id6472096747?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/94/7b/d0/947bd072-9006-bf4f-8aa5-9af8f7ec9b37/AppIcon-0-1x_U007epad-0-1-0-sRGB-85-220-0.png/512x512bb.jpg"
+  },
+  {
     "app": "Peptide Protocol: Dose Tracker",
     "link": "https://apps.apple.com/us/app/peptide-protocol-dose-tracker/id6762055081?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ff/c5/73/ffc57381-77f1-ded8-db61-f9272cf32cc5/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Pebbles: Tax & Visa Tracker` to the Wall of Apps

## Entry

- App ID: 6472096747
- App: Pebbles: Tax & Visa Tracker
- Link: https://apps.apple.com/us/app/pebbles-tax-visa-tracker/id6472096747?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pebbles: Tax & Visa Tracker to the application directory.
  * Included links to its App Store listing and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->