### PR TITLE
fix(review): guide removed item detail commands

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -282,8 +282,11 @@ func printUnknownFlagSuggestion(analysis invocationAnalysis) {
 	printFlagSuggestions(input, candidates)
 }
 
-func printUnknownSubcommandSuggestion(analysis invocationAnalysis) {
+func printUnknownSubcommandSuggestion(analysis invocationAnalysis, commandName string) {
 	if analysis.shape != telemetry.InvocationShapeUnknownChild || analysis.command == nil || analysis.command.Name == "asc" {
+		return
+	}
+	if isRemovedReviewItemDetailInvocation(analysis, commandName) {
 		return
 	}
 	candidates := make([]string, 0, len(analysis.command.Subcommands))
@@ -291,6 +294,12 @@ func printUnknownSubcommandSuggestion(analysis invocationAnalysis) {
 		candidates = append(candidates, sub.Name)
 	}
 	printSuggestions(analysis.unknownToken, candidates, "")
+}
+
+func isRemovedReviewItemDetailInvocation(analysis invocationAnalysis, commandName string) bool {
+	token := strings.TrimSpace(analysis.unknownToken)
+	return (commandName == "asc review" && token == "items-get") ||
+		(commandName == "asc review items" && token == "view")
 }
 
 func printSuggestions(input string, candidates []string, prefix string) {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -103,6 +103,10 @@ func preservesLegacyChild(analysis invocationAnalysis, commandName string) bool 
 	switch commandName {
 	case "asc apps":
 		return token == "create"
+	case "asc review":
+		return token == "items-get"
+	case "asc review items":
+		return token == "view"
 	case "asc submit":
 		return token == "create" || token == "preflight"
 	default:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -90,7 +90,7 @@ func Run(args []string, versionInfo string) int {
 	if shouldRejectUnknownChild(root, analysis, commandName) {
 		runErr := shared.UsageErrorf("unexpected argument(s): %s", shared.SanitizeTerminal(analysis.unknownToken))
 		fmt.Fprint(os.Stderr, analysis.command.UsageFunc(analysis.command))
-		printUnknownSubcommandSuggestion(analysis)
+		printUnknownSubcommandSuggestion(analysis, commandName)
 		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, runErr))
 		return ExitUsage
 	}
@@ -148,11 +148,11 @@ func Run(args []string, versionInfo string) int {
 			return exitCode
 		}
 		if errors.Is(runErr, flag.ErrHelp) {
-			printUnknownSubcommandSuggestion(analysis)
+			printUnknownSubcommandSuggestion(analysis, commandName)
 			emitTelemetry(commandName, versionInfo, elapsed, ExitUsage, validationFailureContext(analysis, runErr))
 			return ExitUsage
 		}
-		printUnknownSubcommandSuggestion(analysis)
+		printUnknownSubcommandSuggestion(analysis, commandName)
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(runErr))
 		exitCode := ExitCodeFromError(runErr)
 		emitTelemetry(commandName, versionInfo, elapsed, exitCode, runtimeFailureContext(analysis, runErr, exitCode))

--- a/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
+++ b/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
@@ -48,13 +48,33 @@ func TestReviewDeprecatedItemSurfacesAreRemoved(t *testing.T) {
 }
 
 func TestReviewRemovedItemCommandsProvideMigrationGuidance(t *testing.T) {
+	root := RootCommand("4.0.0")
+	review := findSubcommand(root, "review")
+	items := findSubcommand(root, "review", "items")
+	if review == nil || items == nil {
+		t.Fatal("review command tree is incomplete")
+	}
+
 	for _, test := range []struct {
 		name       string
 		args       []string
 		wantStderr string
 	}{
-		{name: "nested", args: []string{"review", "items", "view", "--id", "ITEM_ID"}, wantStderr: removedNestedReviewItemGuidance},
-		{name: "flat", args: []string{"review", "items-get", "--id", "ITEM_ID"}, wantStderr: removedFlatReviewItemGuidance},
+		{
+			name:       "nested",
+			args:       []string{"review", "items", "view", "--id", "ITEM_ID"},
+			wantStderr: removedNestedReviewItemGuidance + "\n" + items.UsageFunc(items) + "\n",
+		},
+		{
+			name:       "flat",
+			args:       []string{"review", "items-get", "--id", "ITEM_ID"},
+			wantStderr: removedFlatReviewItemGuidance + "\n" + review.UsageFunc(review) + "\n",
+		},
+		{
+			name:       "ordinary typo",
+			args:       []string{"review", "items", "lits"},
+			wantStderr: "Error: unexpected argument(s): lits\n" + items.UsageFunc(items) + "Did you mean: list?\n",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			stdout, stderr := captureOutput(t, func() {
@@ -66,8 +86,8 @@ func TestReviewRemovedItemCommandsProvideMigrationGuidance(t *testing.T) {
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if !strings.Contains(stderr, test.wantStderr) {
-				t.Fatalf("expected migration guidance %q, got %q", test.wantStderr, stderr)
+			if stderr != test.wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, test.wantStderr)
 			}
 		})
 	}

--- a/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
+++ b/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
+const (
+	removedNestedReviewItemGuidance = "Error: `asc review items view` was removed in 4.0.0; use `asc review items list --submission \"SUBMISSION_ID\"` instead"
+	removedFlatReviewItemGuidance   = "Error: `asc review items-get` was removed in 4.0.0; use `asc review items list --submission \"SUBMISSION_ID\"` instead"
+)
+
 func TestReviewDeprecatedItemSurfacesAreRemoved(t *testing.T) {
 	root := RootCommand("4.0.0")
 
@@ -43,13 +48,17 @@ func TestReviewDeprecatedItemSurfacesAreRemoved(t *testing.T) {
 }
 
 func TestReviewRemovedItemCommandsProvideMigrationGuidance(t *testing.T) {
-	for _, args := range [][]string{
-		{"review", "items", "view", "--id", "ITEM_ID"},
-		{"review", "items-get", "--id", "ITEM_ID"},
+	for _, test := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "nested", args: []string{"review", "items", "view", "--id", "ITEM_ID"}, wantStderr: removedNestedReviewItemGuidance},
+		{name: "flat", args: []string{"review", "items-get", "--id", "ITEM_ID"}, wantStderr: removedFlatReviewItemGuidance},
 	} {
-		t.Run(strings.Join(args[:len(args)-2], " "), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			stdout, stderr := captureOutput(t, func() {
-				if code := cmd.Run(args, "4.0.0"); code != cmd.ExitUsage {
+				if code := cmd.Run(test.args, "4.0.0"); code != cmd.ExitUsage {
 					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
 				}
 			})
@@ -57,9 +66,8 @@ func TestReviewRemovedItemCommandsProvideMigrationGuidance(t *testing.T) {
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			const want = "was removed in 4.0.0; use `asc review items list --submission \"SUBMISSION_ID\"` instead"
-			if !strings.Contains(stderr, want) {
-				t.Fatalf("expected migration guidance %q, got %q", want, stderr)
+			if !strings.Contains(stderr, test.wantStderr) {
+				t.Fatalf("expected migration guidance %q, got %q", test.wantStderr, stderr)
 			}
 		})
 	}
@@ -144,7 +152,7 @@ func TestReviewItemsGroupRejectsUnknownSubcommands(t *testing.T) {
 		{
 			name:    "removed view spelling",
 			args:    []string{"review", "items", "view", "--id", "ITEM_ID"},
-			wantErr: "was removed in 4.0.0; use `asc review items list --submission \"SUBMISSION_ID\"` instead",
+			wantErr: removedNestedReviewItemGuidance,
 		},
 		{
 			name:    "unknown child",

--- a/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
+++ b/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
@@ -42,6 +42,29 @@ func TestReviewDeprecatedItemSurfacesAreRemoved(t *testing.T) {
 	}
 }
 
+func TestReviewRemovedItemCommandsProvideMigrationGuidance(t *testing.T) {
+	for _, args := range [][]string{
+		{"review", "items", "view", "--id", "ITEM_ID"},
+		{"review", "items-get", "--id", "ITEM_ID"},
+	} {
+		t.Run(strings.Join(args[:len(args)-2], " "), func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(args, "4.0.0"); code != cmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			const want = "was removed in 4.0.0; use `asc review items list --submission \"SUBMISSION_ID\"` instead"
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("expected migration guidance %q, got %q", want, stderr)
+			}
+		})
+	}
+}
+
 // TestReviewItemsAddRejectsRemovedItemTypesWithMigrationGuidance keeps the
 // migration text on the item types the CLI no longer accepts, instead of
 // falling back to the generic supported-value list.
@@ -121,7 +144,7 @@ func TestReviewItemsGroupRejectsUnknownSubcommands(t *testing.T) {
 		{
 			name:    "removed view spelling",
 			args:    []string{"review", "items", "view", "--id", "ITEM_ID"},
-			wantErr: "Error: unexpected argument(s): view",
+			wantErr: "was removed in 4.0.0; use `asc review items list --submission \"SUBMISSION_ID\"` instead",
 		},
 		{
 			name:    "unknown child",

--- a/internal/cli/reviews/review.go
+++ b/internal/cli/reviews/review.go
@@ -3,6 +3,7 @@ package reviews
 import (
 	"context"
 	"flag"
+	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
@@ -65,6 +66,9 @@ Examples:
 			ReviewItemsRemoveCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 && strings.TrimSpace(args[0]) == "items-get" {
+				return removedReviewItemDetailUsageError("asc review items-get")
+			}
 			return flag.ErrHelp
 		},
 	}

--- a/internal/cli/reviews/review_items.go
+++ b/internal/cli/reviews/review_items.go
@@ -50,14 +50,23 @@ Examples:
 			reviewItemsRemoveCommand("remove", "review items remove", `asc review items remove [flags]`, `asc review items remove --id "ITEM_ID" --confirm`),
 		},
 		Exec: func(ctx context.Context, args []string) error {
-			// Name the unknown child (including the removed `view`/`get`
-			// spellings) rather than printing bare group help.
 			if len(args) > 0 {
-				return shared.UsageErrorf("unexpected argument(s): %s", shared.SanitizeTerminal(strings.TrimSpace(args[0])))
+				subcommand := strings.TrimSpace(args[0])
+				if subcommand == "view" {
+					return removedReviewItemDetailUsageError("asc review items view")
+				}
+				return shared.UsageErrorf("unexpected argument(s): %s", shared.SanitizeTerminal(subcommand))
 			}
 			return flag.ErrHelp
 		},
 	}
+}
+
+func removedReviewItemDetailUsageError(command string) error {
+	return shared.UsageErrorf(
+		"`%s` was removed in 4.0.0; use `asc review items list --submission \"SUBMISSION_ID\"` instead",
+		command,
+	)
 }
 
 // ReviewItemsListCommand returns the review items list subcommand.


### PR DESCRIPTION
## Summary

- give the two removed 3.x review item-detail paths a precise 4.0 migration error
- keep both paths unregistered and absent from command help
- preserve the generic unknown-child behavior for undocumented spellings

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1` commit hook, including the short test suite
- built-binary checks for stderr, stdout, exit code, and help visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for legacy review commands that are no longer available.
  - Running `asc review items-get` now provides clear removal and usage guidance.
  - Running `asc review items view` directs you to the supported `asc review items list` command.
  - Removed commands now return consistent usage errors without unexpected output or confusing help text.
  - Legacy review command handling now provides consistent migration guidance across supported invocation formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->