### PR TITLE
fix: distinguish direct Claude child sessions

### DIFF
--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -53,7 +53,7 @@ func DetectInvocationSource() InvocationSource {
 		return SourcePi
 	case envTruthy("OPENCODE"):
 		return SourceOpenCode
-	case os.Getenv("CLAUDECODE") == "1":
+	case os.Getenv("CLAUDE_CODE_CHILD_SESSION") == "1":
 		return SourceClaudeCode
 	case os.Getenv("CURSOR_AGENT") != "":
 		return SourceCursorAgent

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -108,8 +108,13 @@ func TestDetectInvocationSource(t *testing.T) {
 			want: SourceTerminal,
 		},
 		{
-			name: "claude code",
+			name: "claude code IDE terminal marker is not a direct child",
 			env:  map[string]string{"CLAUDECODE": "1"},
+			want: SourceTerminal,
+		},
+		{
+			name: "claude code child session",
+			env:  map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"},
 			want: SourceClaudeCode,
 		},
 		{
@@ -154,6 +159,7 @@ func clearContextEnv(t *testing.T) {
 		"OPENCODE",
 		"AGENT",
 		"CLAUDECODE",
+		"CLAUDE_CODE_CHILD_SESSION",
 		"CURSOR_AGENT",
 		"CODEX_SHELL",
 		"CODEX_THREAD_ID",

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -433,7 +433,11 @@ func TestBuildEventReusesInstallIDAcrossLocalInvocationSources(t *testing.T) {
 		env        map[string]string
 		wantSource InvocationSource
 	}{
-		{name: "Claude Code", env: map[string]string{"CLAUDECODE": "1"}, wantSource: SourceClaudeCode},
+		{
+			name:       "Claude Code",
+			env:        map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"},
+			wantSource: SourceClaudeCode,
+		},
 		{name: "Cursor Agent", env: map[string]string{"CURSOR_AGENT": "1"}, wantSource: SourceCursorAgent},
 		{
 			name:       "Codex Desktop",
@@ -480,7 +484,7 @@ func TestBuildEventOmitsInstallIDForEphemeralAgentRuntime(t *testing.T) {
 	}{
 		{
 			name:        "Claude Code in CI",
-			env:         map[string]string{"CI": "true", "CLAUDECODE": "1"},
+			env:         map[string]string{"CI": "true", "CLAUDE_CODE_CHILD_SESSION": "1"},
 			wantRuntime: RuntimeCI,
 			wantSource:  SourceClaudeCode,
 		},


### PR DESCRIPTION
## Summary
- identify direct Claude Code tool children with `CLAUDE_CODE_CHILD_SESSION`
- treat inherited `CLAUDECODE` alone as a terminal invocation
- keep source detection tests isolated across local and CI runtimes

## Compatibility
`CLAUDE_CODE_CHILD_SESSION` is the precise marker in Claude Code 2.1.172 and later. Older clients without it are conservatively classified as terminal instead of risking false attribution from IDE-integrated terminals.

Official reference: https://code.claude.com/docs/en/env-vars#variables

## Verification
- focused detector regression test
- full telemetry package and adjacent command tests
- built-binary event-spool matrix for terminal, inherited IDE marker, and direct child
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Claude Code child sessions in telemetry.
  * Correctly distinguishes IDE terminal sessions from child sessions for more accurate invocation reporting.
* **Tests**
  * Updated telemetry coverage for local and CI environments to validate the revised session detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->