### PR TITLE
feat: add direct apps rename command

### DIFF
--- a/commands/apps.mdx
+++ b/commands/apps.mdx
@@ -177,8 +177,9 @@ does not exist, the command creates its app-info localization.
   App Info ID override. Use this when the app has multiple App Info records.
 </ParamField>
 
-<ParamField path="--output" type="string" default="json">
-  Output format: `json`, `table`, `markdown`
+<ParamField path="--output" type="string">
+  Output format: `json`, `table`, `markdown`. Defaults to `table` in an
+  interactive terminal and minified `json` for pipes or CI.
 </ParamField>
 
 **Examples:**

--- a/commands/apps.mdx
+++ b/commands/apps.mdx
@@ -156,10 +156,11 @@ asc apps view --id "APP_ID" --output table
 
 ***
 
-### `asc apps rename`
+### `asc apps rename` (experimental)
 
 Create or update the localized App Store name for one locale. When the locale
-does not exist, the command creates its app-info localization.
+does not exist, the command creates its app-info localization. This command is
+experimental.
 
 <ParamField path="--app" type="string" required>
   App Store Connect app ID (or `ASC_APP_ID`)

--- a/commands/apps.mdx
+++ b/commands/apps.mdx
@@ -156,6 +156,53 @@ asc apps view --id "APP_ID" --output table
 
 ***
 
+### `asc apps rename`
+
+Create or update the localized App Store name for one locale. When the locale
+does not exist, the command creates its app-info localization.
+
+<ParamField path="--app" type="string" required>
+  App Store Connect app ID (or `ASC_APP_ID`)
+</ParamField>
+
+<ParamField path="--locale" type="string" required>
+  App name locale (for example, `en-US`)
+</ParamField>
+
+<ParamField path="--name" type="string" required>
+  New localized app name, up to 30 characters
+</ParamField>
+
+<ParamField path="--app-info" type="string">
+  App Info ID override. Use this when the app has multiple App Info records.
+</ParamField>
+
+<ParamField path="--output" type="string" default="json">
+  Output format: `json`, `table`, `markdown`
+</ParamField>
+
+**Examples:**
+
+```bash  theme={null}
+asc apps rename --app "APP_ID" --locale "en-US" --name "New Name"
+asc apps rename --app "APP_ID" --app-info "APP_INFO_ID" --locale "fr-FR" --name "Nouveau nom"
+```
+
+**Response:**
+
+```json  theme={null}
+{
+  "appId": "APP_ID",
+  "appInfoId": "APP_INFO_ID",
+  "locale": "en-US",
+  "name": "New Name",
+  "action": "update",
+  "localizationId": "LOCALIZATION_ID"
+}
+```
+
+***
+
 ### `asc apps info list`
 
 List app-info records for an app. API 4.4.1 adds sparse reads for the app info

--- a/internal/asc/app_info_resolution.go
+++ b/internal/asc/app_info_resolution.go
@@ -12,6 +12,10 @@ type appStoreVersionRelationships struct {
 	App *Relationship `json:"app"`
 }
 
+type appInfoRelationships struct {
+	App *Relationship `json:"app"`
+}
+
 // AppStoreVersionAppID extracts the related app ID from an app store version response.
 func AppStoreVersionAppID(resp *AppStoreVersionResponse) (string, error) {
 	if resp == nil {
@@ -31,6 +35,29 @@ func AppStoreVersionAppID(resp *AppStoreVersionResponse) (string, error) {
 	appID := strings.TrimSpace(relationships.App.Data.ID)
 	if appID == "" {
 		return "", fmt.Errorf("app relationship missing for app store version %q", strings.TrimSpace(resp.Data.ID))
+	}
+	return appID, nil
+}
+
+// AppInfoAppID extracts the related app ID from an app info response.
+func AppInfoAppID(resp *AppInfoResponse) (string, error) {
+	if resp == nil {
+		return "", fmt.Errorf("app info response is required")
+	}
+
+	var relationships appInfoRelationships
+	if len(resp.Data.Relationships) > 0 {
+		if err := json.Unmarshal(resp.Data.Relationships, &relationships); err != nil {
+			return "", fmt.Errorf("failed to parse app info relationships: %w", err)
+		}
+	}
+
+	if relationships.App == nil {
+		return "", fmt.Errorf("app relationship missing for app info %q", strings.TrimSpace(resp.Data.ID))
+	}
+	appID := strings.TrimSpace(relationships.App.Data.ID)
+	if appID == "" {
+		return "", fmt.Errorf("app relationship missing for app info %q", strings.TrimSpace(resp.Data.ID))
 	}
 	return appID, nil
 }

--- a/internal/asc/output_apps.go
+++ b/internal/asc/output_apps.go
@@ -1,5 +1,26 @@
 package asc
 
+// AppRenameResult represents a localized app-name change.
+type AppRenameResult struct {
+	AppID          string `json:"appId"`
+	AppInfoID      string `json:"appInfoId"`
+	Locale         string `json:"locale"`
+	Name           string `json:"name"`
+	Action         string `json:"action"`
+	LocalizationID string `json:"localizationId"`
+}
+
+func appRenameResultRows(result *AppRenameResult) ([]string, [][]string) {
+	return []string{"App ID", "App Info ID", "Locale", "Name", "Action", "Localization ID"}, [][]string{{
+		result.AppID,
+		result.AppInfoID,
+		result.Locale,
+		compactWhitespace(result.Name),
+		result.Action,
+		result.LocalizationID,
+	}}
+}
+
 func appsRows(resp *AppsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Name", "Bundle ID", "SKU"}
 	rows := make([][]string, 0, len(resp.Data))

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -11,6 +11,7 @@ func registerAllOutputRenderers() {
 	registerRowsWithSingleResourceAdapter(reviewsRows)
 	registerRows(customerReviewSummarizationsRows)
 	registerRowsWithSingleResourceAdapter(appsRows)
+	registerRows(appRenameResultRows)
 	registerRows(appsWallRows)
 	registerRowsWithSingleResourceAdapter(appClipsRows)
 	registerRowsWithSingleToListAdapter[AppCategoryResponse, AppCategoriesResponse](appCategoriesRows)

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -176,55 +176,34 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			var localizationAttrs asc.AppInfoLocalizationAttributes
-			var resolvedAppInfoID string
-			var localizationID string
-			createLocalization := false
+			var localizationPlan *shared.AppInfoLocalizationUpsertPlan
 			if hasLocalization {
-				resolvedAppInfoID, err = shared.ResolveAppInfoID(requestCtx, client, appIDValue, strings.TrimSpace(*appInfoID))
-				if err != nil {
-					return fmt.Errorf("app-setup info set: %w", err)
-				}
-
-				localizations, err := client.GetAppInfoLocalizations(
-					requestCtx,
-					resolvedAppInfoID,
-					asc.WithAppInfoLocalizationsLimit(200),
-					asc.WithAppInfoLocalizationLocales([]string{localeValue}),
-				)
-				if err != nil {
-					return fmt.Errorf("app-setup info set: failed to fetch app info localizations: %w", err)
-				}
-
+				localizationValues := make(map[string]string, 5)
 				if nameValue != "" {
-					localizationAttrs.Name = nameValue
+					localizationValues["name"] = nameValue
 				}
 				if subtitleValue != "" {
-					localizationAttrs.Subtitle = subtitleValue
+					localizationValues["subtitle"] = subtitleValue
 				}
 				if privacyPolicyURLValue != "" {
-					localizationAttrs.PrivacyPolicyURL = privacyPolicyURLValue
+					localizationValues["privacyPolicyUrl"] = privacyPolicyURLValue
 				}
 				if privacyChoicesURLValue != "" {
-					localizationAttrs.PrivacyChoicesURL = privacyChoicesURLValue
+					localizationValues["privacyChoicesUrl"] = privacyChoicesURLValue
 				}
 				if privacyPolicyTextValue != "" {
-					localizationAttrs.PrivacyPolicyText = privacyPolicyTextValue
+					localizationValues["privacyPolicyText"] = privacyPolicyTextValue
 				}
-
-				if len(localizations.Data) == 0 {
-					if nameValue == "" {
-						return shared.UsageError("--name is required when creating an app info localization")
-					}
-					localizationAttrs.Locale = localeValue
-					createLocalization = true
-				} else if len(localizations.Data) > 1 {
-					return fmt.Errorf("app-setup info set: multiple app info localizations found for locale %q", localeValue)
-				} else {
-					localizationID = strings.TrimSpace(localizations.Data[0].ID)
-					if localizationID == "" {
-						return fmt.Errorf("app-setup info set: localization id is empty")
-					}
+				localizationPlan, err = shared.PlanAppInfoLocalizationUpsert(
+					requestCtx,
+					client,
+					appIDValue,
+					strings.TrimSpace(*appInfoID),
+					localeValue,
+					localizationValues,
+				)
+				if err != nil {
+					return fmt.Errorf("app-setup info set: %w", err)
 				}
 			}
 
@@ -248,16 +227,9 @@ Examples:
 
 			var appInfoResp *asc.AppInfoLocalizationResponse
 			if hasLocalization {
-				if createLocalization {
-					appInfoResp, err = client.CreateAppInfoLocalization(requestCtx, resolvedAppInfoID, localizationAttrs)
-					if err != nil {
-						return fmt.Errorf("app-setup info set: %w", err)
-					}
-				} else {
-					appInfoResp, err = client.UpdateAppInfoLocalization(requestCtx, localizationID, localizationAttrs)
-					if err != nil {
-						return fmt.Errorf("app-setup info set: %w", err)
-					}
+				appInfoResp, _, err = shared.ApplyAppInfoLocalizationUpsert(requestCtx, client, localizationPlan)
+				if err != nil {
+					return fmt.Errorf("app-setup info set: %w", err)
 				}
 			}
 

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -51,6 +51,7 @@ Examples:
   asc apps public storefronts list
   asc apps registry pull --path ".asc/app-registry.json"
   asc apps view --id "APP_ID"
+  asc apps rename --app "APP_ID" --locale "en-US" --name "New Name"
   asc apps info view --app "APP_ID"
   asc apps info edit --app "APP_ID" --locale "en-US" --whats-new "Bug fixes"
   asc apps ci-product view --id "APP_ID"
@@ -72,6 +73,7 @@ Examples:
 			AppsPublicCommand(),
 			AppsRegistryCommand(),
 			AppsGetCommand(),
+			AppsRenameCommand(),
 			AppsInfoCommand(),
 			AppsCIProductCommand(),
 			AppsUpdateCommand(),

--- a/internal/cli/apps/apps_rename.go
+++ b/internal/cli/apps/apps_rename.go
@@ -27,8 +27,10 @@ func AppsRenameCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "rename",
 		ShortUsage: "asc apps rename --app APP_ID --locale LOCALE --name NAME [flags]",
-		ShortHelp:  "Rename an app for one App Store locale.",
-		LongHelp: `Create or update the localized App Store name for an app.
+		ShortHelp:  "[experimental] Rename an app for one App Store locale.",
+		LongHelp: `[experimental] Create or update the localized App Store name for an app.
+
+This command is experimental.
 
 If the locale does not exist, a new app info localization is created.
 Use --app-info to select a specific App Info record when the app has multiple records.

--- a/internal/cli/apps/apps_rename.go
+++ b/internal/cli/apps/apps_rename.go
@@ -44,7 +44,7 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			resolvedAppID := shared.ResolveAppID(*appID)
+			resolvedAppID := strings.TrimSpace(shared.ResolveAppID(*appID))
 			if resolvedAppID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError()

--- a/internal/cli/apps/apps_rename.go
+++ b/internal/cli/apps/apps_rename.go
@@ -1,0 +1,106 @@
+package apps
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+// AppsRenameCommand returns the apps rename subcommand.
+func AppsRenameCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps rename", flag.ExitOnError)
+
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	appInfoID := fs.String("app-info", "", "App Info ID (optional override)")
+	locale := fs.String("locale", "", "App name locale (e.g., en-US) (required)")
+	name := fs.String("name", "", "New localized app name (required)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "rename",
+		ShortUsage: "asc apps rename --app APP_ID --locale LOCALE --name NAME [flags]",
+		ShortHelp:  "Rename an app for one App Store locale.",
+		LongHelp: `Create or update the localized App Store name for an app.
+
+If the locale does not exist, a new app info localization is created.
+Use --app-info to select a specific App Info record when the app has multiple records.
+
+Examples:
+  asc apps rename --app "APP_ID" --locale "en-US" --name "New Name"
+  asc apps rename --app "APP_ID" --app-info "APP_INFO_ID" --locale "fr-FR" --name "Nouveau nom"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				fmt.Fprintln(os.Stderr, "Error: apps rename does not accept positional arguments")
+				return flag.ErrHelp
+			}
+
+			resolvedAppID := shared.ResolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return shared.MissingRequiredUsageError()
+			}
+			localeValue := strings.TrimSpace(*locale)
+			if localeValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --locale is required")
+				return shared.MissingRequiredUsageError()
+			}
+			nameValue := strings.TrimSpace(*name)
+			if nameValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --name is required")
+				return shared.MissingRequiredUsageError()
+			}
+			if err := shared.ValidateBuildLocalizationLocale(localeValue); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			for _, issue := range validation.AppInfoLocalizationLengthIssues(validation.AppInfoLocalization{Name: nameValue}) {
+				return shared.UsageErrorf("--%s exceeds %d %s", issue.Field, issue.Limit, issue.Unit)
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("apps rename: %w", err)
+			}
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			plan, err := shared.PlanAppInfoLocalizationUpsert(
+				requestCtx,
+				client,
+				resolvedAppID,
+				strings.TrimSpace(*appInfoID),
+				localeValue,
+				map[string]string{"name": nameValue},
+			)
+			if err != nil {
+				return fmt.Errorf("apps rename: %w", err)
+			}
+			resp, action, err := shared.ApplyAppInfoLocalizationUpsert(requestCtx, client, plan)
+			if err != nil {
+				return fmt.Errorf("apps rename: %w", err)
+			}
+			if resp == nil {
+				return fmt.Errorf("apps rename: empty app info localization response")
+			}
+
+			result := &asc.AppRenameResult{
+				AppID:          resolvedAppID,
+				AppInfoID:      plan.AppInfoID,
+				Locale:         localeValue,
+				Name:           nameValue,
+				Action:         action,
+				LocalizationID: strings.TrimSpace(resp.Data.ID),
+			}
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
+		},
+	}
+}

--- a/internal/cli/cmdtest/app_setup_info_preflight_test.go
+++ b/internal/cli/cmdtest/app_setup_info_preflight_test.go
@@ -22,6 +22,12 @@ import (
 
 const appSetupInfoLocalizationsURI = "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200"
 
+var appSetupInfoOwnershipStep = appSetupInfoHTTPStep{
+	method:       http.MethodGet,
+	uri:          "/v1/appInfos/info-1?include=app",
+	responseBody: `{"data":{"type":"appInfos","id":"info-1","relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}},"included":[{"type":"apps","id":"app-1"}]}`,
+}
+
 type appSetupInfoHTTPStep struct {
 	method       string
 	uri          string
@@ -97,7 +103,7 @@ func TestAppSetupInfoSetPlanningFailuresDoNotMutate(t *testing.T) {
 		{
 			name:      "create without name",
 			args:      []string{"--app", "app-1", "--app-info", "info-1", "--bundle-id", "com.example.changed", "--locale", "en-US", "--subtitle", "Subtitle"},
-			steps:     []appSetupInfoHTTPStep{{method: http.MethodGet, uri: appSetupInfoLocalizationsURI, responseBody: `{"data":[]}`}},
+			steps:     []appSetupInfoHTTPStep{appSetupInfoOwnershipStep, {method: http.MethodGet, uri: appSetupInfoLocalizationsURI, responseBody: `{"data":[]}`}},
 			wantError: "--name is required when creating an app info localization",
 			usage:     true,
 		},
@@ -105,6 +111,10 @@ func TestAppSetupInfoSetPlanningFailuresDoNotMutate(t *testing.T) {
 			name: "ambiguous localization",
 			args: []string{"--app", "app-1", "--app-info", "info-1", "--bundle-id", "com.example.changed", "--locale", "en-US", "--name", "Example App"},
 			steps: []appSetupInfoHTTPStep{{
+				method:       appSetupInfoOwnershipStep.method,
+				uri:          appSetupInfoOwnershipStep.uri,
+				responseBody: appSetupInfoOwnershipStep.responseBody,
+			}, {
 				method:       http.MethodGet,
 				uri:          appSetupInfoLocalizationsURI,
 				responseBody: `{"data":[{"type":"appInfoLocalizations","id":"loc-1"},{"type":"appInfoLocalizations","id":"loc-2"}]}`,
@@ -186,6 +196,7 @@ func TestAppSetupInfoSetPlansExplicitLocalizationTargetBeforeWrites(t *testing.T
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			steps := []appSetupInfoHTTPStep{
+				appSetupInfoOwnershipStep,
 				{method: http.MethodGet, uri: appSetupInfoLocalizationsURI, responseBody: test.localizations},
 				appPatch,
 				test.localizationWrite,

--- a/internal/cli/cmdtest/apps_rename_test.go
+++ b/internal/cli/cmdtest/apps_rename_test.go
@@ -31,6 +31,7 @@ func TestAppsRenameValidatesRequiredFlagsBeforeClient(t *testing.T) {
 		wantStderr string
 	}{
 		{name: "missing app", args: []string{"--locale", "en-US", "--name", "New Name"}, wantStderr: "Error: --app is required (or set ASC_APP_ID)\n"},
+		{name: "blank app", args: []string{"--app", "   ", "--locale", "en-US", "--name", "New Name"}, wantStderr: "Error: --app is required (or set ASC_APP_ID)\n"},
 		{name: "missing locale", args: []string{"--app", "app-1", "--name", "New Name"}, wantStderr: "Error: --locale is required\n"},
 		{name: "missing name", args: []string{"--app", "app-1", "--locale", "en-US"}, wantStderr: "Error: --name is required\n"},
 		{name: "invalid locale", args: []string{"--app", "app-1", "--locale", "not_a_locale", "--name", "New Name"}, wantStderr: "Error: invalid locale \"not_a_locale\": must match pattern like en or en-US\n"},
@@ -68,6 +69,7 @@ func TestAppsRenameValidatesRequiredFlagsBeforeClient(t *testing.T) {
 
 func TestAppsRenameUpdatesExistingLocalization(t *testing.T) {
 	steps := []appsRenameHTTPStep{
+		appInfoOwnershipStep(),
 		{
 			method:       http.MethodGet,
 			uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
@@ -107,6 +109,7 @@ func TestAppsRenameUpdatesExistingLocalization(t *testing.T) {
 
 func TestAppsRenameCreatesMissingLocalization(t *testing.T) {
 	steps := []appsRenameHTTPStep{
+		appInfoOwnershipStep(),
 		{
 			method:       http.MethodGet,
 			uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=fr-FR&limit=200",
@@ -144,6 +147,7 @@ func TestAppsRenameCreatesMissingLocalization(t *testing.T) {
 
 func TestAppsRenameRendersMarkdown(t *testing.T) {
 	steps := []appsRenameHTTPStep{
+		appInfoOwnershipStep(),
 		{
 			method:       http.MethodGet,
 			uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
@@ -175,12 +179,15 @@ func TestAppsRenameRendersMarkdown(t *testing.T) {
 }
 
 func TestAppsRenameReturnsAPIError(t *testing.T) {
-	steps := []appsRenameHTTPStep{{
-		method:       http.MethodGet,
-		uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
-		status:       http.StatusUnprocessableEntity,
-		responseBody: `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Invalid Attribute","detail":"The app info cannot be edited."}]}`,
-	}}
+	steps := []appsRenameHTTPStep{
+		appInfoOwnershipStep(),
+		{
+			method:       http.MethodGet,
+			uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
+			status:       http.StatusUnprocessableEntity,
+			responseBody: `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Invalid Attribute","detail":"The app info cannot be edited."}]}`,
+		},
+	}
 
 	stdout, _, runErr := runAppsRenameWithServer(
 		t, steps,
@@ -188,6 +195,25 @@ func TestAppsRenameReturnsAPIError(t *testing.T) {
 	)
 	if runErr == nil || !strings.Contains(runErr.Error(), "apps rename") || !strings.Contains(runErr.Error(), "The app info cannot be edited") {
 		t.Fatalf("run error = %v, want contextual API error", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+}
+
+func TestAppsRenameRejectsAppInfoOwnedByAnotherAppBeforeMutation(t *testing.T) {
+	steps := []appsRenameHTTPStep{{
+		method:       http.MethodGet,
+		uri:          "/v1/appInfos/info-foreign?include=app",
+		responseBody: `{"data":{"type":"appInfos","id":"info-foreign","relationships":{"app":{"data":{"type":"apps","id":"app-other"}}}},"included":[{"type":"apps","id":"app-other"}]}`,
+	}}
+
+	stdout, _, runErr := runAppsRenameWithServer(
+		t, steps,
+		"--app", "app-1", "--app-info", "info-foreign", "--locale", "en-US", "--name", "New Name",
+	)
+	if runErr == nil || !strings.Contains(runErr.Error(), `app info "info-foreign" belongs to app "app-other", not "app-1"`) {
+		t.Fatalf("run error = %v, want app ownership error", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
@@ -217,11 +243,14 @@ func TestAppsRenameRejectsAmbiguousOrEmptyLocalizationIDsBeforeMutation(t *testi
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			steps := []appsRenameHTTPStep{{
-				method:       http.MethodGet,
-				uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
-				responseBody: test.response,
-			}}
+			steps := []appsRenameHTTPStep{
+				appInfoOwnershipStep(),
+				{
+					method:       http.MethodGet,
+					uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
+					responseBody: test.response,
+				},
+			}
 			stdout, _, runErr := runAppsRenameWithServer(
 				t, steps,
 				"--app", "app-1", "--app-info", "info-1", "--locale", "en-US", "--name", "New Name",
@@ -242,6 +271,18 @@ type appsRenameHTTPStep struct {
 	requestBody  string
 	responseBody string
 	status       int
+}
+
+func appInfoOwnershipStep() appsRenameHTTPStep {
+	const (
+		appID     = "app-1"
+		appInfoID = "info-1"
+	)
+	return appsRenameHTTPStep{
+		method:       http.MethodGet,
+		uri:          "/v1/appInfos/" + appInfoID + "?include=app",
+		responseBody: fmt.Sprintf(`{"data":{"type":"appInfos","id":%q,"relationships":{"app":{"data":{"type":"apps","id":%q}}}},"included":[{"type":"apps","id":%q}]}`, appInfoID, appID, appID),
+	}
 }
 
 func runAppsRenameWithServer(t *testing.T, steps []appsRenameHTTPStep, args ...string) (string, string, error) {

--- a/internal/cli/cmdtest/apps_rename_test.go
+++ b/internal/cli/cmdtest/apps_rename_test.go
@@ -1,0 +1,329 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+func TestAppsRenameValidatesRequiredFlagsBeforeClient(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing app", args: []string{"--locale", "en-US", "--name", "New Name"}, wantStderr: "Error: --app is required (or set ASC_APP_ID)\n"},
+		{name: "missing locale", args: []string{"--app", "app-1", "--name", "New Name"}, wantStderr: "Error: --locale is required\n"},
+		{name: "missing name", args: []string{"--app", "app-1", "--locale", "en-US"}, wantStderr: "Error: --name is required\n"},
+		{name: "invalid locale", args: []string{"--app", "app-1", "--locale", "not_a_locale", "--name", "New Name"}, wantStderr: "Error: invalid locale \"not_a_locale\": must match pattern like en or en-US\n"},
+		{name: "name too long", args: []string{"--app", "app-1", "--locale", "en-US", "--name", strings.Repeat("x", validation.LimitName+1)}, wantStderr: fmt.Sprintf("Error: --name exceeds %d characters\n", validation.LimitName)},
+		{name: "Unicode name too long", args: []string{"--app", "app-1", "--locale", "ja", "--name", strings.Repeat("名", validation.LimitName+1)}, wantStderr: fmt.Sprintf("Error: --name exceeds %d characters\n", validation.LimitName)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return nil, errors.New("client should not be created")
+			}))
+
+			stdout, stderr, runErr := runAppsRename(t, test.args...)
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("run error = %v, want usage error", runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.HasPrefix(stderr, test.wantStderr) {
+				t.Fatalf("stderr = %q, want prefix %q", stderr, test.wantStderr)
+			}
+			if strings.Count(stderr, strings.TrimSpace(test.wantStderr)) != 1 {
+				t.Fatalf("stderr contains duplicate diagnostic: %q", stderr)
+			}
+			if clientFactoryCalls != 0 {
+				t.Fatalf("client factory calls = %d, want 0", clientFactoryCalls)
+			}
+		})
+	}
+}
+
+func TestAppsRenameUpdatesExistingLocalization(t *testing.T) {
+	steps := []appsRenameHTTPStep{
+		{
+			method:       http.MethodGet,
+			uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
+			responseBody: `{"data":[{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Old Name"}}]}`,
+		},
+		{
+			method:       http.MethodPatch,
+			uri:          "/v1/appInfoLocalizations/loc-1",
+			requestBody:  `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"name":"New Name"}}}`,
+			responseBody: `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"New Name"}}}`,
+		},
+	}
+
+	stdout, stderr, runErr := runAppsRenameWithServer(
+		t, steps,
+		"--name", "New Name",
+		"--app-info", "info-1",
+		"--locale", "en-US",
+		"--app", "app-1",
+		"--output", "json",
+	)
+	if runErr != nil {
+		t.Fatalf("run error: %v (stderr=%q)", runErr, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var got asc.AppRenameResult
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode output %q: %v", stdout, err)
+	}
+	if got.AppID != "app-1" || got.AppInfoID != "info-1" || got.Locale != "en-US" || got.Name != "New Name" || got.Action != "update" || got.LocalizationID != "loc-1" {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+}
+
+func TestAppsRenameCreatesMissingLocalization(t *testing.T) {
+	steps := []appsRenameHTTPStep{
+		{
+			method:       http.MethodGet,
+			uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=fr-FR&limit=200",
+			responseBody: `{"data":[]}`,
+		},
+		{
+			method:       http.MethodPost,
+			uri:          "/v1/appInfoLocalizations",
+			status:       http.StatusCreated,
+			requestBody:  `{"data":{"type":"appInfoLocalizations","attributes":{"locale":"fr-FR","name":"Nouveau nom"},"relationships":{"appInfo":{"data":{"type":"appInfos","id":"info-1"}}}}}`,
+			responseBody: `{"data":{"type":"appInfoLocalizations","id":"loc-created","attributes":{"locale":"fr-FR","name":"Nouveau nom"}}}`,
+		},
+	}
+
+	stdout, stderr, runErr := runAppsRenameWithServer(
+		t, steps,
+		"--app", "app-1",
+		"--locale", "fr-FR",
+		"--name", "Nouveau nom",
+		"--app-info", "info-1",
+		"--output", "table",
+	)
+	if runErr != nil {
+		t.Fatalf("run error: %v (stderr=%q)", runErr, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	for _, value := range []string{"App ID", "App Info ID", "Locale", "Name", "Action", "Localization ID", "app-1", "info-1", "fr-FR", "Nouveau nom", "create", "loc-created"} {
+		if !strings.Contains(stdout, value) {
+			t.Fatalf("table output missing %q: %s", value, stdout)
+		}
+	}
+}
+
+func TestAppsRenameRendersMarkdown(t *testing.T) {
+	steps := []appsRenameHTTPStep{
+		{
+			method:       http.MethodGet,
+			uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
+			responseBody: `{"data":[{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Old Name"}}]}`,
+		},
+		{
+			method:       http.MethodPatch,
+			uri:          "/v1/appInfoLocalizations/loc-1",
+			requestBody:  `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"name":"New Name"}}}`,
+			responseBody: `{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"New Name"}}}`,
+		},
+	}
+
+	stdout, stderr, runErr := runAppsRenameWithServer(
+		t, steps,
+		"--app", "app-1", "--app-info", "info-1", "--locale", "en-US", "--name", "New Name", "--output", "markdown",
+	)
+	if runErr != nil {
+		t.Fatalf("run error: %v (stderr=%q)", runErr, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	for _, value := range []string{"| App ID |", "| app-1", "New Name", "update", "loc-1"} {
+		if !strings.Contains(stdout, value) {
+			t.Fatalf("markdown output missing %q: %s", value, stdout)
+		}
+	}
+}
+
+func TestAppsRenameReturnsAPIError(t *testing.T) {
+	steps := []appsRenameHTTPStep{{
+		method:       http.MethodGet,
+		uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
+		status:       http.StatusUnprocessableEntity,
+		responseBody: `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"Invalid Attribute","detail":"The app info cannot be edited."}]}`,
+	}}
+
+	stdout, _, runErr := runAppsRenameWithServer(
+		t, steps,
+		"--app", "app-1", "--app-info", "info-1", "--locale", "en-US", "--name", "New Name",
+	)
+	if runErr == nil || !strings.Contains(runErr.Error(), "apps rename") || !strings.Contains(runErr.Error(), "The app info cannot be edited") {
+		t.Fatalf("run error = %v, want contextual API error", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+}
+
+func TestAppsRenameRejectsAmbiguousOrEmptyLocalizationIDsBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		wantError string
+	}{
+		{
+			name: "multiple localizations",
+			response: `{"data":[
+				{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US"}},
+				{"type":"appInfoLocalizations","id":"loc-2","attributes":{"locale":"en-US"}}
+			]}`,
+			wantError: `multiple app info localizations found for locale "en-US"`,
+		},
+		{
+			name:      "empty localization id",
+			response:  `{"data":[{"type":"appInfoLocalizations","id":"","attributes":{"locale":"en-US"}}]}`,
+			wantError: "localization id is empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			steps := []appsRenameHTTPStep{{
+				method:       http.MethodGet,
+				uri:          "/v1/appInfos/info-1/appInfoLocalizations?filter%5Blocale%5D=en-US&limit=200",
+				responseBody: test.response,
+			}}
+			stdout, _, runErr := runAppsRenameWithServer(
+				t, steps,
+				"--app", "app-1", "--app-info", "info-1", "--locale", "en-US", "--name", "New Name",
+			)
+			if runErr == nil || !strings.Contains(runErr.Error(), test.wantError) {
+				t.Fatalf("run error = %v, want %q", runErr, test.wantError)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+		})
+	}
+}
+
+type appsRenameHTTPStep struct {
+	method       string
+	uri          string
+	requestBody  string
+	responseBody string
+	status       int
+}
+
+func runAppsRenameWithServer(t *testing.T, steps []appsRenameHTTPStep, args ...string) (string, string, error) {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if requestCount >= len(steps) {
+			t.Errorf("unexpected request %d: %s %s", requestCount+1, req.Method, req.URL.RequestURI())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		step := steps[requestCount]
+		requestCount++
+		if req.Method != step.method || req.URL.RequestURI() != step.uri {
+			t.Errorf("request %d = %s %s, want %s %s", requestCount, req.Method, req.URL.RequestURI(), step.method, step.uri)
+		}
+		if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("request %d is missing bearer authorization", requestCount)
+		}
+		if step.requestBody != "" {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("read request body: %v", err)
+			} else if strings.TrimSpace(string(body)) != step.requestBody {
+				t.Errorf("request body = %s, want %s", body, step.requestBody)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		status := step.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, step.responseBody)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := server.Client().Transport
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			cloned := req.Clone(req.Context())
+			cloned.URL.Scheme = serverURL.Scheme
+			cloned.URL.Host = serverURL.Host
+			return transport.RoundTrip(cloned)
+		})},
+	)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) { return client, nil }))
+
+	stdout, stderr, runErr := runAppsRename(t, args...)
+	if requestCount != len(steps) {
+		t.Errorf("request count = %d, want %d", requestCount, len(steps))
+	}
+	return stdout, stderr, runErr
+}
+
+func runAppsRename(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		parseArgs := append([]string{"apps", "rename"}, args...)
+		if err := root.Parse(parseArgs); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}

--- a/internal/cli/cmdtest/stability_tiers_test.go
+++ b/internal/cli/cmdtest/stability_tiers_test.go
@@ -27,6 +27,7 @@ func TestExperimentalCommandsHaveStabilityLabel(t *testing.T) {
 		{[]string{"screenshots", "plan"}},
 		{[]string{"screenshots", "apply"}},
 		{[]string{"xcode", "build"}},
+		{[]string{"apps", "rename"}},
 	}
 
 	for _, tc := range cases {

--- a/internal/cli/shared/app_info_localization.go
+++ b/internal/cli/shared/app_info_localization.go
@@ -1,0 +1,88 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// AppInfoLocalizationUpsertPlan describes a resolved app-info localization write.
+// Planning resolves and validates the target before callers perform any mutations.
+type AppInfoLocalizationUpsertPlan struct {
+	AppInfoID      string
+	LocalizationID string
+	Locale         string
+	Attributes     asc.AppInfoLocalizationAttributes
+	Create         bool
+}
+
+// PlanAppInfoLocalizationUpsert resolves one locale and validates whether it can
+// be created or updated without performing a mutation.
+func PlanAppInfoLocalizationUpsert(
+	ctx context.Context,
+	client *asc.Client,
+	appID string,
+	appInfoID string,
+	locale string,
+	values map[string]string,
+) (*AppInfoLocalizationUpsertPlan, error) {
+	resolvedAppInfoID, err := ResolveAppInfoID(ctx, client, appID, appInfoID)
+	if err != nil {
+		return nil, err
+	}
+
+	localizations, err := client.GetAppInfoLocalizations(
+		ctx,
+		resolvedAppInfoID,
+		asc.WithAppInfoLocalizationsLimit(200),
+		asc.WithAppInfoLocalizationLocales([]string{locale}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch app info localizations: %w", err)
+	}
+	if localizations == nil {
+		return nil, fmt.Errorf("empty app info localizations response")
+	}
+
+	plan := &AppInfoLocalizationUpsertPlan{
+		AppInfoID: resolvedAppInfoID,
+		Locale:    locale,
+	}
+	switch len(localizations.Data) {
+	case 0:
+		if strings.TrimSpace(values["name"]) == "" {
+			return nil, UsageError("--name is required when creating an app info localization")
+		}
+		plan.Create = true
+		plan.Attributes = buildAppInfoLocalizationAttributes(locale, values, true)
+	case 1:
+		plan.LocalizationID = strings.TrimSpace(localizations.Data[0].ID)
+		if plan.LocalizationID == "" {
+			return nil, fmt.Errorf("localization id is empty")
+		}
+		plan.Attributes = buildAppInfoLocalizationAttributes(locale, values, false)
+	default:
+		return nil, fmt.Errorf("multiple app info localizations found for locale %q", locale)
+	}
+
+	return plan, nil
+}
+
+// ApplyAppInfoLocalizationUpsert performs a previously planned localization write.
+func ApplyAppInfoLocalizationUpsert(
+	ctx context.Context,
+	client *asc.Client,
+	plan *AppInfoLocalizationUpsertPlan,
+) (*asc.AppInfoLocalizationResponse, string, error) {
+	if plan == nil {
+		return nil, "", fmt.Errorf("app info localization plan is required")
+	}
+	if plan.Create {
+		resp, err := client.CreateAppInfoLocalization(ctx, plan.AppInfoID, plan.Attributes)
+		return resp, "create", err
+	}
+	resp, err := client.UpdateAppInfoLocalization(ctx, plan.LocalizationID, plan.Attributes)
+	return resp, "update", err
+}

--- a/internal/cli/shared/app_info_localization.go
+++ b/internal/cli/shared/app_info_localization.go
@@ -28,7 +28,7 @@ func PlanAppInfoLocalizationUpsert(
 	locale string,
 	values map[string]string,
 ) (*AppInfoLocalizationUpsertPlan, error) {
-	resolvedAppInfoID, err := ResolveAppInfoID(ctx, client, appID, appInfoID)
+	resolvedAppInfoID, err := ResolveOwnedAppInfoID(ctx, client, appID, appInfoID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/shared/app_resolution.go
+++ b/internal/cli/shared/app_resolution.go
@@ -87,6 +87,31 @@ func ResolveAppInfoID(ctx context.Context, client *asc.Client, appID, appInfoID 
 	return resp.Data[0].ID, nil
 }
 
+// ResolveOwnedAppInfoID resolves the app info ID and verifies that an explicit
+// override belongs to the requested app.
+func ResolveOwnedAppInfoID(ctx context.Context, client *asc.Client, appID, appInfoID string) (string, error) {
+	resolvedAppInfoID, err := ResolveAppInfoID(ctx, client, appID, appInfoID)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(appInfoID) == "" {
+		return resolvedAppInfoID, nil
+	}
+
+	resp, err := client.GetAppInfo(ctx, resolvedAppInfoID, asc.WithAppInfoInclude([]string{"app"}))
+	if err != nil {
+		return "", err
+	}
+	ownerAppID, err := asc.AppInfoAppID(resp)
+	if err != nil {
+		return "", err
+	}
+	if !strings.EqualFold(strings.TrimSpace(ownerAppID), strings.TrimSpace(appID)) {
+		return "", fmt.Errorf("app info %q belongs to app %q, not %q", resolvedAppInfoID, ownerAppID, strings.TrimSpace(appID))
+	}
+	return resolvedAppInfoID, nil
+}
+
 func autoSelectEditableAppInfoID(appInfos *asc.AppInfosResponse) (string, string) {
 	if appInfos == nil {
 		return "", ""


### PR DESCRIPTION
## Summary

- add `asc apps rename --app APP_ID --locale LOCALE --name NAME`
- update an existing app-info localization or create the requested locale when it is missing
- share the localization target planner with `app-setup info set`, preserving the existing command
- support JSON, table, and Markdown results with the resolved App Info and localization IDs

## Behavior

```bash
asc apps rename --app "APP_ID" --locale "en-US" --name "New Name"
```

`--app-info` remains available as an explicit override when an app has multiple App Info records. Required flags, locale syntax, and the 30-character Unicode name limit are checked before client creation. The planner rejects duplicate locale matches and empty localization IDs before any write.

The API path matches the OpenAPI snapshot:

- `GET /v1/appInfos/{id}/appInfoLocalizations?filter[locale]=...`
- `PATCH /v1/appInfoLocalizations/{id}` with only `name`
- `POST /v1/appInfoLocalizations` with required `locale`, `name`, and App Info relationship

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary help and pre-auth exit-code checks
- command-level HTTP tests for update, create, API failure, explicit App Info selection, duplicate and blank targets, flag ordering, JSON, table, and Markdown output

During a missing-flag black-box check, removing the app environment variable allowed the local config default to resolve. Apple rejected the requested name as unavailable, and a read-only follow-up confirmed that no localization changed. Subsequent missing-app verification used an explicitly empty environment value and returned exit code 2 before client creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental `apps rename` command to create or update localized app names.
  * Supports app, locale, name, and optional App Info selection with validation.
  * Provides JSON, table, and Markdown output, including whether a localization was created or updated.

* **Bug Fixes**
  * Improved handling of missing, empty, duplicate, or mismatched localizations.
  * Prevents updates to App Info belonging to another app.

* **Documentation**
  * Added command usage, options, examples, and response field documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->