### PR TITLE
apps wall: add SAO: Luxury Hotel Journal

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1316,6 +1316,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/09/1e/b6/091eb6fc-de14-9b7c-e7f6-b1e59b8be9ac/AppIcon-0-0-1x_U007emarketing-0-8-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "SAO: Luxury Hotel Journal",
+    "link": "https://apps.apple.com/us/app/sao-luxury-hotel-journal/id6757209978?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c5/60/ff/c560ffff-1d5c-15c9-ae25-ce1f62a7396d/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Scap: Screenshot & Markup Edit",
     "link": "https://apps.apple.com/us/app/scap-screenshot-markup-edit/id6758053530?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/95/ed/7c/95ed7cad-90a7-5d3b-8742-444542d3dc55/AppIcon-0-0-85-220-0-0-5-0-2x-0-0-0.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `SAO: Luxury Hotel Journal` to the Wall of Apps

## Entry

- App ID: 6757209978
- App: SAO: Luxury Hotel Journal
- Link: https://apps.apple.com/us/app/sao-luxury-hotel-journal/id6757209978?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “SAO: Luxury Hotel Journal” to the app listing, including its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->