### PR TITLE
fix(subscriptions): resolve availability territories from subscription

### DIFF
--- a/internal/cli/cmdtest/analytics_flag_aliases_surface_test.go
+++ b/internal/cli/cmdtest/analytics_flag_aliases_surface_test.go
@@ -59,7 +59,6 @@ func TestAnalyticsRankedAmbiguousFlagsRemainRejected(t *testing.T) {
 		{path: []string{"screenshots", "list"}, flag: "app"},
 		{path: []string{"screenshots", "list"}, flag: "paginate"},
 		{path: []string{"localizations", "update"}, flag: "localization-id"},
-		{path: []string{"subscriptions", "pricing", "availability", "available-territories"}, flag: "subscription-id"},
 		{path: []string{"profiles", "list"}, flag: "bundle-id"},
 		{path: []string{"subscriptions", "localizations", "update"}, flag: "subscription-id"},
 	}

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1623,7 +1623,7 @@ func TestSubscriptionsValidationErrors(t *testing.T) {
 		{
 			name:    "subscriptions pricing availability available-territories missing id",
 			args:    []string{"subscriptions", "pricing", "availability", "available-territories"},
-			wantErr: "--availability-id is required",
+			wantErr: "--availability-id or --subscription-id is required",
 		},
 		{
 			name:    "subscriptions review app-store-screenshot get missing id",

--- a/internal/cli/cmdtest/subscriptions_availability_territories_selector_test.go
+++ b/internal/cli/cmdtest/subscriptions_availability_territories_selector_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -122,8 +123,17 @@ func TestSubscriptionsAvailabilityAvailableTerritoriesRequiresSubscriptionForApp
 	}
 }
 
-func TestSubscriptionsAvailabilityAvailableTerritoriesRequiresAppForProductSelector(t *testing.T) {
-	setupStableSelectorAuth(t)
+func TestSubscriptionsAvailabilityAvailableTerritoriesRequiresAppBeforeAuth(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_STRICT_AUTH", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -132,11 +142,13 @@ func TestSubscriptionsAvailabilityAvailableTerritoriesRequiresAppForProductSelec
 		return nil, nil
 	})
 
-	_, _, runErr := runRootCommand(t, []string{
-		"subscriptions", "pricing", "availability", "available-territories",
-		"--subscription-id", "com.example.monthly",
-	})
-	if runErr == nil || !strings.Contains(runErr.Error(), "--app is required (or set ASC_APP_ID)") {
-		t.Fatalf("expected app context error, got %v", runErr)
+	for _, selector := range []string{"com.example.monthly", "Monthly"} {
+		_, _, runErr := runRootCommand(t, []string{
+			"subscriptions", "pricing", "availability", "available-territories",
+			"--subscription-id", selector,
+		})
+		if runErr == nil || !strings.Contains(runErr.Error(), "--app is required (or set ASC_APP_ID)") {
+			t.Fatalf("selector %q: expected app context error before authentication, got %v", selector, runErr)
+		}
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_availability_territories_selector_test.go
+++ b/internal/cli/cmdtest/subscriptions_availability_territories_selector_test.go
@@ -1,0 +1,142 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSubscriptionsAvailabilityAvailableTerritoriesResolvesSubscriptionSelector(t *testing.T) {
+	setupStableSelectorAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.Header.Get("Authorization") == "" {
+			t.Fatal("expected authorization header")
+		}
+		switch req.URL.Path {
+		case "/v1/apps/app-1/subscriptionGroups":
+			return selectorJSONResponse(`{"data":[{"type":"subscriptionGroups","id":"group-1"}]}`), nil
+		case "/v1/subscriptionGroups/group-1/subscriptions":
+			if got := req.URL.Query().Get("filter[productId]"); got != "com.example.monthly" {
+				t.Fatalf("expected product ID filter, got %q", got)
+			}
+			return selectorJSONResponse(`{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Monthly","productId":"com.example.monthly"}}]}`), nil
+		case "/v1/subscriptions/sub-1/subscriptionAvailability":
+			return selectorJSONResponse(`{"data":{"type":"subscriptionAvailabilities","id":"avail-1"}}`), nil
+		case "/v1/subscriptionAvailabilities/avail-1/availableTerritories":
+			if got := req.URL.Query().Get("limit"); got != "7" {
+				t.Fatalf("expected limit=7, got %q", got)
+			}
+			return selectorJSONResponse(`{"data":[{"type":"territories","id":"USA","attributes":{"currency":"USD"}}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	stdout, stderr, runErr := runRootCommand(t, []string{
+		"subscriptions", "pricing", "availability", "available-territories",
+		"--app", "app-1",
+		"--subscription-id", "com.example.monthly",
+		"--limit", "7",
+		"--output", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("expected nil error, got %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requests != 4 {
+		t.Fatalf("expected 4 requests, got %d", requests)
+	}
+
+	var out struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if len(out.Data) != 1 || out.Data[0].ID != "USA" {
+		t.Fatalf("expected USA territory, got %#v", out.Data)
+	}
+}
+
+func TestSubscriptionsAvailabilityAvailableTerritoriesReportsAvailabilityLookupFailure(t *testing.T) {
+	setupStableSelectorAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/8000000001/subscriptionAvailability" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","title":"Not Found"}]}`), nil
+	})
+
+	_, _, runErr := runRootCommand(t, []string{
+		"subscriptions", "pricing", "availability", "available-territories",
+		"--subscription-id", "8000000001",
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "failed to resolve availability") {
+		t.Fatalf("expected availability lookup failure, got %v", runErr)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one failed lookup request, got %d", requests)
+	}
+}
+
+func TestSubscriptionsAvailabilityAvailableTerritoriesRejectsConflictingSelectors(t *testing.T) {
+	_, _, runErr := runRootCommand(t, []string{
+		"subscriptions", "pricing", "availability", "available-territories",
+		"--availability-id", "avail-1",
+		"--subscription-id", "sub-1",
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "--availability-id and --subscription-id are mutually exclusive") {
+		t.Fatalf("expected selector conflict, got %v", runErr)
+	}
+}
+
+func TestSubscriptionsAvailabilityAvailableTerritoriesRequiresSubscriptionForApp(t *testing.T) {
+	_, _, runErr := runRootCommand(t, []string{
+		"subscriptions", "pricing", "availability", "available-territories",
+		"--availability-id", "avail-1",
+		"--app", "app-1",
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "--app requires --subscription-id") {
+		t.Fatalf("expected app selector error, got %v", runErr)
+	}
+}
+
+func TestSubscriptionsAvailabilityAvailableTerritoriesRequiresAppForProductSelector(t *testing.T) {
+	setupStableSelectorAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	_, _, runErr := runRootCommand(t, []string{
+		"subscriptions", "pricing", "availability", "available-territories",
+		"--subscription-id", "com.example.monthly",
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "--app is required (or set ASC_APP_ID)") {
+		t.Fatalf("expected app context error, got %v", runErr)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_availability_territories_selector_test.go
+++ b/internal/cli/cmdtest/subscriptions_availability_territories_selector_test.go
@@ -2,10 +2,14 @@ package cmdtest
 
 import (
 	"encoding/json"
+	"errors"
+	"flag"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestSubscriptionsAvailabilityAvailableTerritoriesResolvesSubscriptionSelector(t *testing.T) {
@@ -150,5 +154,53 @@ func TestSubscriptionsAvailabilityAvailableTerritoriesRequiresAppBeforeAuth(t *t
 		if runErr == nil || !strings.Contains(runErr.Error(), "--app is required (or set ASC_APP_ID)") {
 			t.Fatalf("selector %q: expected app context error before authentication, got %v", selector, runErr)
 		}
+	}
+}
+
+func TestSubscriptionsAvailabilityAvailableTerritoriesClassifiesPaginationValidationAsUsage(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "invalid limit",
+			args: []string{
+				"subscriptions", "pricing", "availability", "available-territories",
+				"--availability-id", "avail-1",
+				"--limit", "201",
+			},
+			wantErr: "subscriptions pricing availability available-territories: --limit must be between 1 and 200",
+		},
+		{
+			name: "invalid next URL",
+			args: []string{
+				"subscriptions", "pricing", "availability", "available-territories",
+				"--next", "https://example.com/v1/subscriptionAvailabilities/avail-1/availableTerritories?cursor=x",
+			},
+			wantErr: "subscriptions pricing availability available-territories: --next must be an App Store Connect URL",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr, runErr := runRootCommand(t, test.args)
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("expected usage exit code %d, got %d", rootcmd.ExitUsage, got)
+			}
+			if runErr.Error() != test.wantErr {
+				t.Fatalf("expected error %q, got %q", test.wantErr, runErr.Error())
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			wantStderrPrefix := "Error: " + test.wantErr + "\nDESCRIPTION\n"
+			if !strings.HasPrefix(stderr, wantStderrPrefix) {
+				t.Fatalf("expected stderr prefix %q, got %q", wantStderrPrefix, stderr)
+			}
+		})
 	}
 }

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -63,6 +63,11 @@ func TestSubscriptionsAvailabilityHelpMatchesRegisteredPath(t *testing.T) {
 			}
 		})
 	}
+
+	availableTerritories := findSubcommand(source, "available-territories")
+	if !strings.Contains(availableTerritories.LongHelp, "Use --next instead of either selector") {
+		t.Fatalf("expected available-territories help to explain cursor continuation, got %q", availableTerritories.LongHelp)
+	}
 }
 
 func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -5,7 +5,65 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/subscriptions"
 )
+
+func TestSubscriptionsAvailabilityHelpMatchesRegisteredPath(t *testing.T) {
+	root := RootCommand("1.2.3")
+	source := subscriptions.SubscriptionsAvailabilityCommand()
+
+	tests := []struct {
+		name          string
+		sourceCommand *ffcli.Command
+		rootPath      []string
+		usagePrefix   string
+	}{
+		{
+			name:          "group",
+			sourceCommand: source,
+			rootPath:      []string{"subscriptions", "pricing", "availability"},
+			usagePrefix:   "asc subscriptions pricing availability ",
+		},
+		{
+			name:          "view",
+			sourceCommand: findSubcommand(source, "view"),
+			rootPath:      []string{"subscriptions", "pricing", "availability", "view"},
+			usagePrefix:   "asc subscriptions pricing availability view ",
+		},
+		{
+			name:          "available-territories",
+			sourceCommand: findSubcommand(source, "available-territories"),
+			rootPath:      []string{"subscriptions", "pricing", "availability", "available-territories"},
+			usagePrefix:   "asc subscriptions pricing availability available-territories ",
+		},
+		{
+			name:          "edit",
+			sourceCommand: findSubcommand(source, "edit"),
+			rootPath:      []string{"subscriptions", "pricing", "availability", "edit"},
+			usagePrefix:   "asc subscriptions pricing availability edit ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.sourceCommand == nil {
+				t.Fatal("expected source command")
+			}
+			if registered := findSubcommand(root, test.rootPath...); registered == nil {
+				t.Fatalf("expected registered command %q", strings.Join(test.rootPath, " "))
+			}
+			if !strings.HasPrefix(test.sourceCommand.ShortUsage, test.usagePrefix) {
+				t.Fatalf("expected source usage to match registered path %q, got %q", strings.Join(test.rootPath, " "), test.sourceCommand.ShortUsage)
+			}
+			if strings.Contains(test.sourceCommand.LongHelp, "asc subscriptions availability") {
+				t.Fatalf("expected examples to use registered pricing path, got %q", test.sourceCommand.LongHelp)
+			}
+		})
+	}
+}
 
 func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 	root := RootCommand("1.2.3")

--- a/internal/cli/cmdtest/subscriptions_next_validation_phase62_test.go
+++ b/internal/cli/cmdtest/subscriptions_next_validation_phase62_test.go
@@ -3,7 +3,7 @@ package cmdtest
 import "testing"
 
 func TestSubscriptionsAvailabilityAvailableTerritoriesRejectsInvalidNextURLPhase62(t *testing.T) {
-	runGameCenterAchievementsInvalidNextURLCases(
+	runInvalidNextURLUsageErrorCases(
 		t,
 		[]string{"subscriptions", "pricing", "availability", "available-territories"},
 		"subscriptions pricing availability available-territories: --next",

--- a/internal/cli/subscriptions/pricing_family.go
+++ b/internal/cli/subscriptions/pricing_family.go
@@ -109,12 +109,7 @@ func SubscriptionsPricingPricePointsCommand() *ffcli.Command {
 
 // SubscriptionsPricingAvailabilityCommand returns the canonical availability subgroup.
 func SubscriptionsPricingAvailabilityCommand() *ffcli.Command {
-	cmd := wrapSubscriptionsCommand(
-		SubscriptionsAvailabilityCommand(),
-		"asc subscriptions availability",
-		"asc subscriptions pricing availability",
-		"availability",
-		"Manage subscription availability.",
-	)
+	cmd := SubscriptionsAvailabilityCommand()
+	cmd.ShortHelp = "Manage subscription availability."
 	return cmd
 }

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1631,10 +1631,10 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("subscriptions pricing availability available-territories: --limit must be between 1 and 200")
+				return shared.UsageErrorf("subscriptions pricing availability available-territories: --limit must be between 1 and 200")
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
-				return fmt.Errorf("subscriptions pricing availability available-territories: %w", err)
+				return shared.UsageErrorf("subscriptions pricing availability available-territories: %v", err)
 			}
 			if err := validateNextExclusiveFlags(fs, *next, "availability-id", "subscription-id", "app", "limit"); err != nil {
 				return err

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1608,6 +1608,8 @@ func SubscriptionsAvailabilityAvailableTerritoriesCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("availability available-territories", flag.ExitOnError)
 
 	availabilityID := fs.String("availability-id", "", "Subscription availability ID")
+	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
+	appID := addSubscriptionLookupAppFlag(fs)
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -1615,12 +1617,14 @@ func SubscriptionsAvailabilityAvailableTerritoriesCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "available-territories",
-		ShortUsage: "asc subscriptions availability available-territories --availability-id \"AVAILABILITY_ID\"",
+		ShortUsage: "asc subscriptions availability available-territories [flags]",
 		ShortHelp:  "List available territories for a subscription availability.",
-		LongHelp: `List available territories for a subscription availability.
+		LongHelp: `List available territories by subscription availability or subscription.
+Provide exactly one of --availability-id or --subscription-id.
 
 Examples:
   asc subscriptions availability available-territories --availability-id "AVAILABILITY_ID"
+  asc subscriptions availability available-territories --subscription-id "SUB_ID"
   asc subscriptions availability available-territories --availability-id "AVAILABILITY_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -1631,16 +1635,43 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("subscriptions availability available-territories: %w", err)
 			}
+			if err := validateNextExclusiveFlags(fs, *next, "availability-id", "subscription-id", "app", "limit"); err != nil {
+				return err
+			}
 
-			id := strings.TrimSpace(*availabilityID)
-			if id == "" && strings.TrimSpace(*next) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --availability-id is required")
+			availabilityValue := strings.TrimSpace(*availabilityID)
+			subscriptionValue := strings.TrimSpace(*subscriptionID)
+			if availabilityValue == "" && subscriptionValue == "" && strings.TrimSpace(*next) == "" {
+				fmt.Fprintln(os.Stderr, "Error: --availability-id or --subscription-id is required")
 				return shared.MissingRequiredUsageError()
+			}
+			if availabilityValue != "" && subscriptionValue != "" {
+				return shared.UsageError("--availability-id and --subscription-id are mutually exclusive")
+			}
+			if subscriptionValue == "" && flagWasProvided(fs, "app") {
+				return shared.UsageError("--app requires --subscription-id")
 			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("subscriptions availability available-territories: %w", err)
+			}
+			if subscriptionValue != "" {
+				subscriptionValue, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, *appID, subscriptionValue)
+				if err != nil {
+					return err
+				}
+
+				availabilityCtx, availabilityCancel := shared.ContextWithTimeout(ctx)
+				availability, fetchErr := client.GetSubscriptionAvailabilityForSubscription(availabilityCtx, subscriptionValue)
+				availabilityCancel()
+				if fetchErr != nil {
+					return fmt.Errorf("subscriptions availability available-territories: failed to resolve availability: %w", fetchErr)
+				}
+				if availability == nil || strings.TrimSpace(availability.Data.ID) == "" {
+					return fmt.Errorf("subscriptions availability available-territories: subscription availability response did not include an ID")
+				}
+				availabilityValue = strings.TrimSpace(availability.Data.ID)
 			}
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
@@ -1653,13 +1684,13 @@ Examples:
 
 			if *paginate {
 				paginateOpts := append(opts, asc.WithSubscriptionAvailabilityTerritoriesLimit(200))
-				firstPage, err := client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, id, paginateOpts...)
+				firstPage, err := client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, availabilityValue, paginateOpts...)
 				if err != nil {
 					return fmt.Errorf("subscriptions availability available-territories: failed to fetch: %w", err)
 				}
 
 				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-					return client.GetSubscriptionAvailabilityAvailableTerritories(ctx, id, asc.WithSubscriptionAvailabilityTerritoriesNextURL(nextURL))
+					return client.GetSubscriptionAvailabilityAvailableTerritories(ctx, availabilityValue, asc.WithSubscriptionAvailabilityTerritoriesNextURL(nextURL))
 				})
 				if err != nil {
 					return fmt.Errorf("subscriptions availability available-territories: %w", err)
@@ -1668,7 +1699,7 @@ Examples:
 				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 			}
 
-			resp, err := client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, id, opts...)
+			resp, err := client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, availabilityValue, opts...)
 			if err != nil {
 				return fmt.Errorf("subscriptions availability available-territories: failed to fetch: %w", err)
 			}

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1505,13 +1505,13 @@ Examples:
 	}
 }
 
-// SubscriptionsAvailabilityCommand returns the subscriptions availability command group.
+// SubscriptionsAvailabilityCommand returns the subscriptions pricing availability command group.
 func SubscriptionsAvailabilityCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("availability", flag.ExitOnError)
 
 	return &ffcli.Command{
 		Name:       "availability",
-		ShortUsage: "asc subscriptions availability <subcommand> [flags]",
+		ShortUsage: "asc subscriptions pricing availability <subcommand> [flags]",
 		ShortHelp:  "Manage subscription availability (deprecated by Apple).",
 		LongHelp: `Manage subscription availability.
 
@@ -1521,9 +1521,9 @@ commands keep working for now; for plan-based availability use
 ` + "`asc subscriptions pricing monthly-commitment`" + ` (enable/disable/list).
 
 Examples:
-  asc subscriptions availability view --availability-id "AVAILABILITY_ID"
-  asc subscriptions availability edit --subscription-id "SUB_ID" --territories "US,Canada"
-  asc subscriptions availability available-territories --availability-id "AVAILABILITY_ID"`,
+  asc subscriptions pricing availability view --availability-id "AVAILABILITY_ID"
+  asc subscriptions pricing availability edit --subscription-id "SUB_ID" --territories "US,Canada"
+  asc subscriptions pricing availability available-territories --availability-id "AVAILABILITY_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.VisibleUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -1548,13 +1548,13 @@ func SubscriptionsAvailabilityViewCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "view",
-		ShortUsage: "asc subscriptions availability view --availability-id \"AVAILABILITY_ID\"",
+		ShortUsage: "asc subscriptions pricing availability view --availability-id \"AVAILABILITY_ID\"",
 		ShortHelp:  "View subscription availability by ID or subscription.",
 		LongHelp: `View subscription availability by ID or subscription.
 
 Examples:
-  asc subscriptions availability view --availability-id "AVAILABILITY_ID"
-  asc subscriptions availability view --subscription-id "SUB_ID"`,
+  asc subscriptions pricing availability view --availability-id "AVAILABILITY_ID"
+  asc subscriptions pricing availability view --subscription-id "SUB_ID"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -1571,7 +1571,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("subscriptions availability view: %w", err)
+				return fmt.Errorf("subscriptions pricing availability view: %w", err)
 			}
 
 			if availabilityValue != "" {
@@ -1580,7 +1580,7 @@ Examples:
 
 				resp, err := client.GetSubscriptionAvailability(requestCtx, availabilityValue)
 				if err != nil {
-					return fmt.Errorf("subscriptions availability view: failed to fetch: %w", err)
+					return fmt.Errorf("subscriptions pricing availability view: failed to fetch: %w", err)
 				}
 				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 			}
@@ -1595,7 +1595,7 @@ Examples:
 
 			resp, err := client.GetSubscriptionAvailabilityForSubscription(requestCtx, subscriptionValue)
 			if err != nil {
-				return fmt.Errorf("subscriptions availability view: failed to fetch: %w", err)
+				return fmt.Errorf("subscriptions pricing availability view: failed to fetch: %w", err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -1617,23 +1617,23 @@ func SubscriptionsAvailabilityAvailableTerritoriesCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "available-territories",
-		ShortUsage: "asc subscriptions availability available-territories [flags]",
+		ShortUsage: "asc subscriptions pricing availability available-territories [flags]",
 		ShortHelp:  "List available territories for a subscription availability.",
 		LongHelp: `List available territories by subscription availability or subscription.
 Provide exactly one of --availability-id or --subscription-id.
 
 Examples:
-  asc subscriptions availability available-territories --availability-id "AVAILABILITY_ID"
-  asc subscriptions availability available-territories --subscription-id "SUB_ID"
-  asc subscriptions availability available-territories --availability-id "AVAILABILITY_ID" --paginate`,
+  asc subscriptions pricing availability available-territories --availability-id "AVAILABILITY_ID"
+  asc subscriptions pricing availability available-territories --subscription-id "SUB_ID"
+  asc subscriptions pricing availability available-territories --availability-id "AVAILABILITY_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("subscriptions availability available-territories: --limit must be between 1 and 200")
+				return fmt.Errorf("subscriptions pricing availability available-territories: --limit must be between 1 and 200")
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
-				return fmt.Errorf("subscriptions availability available-territories: %w", err)
+				return fmt.Errorf("subscriptions pricing availability available-territories: %w", err)
 			}
 			if err := validateNextExclusiveFlags(fs, *next, "availability-id", "subscription-id", "app", "limit"); err != nil {
 				return err
@@ -1658,7 +1658,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("subscriptions availability available-territories: %w", err)
+				return fmt.Errorf("subscriptions pricing availability available-territories: %w", err)
 			}
 			if subscriptionValue != "" {
 				subscriptionValue, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, resolvedAppID, subscriptionValue)
@@ -1670,10 +1670,10 @@ Examples:
 				availability, fetchErr := client.GetSubscriptionAvailabilityForSubscription(availabilityCtx, subscriptionValue)
 				availabilityCancel()
 				if fetchErr != nil {
-					return fmt.Errorf("subscriptions availability available-territories: failed to resolve availability: %w", fetchErr)
+					return fmt.Errorf("subscriptions pricing availability available-territories: failed to resolve availability: %w", fetchErr)
 				}
 				if availability == nil || strings.TrimSpace(availability.Data.ID) == "" {
-					return fmt.Errorf("subscriptions availability available-territories: subscription availability response did not include an ID")
+					return fmt.Errorf("subscriptions pricing availability available-territories: subscription availability response did not include an ID")
 				}
 				availabilityValue = strings.TrimSpace(availability.Data.ID)
 			}
@@ -1690,14 +1690,14 @@ Examples:
 				paginateOpts := append(opts, asc.WithSubscriptionAvailabilityTerritoriesLimit(200))
 				firstPage, err := client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, availabilityValue, paginateOpts...)
 				if err != nil {
-					return fmt.Errorf("subscriptions availability available-territories: failed to fetch: %w", err)
+					return fmt.Errorf("subscriptions pricing availability available-territories: failed to fetch: %w", err)
 				}
 
 				resp, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
 					return client.GetSubscriptionAvailabilityAvailableTerritories(ctx, availabilityValue, asc.WithSubscriptionAvailabilityTerritoriesNextURL(nextURL))
 				})
 				if err != nil {
-					return fmt.Errorf("subscriptions availability available-territories: %w", err)
+					return fmt.Errorf("subscriptions pricing availability available-territories: %w", err)
 				}
 
 				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -1705,7 +1705,7 @@ Examples:
 
 			resp, err := client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, availabilityValue, opts...)
 			if err != nil {
-				return fmt.Errorf("subscriptions availability available-territories: failed to fetch: %w", err)
+				return fmt.Errorf("subscriptions pricing availability available-territories: failed to fetch: %w", err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -1726,13 +1726,13 @@ func SubscriptionsAvailabilityEditCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "edit",
-		ShortUsage: "asc subscriptions availability edit [flags]",
+		ShortUsage: "asc subscriptions pricing availability edit [flags]",
 		ShortHelp:  "Edit subscription availability in territories.",
 		LongHelp: `Edit subscription availability in territories.
 
 Examples:
-  asc subscriptions availability edit --subscription-id "SUB_ID" --territories "US,Canada"
-  asc subscriptions availability edit --subscription-id "SUB_ID" --billing-mode monthly-commitment --territories "Norway,Germany"`,
+  asc subscriptions pricing availability edit --subscription-id "SUB_ID" --territories "US,Canada"
+  asc subscriptions pricing availability edit --subscription-id "SUB_ID" --billing-mode monthly-commitment --territories "Norway,Germany"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -1771,7 +1771,7 @@ Examples:
 
 			client, err := shared.GetASCClient()
 			if err != nil {
-				return fmt.Errorf("subscriptions availability edit: %w", err)
+				return fmt.Errorf("subscriptions pricing availability edit: %w", err)
 			}
 
 			id, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, *appID, id)
@@ -1784,7 +1784,7 @@ Examples:
 				existing, err := client.GetSubscriptionPlanAvailabilitiesForSubscription(listCtx, id)
 				listCancel()
 				if err != nil {
-					return fmt.Errorf("subscriptions availability edit: failed to fetch monthly-commitment plan availability: %w", err)
+					return fmt.Errorf("subscriptions pricing availability edit: failed to fetch monthly-commitment plan availability: %w", err)
 				}
 
 				var resp *asc.SubscriptionPlanAvailabilityResponse
@@ -1800,7 +1800,7 @@ Examples:
 					createCancel()
 				}
 				if err != nil {
-					return fmt.Errorf("subscriptions availability edit: failed to set monthly-commitment plan availability: %w", err)
+					return fmt.Errorf("subscriptions pricing availability edit: failed to set monthly-commitment plan availability: %w", err)
 				}
 				return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 			}
@@ -1814,7 +1814,7 @@ Examples:
 
 			resp, err := client.CreateSubscriptionAvailability(requestCtx, id, territoryIDs, attrs)
 			if err != nil {
-				return fmt.Errorf("subscriptions availability edit: failed to set: %w", err)
+				return fmt.Errorf("subscriptions pricing availability edit: failed to set: %w", err)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1620,7 +1620,8 @@ func SubscriptionsAvailabilityAvailableTerritoriesCommand() *ffcli.Command {
 		ShortUsage: "asc subscriptions pricing availability available-territories [flags]",
 		ShortHelp:  "List available territories for a subscription availability.",
 		LongHelp: `List available territories by subscription availability or subscription.
-Provide exactly one of --availability-id or --subscription-id.
+Provide exactly one of --availability-id or --subscription-id for an initial request.
+Use --next instead of either selector to continue from a previous response.
 
 Examples:
   asc subscriptions pricing availability available-territories --availability-id "AVAILABILITY_ID"

--- a/internal/cli/subscriptions/subscriptions.go
+++ b/internal/cli/subscriptions/subscriptions.go
@@ -1651,13 +1651,17 @@ Examples:
 			if subscriptionValue == "" && flagWasProvided(fs, "app") {
 				return shared.UsageError("--app requires --subscription-id")
 			}
+			resolvedAppID := shared.ResolveAppID(*appID)
+			if err := shared.RequireAppForStableSelector(resolvedAppID, subscriptionValue, "--subscription-id"); err != nil {
+				return err
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("subscriptions availability available-territories: %w", err)
 			}
 			if subscriptionValue != "" {
-				subscriptionValue, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, *appID, subscriptionValue)
+				subscriptionValue, err = resolveSubscriptionLookupIDWithTimeout(ctx, client, resolvedAppID, subscriptionValue)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Summary
- allow `subscriptions pricing availability available-territories` to select a subscription directly
- resolve product IDs and exact names through the existing app-scoped selector flow
- fetch the related availability resource before listing territories
- reject conflicting selectors and cursor-query combinations before network access

## Verification
- `make format`
- `make check-docs`
- `make lint`
- focused command and HTTP tests
- repository commit-hook suite with the configured Xcode developer directory
- built-binary help, stderr, stdout, and exit-code checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription availability commands are now organized under `subscriptions pricing availability`.
  * The `available-territories` command accepts an availability ID or subscription selector.
  * Subscription-based lookups can resolve availability using an app context.
  * Help text and examples now reflect supported command paths and selection options.

* **Bug Fixes**
  * Improved validation for conflicting selectors, missing app context, pagination options, and unavailable resources.
  * Territory requests and pagination now use the resolved availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->