### PR TITLE
fix: preserve metadata apply failure classification

### DIFF
--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -14,6 +14,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -440,6 +441,130 @@ func TestRun_MetadataValidateFindingsEmitExpectedNegative(t *testing.T) {
 		gotContext.OutcomeKind != telemetry.OutcomeExpectedNegative {
 		t.Fatalf("unexpected telemetry: exit=%d context=%+v", gotExitCode, gotContext)
 	}
+}
+
+func TestRun_MetadataApplyMixedFailuresUseFirstCauseConsistently(t *testing.T) {
+	resetReportFlags(t)
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	keyPath := filepath.Join(tempDir, "AuthKey.p8")
+	writeRunTestECDSAPEM(t, keyPath)
+	metadataDir := filepath.Join(tempDir, "metadata")
+	versionDir := filepath.Join(metadataDir, "version", "1.2.3")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll() error: %v", err)
+	}
+	for locale, description := range map[string]string{
+		"fr-FR": "French update",
+		"ja":    "Japanese update",
+	} {
+		path := filepath.Join(versionDir, locale+".json")
+		if err := os.WriteFile(path, []byte(fmt.Sprintf(`{"description":%q}`, description)), 0o600); err != nil {
+			t.Fatalf("os.WriteFile(%q) error: %v", locale, err)
+		}
+	}
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(tempDir, "missing.json"))
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "ENVKEY")
+	t.Setenv("ASC_ISSUER_ID", "ENVISS")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_MAX_RETRIES", "0")
+	resetSelectedProfile(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = metadataApplyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		responses := map[string]struct {
+			status int
+			body   string
+		}{
+			"/v1/apps/app-1/appInfos": {
+				status: http.StatusOK,
+				body:   `{"data":[{"type":"appInfos","id":"appinfo-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`,
+			},
+			"/v1/apps/app-1/appStoreVersions": {
+				status: http.StatusOK,
+				body:   `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}],"links":{"next":""}}`,
+			},
+			"/v1/appInfos/appinfo-1/appInfoLocalizations": {
+				status: http.StatusOK,
+				body:   `{"data":[],"links":{"next":""}}`,
+			},
+			"/v1/appStoreVersions/version-1/appStoreVersionLocalizations": {
+				status: http.StatusOK,
+				body:   `{"data":[{"type":"appStoreVersionLocalizations","id":"loc-fr","attributes":{"locale":"fr-FR","description":"Old French"}},{"type":"appStoreVersionLocalizations","id":"loc-ja","attributes":{"locale":"ja","description":"Old Japanese"}}],"links":{"next":""}}`,
+			},
+			"/v1/appStoreVersionLocalizations/loc-fr": {
+				status: http.StatusInternalServerError,
+				body:   `{"errors":[{"status":"500","code":"INTERNAL_ERROR","detail":"first failure"}]}`,
+			},
+			"/v1/appStoreVersionLocalizations/loc-ja": {
+				status: http.StatusNotFound,
+				body:   `{"errors":[{"status":"404","code":"NOT_FOUND","detail":"later failure"}]}`,
+			},
+		}
+		response, ok := responses[req.URL.Path]
+		if !ok {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: response.status,
+			Body:       io.NopCloser(strings.NewReader(response.body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+	var gotExitCode int
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+		gotExitCode = exitCode
+		gotContext = eventContext
+	}
+
+	var exitCode int
+	stdout, stderr := captureCommandOutput(t, func() {
+		exitCode = Run([]string{
+			"metadata", "apply",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--dir", metadataDir,
+			"--output", "json",
+		}, "1.0.0")
+	})
+	if exitCode != ExitHTTPInternalServer {
+		t.Fatalf("Run() exit code = %d, want %d; stdout=%s", exitCode, ExitHTTPInternalServer, stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result struct {
+		Failed  int `json:"failed"`
+		Actions []struct {
+			Status string `json:"status"`
+		} `json:"actions"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+	if result.Failed != 2 || len(result.Actions) != 2 || result.Actions[0].Status != "failed" || result.Actions[1].Status != "failed" {
+		t.Fatalf("unexpected partial result: %+v", result)
+	}
+	if gotExitCode != ExitHTTPInternalServer || gotContext.HTTPStatus != http.StatusInternalServerError ||
+		gotContext.OutcomeKind != telemetry.OutcomeAPIServerError {
+		t.Fatalf("inconsistent event classification: exit=%d context=%+v", gotExitCode, gotContext)
+	}
+}
+
+type metadataApplyRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn metadataApplyRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func TestRun_MissingRequiredFlagsEmitContext(t *testing.T) {

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -736,6 +736,9 @@ func TestMetadataApplyFailsOnPartialMutation(t *testing.T) {
 	if _, ok := errors.AsType[ReportedError](runErr); !ok {
 		t.Fatalf("expected reported partial failure, got %T: %v", runErr, runErr)
 	}
+	if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitHTTPInternalServer {
+		t.Fatalf("expected partial server failure exit %d, got %d", rootcmd.ExitHTTPInternalServer, got)
+	}
 	if patchCount != 3 {
 		t.Fatalf("expected all three patch attempts despite the middle failure, got %d", patchCount)
 	}
@@ -1644,10 +1647,10 @@ func (r *cancelOnEOFReadCloser) Close() error {
 	return nil
 }
 
-func TestMetadataApplyPartialBatchExitCode(t *testing.T) {
+func TestMetadataApplyPartialBatchPreservesTypedExitCode(t *testing.T) {
 	run := runFailedMetadataApply(t, "json", true, false)
-	if run.code != rootcmd.ExitError {
-		t.Fatalf("expected partial exit %d, got %d; stderr=%q", rootcmd.ExitError, run.code, run.stderr)
+	if run.code != rootcmd.ExitHTTPUnprocessable {
+		t.Fatalf("expected partial exit %d, got %d; stderr=%q", rootcmd.ExitHTTPUnprocessable, run.code, run.stderr)
 	}
 	if run.stderr != "" {
 		t.Fatalf("expected reported error to avoid duplicate stderr, got %q", run.stderr)

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -240,11 +240,37 @@ Notes:
 }
 
 func representativeMetadataMutationError(err error) error {
+	// Keep batch classification tied to the first failed action. Reconciliation
+	// may join its mutation and readback errors, so prefer a status-bearing cause
+	// within that action before falling back to its first leaf.
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		err = nil
+		for _, child := range joined.Unwrap() {
+			if child != nil {
+				err = child
+				break
+			}
+		}
+	}
+	if err == nil {
+		return nil
+	}
+
+	var statusErr interface {
+		error
+		HTTPStatusCode() int
+	}
+	if errors.As(err, &statusErr) {
+		status := statusErr.HTTPStatusCode()
+		if status >= 400 && status <= 599 {
+			return statusErr
+		}
+	}
+
 	for err != nil {
 		if joined, ok := err.(interface{ Unwrap() []error }); ok {
-			children := joined.Unwrap()
 			err = nil
-			for _, child := range children {
+			for _, child := range joined.Unwrap() {
 				if child != nil {
 					err = child
 					break

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -230,13 +230,35 @@ Notes:
 				}
 				reportedErr := errors.New(message)
 				if err != nil {
-					reportedErr = shared.NewErrorWithCause(reportedErr, err)
+					reportedErr = shared.NewErrorWithCause(reportedErr, representativeMetadataMutationError(err))
 				}
 				return shared.NewReportedError(reportedErr)
 			}
 			return nil
 		},
 	}
+}
+
+func representativeMetadataMutationError(err error) error {
+	for err != nil {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			children := joined.Unwrap()
+			err = nil
+			for _, child := range children {
+				if child != nil {
+					err = child
+					break
+				}
+			}
+			continue
+		}
+		wrapped, ok := err.(interface{ Unwrap() error })
+		if !ok || wrapped.Unwrap() == nil {
+			return err
+		}
+		err = wrapped.Unwrap()
+	}
+	return nil
 }
 
 // MetadataPushCommand returns the metadata push subcommand.

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -240,51 +240,91 @@ Notes:
 }
 
 func representativeMetadataMutationError(err error) error {
-	// Keep batch classification tied to the first failed action. Reconciliation
-	// may join its mutation and readback errors, so prefer a status-bearing cause
-	// within that action before falling back to its first leaf.
-	if joined, ok := err.(interface{ Unwrap() []error }); ok {
-		err = nil
-		for _, child := range joined.Unwrap() {
-			if child != nil {
-				err = child
-				break
-			}
-		}
+	// Aggregation and reconciliation both use joined errors. The action marker
+	// identifies the first failed action without relying on the surrounding
+	// wrapper shape, then classification stays within that action's causes.
+	actionCause := firstMetadataMutationActionCause(err)
+	if actionCause == nil {
+		return firstMetadataMutationErrorLeaf(err)
 	}
+	if statusErr := firstMetadataMutationHTTPError(actionCause); statusErr != nil {
+		return statusErr
+	}
+	return firstMetadataMutationErrorLeaf(actionCause)
+}
+
+type metadataMutationActionError struct {
+	cause error
+}
+
+func newMetadataMutationActionError(cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return &metadataMutationActionError{cause: cause}
+}
+
+func (e *metadataMutationActionError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *metadataMutationActionError) Unwrap() error {
+	return e.cause
+}
+
+func firstMetadataMutationActionCause(err error) error {
+	var actionErr *metadataMutationActionError
+	if !errors.As(err, &actionErr) {
+		return nil
+	}
+	return actionErr.cause
+}
+
+func firstMetadataMutationHTTPError(err error) error {
 	if err == nil {
 		return nil
 	}
-
-	var statusErr interface {
+	// Inspect this node directly so a status-zero wrapper does not stop the
+	// depth-first search before a later child with a valid HTTP status.
+	if statusErr, ok := err.(interface { //nolint:errorlint
 		error
 		HTTPStatusCode() int
-	}
-	if errors.As(err, &statusErr) {
+	}); ok {
 		status := statusErr.HTTPStatusCode()
 		if status >= 400 && status <= 599 {
 			return statusErr
 		}
 	}
-
-	for err != nil {
-		if joined, ok := err.(interface{ Unwrap() []error }); ok {
-			err = nil
-			for _, child := range joined.Unwrap() {
-				if child != nil {
-					err = child
-					break
-				}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range joined.Unwrap() {
+			if statusErr := firstMetadataMutationHTTPError(child); statusErr != nil {
+				return statusErr
 			}
-			continue
 		}
-		wrapped, ok := err.(interface{ Unwrap() error })
-		if !ok || wrapped.Unwrap() == nil {
-			return err
-		}
-		err = wrapped.Unwrap()
+		return nil
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		return firstMetadataMutationHTTPError(wrapped.Unwrap())
 	}
 	return nil
+}
+
+func firstMetadataMutationErrorLeaf(err error) error {
+	if err == nil {
+		return nil
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range joined.Unwrap() {
+			if leaf := firstMetadataMutationErrorLeaf(child); leaf != nil {
+				return leaf
+			}
+		}
+		return nil
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok && wrapped.Unwrap() != nil {
+		return firstMetadataMutationErrorLeaf(wrapped.Unwrap())
+	}
+	return err
 }
 
 // MetadataPushCommand returns the metadata push subcommand.
@@ -794,7 +834,7 @@ func applyAppInfoChanges(
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if action, ok := canceledAppInfoAction(locale, localPatch, remoteState, localExists, remoteExists, allowDeletes, ctxErr); ok {
 				if !contextErrorRecorded {
-					applyErrors = append(applyErrors, ctxErr)
+					applyErrors = append(applyErrors, newMetadataMutationActionError(ctxErr))
 					contextErrorRecorded = true
 				}
 				actions = append(actions, action)
@@ -821,7 +861,7 @@ func applyAppInfoChanges(
 			)
 			if err != nil {
 				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "delete", remoteState.id, nil, err))
-				applyErrors = append(applyErrors, fmt.Errorf("delete app-info localization %s: %w", locale, err))
+				applyErrors = append(applyErrors, newMetadataMutationActionError(fmt.Errorf("delete app-info localization %s: %w", locale, err)))
 			} else {
 				actions = append(actions, successfulMetadataAction(appInfoDirName, locale, "", action, id))
 			}
@@ -842,7 +882,7 @@ func applyAppInfoChanges(
 			if strings.TrimSpace(localPatch.localization.Name) == "" {
 				err := fmt.Errorf("cannot create app-info localization %q without name", locale)
 				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "create", "", localPatch.setFields, err))
-				applyErrors = append(applyErrors, err)
+				applyErrors = append(applyErrors, newMetadataMutationActionError(err))
 				continue
 			}
 			desired := appInfoFields(localPatch.localization)
@@ -861,7 +901,7 @@ func applyAppInfoChanges(
 			)
 			if err != nil {
 				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "create", "", desired, err))
-				applyErrors = append(applyErrors, fmt.Errorf("create app-info localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields), err))
+				applyErrors = append(applyErrors, newMetadataMutationActionError(fmt.Errorf("create app-info localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields), err)))
 			} else {
 				actions = append(actions, successfulMetadataAction(appInfoDirName, locale, "", action, id))
 			}
@@ -881,7 +921,7 @@ func applyAppInfoChanges(
 			)
 			if err != nil {
 				actions = append(actions, failedMetadataAction(appInfoDirName, locale, "", "update", remoteState.id, localPatch.setFields, err))
-				applyErrors = append(applyErrors, fmt.Errorf("update app-info localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields), err))
+				applyErrors = append(applyErrors, newMetadataMutationActionError(fmt.Errorf("update app-info localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(appInfoPlanFields, localPatch.setFields), err)))
 			} else {
 				actions = append(actions, successfulMetadataAction(appInfoDirName, locale, "", action, id))
 			}
@@ -930,7 +970,7 @@ func applyVersionChanges(
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if action, ok := canceledVersionAction(locale, version, localPatch, remoteState, localExists, remoteExists, allowDeletes, ctxErr); ok {
 				if !contextErrorRecorded {
-					applyErrors = append(applyErrors, ctxErr)
+					applyErrors = append(applyErrors, newMetadataMutationActionError(ctxErr))
 					contextErrorRecorded = true
 				}
 				actions = append(actions, action)
@@ -957,7 +997,7 @@ func applyVersionChanges(
 			)
 			if err != nil {
 				actions = append(actions, failedMetadataAction(versionDirName, locale, version, "delete", remoteState.id, nil, err))
-				applyErrors = append(applyErrors, fmt.Errorf("delete version localization %s: %w", locale, err))
+				applyErrors = append(applyErrors, newMetadataMutationActionError(fmt.Errorf("delete version localization %s: %w", locale, err)))
 			} else {
 				actions = append(actions, successfulMetadataAction(versionDirName, locale, version, action, id))
 			}
@@ -995,7 +1035,7 @@ func applyVersionChanges(
 			)
 			if err != nil {
 				actions = append(actions, failedMetadataAction(versionDirName, locale, version, "create", "", desired, err))
-				applyErrors = append(applyErrors, fmt.Errorf("create version localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(versionPlanFields, localPatch.setFields), err))
+				applyErrors = append(applyErrors, newMetadataMutationActionError(fmt.Errorf("create version localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(versionPlanFields, localPatch.setFields), err)))
 			} else {
 				actions = append(actions, successfulMetadataAction(versionDirName, locale, version, action, id))
 			}
@@ -1015,7 +1055,7 @@ func applyVersionChanges(
 			)
 			if err != nil {
 				actions = append(actions, failedMetadataAction(versionDirName, locale, version, "update", remoteState.id, localPatch.setFields, err))
-				applyErrors = append(applyErrors, fmt.Errorf("update version localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(versionPlanFields, localPatch.setFields), err))
+				applyErrors = append(applyErrors, newMetadataMutationActionError(fmt.Errorf("update version localization %s (fields: %s): %w", locale, formatAttemptedFieldMap(versionPlanFields, localPatch.setFields), err)))
 			} else {
 				actions = append(actions, successfulMetadataAction(versionDirName, locale, version, action, id))
 			}

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -228,7 +228,11 @@ Notes:
 				if result.FailureArtifactError != "" {
 					message += "; write failure artifact: " + result.FailureArtifactError
 				}
-				return shared.NewReportedError(fmt.Errorf("%s", message))
+				reportedErr := errors.New(message)
+				if err != nil {
+					reportedErr = shared.NewErrorWithCause(reportedErr, err)
+				}
+				return shared.NewReportedError(reportedErr)
 			}
 			return nil
 		},

--- a/internal/cli/metadata/push_test.go
+++ b/internal/cli/metadata/push_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,21 @@ func TestExecutePushPrefixesLocalMetadataReadErrors(t *testing.T) {
 				t.Fatalf("expected %q in error, got %v", want, err)
 			}
 		})
+	}
+}
+
+func TestRepresentativeMetadataMutationErrorPrefersHTTPStatusWithinFirstAction(t *testing.T) {
+	mutationErr := errors.New("connection reset")
+	readbackErr := &asc.APIError{StatusCode: 503, Code: "SERVICE_UNAVAILABLE"}
+	laterActionErr := &asc.APIError{StatusCode: 404, Code: "NOT_FOUND"}
+	firstActionErr := fmt.Errorf("mutation and readback failed: %w", errors.Join(mutationErr, readbackErr))
+
+	got := representativeMetadataMutationError(errors.Join(
+		fmt.Errorf("update version localization fr-FR: %w", firstActionErr),
+		fmt.Errorf("update version localization ja: %w", laterActionErr),
+	))
+	if !errors.Is(got, readbackErr) {
+		t.Fatalf("representative error = %T %v, want first action HTTP cause %v", got, got, readbackErr)
 	}
 }
 

--- a/internal/cli/metadata/push_test.go
+++ b/internal/cli/metadata/push_test.go
@@ -40,18 +40,33 @@ func TestExecutePushPrefixesLocalMetadataReadErrors(t *testing.T) {
 	}
 }
 
-func TestRepresentativeMetadataMutationErrorPrefersHTTPStatusWithinFirstAction(t *testing.T) {
-	mutationErr := errors.New("connection reset")
+func TestRepresentativeMetadataMutationErrorPrefersPositiveHTTPStatusWithinFirstAction(t *testing.T) {
+	mutationErr := &asc.RetryableError{Err: errors.New("connection reset")}
 	readbackErr := &asc.APIError{StatusCode: 503, Code: "SERVICE_UNAVAILABLE"}
 	laterActionErr := &asc.APIError{StatusCode: 404, Code: "NOT_FOUND"}
 	firstActionErr := fmt.Errorf("mutation and readback failed: %w", errors.Join(mutationErr, readbackErr))
 
-	got := representativeMetadataMutationError(errors.Join(
-		fmt.Errorf("update version localization fr-FR: %w", firstActionErr),
-		fmt.Errorf("update version localization ja: %w", laterActionErr),
-	))
+	got := representativeMetadataMutationError(fmt.Errorf("metadata apply: %w", errors.Join(
+		errors.Join(newMetadataMutationActionError(fmt.Errorf("update version localization fr-FR: %w", firstActionErr))),
+		errors.Join(newMetadataMutationActionError(fmt.Errorf("update version localization ja: %w", laterActionErr))),
+	)))
 	if !errors.Is(got, readbackErr) {
 		t.Fatalf("representative error = %T %v, want first action HTTP cause %v", got, got, readbackErr)
+	}
+}
+
+func TestRepresentativeMetadataMutationErrorStaysWithinFirstAction(t *testing.T) {
+	firstMutationErr := errors.New("connection reset")
+	firstReadbackErr := errors.New("readback timeout")
+	laterActionErr := &asc.APIError{StatusCode: 404, Code: "NOT_FOUND"}
+	firstActionErr := fmt.Errorf("mutation and readback failed: %w", errors.Join(firstMutationErr, firstReadbackErr))
+
+	got := representativeMetadataMutationError(fmt.Errorf("metadata apply: %w", errors.Join(
+		errors.Join(newMetadataMutationActionError(fmt.Errorf("update version localization fr-FR: %w", firstActionErr))),
+		errors.Join(newMetadataMutationActionError(fmt.Errorf("update version localization ja: %w", laterActionErr))),
+	)))
+	if !errors.Is(got, firstMutationErr) {
+		t.Fatalf("representative error = %T %v, want first action leaf %v", got, got, firstMutationErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- retain the underlying mutation error after rendering a partial apply result
- preserve HTTP-specific exit codes for partial 4xx and 5xx failures
- keep structured recovery output and duplicate-stderr suppression unchanged

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 go test ./...`
- focused command and metadata package tests
- built-binary usage-error smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata operation error reporting by preserving underlying failure details.
  * Corrected command exit codes for server and validation errors.
  * Ensured mixed metadata failures report the first encountered HTTP error consistently in command results and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->