### PR TITLE
fix(review): classify missing versions as not found

### DIFF
--- a/cmd/review_submit_outcome_test.go
+++ b/cmd/review_submit_outcome_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+)
+
+func TestRunReviewSubmitMissingVersionIsNotFound(t *testing.T) {
+	resetReportFlags(t)
+	t.Setenv("ASC_APP_ID", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/appStoreVersions" {
+			t.Fatalf("request = %s %s, want GET /v1/apps/app-1/appStoreVersions", req.Method, req.URL.Path)
+		}
+		if got := req.URL.Query().Get("filter[versionString]"); got != "9.9.9" {
+			t.Fatalf("filter[versionString] = %q, want 9.9.9", got)
+		}
+		if got := req.URL.Query().Get("filter[platform]"); got != "IOS" {
+			t.Fatalf("filter[platform] = %q, want IOS", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[]}`)
+	}))
+	defer server.Close()
+
+	client := newHTTPStatusTestClient(t, server.URL)
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
+
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+	var gotExitCode int
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+		gotExitCode = exitCode
+		gotContext = eventContext
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"review", "submit",
+			"--app", "app-1",
+			"--version", "9.9.9",
+			"--build", "build-1",
+			"--dry-run",
+		}, "4.0.0"); code != ExitNotFound {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitNotFound)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, `app store version not found for version "9.9.9" and platform "IOS"`) {
+		t.Fatalf("stderr = %q, want missing-version diagnostic", stderr)
+	}
+	if gotExitCode != ExitNotFound || gotContext.OutcomeKind != telemetry.OutcomeNotFound {
+		t.Fatalf("unexpected telemetry: exit=%d context=%+v", gotExitCode, gotContext)
+	}
+}

--- a/internal/cli/shared/app_resolution.go
+++ b/internal/cli/shared/app_resolution.go
@@ -21,7 +21,10 @@ func ResolveAppStoreVersionIDAndState(ctx context.Context, client *asc.Client, a
 		return "", "", err
 	}
 	if resp == nil || len(resp.Data) == 0 {
-		return "", "", fmt.Errorf("app store version not found for version %q and platform %q", version, platform)
+		return "", "", NewErrorWithCause(
+			fmt.Errorf("app store version not found for version %q and platform %q", version, platform),
+			asc.ErrNotFound,
+		)
 	}
 	if len(resp.Data) > 1 {
 		return "", "", fmt.Errorf("multiple app store versions found for version %q and platform %q (use --version-id)", version, platform)

--- a/internal/cli/shared/app_resolution_test.go
+++ b/internal/cli/shared/app_resolution_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -118,6 +119,17 @@ func TestResolveAppStoreVersionIDAndState_FallsBackToTrimmedAppStoreState(t *tes
 	}
 	if versionState != "READY_FOR_SALE" {
 		t.Fatalf("expected fallback state READY_FOR_SALE, got %q", versionState)
+	}
+}
+
+func TestResolveAppStoreVersionIDAndState_EmptyCollectionIsNotFound(t *testing.T) {
+	client := newAppResolutionTestClient(t, func(req *http.Request) (*http.Response, error) {
+		return appResolutionJSONResponse(`{"data":[]}`)
+	})
+
+	_, _, err := ResolveAppStoreVersionIDAndState(context.Background(), client, "app-1", "9.9.9", "IOS")
+	if !errors.Is(err, asc.ErrNotFound) {
+		t.Fatalf("ResolveAppStoreVersionIDAndState() error = %v, want asc.ErrNotFound", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve the existing missing-version diagnostic while attaching the canonical not-found cause
- return exit code 4 when `review submit --version` cannot resolve an App Store version
- cover the resolver contract and the top-level command outcome

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 go test -short ./...`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built `/tmp/asc-review-submit-outcome` and ran a read-only missing-version lookup against app `6759231657`; it returned exit 4 with empty stdout and the unchanged diagnostic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when a requested App Store version cannot be found.
  - Review submission now reports a clear missing-version diagnostic instead of an ambiguous error.
  - Commands correctly return a not-found status and avoid producing misleading standard output.
  - Improved telemetry classification for missing App Store versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->