### PR TITLE
fix: clarify screenshot upload selector requirements

### DIFF
--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -550,7 +550,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 
 	if locID == "" {
 		if !appModeRequested {
-			fmt.Fprintln(os.Stderr, "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH")
+			fmt.Fprintln(os.Stderr, "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; (--app APP_ID or ASC_APP_ID) with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH")
 			return nil, shared.MissingRequiredUsageError()
 		}
 	} else if appModeRequested {

--- a/internal/cli/assets/assets_screenshots.go
+++ b/internal/cli/assets/assets_screenshots.go
@@ -550,7 +550,7 @@ func executeScreenshotUploadCommand(ctx context.Context, opts screenshotUploadCo
 
 	if locID == "" {
 		if !appModeRequested {
-			fmt.Fprintln(os.Stderr, "Error: --version-localization is required")
+			fmt.Fprintln(os.Stderr, "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH")
 			return nil, shared.MissingRequiredUsageError()
 		}
 	} else if appModeRequested {

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -337,7 +337,7 @@ func TestAssetsScreenshotsUploadCommandRequiresUploadMode(t *testing.T) {
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
 	}
-	const want = "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH\n"
+	const want = "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; (--app APP_ID or ASC_APP_ID) with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH\n"
 	if stderr != want {
 		t.Fatalf("stderr = %q, want %q", stderr, want)
 	}

--- a/internal/cli/assets/assets_screenshots_test.go
+++ b/internal/cli/assets/assets_screenshots_test.go
@@ -319,6 +319,30 @@ func TestAssetsScreenshotsUploadCommandRejectsSkipExistingWithReplace(t *testing
 	}
 }
 
+func TestAssetsScreenshotsUploadCommandRequiresUploadMode(t *testing.T) {
+	cmd := AssetsScreenshotsUploadCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse(nil); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), cmd.FlagSet.Args())
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+	}
+	const want = "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+}
+
 func TestAssetsScreenshotsUploadCommandRejectsMaxScreenshotsWithResume(t *testing.T) {
 	cmd := AssetsScreenshotsUploadCommand()
 	cmd.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3529,7 +3529,7 @@ func TestScreenshotsAndVideoPreviewsValidationErrors(t *testing.T) {
 		{
 			name:    "screenshots upload missing mode",
 			args:    []string{"screenshots", "upload", "--path", "./screenshots", "--device-type", "IPHONE_65"},
-			wantErr: "choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH",
+			wantErr: "choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; (--app APP_ID or ASC_APP_ID) with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH",
 		},
 		{
 			name:    "screenshots validate missing path",

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3527,9 +3527,9 @@ func TestScreenshotsAndVideoPreviewsValidationErrors(t *testing.T) {
 			wantErr: "--version-localization is required",
 		},
 		{
-			name:    "screenshots upload missing localization",
+			name:    "screenshots upload missing mode",
 			args:    []string{"screenshots", "upload", "--path", "./screenshots", "--device-type", "IPHONE_65"},
-			wantErr: "--version-localization is required",
+			wantErr: "choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH",
 		},
 		{
 			name:    "screenshots validate missing path",

--- a/internal/cli/cmdtest/screenshots_upload_fanout_test.go
+++ b/internal/cli/cmdtest/screenshots_upload_fanout_test.go
@@ -68,7 +68,7 @@ func TestScreenshotsUploadIgnoresASCAppIDUntilAppScopedModeIsRequested(t *testin
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
 	}
-	if !strings.Contains(stderr, "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH") {
+	if !strings.Contains(stderr, "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; (--app APP_ID or ASC_APP_ID) with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH") {
 		t.Fatalf("expected upload mode selector error, got %q", stderr)
 	}
 }

--- a/internal/cli/cmdtest/screenshots_upload_fanout_test.go
+++ b/internal/cli/cmdtest/screenshots_upload_fanout_test.go
@@ -68,8 +68,8 @@ func TestScreenshotsUploadIgnoresASCAppIDUntilAppScopedModeIsRequested(t *testin
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp, got %v", runErr)
 	}
-	if !strings.Contains(stderr, "Error: --version-localization is required") {
-		t.Fatalf("expected direct-mode selector error, got %q", stderr)
+	if !strings.Contains(stderr, "Error: choose an upload mode: --version-localization VERSION_LOCALIZATION_ID; --app APP_ID with --version VERSION or --version-id VERSION_ID; or --resume ARTIFACT_PATH") {
+		t.Fatalf("expected upload mode selector error, got %q", stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- explain every supported upload mode when no target selector is provided
- preserve usage exit code 2 and stderr-only diagnostics
- cover the behavior at command and built-command boundaries

## Verification

- make format
- make check-docs
- make lint
- DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 make test
- built asc screenshots upload: exit 2, empty stdout, complete selector guidance on stderr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the screenshot upload command’s error message when no upload mode is selected.
  * Guidance now lists all supported modes: localization upload, app/version upload, and resume artifacts.
  * The command clearly indicates that users must select one of these upload modes before continuing.
* **Tests**
  * Added coverage confirming the command fails cleanly, produces no standard output, and provides the correct usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->