### PR TITLE
fix: preserve public storefront HTTP status context

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -203,6 +203,8 @@ func runtimeOutcomeKind(err error, exitCode int, eventContext telemetry.EventCon
 		return telemetry.OutcomeAuthError
 	case shared.IsValidationError(err):
 		return telemetry.OutcomeExpectedNegative
+	case isPublicStorefrontError(err) && (eventContext.HTTPStatus == 401 || eventContext.HTTPStatus == 403):
+		return telemetry.OutcomeAPIClientError
 	case eventContext.HTTPStatus == 401 || eventContext.HTTPStatus == 403:
 		return telemetry.OutcomeAuthError
 	case eventContext.HTTPStatus == 404:
@@ -222,6 +224,11 @@ func runtimeOutcomeKind(err error, exitCode int, eventContext telemetry.EventCon
 	default:
 		return telemetry.OutcomeInternalError
 	}
+}
+
+func isPublicStorefrontError(err error) bool {
+	var storefrontError interface{ PublicStorefrontError() bool }
+	return errors.As(err, &storefrontError) && storefrontError.PublicStorefrontError()
 }
 
 func httpStatusFromError(err error) int {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -162,10 +162,11 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 	}
 
 	eventContext := telemetry.EventContext{
-		InvocationShape: analysis.shape,
-		ErrorKind:       telemetry.ErrorKindOther,
-		FailureStage:    telemetry.FailureStageExecution,
-		HTTPStatus:      httpStatusFromError(err),
+		InvocationShape:  analysis.shape,
+		ErrorKind:        telemetry.ErrorKindOther,
+		FailureStage:     telemetry.FailureStageExecution,
+		HTTPStatus:       httpStatusFromError(err),
+		PublicStorefront: isPublicStorefrontError(err),
 	}
 	switch {
 	case errors.Is(err, shared.ErrMissingAuth):
@@ -203,7 +204,7 @@ func runtimeOutcomeKind(err error, exitCode int, eventContext telemetry.EventCon
 		return telemetry.OutcomeAuthError
 	case shared.IsValidationError(err):
 		return telemetry.OutcomeExpectedNegative
-	case isPublicStorefrontError(err) && (eventContext.HTTPStatus == 401 || eventContext.HTTPStatus == 403):
+	case eventContext.PublicStorefront && (eventContext.HTTPStatus == 401 || eventContext.HTTPStatus == 403):
 		return telemetry.OutcomeAPIClientError
 	case eventContext.HTTPStatus == 401 || eventContext.HTTPStatus == 403:
 		return telemetry.OutcomeAuthError

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -23,6 +23,18 @@ func TestRuntimeFailureContextClassifiesItunesHTTPStatus(t *testing.T) {
 		wantOutcome telemetry.OutcomeKind
 	}{
 		{
+			name:        "public unauthorized response",
+			statusCode:  http.StatusUnauthorized,
+			wantKind:    telemetry.ErrorKindOther,
+			wantOutcome: telemetry.OutcomeAPIClientError,
+		},
+		{
+			name:        "public forbidden response",
+			statusCode:  http.StatusForbidden,
+			wantKind:    telemetry.ErrorKindOther,
+			wantOutcome: telemetry.OutcomeAPIClientError,
+		},
+		{
 			name:        "client error",
 			statusCode:  http.StatusTooManyRequests,
 			wantKind:    telemetry.ErrorKindOther,

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -4,13 +4,70 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/itunes"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
+
+func TestRuntimeFailureContextClassifiesItunesHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		wantKind    telemetry.ErrorKind
+		wantOutcome telemetry.OutcomeKind
+	}{
+		{
+			name:        "client error",
+			statusCode:  http.StatusTooManyRequests,
+			wantKind:    telemetry.ErrorKindOther,
+			wantOutcome: telemetry.OutcomeAPIClientError,
+		},
+		{
+			name:        "server error",
+			statusCode:  http.StatusServiceUnavailable,
+			wantKind:    telemetry.ErrorKindAPI5xx,
+			wantOutcome: telemetry.OutcomeAPIServerError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.statusCode)
+			}))
+			defer server.Close()
+
+			client := &itunes.Client{BaseURL: server.URL, HTTPClient: server.Client()}
+			_, err := client.SearchApps(context.Background(), "focus", "us", 20)
+			if err == nil {
+				t.Fatal("expected non-success response error")
+			}
+
+			got := runtimeFailureContext(
+				invocationAnalysis{shape: telemetry.InvocationShapeLeaf},
+				err,
+				ExitError,
+			)
+			if got.ErrorKind != test.wantKind || got.FailureStage != telemetry.FailureStageRequest ||
+				got.OutcomeKind != test.wantOutcome || got.HTTPStatus != test.statusCode {
+				t.Fatalf(
+					"runtimeFailureContext() = %+v, want kind=%q stage=%q outcome=%q status=%d",
+					got,
+					test.wantKind,
+					telemetry.FailureStageRequest,
+					test.wantOutcome,
+					test.statusCode,
+				)
+			}
+		})
+	}
+}
 
 func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 	analysis := invocationAnalysis{shape: telemetry.InvocationShapeLeaf}

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -67,9 +67,9 @@ func TestRuntimeFailureContextClassifiesItunesHTTPStatus(t *testing.T) {
 				ExitError,
 			)
 			if got.ErrorKind != test.wantKind || got.FailureStage != telemetry.FailureStageRequest ||
-				got.OutcomeKind != test.wantOutcome || got.HTTPStatus != test.statusCode {
+				got.OutcomeKind != test.wantOutcome || got.HTTPStatus != test.statusCode || !got.PublicStorefront {
 				t.Fatalf(
-					"runtimeFailureContext() = %+v, want kind=%q stage=%q outcome=%q status=%d",
+					"runtimeFailureContext() = %+v, want kind=%q stage=%q outcome=%q status=%d public storefront",
 					got,
 					test.wantKind,
 					telemetry.FailureStageRequest,

--- a/internal/cli/reviews/reviews_ratings.go
+++ b/internal/cli/reviews/reviews_ratings.go
@@ -17,6 +17,18 @@ import (
 
 const ratingsAppSearchLimit = 200
 
+type ratingsBundleLookupError struct {
+	cause error
+}
+
+func (e *ratingsBundleLookupError) Error() string {
+	return "could not resolve --app by bundle ID; pass a numeric App Store ID or try again later"
+}
+
+func (e *ratingsBundleLookupError) Unwrap() error {
+	return e.cause
+}
+
 // ReviewsRatingsCommand returns the reviews ratings subcommand.
 func ReviewsRatingsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("ratings", flag.ExitOnError)
@@ -122,7 +134,7 @@ func resolveRatingsAppID(ctx context.Context, client *itunes.Client, app string,
 			IncludeSoftwareEntity: true,
 		})
 		if err != nil {
-			return "", fmt.Errorf("could not resolve --app by bundle ID; pass a numeric App Store ID or try again later")
+			return "", &ratingsBundleLookupError{cause: err}
 		}
 		if result != nil && result.AppID != 0 {
 			return strconv.FormatInt(result.AppID, 10), nil

--- a/internal/cli/reviews/reviews_ratings_test.go
+++ b/internal/cli/reviews/reviews_ratings_test.go
@@ -278,8 +278,74 @@ func TestResolveRatingsAppIDHidesBundleLookupFailureDetails(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected lookup failure")
 	}
+	const wantError = "could not resolve --app by bundle ID; pass a numeric App Store ID or try again later"
+	if err.Error() != wantError {
+		t.Fatalf("error = %q, want %q", err, wantError)
+	}
 	if strings.Contains(err.Error(), "com.example.secret") || strings.Contains(err.Error(), "backend leaked") {
 		t.Fatalf("expected generic lookup error, got %q", err.Error())
+	}
+	var statusError interface{ HTTPStatusCode() int }
+	if !errors.As(err, &statusError) {
+		t.Fatalf("error %T does not retain HTTP status", err)
+	}
+	if got := statusError.HTTPStatusCode(); got != http.StatusInternalServerError {
+		t.Fatalf("HTTPStatusCode() = %d, want %d", got, http.StatusInternalServerError)
+	}
+}
+
+func TestExecuteRatingsRetainsPublicHTTPStatusWithoutChangingErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		app       string
+		all       bool
+		wantError string
+	}{
+		{
+			name:      "bundle ID resolution",
+			app:       "com.example.secret",
+			wantError: "reviews ratings: could not resolve --app by bundle ID; pass a numeric App Store ID or try again later",
+		},
+		{
+			name:      "all storefronts",
+			app:       "123",
+			all:       true,
+			wantError: "reviews ratings: app not found in any country: 123",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			defer server.Close()
+
+			client := &itunes.Client{BaseURL: server.URL, HTTPClient: server.Client()}
+			err := executeRatingsWithClient(
+				context.Background(),
+				client,
+				test.app,
+				"us",
+				test.all,
+				5,
+				"json",
+				false,
+			)
+			if err == nil {
+				t.Fatal("expected request failure")
+			}
+			if err.Error() != test.wantError {
+				t.Fatalf("error = %q, want %q", err, test.wantError)
+			}
+			var statusError interface{ HTTPStatusCode() int }
+			if !errors.As(err, &statusError) {
+				t.Fatalf("error %T does not retain HTTP status", err)
+			}
+			if got := statusError.HTTPStatusCode(); got != http.StatusServiceUnavailable {
+				t.Fatalf("HTTPStatusCode() = %d, want %d", got, http.StatusServiceUnavailable)
+			}
+		})
 	}
 }
 

--- a/internal/itunes/client_test.go
+++ b/internal/itunes/client_test.go
@@ -253,6 +253,10 @@ func TestGetAllRatings_Aggregation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/lookup" {
 			country := r.URL.Query().Get("country")
+			if country == "fr" {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
 			if resp, ok := responses[country]; ok {
 				w.Header().Set("Content-Type", "application/json")
 				writeBody(t, w, resp)
@@ -375,6 +379,35 @@ func TestGetAllRatings_NoRatings(t *testing.T) {
 	}
 	if global.CountryCount != 0 {
 		t.Fatalf("CountryCount = %d, want 0", global.CountryCount)
+	}
+}
+
+func TestGetAllRatings_AllStorefrontHTTPFailuresRetainStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		HTTPClient: &http.Client{
+			Transport: &testTransport{baseURL: server.URL},
+		},
+	}
+
+	_, err := client.GetAllRatings(context.Background(), "123", 5, context.WithCancel)
+	if err == nil {
+		t.Fatal("expected all-storefront failure")
+	}
+	const wantError = "app not found in any country: 123"
+	if err.Error() != wantError {
+		t.Fatalf("error = %q, want %q", err, wantError)
+	}
+	var statusError interface{ HTTPStatusCode() int }
+	if !errors.As(err, &statusError) {
+		t.Fatalf("error %T does not retain HTTP status", err)
+	}
+	if got := statusError.HTTPStatusCode(); got != http.StatusServiceUnavailable {
+		t.Fatalf("HTTPStatusCode() = %d, want %d", got, http.StatusServiceUnavailable)
 	}
 }
 

--- a/internal/itunes/client_test.go
+++ b/internal/itunes/client_test.go
@@ -413,23 +413,36 @@ func TestGetAllRatings_AllStorefrontHTTPFailuresRetainStatus(t *testing.T) {
 
 func TestGetAllRatings_MixedHTTPFailuresSelectServerStatusDeterministically(t *testing.T) {
 	tests := []struct {
-		name        string
-		firstStatus int
-		restStatus  int
+		name            string
+		completionOrder []int
 	}{
-		{name: "client finishes first", firstStatus: http.StatusTooManyRequests, restStatus: http.StatusServiceUnavailable},
-		{name: "server finishes first", firstStatus: http.StatusServiceUnavailable, restStatus: http.StatusTooManyRequests},
+		{name: "client finishes first", completionOrder: []int{1, 2}},
+		{name: "server finishes first", completionOrder: []int{2, 1}},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var requestCount atomic.Int32
+			ready := make(chan int, 2)
+			finished := make(chan int, 2)
+			releases := []chan struct{}{make(chan struct{}), make(chan struct{})}
+			releaseRemaining := make(chan struct{})
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				status := test.restStatus
-				if requestCount.Add(1) == 1 {
-					status = test.firstStatus
+				request := int(requestCount.Add(1))
+				status := http.StatusTooManyRequests
+				if request <= 2 {
+					ready <- request
+					<-releases[request-1]
+					if request == 2 {
+						status = http.StatusServiceUnavailable
+					}
+				} else {
+					<-releaseRemaining
 				}
 				w.WriteHeader(status)
+				if request <= 2 {
+					finished <- request
+				}
 			}))
 			defer server.Close()
 
@@ -439,7 +452,24 @@ func TestGetAllRatings_MixedHTTPFailuresSelectServerStatusDeterministically(t *t
 				},
 			}
 
-			_, err := client.GetAllRatings(context.Background(), "123", 1, context.WithCancel)
+			errCh := make(chan error, 1)
+			go func() {
+				_, err := client.GetAllRatings(context.Background(), "123", 2, context.WithCancel)
+				errCh <- err
+			}()
+
+			for range 2 {
+				<-ready
+			}
+			for _, request := range test.completionOrder {
+				close(releases[request-1])
+				if got := <-finished; got != request {
+					t.Fatalf("request %d completed, want %d", got, request)
+				}
+			}
+			close(releaseRemaining)
+
+			err := <-errCh
 			if err == nil {
 				t.Fatal("expected all-storefront failure")
 			}

--- a/internal/itunes/client_test.go
+++ b/internal/itunes/client_test.go
@@ -411,6 +411,49 @@ func TestGetAllRatings_AllStorefrontHTTPFailuresRetainStatus(t *testing.T) {
 	}
 }
 
+func TestGetAllRatings_MixedHTTPFailuresSelectServerStatusDeterministically(t *testing.T) {
+	tests := []struct {
+		name        string
+		firstStatus int
+		restStatus  int
+	}{
+		{name: "client finishes first", firstStatus: http.StatusTooManyRequests, restStatus: http.StatusServiceUnavailable},
+		{name: "server finishes first", firstStatus: http.StatusServiceUnavailable, restStatus: http.StatusTooManyRequests},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				status := test.restStatus
+				if requestCount.Add(1) == 1 {
+					status = test.firstStatus
+				}
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+
+			client := &Client{
+				HTTPClient: &http.Client{
+					Transport: &testTransport{baseURL: server.URL},
+				},
+			}
+
+			_, err := client.GetAllRatings(context.Background(), "123", 1, context.WithCancel)
+			if err == nil {
+				t.Fatal("expected all-storefront failure")
+			}
+			var statusError interface{ HTTPStatusCode() int }
+			if !errors.As(err, &statusError) {
+				t.Fatalf("error %T does not retain HTTP status", err)
+			}
+			if got := statusError.HTTPStatusCode(); got != http.StatusServiceUnavailable {
+				t.Fatalf("HTTPStatusCode() = %d, want deterministic server status %d", got, http.StatusServiceUnavailable)
+			}
+		})
+	}
+}
+
 func TestGetAllRatings_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/itunes/errors.go
+++ b/internal/itunes/errors.go
@@ -1,0 +1,16 @@
+package itunes
+
+import "fmt"
+
+type httpStatusError struct {
+	operation  string
+	statusCode int
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("%s request returned status %d", e.operation, e.statusCode)
+}
+
+func (e *httpStatusError) HTTPStatusCode() int {
+	return e.statusCode
+}

--- a/internal/itunes/errors.go
+++ b/internal/itunes/errors.go
@@ -14,3 +14,7 @@ func (e *httpStatusError) Error() string {
 func (e *httpStatusError) HTTPStatusCode() int {
 	return e.statusCode
 }
+
+func (e *httpStatusError) PublicStorefrontError() bool {
+	return true
+}

--- a/internal/itunes/lookup.go
+++ b/internal/itunes/lookup.go
@@ -144,7 +144,7 @@ func (c *Client) LookupApps(ctx context.Context, ids []string, opts LookupOption
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("lookup request returned status %d", resp.StatusCode)
+		return nil, &httpStatusError{operation: "lookup", statusCode: resp.StatusCode}
 	}
 
 	var lookup lookupResponse
@@ -229,7 +229,7 @@ func (c *Client) LookupAppByBundleID(ctx context.Context, bundleID string, opts 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("lookup request returned status %d", resp.StatusCode)
+		return nil, &httpStatusError{operation: "lookup", statusCode: resp.StatusCode}
 	}
 
 	var lookup lookupResponse

--- a/internal/itunes/public_test.go
+++ b/internal/itunes/public_test.go
@@ -2,12 +2,88 @@ package itunes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
 	"testing"
 )
+
+func TestNonSuccessResponsesExposeHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantError  string
+		call       func(*Client) error
+	}{
+		{
+			name:       "search",
+			statusCode: http.StatusTooManyRequests,
+			wantError:  "search request returned status 429",
+			call: func(client *Client) error {
+				_, err := client.SearchApps(context.Background(), "focus", "us", 20)
+				return err
+			},
+		},
+		{
+			name:       "lookup",
+			statusCode: http.StatusServiceUnavailable,
+			wantError:  "lookup request returned status 503",
+			call: func(client *Client) error {
+				_, err := client.LookupApps(context.Background(), []string{"123"}, LookupOptions{})
+				return err
+			},
+		},
+		{
+			name:       "lookup by bundle ID",
+			statusCode: http.StatusNotFound,
+			wantError:  "lookup request returned status 404",
+			call: func(client *Client) error {
+				_, err := client.LookupAppByBundleID(
+					context.Background(),
+					"com.example.app",
+					LookupOptions{},
+				)
+				return err
+			},
+		},
+		{
+			name:       "ratings histogram",
+			statusCode: http.StatusBadGateway,
+			wantError:  "histogram request returned status 502",
+			call: func(client *Client) error {
+				return client.fetchHistogram(context.Background(), "123", "us", &AppRatings{})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.statusCode)
+			}))
+			defer server.Close()
+
+			client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+			err := test.call(client)
+			if err == nil {
+				t.Fatal("expected non-success response error")
+			}
+			if err.Error() != test.wantError {
+				t.Fatalf("error = %q, want %q", err, test.wantError)
+			}
+
+			var statusError interface{ HTTPStatusCode() int }
+			if !errors.As(err, &statusError) {
+				t.Fatalf("error %T does not expose HTTP status", err)
+			}
+			if got := statusError.HTTPStatusCode(); got != test.statusCode {
+				t.Fatalf("HTTPStatusCode() = %d, want %d", got, test.statusCode)
+			}
+		})
+	}
+}
 
 func TestNormalizeCountryCode(t *testing.T) {
 	country, err := NormalizeCountryCode(" US ")

--- a/internal/itunes/public_test.go
+++ b/internal/itunes/public_test.go
@@ -81,6 +81,10 @@ func TestNonSuccessResponsesExposeHTTPStatus(t *testing.T) {
 			if got := statusError.HTTPStatusCode(); got != test.statusCode {
 				t.Fatalf("HTTPStatusCode() = %d, want %d", got, test.statusCode)
 			}
+			var storefrontError interface{ PublicStorefrontError() bool }
+			if !errors.As(err, &storefrontError) || !storefrontError.PublicStorefrontError() {
+				t.Fatalf("error %T does not retain public storefront semantics", err)
+			}
 		})
 	}
 }

--- a/internal/itunes/ratings.go
+++ b/internal/itunes/ratings.go
@@ -37,6 +37,19 @@ type GlobalRatings struct {
 	ByCountry     []AppRatings  `json:"byCountry"`
 }
 
+type allRatingsLookupError struct {
+	appID string
+	cause error
+}
+
+func (e *allRatingsLookupError) Error() string {
+	return fmt.Sprintf("app not found in any country: %s", e.appID)
+}
+
+func (e *allRatingsLookupError) Unwrap() error {
+	return e.cause
+}
+
 // GetRatings fetches rating statistics for an app in a specific country.
 func (c *Client) GetRatings(ctx context.Context, appID, country string) (*AppRatings, error) {
 	normalizedCountry := strings.ToLower(strings.TrimSpace(country))
@@ -139,6 +152,8 @@ func (c *Client) GetAllRatings(
 		wg                 sync.WaitGroup
 		deadlineOnce       sync.Once
 		countryDeadlineErr error
+		httpFailureCount   int
+		representativeErr  error
 		results            []*AppRatings
 		appName            string
 		appIDInt           int64
@@ -177,6 +192,15 @@ func (c *Client) GetAllRatings(
 				return
 			}
 			if err != nil {
+				var statusError interface{ HTTPStatusCode() int }
+				if errors.As(err, &statusError) {
+					mu.Lock()
+					httpFailureCount++
+					if representativeErr == nil {
+						representativeErr = err
+					}
+					mu.Unlock()
+				}
 				return
 			}
 
@@ -210,6 +234,9 @@ func (c *Client) GetAllRatings(
 		return nil, countryDeadlineErr
 	}
 	if !found {
+		if httpFailureCount == len(countries) {
+			return nil, &allRatingsLookupError{appID: appID, cause: representativeErr}
+		}
 		return nil, fmt.Errorf("app not found in any country: %s", appID)
 	}
 	if len(results) == 0 {

--- a/internal/itunes/ratings.go
+++ b/internal/itunes/ratings.go
@@ -153,7 +153,7 @@ func (c *Client) GetAllRatings(
 		deadlineOnce       sync.Once
 		countryDeadlineErr error
 		httpFailureCount   int
-		representativeErr  error
+		httpFailures       = make(map[int]error)
 		results            []*AppRatings
 		appName            string
 		appIDInt           int64
@@ -196,8 +196,9 @@ func (c *Client) GetAllRatings(
 				if errors.As(err, &statusError) {
 					mu.Lock()
 					httpFailureCount++
-					if representativeErr == nil {
-						representativeErr = err
+					status := statusError.HTTPStatusCode()
+					if _, exists := httpFailures[status]; !exists {
+						httpFailures[status] = err
 					}
 					mu.Unlock()
 				}
@@ -235,7 +236,7 @@ func (c *Client) GetAllRatings(
 	}
 	if !found {
 		if httpFailureCount == len(countries) {
-			return nil, &allRatingsLookupError{appID: appID, cause: representativeErr}
+			return nil, &allRatingsLookupError{appID: appID, cause: preferredRatingsHTTPError(httpFailures)}
 		}
 		return nil, fmt.Errorf("app not found in any country: %s", appID)
 	}
@@ -274,4 +275,20 @@ func (c *Client) GetAllRatings(
 		Histogram:     histogram,
 		ByCountry:     byCountry,
 	}, nil
+}
+
+func preferredRatingsHTTPError(failures map[int]error) error {
+	selectedStatus := 0
+	var selected error
+	for status, err := range failures {
+		// Server failures take precedence over client failures because they best
+		// represent a full-storefront outage. Within a class, use the lowest
+		// status so the result is stable regardless of goroutine completion order.
+		if selected == nil || (status >= 500 && selectedStatus < 500) ||
+			(status/100 == selectedStatus/100 && status < selectedStatus) {
+			selectedStatus = status
+			selected = err
+		}
+	}
+	return selected
 }

--- a/internal/itunes/ratings.go
+++ b/internal/itunes/ratings.go
@@ -92,7 +92,7 @@ func (c *Client) fetchHistogram(ctx context.Context, appID, country string, rati
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("histogram request returned status %d", resp.StatusCode)
+		return &httpStatusError{operation: "histogram", statusCode: resp.StatusCode}
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/itunes/search.go
+++ b/internal/itunes/search.go
@@ -59,7 +59,7 @@ func (c *Client) SearchApps(ctx context.Context, term, country string, limit int
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("search request returned status %d", resp.StatusCode)
+		return nil, &httpStatusError{operation: "search", statusCode: resp.StatusCode}
 	}
 
 	var payload searchResponse

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -87,6 +87,7 @@ type EventContext struct {
 	FailureParameter string
 	OutcomeKind      OutcomeKind
 	HTTPStatus       int
+	PublicStorefront bool
 }
 
 // processSessionID groups events from one CLI process without linking separate
@@ -194,6 +195,8 @@ func normalizeEventContext(eventContext EventContext, exitCode int) EventContext
 func normalizeOutcomeKind(eventContext EventContext, exitCode int) OutcomeKind {
 	status := eventContext.HTTPStatus
 	switch {
+	case eventContext.PublicStorefront && (status == 401 || status == 403):
+		return OutcomeAPIClientError
 	case status == 401 || status == 403:
 		return OutcomeAuthError
 	case status == 404:

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -133,6 +133,32 @@ func TestBuildEventWithContextCapturesBoundedHTTPContext(t *testing.T) {
 	}
 }
 
+func TestBuildEventWithContextPreservesPublicStorefrontAuthorizationOutcome(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	event, ok := BuildEventWithContext(
+		"asc apps public search",
+		"1.2.3",
+		time.Second,
+		1,
+		EventContext{
+			InvocationShape:  InvocationShapeLeaf,
+			ErrorKind:        ErrorKindOther,
+			FailureStage:     FailureStageRequest,
+			OutcomeKind:      OutcomeAPIClientError,
+			HTTPStatus:       403,
+			PublicStorefront: true,
+		},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if event.OutcomeKind != OutcomeAPIClientError {
+		t.Fatalf("OutcomeKind = %q, want %q", event.OutcomeKind, OutcomeAPIClientError)
+	}
+}
+
 func TestBuildEventWithContextPreservesAPIOutcomesWithoutHTTPStatus(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)


### PR DESCRIPTION
## Summary
- preserve upstream HTTP status codes for public storefront search, lookup, and ratings failures
- retain status context through bundle-ID rating resolution and all-storefront outages
- classify mixed storefront failures deterministically
- keep public 401/403 outcomes source-aware through final event normalization
- keep user-facing error text and process exit behavior unchanged

## Test plan
- `make format`
- `make check-docs`
- `make lint`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 make test`
- focused source-attribution, storefront client, ratings execution, emitted-event normalization, and runtime-classification tests
- built binary: read-only `apps public search` against the live public storefront API with event collection disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of iTunes API errors across search, lookup, bundle-ID lookup, and ratings requests.
  * Error messages now consistently identify the affected operation and HTTP status code.
  * Ratings errors preserve underlying HTTP status details, including when all storefront requests fail.
  * Runtime failure reporting more accurately classifies client and server responses, including public storefront authorization errors.

* **Tests**
  * Added coverage for non-success responses, status preservation, error wrapping, and deterministic ratings failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->