### PR TITLE
fix: retain key type failure parameter

### DIFF
--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -296,6 +296,41 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	}
 }
 
+func TestRun_AuthLoginInvalidKeyTypeEmitsFailureParameter(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		gotContext = eventContext
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"auth", "login",
+			"--name", "Test Key",
+			"--key-id", "KEY123",
+			"--key-type", "personal",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--key-type must be one of: team, individual") {
+		t.Fatalf("expected invalid key type error, got %q", stderr)
+	}
+	if gotContext.ErrorKind != telemetry.ErrorKindInvalidValue ||
+		gotContext.FailureStage != telemetry.FailureStageValidation ||
+		gotContext.OutcomeKind != telemetry.OutcomeUsageError ||
+		gotContext.FailureParameter != "--key-type" {
+		t.Fatalf("unexpected invalid-value context: %+v", gotContext)
+	}
+}
+
 func TestRun_AuthStatusValidationFailuresEmitExpectedNegative(t *testing.T) {
 	resetReportFlags(t)
 	tempDir := t.TempDir()

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -298,6 +298,20 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 
 func TestRun_AuthLoginInvalidKeyTypeEmitsFailureParameter(t *testing.T) {
 	resetReportFlags(t)
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(tempDir, "missing.json"))
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_KEY_TYPE", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_STRICT_AUTH", "")
+	resetSelectedProfile(t)
+
 	originalEmitTelemetry := emitTelemetry
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -347,6 +347,7 @@ var knownFailureParameters = map[string]struct{}{
 	"ipa":             {},
 	"issuer-id":       {},
 	"key-id":          {},
+	"key-type":        {},
 	"limit":           {},
 	"locale":          {},
 	"localization-id": {},

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -211,7 +211,7 @@ func TestBuildEventWithContextAllowsKnownFailureParameters(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
 
-	for _, parameter := range []string{"--id", "--app", "--app-id"} {
+	for _, parameter := range []string{"--id", "--app", "--app-id", "--key-type"} {
 		t.Run(parameter, func(t *testing.T) {
 			ev, ok := BuildEventWithContext(
 				"asc apps view",
@@ -232,6 +232,37 @@ func TestBuildEventWithContextAllowsKnownFailureParameters(t *testing.T) {
 				t.Fatalf("FailureParameter = %v, want %q", ev.FailureParameter, parameter)
 			}
 		})
+	}
+}
+
+func TestBuildEventWithContextStripsKnownFailureParameterValue(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc auth login",
+		"1.2.3",
+		0,
+		2,
+		EventContext{
+			InvocationShape:  InvocationShapeLeaf,
+			ErrorKind:        ErrorKindInvalidValue,
+			FailureStage:     FailureStageValidation,
+			FailureParameter: "--key-type=individual",
+		},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.FailureParameter == nil || *ev.FailureParameter != "--key-type" {
+		t.Fatalf("FailureParameter = %v, want --key-type", ev.FailureParameter)
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	if strings.Contains(string(data), "individual") {
+		t.Fatalf("payload leaked failure parameter value: %s", data)
 	}
 }
 
@@ -346,7 +377,7 @@ func TestBuildEventWithContextRejectsUnknownFailureParameterNames(t *testing.T) 
 			InvocationShape:  InvocationShapeLeaf,
 			ErrorKind:        ErrorKindUnknownFlag,
 			FailureStage:     FailureStageParse,
-			FailureParameter: "--my-secret-project",
+			FailureParameter: "--my-secret-project=SECRET",
 		},
 	)
 	if !ok {


### PR DESCRIPTION
## Summary

- retain the public `--key-type` flag name when classifying failed commands
- strip attached values before event serialization
- keep unknown flag-shaped values outside the bounded failure-parameter set

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/telemetry ./cmd -count=1`
- `make build` and manual invalid-value invocation: exit 2, empty stdout, existing diagnostic on stderr
- `make format`
- `make check-docs`
- `make lint`
- commit hook short suite with full Xcode selected
- full `go test ./...` initially hit the machine-wide Command Line Tools selection in one Xcode export test; the exact test passed with `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation feedback when an invalid personal key type is provided during login.
  * Ensured invalid key-type values are omitted from telemetry payloads to protect sensitive input.
  * Added regression coverage for login failures and telemetry sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->