### PR TITLE
feat(builds): list TestFlight groups for a build

### DIFF
--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -406,6 +406,7 @@ Examples:
   asc builds upload --app "123456789" --pkg "app.pkg" --version "1.0.0" --build-number "1"
   asc builds uploads list --app "123456789"
   asc builds test-notes list --build-id "BUILD_ID"
+  asc builds groups list --build-id "BUILD_ID"
   asc builds individual-testers list --app "123456789" --latest
   asc builds update --app "123456789" --latest --uses-non-exempt-encryption=false
   asc builds add-groups --app "123456789" --latest --group "GROUP_ID"
@@ -433,6 +434,7 @@ Examples:
 			BuildsUploadsCommand(),
 			BuildsTestNotesCommand(),
 			BuildsAppEncryptionDeclarationCommand(),
+			BuildsGroupsCommand(),
 			BuildsUpdateCommand(),
 			BuildsAddGroupsCommand(),
 			BuildsRemoveGroupsCommand(),

--- a/internal/cli/builds/builds_groups.go
+++ b/internal/cli/builds/builds_groups.go
@@ -1,0 +1,49 @@
+package builds
+
+import (
+	"context"
+	"flag"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/testflight"
+)
+
+// BuildsGroupsCommand returns the build beta-groups command group.
+func BuildsGroupsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("groups", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "groups",
+		ShortUsage: "asc builds groups <subcommand> [flags]",
+		ShortHelp:  "View TestFlight beta groups for builds.",
+		LongHelp: `View TestFlight beta groups for builds.
+
+Examples:
+  asc builds groups list --build-id "BUILD_ID"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			testflight.BuildGroupsListCommand(testflight.BuildGroupsListCommandConfig{
+				ShortUsage: "asc builds groups list --build-id \"BUILD_ID\" [flags]",
+				ShortHelp:  "[experimental] List TestFlight beta groups that contain a build.",
+				LongHelp: `List TestFlight beta groups that contain a build.
+
+The membership lookup is experimental. It resolves the build's app and
+automatically fetches all required pages. The lookup uses the documented
+betaGroups build filter and checks inverse group-to-build relationships for
+all-build access. The command returns the same structured membership result as
+asc testflight groups list --build-id.
+
+Examples:
+  asc builds groups list --build-id "BUILD_ID"
+  asc builds groups list --build-id "BUILD_ID" --output table`,
+				ErrorPrefix: "builds groups list",
+			}),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/cli/cmdtest/testflight_build_group_membership_test.go
+++ b/internal/cli/cmdtest/testflight_build_group_membership_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 type buildGroupMembershipOutput struct {
@@ -35,6 +37,225 @@ type buildGroupMembershipRecord struct {
 type buildGroupMembershipFailure struct {
 	GroupID string `json:"groupId"`
 	Error   string `json:"error"`
+}
+
+func TestBuildsGroupsListCommandHasNarrowBuildSurface(t *testing.T) {
+	root := RootCommand("1.2.3")
+	list := findCommand(root, "builds", "groups", "list")
+	if list == nil {
+		t.Fatal("expected builds groups list command")
+	}
+
+	wantFlags := map[string]bool{
+		"build-id": true,
+		"output":   true,
+		"pretty":   true,
+	}
+	list.FlagSet.VisitAll(func(value *flag.Flag) {
+		if !wantFlags[value.Name] {
+			t.Errorf("unexpected --%s flag on builds groups list", value.Name)
+		}
+		delete(wantFlags, value.Name)
+	})
+	for name := range wantFlags {
+		t.Errorf("missing --%s flag on builds groups list", name)
+	}
+
+	for _, forbidden := range []string{"app", "global", "internal", "external", "limit", "next", "paginate"} {
+		if list.FlagSet.Lookup(forbidden) != nil {
+			t.Errorf("builds groups list must not expose --%s", forbidden)
+		}
+	}
+}
+
+func TestBuildsGroupsListRequiresBuildIDBeforeAuth(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_STRICT_AUTH", "")
+
+	tests := []struct {
+		name       string
+		args       []string
+		diagnostic string
+	}{
+		{name: "missing", args: nil, diagnostic: "Error: --build-id is required"},
+		{name: "blank", args: []string{"--build-id", " "}, diagnostic: "Error: --build-id cannot be empty"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			args := append([]string{"builds", "groups", "list"}, test.args...)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.diagnostic) {
+				t.Fatalf("expected %q diagnostic, got %q", test.diagnostic, stderr)
+			}
+			if strings.Contains(stderr, "authentication") || strings.Contains(stderr, "credentials") {
+				t.Fatalf("required flag must fail before auth, got %q", stderr)
+			}
+		})
+	}
+}
+
+func TestBuildsGroupsListUsesExistingBuildMembershipLookup(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "ambient-app-must-not-be-used")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-1/relationships/app" {
+				t.Fatalf("unexpected app lookup: %s %s", req.Method, req.URL.String())
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+		case 2:
+			assertBuildMembershipGroupQuery(t, req.URL, "filter[app]", "app-1")
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		case 3:
+			assertBuildMembershipGroupQuery(t, req.URL, "filter[builds]", "build-1")
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "groups", "list", "--output", "json", "--build-id", "build-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 3 {
+		t.Fatalf("expected three requests, got %d", requestCount)
+	}
+
+	var got buildGroupMembershipOutput
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if got.BuildID != "build-1" || got.AppID != "app-1" || !got.Complete || got.GroupCount != 1 {
+		t.Fatalf("unexpected lookup result: %#v", got)
+	}
+	if len(got.Groups) != 1 || got.Groups[0].ID != "group-1" || got.Groups[0].Membership != "explicit" {
+		t.Fatalf("unexpected groups: %#v", got.Groups)
+	}
+}
+
+func TestBuildsGroupsListMatchesTestFlightBuildMembershipSurface(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "ambient-app-must-not-be-used")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	run := func(args []string) (string, string, []string, error) {
+		t.Helper()
+		requests := make([]string, 0, 3)
+		http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests = append(requests, req.Method+" "+req.URL.String())
+			switch len(requests) {
+			case 1:
+				return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1"}}`), nil
+			case 2, 3:
+				return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"External QA","isInternalGroup":false}}]}`), nil
+			default:
+				t.Fatalf("unexpected request: %s", req.URL.String())
+				return nil, nil
+			}
+		})
+
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+		var runErr error
+		stdout, stderr := captureOutput(t, func() {
+			if err := root.Parse(args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			runErr = root.Run(context.Background())
+		})
+		return stdout, stderr, requests, runErr
+	}
+
+	buildsStdout, buildsStderr, buildsRequests, buildsErr := run([]string{"builds", "groups", "list", "--build-id", "build-1"})
+	testflightStdout, testflightStderr, testflightRequests, testflightErr := run([]string{"testflight", "groups", "list", "--build-id", "build-1"})
+
+	if buildsErr != nil || testflightErr != nil {
+		t.Fatalf("unexpected parity errors: builds=%v testflight=%v", buildsErr, testflightErr)
+	}
+	if buildsStdout != testflightStdout || buildsStderr != testflightStderr {
+		t.Fatalf("surface output differs:\nbuilds stdout=%q stderr=%q\ntestflight stdout=%q stderr=%q", buildsStdout, buildsStderr, testflightStdout, testflightStderr)
+	}
+	if strings.Join(buildsRequests, "\n") != strings.Join(testflightRequests, "\n") {
+		t.Fatalf("HTTP behavior differs:\nbuilds=%v\ntestflight=%v", buildsRequests, testflightRequests)
+	}
+}
+
+func TestBuildsGroupsListPreservesLookupAPIErrors(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/builds/build-1/relationships/app" {
+			t.Fatalf("unexpected request: %s", req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","title":"Temporary failure"}]}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"builds", "groups", "list", "--build-id", "build-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil || !strings.Contains(runErr.Error(), "builds groups list: failed to resolve app for build") {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected empty streams, got stdout=%q stderr=%q", stdout, stderr)
+	}
 }
 
 func TestTestFlightGroupsListBuildMembershipFlagIsExperimental(t *testing.T) {

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -154,14 +154,6 @@ Examples:
 				if appIDSet {
 					expectedAppID = strings.TrimSpace(*appID)
 				}
-				client, err := shared.GetASCClient()
-				if err != nil {
-					return fmt.Errorf("beta-groups list: %w", err)
-				}
-
-				requestCtx, cancel := contextWithBuildGroupMembershipTimeout(ctx)
-				defer cancel()
-
 				var internalFilter *bool
 				if *internal {
 					value := true
@@ -171,27 +163,15 @@ Examples:
 					internalFilter = &value
 				}
 
-				result, usedFallback, lookupErr := lookupBuildGroupMembership(
-					requestCtx,
-					client,
+				return runBuildGroupMembershipList(
+					ctx,
 					resolvedBuildID,
 					expectedAppID,
 					internalFilter,
+					*output.Output,
+					*output.Pretty,
+					"beta-groups list",
 				)
-				if usedFallback {
-					fmt.Fprintln(os.Stderr, "Apple rejected the documented betaGroups build filter; falling back to inverse group build relationships (cost scales with groups and build pages)")
-				}
-				if result == nil {
-					return fmt.Errorf("beta-groups list: %w", lookupErr)
-				}
-				if err := shared.PrintOutput(result, *output.Output, *output.Pretty); err != nil {
-					return err
-				}
-				if lookupErr != nil {
-					fmt.Fprintf(os.Stderr, "%d group relationship lookup failed; membership result is incomplete\n", len(result.Failures))
-					return shared.NewReportedError(lookupErr)
-				}
-				return nil
 			}
 
 			// Reject --global + --app combination (check explicit flag, not resolved value)
@@ -343,6 +323,105 @@ Examples:
 			return shared.PrintOutput(groups, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+// BuildGroupsListCommandConfig configures the build-centric beta-group lookup
+// surface while keeping the membership implementation in one place.
+type BuildGroupsListCommandConfig struct {
+	ShortUsage  string
+	ShortHelp   string
+	LongHelp    string
+	ErrorPrefix string
+}
+
+// BuildGroupsListCommand returns a narrow list command for beta groups that
+// contain a required build ID.
+func BuildGroupsListCommand(config BuildGroupsListCommandConfig) *ffcli.Command {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+
+	buildID := fs.String("build-id", "", "[experimental] Build ID whose TestFlight groups should be listed")
+	output := shared.BindOutputFlags(fs)
+
+	errorPrefix := strings.TrimSpace(config.ErrorPrefix)
+	if errorPrefix == "" {
+		errorPrefix = "builds groups list"
+	}
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: config.ShortUsage,
+		ShortHelp:  config.ShortHelp,
+		LongHelp:   config.LongHelp,
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolvedBuildID := strings.TrimSpace(*buildID)
+			buildIDSet := false
+			fs.Visit(func(value *flag.Flag) {
+				if value.Name == "build-id" {
+					buildIDSet = true
+				}
+			})
+			if buildIDSet && resolvedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build-id cannot be empty")
+				return shared.MissingRequiredUsageError()
+			}
+			if resolvedBuildID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --build-id is required")
+				return shared.MissingRequiredUsageError()
+			}
+
+			return runBuildGroupMembershipList(
+				ctx,
+				resolvedBuildID,
+				"",
+				nil,
+				*output.Output,
+				*output.Pretty,
+				errorPrefix,
+			)
+		},
+	}
+}
+
+func runBuildGroupMembershipList(
+	ctx context.Context,
+	buildID string,
+	expectedAppID string,
+	internalFilter *bool,
+	output string,
+	pretty bool,
+	errorPrefix string,
+) error {
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return fmt.Errorf("%s: %w", errorPrefix, err)
+	}
+
+	requestCtx, cancel := contextWithBuildGroupMembershipTimeout(ctx)
+	defer cancel()
+
+	result, usedFallback, lookupErr := lookupBuildGroupMembership(
+		requestCtx,
+		client,
+		buildID,
+		expectedAppID,
+		internalFilter,
+	)
+	if usedFallback {
+		fmt.Fprintln(os.Stderr, "Apple rejected the documented betaGroups build filter; falling back to inverse group build relationships (cost scales with groups and build pages)")
+	}
+	if result == nil {
+		return fmt.Errorf("%s: %w", errorPrefix, lookupErr)
+	}
+	if err := shared.PrintOutput(result, output, pretty); err != nil {
+		return err
+	}
+	if lookupErr != nil {
+		fmt.Fprintf(os.Stderr, "%d group relationship lookup failed; membership result is incomplete\n", len(result.Failures))
+		return shared.NewReportedError(lookupErr)
+	}
+	return nil
 }
 
 func contextWithBuildGroupMembershipTimeout(ctx context.Context) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
## Summary

- add `asc builds groups list --build-id BUILD_ID` where build-focused workflows naturally look for TestFlight membership
- keep the surface narrow to the required build ID and output formatting flags
- share the existing membership lookup, pagination, fallback, partial-result, and output implementation with `asc testflight groups list --build-id`

## Behavior

```bash
asc builds groups list --build-id "BUILD_ID"
asc builds groups list --build-id "BUILD_ID" --output table
```

The existing TestFlight command remains available without changes. The new command ignores ambient app selection, requires a non-empty build ID before authentication, and does not expose app, global, or pagination selectors because membership lookup always fetches every required page.

## Verification

- TDD: new root-route tests failed before implementation and pass afterward
- focused command, HTTP, structured JSON, table, API error, flag-surface, and route-parity coverage
- `make format`
- `make check-docs`
- `make lint`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`
- built-binary help and missing-flag verification; missing `--build-id` exits 2 with empty stdout before auth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `asc builds groups list` to view TestFlight beta groups containing a specific build.
  * Requires a build ID and supports structured output, pagination, and experimental-feature guidance.
  * Added command examples and help documentation.
* **Bug Fixes**
  * Improved validation for missing or blank build IDs before authentication.
  * Preserved API errors and incomplete-result handling during group lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->