### PR TITLE
docs: explain required resource ID discovery

### DIFF
--- a/internal/cli/cmdtest/resource_id_discovery_help_test.go
+++ b/internal/cli/cmdtest/resource_id_discovery_help_test.go
@@ -17,7 +17,7 @@ func TestResourceIDHelpShowsDiscoveryCommands(t *testing.T) {
 			path: []string{"iap", "versions", "list"},
 			want: []string{
 				"To find the in-app purchase ID",
-				`asc iap list --app "APP_ID" --output json`,
+				`asc iap list --app "APP_ID" --paginate --output json`,
 			},
 		},
 		{
@@ -25,8 +25,8 @@ func TestResourceIDHelpShowsDiscoveryCommands(t *testing.T) {
 			path: []string{"versions", "attach-build"},
 			want: []string{
 				"To find the version and build IDs",
-				`asc versions list --app "APP_ID" --output json`,
-				`asc builds list --app "APP_ID" --output json`,
+				`asc versions list --app "APP_ID" --paginate --output json`,
+				`asc builds list --app "APP_ID" --paginate --output json`,
 			},
 		},
 		{
@@ -34,7 +34,7 @@ func TestResourceIDHelpShowsDiscoveryCommands(t *testing.T) {
 			path: []string{"testflight", "distribution", "view"},
 			want: []string{
 				"To find the build ID",
-				`asc builds list --app "APP_ID" --output json`,
+				`asc builds list --app "APP_ID" --paginate --output json`,
 			},
 		},
 	}

--- a/internal/cli/cmdtest/resource_id_discovery_help_test.go
+++ b/internal/cli/cmdtest/resource_id_discovery_help_test.go
@@ -1,0 +1,55 @@
+package cmdtest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResourceIDHelpShowsDiscoveryCommands(t *testing.T) {
+	root := RootCommand("1.2.3")
+	tests := []struct {
+		name string
+		path []string
+		want []string
+	}{
+		{
+			name: "in-app purchase versions list",
+			path: []string{"iap", "versions", "list"},
+			want: []string{
+				"To find the in-app purchase ID",
+				`asc iap list --app "APP_ID" --output json`,
+			},
+		},
+		{
+			name: "attach build",
+			path: []string{"versions", "attach-build"},
+			want: []string{
+				"To find the version and build IDs",
+				`asc versions list --app "APP_ID" --output json`,
+				`asc builds list --app "APP_ID" --output json`,
+			},
+		},
+		{
+			name: "TestFlight distribution view",
+			path: []string{"testflight", "distribution", "view"},
+			want: []string{
+				"To find the build ID",
+				`asc builds list --app "APP_ID" --output json`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := findSubcommand(root, test.path...)
+			if command == nil {
+				t.Fatalf("command %v not found", test.path)
+			}
+			for _, want := range test.want {
+				if !strings.Contains(command.LongHelp, want) {
+					t.Fatalf("expected help for %v to contain %q, got %q", test.path, want, command.LongHelp)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/iap/versions.go
+++ b/internal/cli/iap/versions.go
@@ -230,7 +230,15 @@ func IAPVersionsListCommand() *ffcli.Command {
 	output := shared.BindOutputFlags(fs)
 	return &ffcli.Command{
 		Name: "list", ShortUsage: `asc iap versions list --iap-id "IAP_ID" [flags]`, ShortHelp: "List versions for an in-app purchase.",
-		LongHelp: "List versions for an in-app purchase.\n\nExamples:\n  asc iap versions list --iap-id \"IAP_ID\"\n  asc iap versions list --iap-id \"IAP_ID\" --state PREPARE_FOR_SUBMISSION --paginate", FlagSet: fs, UsageFunc: shared.DefaultUsageFunc,
+		LongHelp: `List versions for an in-app purchase.
+
+To find the in-app purchase ID, list the app's in-app purchases and use the
+returned id field:
+  asc iap list --app "APP_ID" --output json
+
+Examples:
+  asc iap versions list --iap-id "IAP_ID"
+  asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate`, FlagSet: fs, UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if err := rejectIAPVersionArgs(args); err != nil {
 				return err

--- a/internal/cli/iap/versions.go
+++ b/internal/cli/iap/versions.go
@@ -234,7 +234,7 @@ func IAPVersionsListCommand() *ffcli.Command {
 
 To find the in-app purchase ID, list the app's in-app purchases and use the
 returned id field:
-  asc iap list --app "APP_ID" --output json
+  asc iap list --app "APP_ID" --paginate --output json
 
 Examples:
   asc iap versions list --iap-id "IAP_ID"

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -561,6 +561,9 @@ func TestFlightBetaDetailsGetCommand() *ffcli.Command {
 		ShortHelp:  "View build beta details for a build.",
 		LongHelp: `View build beta details for a build.
 
+To find the build ID, list the app's builds and use the returned id field:
+  asc builds list --app "APP_ID" --output json
+
 Examples:
   asc testflight beta-details view --build-id "BUILD_ID"`,
 		FlagSet:   fs,

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -562,7 +562,7 @@ func TestFlightBetaDetailsGetCommand() *ffcli.Command {
 		LongHelp: `View build beta details for a build.
 
 To find the build ID, list the app's builds and use the returned id field:
-  asc builds list --app "APP_ID" --output json
+  asc builds list --app "APP_ID" --paginate --output json
 
 Examples:
   asc testflight beta-details view --build-id "BUILD_ID"`,

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -538,8 +538,8 @@ func VersionsAttachBuildCommand() *ffcli.Command {
 
 To find the version and build IDs, list each resource for the app and use its
 returned id field:
-  asc versions list --app "APP_ID" --output json
-  asc builds list --app "APP_ID" --output json
+  asc versions list --app "APP_ID" --paginate --output json
+  asc builds list --app "APP_ID" --paginate --output json
 
 Examples:
   asc versions attach-build --version-id "VERSION_ID" --build-id "BUILD_ID"`,

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -536,6 +536,11 @@ func VersionsAttachBuildCommand() *ffcli.Command {
 		ShortHelp:  "Attach a build to an app store version.",
 		LongHelp: `Attach a build to an app store version.
 
+To find the version and build IDs, list each resource for the app and use its
+returned id field:
+  asc versions list --app "APP_ID" --output json
+  asc builds list --app "APP_ID" --output json
+
 Examples:
   asc versions attach-build --version-id "VERSION_ID" --build-id "BUILD_ID"`,
 		FlagSet:   fs,


### PR DESCRIPTION
## Summary

- explain how to find the in-app purchase ID required by `iap versions list`
- show the canonical version and build lookup commands before `versions attach-build`
- show how to find a build ID before `testflight distribution view`
- cover each help contract with a focused command-tree test

## Compatibility

This only adds help guidance. Command shapes, flags, API requests, output, and exit codes are unchanged. Resource-specific flags remain distinct; no aliases or implicit lookups are added.

## Verification

- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 go test -short ./...`
- focused help and adjacent validation tests
- built-binary `--help` checks for all three commands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved command-line help for finding in-app purchase, app version, and build IDs.
  * Added practical command examples to in-app purchase version listing and build attachment guidance.
  * Added instructions for locating build IDs when viewing TestFlight beta details.

* **Tests**
  * Added coverage verifying resource ID discovery guidance appears in relevant command help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->