### PR TITLE
feat(xcode): support release-testing exports

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -110,7 +110,8 @@ asc publish testflight \
 ```
 
 An explicit `--export-options` plist cannot be combined with `--method`,
-`--signing-style`, or `--team-id`; the plist remains authoritative when supplied.
+`--signing-style`, or `--team-id`. When supplied without those flags, the
+plist is authoritative.
 
 Create `.asc/deployment.json`:
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -67,6 +67,21 @@ cross-platform and only reads archive metadata. Manual signing resolution is
 Darwin-only because it inspects local Xcode signing identities and provisioning
 profiles.
 
+To export an IPA for registered devices, use the experimental modern Xcode
+method name `release-testing` (the older `ad-hoc` spelling is deprecated):
+
+```bash
+asc xcode export \
+  --archive-path .asc/artifacts/App.xcarchive \
+  --ipa-path .asc/artifacts/App.ipa \
+  --method release-testing \
+  --signing-style manual \
+  --team-id TEAM_ID
+```
+
+The default remains `app-store-connect`; release-testing always produces a
+local export and cannot be combined with `--wait`.
+
 For a PCC-capable app, or another multi-target app that needs manual signing,
 pass the signing policy directly to export. ASC reads the archive and matches
 installed profiles for the app and its embedded targets, so the command does
@@ -94,8 +109,8 @@ asc publish testflight \
   --team-id TEAM_ID
 ```
 
-An explicit `--export-options` plist cannot be combined with
-`--signing-style` or `--team-id`; the plist remains authoritative when supplied.
+An explicit `--export-options` plist cannot be combined with `--method`,
+`--signing-style`, or `--team-id`; the plist remains authoritative when supplied.
 
 Create `.asc/deployment.json`:
 

--- a/docs/design/agent-native-ad-hoc-distribution.md
+++ b/docs/design/agent-native-ad-hoc-distribution.md
@@ -4,7 +4,8 @@
 
 ASC should turn a local Xcode archive into a verifiable install result that an
 agent can hand to a person or another system. The public contract is based on
-the outcome, not on Fastlane lanes or AWS-specific vocabulary. Each stage emits
+the outcome, not on a particular automation framework or storage-provider
+vocabulary. Each stage emits
 structured output, writes deterministic artifacts under an operator-selected
 root, and can be retried without repeating completed account mutations.
 

--- a/docs/design/agent-native-ad-hoc-distribution.md
+++ b/docs/design/agent-native-ad-hoc-distribution.md
@@ -95,6 +95,23 @@ Coverage must establish:
 - real archive export with Xcode 26.6 and Xcode 27 before the distribution stack
   is declared complete.
 
+## Handoff and promotion gates
+
+Each slice must be committed on its own feature branch and pushed at the exact
+revision that passed its focused tests and repository validation gates. A
+downstream slice must not be folded into the same commit merely because it uses
+the preceding command. Review handoff must record the tested Xcode versions,
+the exact commit, live verification performed, and any gate that remains.
+
+`--method` remains experimental until the complete workflow has exported a real
+archive, published a fetch-verified HTTPS manifest and IPA, and installed the
+expected bundle and build on a registered device. Manual exports still depend
+on a locally available distribution private key and provisioning profiles that
+cover every embedded target and capability. Later slices must also settle the
+security and retention contract for caller-provided storage, bearer install
+URLs, device identifiers, and resumable state before `asc distribute` can be
+promoted to stable.
+
 ## Alternatives
 
 Accepting `ad-hoc` would mirror older automation tools but create a deprecated

--- a/docs/design/agent-native-ad-hoc-distribution.md
+++ b/docs/design/agent-native-ad-hoc-distribution.md
@@ -1,0 +1,104 @@
+# Agent-native ad hoc distribution
+
+## Product direction
+
+ASC should turn a local Xcode archive into a verifiable install result that an
+agent can hand to a person or another system. The public contract is based on
+the outcome, not on Fastlane lanes or AWS-specific vocabulary. Each stage emits
+structured output, writes deterministic artifacts under an operator-selected
+root, and can be retried without repeating completed account mutations.
+
+The complete workflow is planned as separate reviewable changes:
+
+1. Generate modern Xcode `release-testing` export options and export an IPA.
+2. Inspect the IPA and prepare a self-contained web-install bundle.
+3. Publish that bundle through a caller-provided S3-compatible endpoint.
+4. Reconcile registered devices and ad hoc provisioning profiles.
+5. Sync and install the private signing identity under explicit local control.
+6. Compose the stages into a resumable run with a durable receipt.
+
+The first change in this stack owns only item 1.
+
+## Placement and current behavior
+
+`asc xcode export-options generate` currently always writes
+`method=app-store-connect`. `asc xcode export` implicitly generates the same
+options when `--export-options` is omitted. A caller can provide a custom plist,
+but ASC cannot generate the non-App-Store export used for ad hoc delivery.
+
+Xcode 26.6 and Xcode 27 call this method `release-testing`. Both versions still
+accept `ad-hoc`, but mark it deprecated. ASC will use the current Xcode name and
+will not introduce the deprecated spelling as a new public value.
+
+## PR 1 public contract
+
+The standalone generator adds:
+
+```text
+asc xcode export-options generate \
+  --archive-path .asc/artifacts/App.xcarchive \
+  [--method app-store-connect|release-testing] \
+  [--destination export|upload] \
+  [--signing-style automatic|manual]
+```
+
+`--method` defaults to `app-store-connect`, preserving every existing
+invocation. `release-testing` requires `--destination export` because it creates
+a local IPA rather than an App Store Connect upload. Its default output is
+`.asc/export-options-release-testing.plist`; the existing App Store default
+remains `.asc/export-options-app-store.plist`.
+
+`asc xcode export` receives the same `--method` flag for its implicit generator:
+
+```text
+asc xcode export \
+  --archive-path .asc/artifacts/App.xcarchive \
+  --method release-testing \
+  --signing-style manual \
+  --ipa-path .asc/artifacts/App.ipa
+```
+
+An explicit `--export-options` file remains authoritative and cannot be combined
+with `--method`, `--signing-style`, or `--team-id`. The default export method
+remains `app-store-connect`. No existing output field changes; `method` reports
+the actual generated value. Invalid values are usage errors with exit code 2.
+Data remains on stdout and diagnostics remain on stderr.
+
+## Implementation and compatibility
+
+The repository-owned generator passes the selected method to the pinned Bitrise
+typed models. App Store Connect continues to use the App Store model.
+Release-testing uses the non-App-Store model. Manual signing resolution receives
+the selected method so profile selection matches the requested export. The
+pinned resolver still classifies installed ad hoc profiles with Xcode's legacy
+`ad-hoc` enum, so ASC translates only at that internal resolver boundary and
+continues to emit `release-testing` in the generated plist.
+
+The change is additive. No deprecation or migration is required. The legacy
+`ad-hoc` Xcode spelling is intentionally rejected with guidance to use
+`release-testing`.
+
+## RED-GREEN and verification
+
+Coverage must establish:
+
+- valid generator and implicit-export parsing for both methods;
+- invalid and explicitly empty method values as usage errors;
+- rejection of release-testing with `destination=upload` or `xcode export --wait`;
+- conflict errors when `--method` accompanies an explicit plist;
+- exact `method=release-testing` plist and JSON output;
+- manual generator receipt of the selected method;
+- portable and Darwin typed-model parity;
+- unchanged app-store-connect defaults;
+- generated command documentation, focused tests, built-binary stdout/stderr and
+  exit codes, followed by the repository validation gate;
+- real archive export with Xcode 26.6 and Xcode 27 before the distribution stack
+  is declared complete.
+
+## Alternatives
+
+Accepting `ad-hoc` would mirror older automation tools but create a deprecated
+surface on day one. Hiding the method only inside the future distribution
+orchestrator would leave `asc xcode export` incomplete and make that orchestrator
+depend on a private code path. Supporting every Xcode export method in this
+change would widen the review without helping the first install-link workflow.

--- a/docs/design/xcode-export-options-generation.md
+++ b/docs/design/xcode-export-options-generation.md
@@ -105,9 +105,11 @@ It does not create or mutate signing assets.
 
 ## Compatibility and lifecycle
 
-This is an additive stable subcommand plus a relaxation of one required flag.
-Explicit export-options files retain precedence and behavior, including custom
-Xcode keys not modeled by ASC or Bitrise. No deprecation is required.
+The existing generator remains a stable additive subcommand. The new `--method`
+extension and its `release-testing` value are experimental until the complete
+direct-install workflow passes its promotion gates. Explicit export-options
+files retain precedence and behavior, including custom Xcode keys not modeled
+by ASC or Bitrise. No deprecation is required.
 
 The command remains visible on every platform with the rest of `asc xcode`.
 Automatic plist construction and atomic writing are cross-platform when the

--- a/docs/design/xcode-export-options-generation.md
+++ b/docs/design/xcode-export-options-generation.md
@@ -18,20 +18,23 @@ The standalone command is:
 ```text
 asc xcode export-options generate \
   --archive-path .asc/artifacts/App.xcarchive \
-  [--output-path .asc/export-options-app-store.plist] \
+  [--method app-store-connect|release-testing] \
+  [--output-path ExportOptions.plist] \
   [--destination export|upload] \
   [--signing-style automatic|manual] \
   [--team-id TEAM_ID] [--overwrite] \
   [--output json|table|markdown] [--pretty]
 ```
 
-Defaults are `app-store-connect`, `destination=export`,
+Defaults are `method=app-store-connect`, `destination=export`,
 `signingStyle=automatic`, and the deterministic
-`.asc/export-options-app-store.plist` output path. The command never silently
+`.asc/export-options-app-store.plist` output path. `release-testing` uses
+`.asc/export-options-release-testing.plist` and requires `destination=export`.
+The command never silently
 replaces that file: a repeat write requires explicit `--overwrite` consent. The first
-release intentionally fixes the method to App Store Connect because this is the
-shared contract used by `asc xcode export` and both local-build publish flows.
-Other Xcode export methods can be added without changing this contract.
+release supported only App Store Connect; this extension adds Xcode's current
+name for registered-device distribution. Xcode's deprecated `ad-hoc` spelling
+is rejected with guidance to use `release-testing`.
 
 The archive is required so ASC can validate that the artifact is an Xcode
 archive and infer its team and bundle metadata. `--team-id` overrides archive
@@ -42,7 +45,8 @@ export-options generator for its supported iOS/tvOS archive shapes and fails
 clearly for unsupported or ambiguous archives; users can always retain an
 explicit custom plist.
 
-Existing invocations remain valid. `asc xcode export` makes
+Existing invocations remain valid. `asc xcode export` accepts the same
+`--method` value for implicit generation and makes
 `--export-options` optional. When omitted it generates a uniquely named,
 archive-adjacent plist for the current run; `--wait` selects
 `destination=upload`, otherwise `destination=export`. The implicit path is
@@ -67,7 +71,7 @@ The generator result contains:
 - `method`, `destination`, and `signing_style`;
 - inferred or explicit `team_id` when available;
 - `signing_certificate` and a stable bundle-ID-to-profile map for manual
-  signing;
+  signing and both supported methods;
 - `overwritten`.
 
 JSON uses those field names. Table and Markdown render the same values with one

--- a/internal/cli/xcode/export_options.go
+++ b/internal/cli/xcode/export_options.go
@@ -59,7 +59,7 @@ func XcodeExportOptionsCommand() *ffcli.Command {
 
 	archivePath := fs.String("archive-path", "", "Path to the .xcarchive input (required)")
 	outputPath := fs.String("output-path", "", "Destination path for the generated ExportOptions.plist (defaults to a method-specific .asc path)")
-	method := fs.String("method", "app-store-connect", "Xcode export method: app-store-connect or release-testing")
+	method := fs.String("method", "app-store-connect", "[experimental] Xcode export method: app-store-connect or release-testing")
 	destination := fs.String("destination", "export", "Xcode export destination: export or upload")
 	signingStyle := fs.String("signing-style", "automatic", "Signing style: automatic or manual")
 	teamID := fs.String("team-id", "", "Apple Developer team ID (overrides archive metadata)")

--- a/internal/cli/xcode/export_options.go
+++ b/internal/cli/xcode/export_options.go
@@ -15,7 +15,10 @@ import (
 	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 )
 
-const defaultXcodeExportOptionsPath = ".asc/export-options-app-store.plist"
+const (
+	defaultXcodeExportOptionsPath          = ".asc/export-options-app-store.plist"
+	defaultReleaseTestingExportOptionsPath = ".asc/export-options-release-testing.plist"
+)
 
 // XcodeExportOptionsGroupCommand returns the export-options command group.
 func XcodeExportOptionsGroupCommand() *ffcli.Command {
@@ -27,12 +30,14 @@ func XcodeExportOptionsGroupCommand() *ffcli.Command {
 		ShortHelp:  "Generate Xcode ExportOptions.plist files.",
 		LongHelp: `Generate Xcode ExportOptions.plist files.
 
-Use generate to create App Store Connect export options from an existing
-.xcarchive. Automatic signing lets Xcode resolve signing for the app and any
-embedded targets; provide --signing-style manual to resolve local profiles.
+Use generate to create App Store Connect or release-testing export options from
+an existing .xcarchive. Automatic signing lets Xcode resolve signing for the
+app and any embedded targets; provide --signing-style manual to resolve local
+profiles.
 
 Examples:
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive
+  asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive --method release-testing
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive --destination upload --output-path .asc/UploadExportOptions.plist`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -53,7 +58,8 @@ func XcodeExportOptionsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("xcode export-options generate", flag.ExitOnError)
 
 	archivePath := fs.String("archive-path", "", "Path to the .xcarchive input (required)")
-	outputPath := fs.String("output-path", defaultXcodeExportOptionsPath, "Destination path for the generated ExportOptions.plist")
+	outputPath := fs.String("output-path", "", "Destination path for the generated ExportOptions.plist (defaults to a method-specific .asc path)")
+	method := fs.String("method", "app-store-connect", "Xcode export method: app-store-connect or release-testing")
 	destination := fs.String("destination", "export", "Xcode export destination: export or upload")
 	signingStyle := fs.String("signing-style", "automatic", "Signing style: automatic or manual")
 	teamID := fs.String("team-id", "", "Apple Developer team ID (overrides archive metadata)")
@@ -64,14 +70,16 @@ func XcodeExportOptionsCommand() *ffcli.Command {
 		Name:       "generate",
 		ShortUsage: "asc xcode export-options generate [flags]",
 		ShortHelp:  "Generate an ExportOptions.plist from an Xcode archive.",
-		LongHelp: `Generate an App Store Connect ExportOptions.plist from an Xcode archive.
+		LongHelp: `Generate an ExportOptions.plist from an Xcode archive.
 
-The generated plist uses app-store-connect exports. By default it uses
-automatic signing and an export destination. Use --destination upload only for
-direct Xcode uploads, such as asc xcode export --wait.
+The generated plist uses app-store-connect by default. Use
+--method release-testing to create a local IPA for registered devices. Xcode's
+older ad-hoc method name is deprecated and is not accepted. Release-testing
+requires destination=export.
 
 Examples:
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive
+  asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive --method release-testing --signing-style manual
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive --destination upload --output-path .asc/UploadExportOptions.plist
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive --signing-style manual --team-id TEAM_ID --overwrite --output json`,
 		FlagSet:   fs,
@@ -90,13 +98,32 @@ Examples:
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
+			trimmedMethod, err := localxcode.NormalizeExportOptionsMethod(*method)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if trimmedMethod == "release-testing" && trimmedDestination != "export" {
+				return shared.UsageError("release-testing requires destination=export")
+			}
 
 			trimmedArchivePath := strings.TrimSpace(*archivePath)
 			if trimmedArchivePath == "" {
 				fmt.Fprintln(os.Stderr, "Error: --archive-path is required")
 				return shared.MissingRequiredUsageError()
 			}
+			outputPathSet := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "output-path" {
+					outputPathSet = true
+				}
+			})
 			trimmedOutputPath := strings.TrimSpace(*outputPath)
+			if !outputPathSet {
+				trimmedOutputPath = defaultXcodeExportOptionsPath
+				if trimmedMethod == "release-testing" {
+					trimmedOutputPath = defaultReleaseTestingExportOptionsPath
+				}
+			}
 			if trimmedOutputPath == "" {
 				fmt.Fprintln(os.Stderr, "Error: --output-path is required")
 				return shared.MissingRequiredUsageError()
@@ -105,6 +132,7 @@ Examples:
 			result, err := runGenerateExportOptions(ctx, localxcode.ExportOptionsGenerateOptions{
 				ArchivePath:  trimmedArchivePath,
 				OutputPath:   trimmedOutputPath,
+				Method:       trimmedMethod,
 				Destination:  trimmedDestination,
 				SigningStyle: trimmedSigningStyle,
 				TeamID:       strings.TrimSpace(*teamID),

--- a/internal/cli/xcode/export_options_test.go
+++ b/internal/cli/xcode/export_options_test.go
@@ -12,9 +12,30 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/peterbourgon/ff/v3/ffcli"
 	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 	"howett.net/plist"
 )
+
+func TestXcodeExportMethodFlagsAreExperimental(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  *ffcli.Command
+	}{
+		{name: "export options generate", cmd: XcodeExportOptionsCommand()},
+		{name: "export", cmd: XcodeExportCommand()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			methodFlag := tc.cmd.FlagSet.Lookup("method")
+			if methodFlag == nil {
+				t.Fatal("method flag is not registered")
+			}
+			if !strings.HasPrefix(methodFlag.Usage, "[experimental] ") {
+				t.Fatalf("method flag usage = %q, want experimental lifecycle label", methodFlag.Usage)
+			}
+		})
+	}
+}
 
 func TestXcodeExportOptionsGenerateWritesRequestedAutomaticOptionsAndJSON(t *testing.T) {
 	archivePath := writeXcodeExportOptionsTestArchive(t)

--- a/internal/cli/xcode/export_options_test.go
+++ b/internal/cli/xcode/export_options_test.go
@@ -79,6 +79,87 @@ func TestXcodeExportOptionsGenerateWritesRequestedAutomaticOptionsAndJSON(t *tes
 	}
 }
 
+func TestXcodeExportOptionsGenerateWritesReleaseTestingOptionsAndJSON(t *testing.T) {
+	archivePath := writeXcodeExportOptionsTestArchive(t)
+	outputPath := filepath.Join(t.TempDir(), "generated", "ExportOptions.plist")
+
+	cmd := XcodeExportOptionsCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", archivePath,
+		"--output-path", outputPath,
+		"--method", "release-testing",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if runErr != nil {
+		t.Fatalf("Exec() error: %v\nstderr=%s", runErr, stderr)
+	}
+
+	var result struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v\nstdout=%s", err, stdout)
+	}
+	if result.Method != "release-testing" {
+		t.Fatalf("result method = %q, want release-testing", result.Method)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile() generated options error: %v", err)
+	}
+	var options map[string]any
+	if _, err := plist.Unmarshal(data, &options); err != nil {
+		t.Fatalf("plist.Unmarshal() error: %v", err)
+	}
+	if options["method"] != "release-testing" || options["destination"] != "export" {
+		t.Fatalf("unexpected generated plist: %+v", options)
+	}
+}
+
+func TestXcodeExportOptionsGenerateUsesReleaseTestingDefaultPath(t *testing.T) {
+	t.Chdir(t.TempDir())
+	archivePath := writeXcodeExportOptionsTestArchive(t)
+
+	cmd := XcodeExportOptionsCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", archivePath,
+		"--method", "release-testing",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+	var result struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v\nstdout=%s", err, stdout)
+	}
+	if result.Path != defaultReleaseTestingExportOptionsPath {
+		t.Fatalf("result path = %q, want %q", result.Path, defaultReleaseTestingExportOptionsPath)
+	}
+	if _, err := os.Stat(defaultReleaseTestingExportOptionsPath); err != nil {
+		t.Fatalf("release-testing default output was not written: %v", err)
+	}
+}
+
 func TestXcodeExportOptionsGenerateRejectsInvalidValues(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -99,6 +180,16 @@ func TestXcodeExportOptionsGenerateRejectsInvalidValues(t *testing.T) {
 			name:    "empty signing style",
 			args:    []string{"--archive-path", "Demo.xcarchive", "--signing-style", ""},
 			message: "Error: --signing-style must be one of: automatic, manual",
+		},
+		{
+			name:    "method",
+			args:    []string{"--archive-path", "Demo.xcarchive", "--method", "ad-hoc"},
+			message: "Error: --method must be one of: app-store-connect, release-testing; use release-testing instead of deprecated ad-hoc",
+		},
+		{
+			name:    "empty method",
+			args:    []string{"--archive-path", "Demo.xcarchive", "--method", ""},
+			message: "Error: --method must be one of: app-store-connect, release-testing",
 		},
 	}
 
@@ -246,11 +337,105 @@ func TestXcodeExportThreadsManualSigningOptionsToImplicitGeneration(t *testing.T
 	}
 }
 
+func TestXcodeExportThreadsReleaseTestingToImplicitGeneration(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	archivePath := writeXcodeExportOptionsTestArchive(t)
+	wantErr := errors.New("stop after generation")
+	var generatedOptions localxcode.ExportOptionsGenerateOptions
+	runGenerateExportOptions = func(_ context.Context, opts localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		generatedOptions = opts
+		return &localxcode.ExportOptionsGenerateResult{Path: opts.OutputPath}, nil
+	}
+	runExport = func(_ context.Context, _ localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		return nil, wantErr
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", archivePath,
+		"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+		"--method", "release-testing",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	runErr := cmd.Exec(context.Background(), nil)
+	if !errors.Is(runErr, wantErr) {
+		t.Fatalf("expected export sentinel, got %v", runErr)
+	}
+	if generatedOptions.Method != "release-testing" {
+		t.Fatalf("generated method = %q, want release-testing", generatedOptions.Method)
+	}
+}
+
+func TestXcodeExportRejectsReleaseTestingWithWaitBeforeSideEffects(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	runXcodeExportPreflight = func(context.Context) error {
+		t.Fatal("preflight must not run for release-testing with --wait")
+		return nil
+	}
+	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		t.Fatal("generator must not run for release-testing with --wait")
+		return nil, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+		"--method", "release-testing",
+		"--wait",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	runErr := cmd.Exec(context.Background(), nil)
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--wait cannot be combined with --method release-testing") {
+		t.Fatalf("expected release-testing wait usage error, got %v", runErr)
+	}
+}
+
+func TestXcodeExportRejectsInvalidMethodBeforeSideEffects(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	runXcodeExportPreflight = func(context.Context) error {
+		t.Fatal("preflight must not run for an invalid method")
+		return nil
+	}
+	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		t.Fatal("generator must not run for an invalid method")
+		return nil, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--ipa-path", filepath.Join(t.TempDir(), "Demo.ipa"),
+		"--method", "ad-hoc",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	runErr := cmd.Exec(context.Background(), nil)
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "use release-testing instead of deprecated ad-hoc") {
+		t.Fatalf("expected deprecated method usage error, got %v", runErr)
+	}
+}
+
 func TestXcodeExportRejectsGenerationFlagsWithExplicitOptions(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		args []string
 	}{
+		{name: "method", args: []string{"--method", "release-testing"}},
 		{name: "signing style", args: []string{"--signing-style", "automatic"}},
 		{name: "team ID", args: []string{"--team-id", "TEAM123456"}},
 	} {
@@ -284,7 +469,7 @@ func TestXcodeExportRejectsGenerationFlagsWithExplicitOptions(t *testing.T) {
 			}
 
 			runErr := cmd.Exec(context.Background(), nil)
-			if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--export-options cannot be combined with --signing-style or --team-id") {
+			if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), "--export-options cannot be combined with --method, --signing-style, or --team-id") {
 				t.Fatalf("expected explicit-options conflict usage error, got %v", runErr)
 			}
 		})

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -180,7 +180,7 @@ func XcodeExportCommand() *ffcli.Command {
 
 	archivePath := fs.String("archive-path", "", "Path to the .xcarchive input (required)")
 	exportOptions := fs.String("export-options", "", "Path to ExportOptions.plist (generated automatically when omitted)")
-	method := fs.String("method", "app-store-connect", "Method for generated options: app-store-connect or release-testing")
+	method := fs.String("method", "app-store-connect", "[experimental] Method for generated options: app-store-connect or release-testing")
 	signingStyle := fs.String("signing-style", "automatic", "Signing style for generated options: automatic or manual")
 	teamID := fs.String("team-id", "", "Apple Developer team ID for generated options (overrides archive metadata)")
 	ipaPath := fs.String("ipa-path", "", "Destination path for a local .ipa when one is produced (required)")

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -180,6 +180,7 @@ func XcodeExportCommand() *ffcli.Command {
 
 	archivePath := fs.String("archive-path", "", "Path to the .xcarchive input (required)")
 	exportOptions := fs.String("export-options", "", "Path to ExportOptions.plist (generated automatically when omitted)")
+	method := fs.String("method", "app-store-connect", "Method for generated options: app-store-connect or release-testing")
 	signingStyle := fs.String("signing-style", "automatic", "Signing style for generated options: automatic or manual")
 	teamID := fs.String("team-id", "", "Apple Developer team ID for generated options (overrides archive metadata)")
 	ipaPath := fs.String("ipa-path", "", "Destination path for a local .ipa when one is produced (required)")
@@ -199,9 +200,10 @@ func XcodeExportCommand() *ffcli.Command {
 
 This command runs xcodebuild -exportArchive into a temporary directory.
 When --export-options is omitted, asc generates archive-adjacent options. It
-uses automatic signing by default and destination=upload with --wait, otherwise
-destination=export. Use --signing-style manual to match locally installed
-certificates and profiles; --team-id optionally overrides archive metadata.
+uses app-store-connect and automatic signing by default. Use
+--method release-testing for a local IPA installable on registered devices. Use
+--signing-style manual to match locally installed certificates and profiles;
+--team-id optionally overrides archive metadata.
 When ExportOptions.plist produces a local IPA, asc moves it to --ipa-path.
 When ExportOptions.plist uses destination=upload, xcodebuild uploads directly
 to App Store Connect and asc returns archive metadata without writing a local
@@ -210,6 +212,7 @@ finishes processing.
 
 Examples:
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa
+  asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --method release-testing --signing-style manual
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --signing-style manual --team-id TEAM_ID
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --timeout 10m
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options UploadExportOptions.plist --ipa-path .asc/artifacts/App.ipa --wait
@@ -239,10 +242,14 @@ Examples:
 				return shared.UsageError(err.Error())
 			}
 			generationFlagsSet := false
+			methodSet := false
 			signingStyleSet := false
 			teamIDSet := false
 			fs.Visit(func(f *flag.Flag) {
 				switch f.Name {
+				case "method":
+					generationFlagsSet = true
+					methodSet = true
 				case "signing-style":
 					generationFlagsSet = true
 					signingStyleSet = true
@@ -251,6 +258,13 @@ Examples:
 					teamIDSet = true
 				}
 			})
+			if methodSet && strings.TrimSpace(*method) == "" {
+				return shared.UsageError("--method must be one of: app-store-connect, release-testing")
+			}
+			methodValue, err := localxcode.NormalizeExportOptionsMethod(*method)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
 			if signingStyleSet && strings.TrimSpace(*signingStyle) == "" {
 				return shared.UsageError("--signing-style must be one of: automatic, manual")
 			}
@@ -265,7 +279,10 @@ Examples:
 			trimmedArchivePath := strings.TrimSpace(*archivePath)
 			exportOptionsPath := strings.TrimSpace(*exportOptions)
 			if exportOptionsPath != "" && generationFlagsSet {
-				return shared.UsageError("--export-options cannot be combined with --signing-style or --team-id")
+				return shared.UsageError("--export-options cannot be combined with --method, --signing-style, or --team-id")
+			}
+			if *wait && methodValue == "release-testing" {
+				return shared.UsageError("--wait cannot be combined with --method release-testing")
 			}
 			if exportOptionsPath == "" {
 				destination := "export"
@@ -294,6 +311,7 @@ Examples:
 				generated, err := runGenerateExportOptions(ctx, localxcode.ExportOptionsGenerateOptions{
 					ArchivePath:  trimmedArchivePath,
 					OutputPath:   generatedPath,
+					Method:       methodValue,
 					Destination:  destination,
 					SigningStyle: signingStyleValue,
 					TeamID:       teamIDValue,

--- a/internal/xcode/export_options.go
+++ b/internal/xcode/export_options.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	exportOptionsMethodAppStoreConnect = "app-store-connect"
+	exportOptionsMethodReleaseTesting  = "release-testing"
 	exportOptionsDestinationExport     = "export"
 	exportOptionsDestinationUpload     = "upload"
 	exportOptionsSigningStyleAutomatic = "automatic"
@@ -26,6 +27,7 @@ const (
 type ExportOptionsGenerateOptions struct {
 	ArchivePath  string
 	OutputPath   string
+	Method       string
 	Destination  string
 	SigningStyle string
 	TeamID       string
@@ -124,7 +126,7 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 		if err := preflightExportOptionsParentFn(opts.OutputPath); err != nil {
 			return nil, err
 		}
-		manual, err = manualExportOptionsGeneratorFn(ctx, opts.ArchivePath, teamID)
+		manual, err = manualExportOptionsGeneratorFn(ctx, opts.ArchivePath, teamID, opts.Method)
 		if err != nil {
 			return nil, fmt.Errorf("generate manual export options: %w", err)
 		}
@@ -141,7 +143,7 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	}
 
 	payload := buildExportOptionsPayload(opts, teamID, manual)
-	if err := validateExportOptionsPayload(payload, opts.SigningStyle); err != nil {
+	if err := validateExportOptionsPayload(payload, opts.Method, opts.SigningStyle); err != nil {
 		return nil, err
 	}
 	data, err := plist.MarshalIndent(payload, plist.XMLFormat, "\t")
@@ -152,7 +154,7 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	if _, err := plist.Unmarshal(data, &decoded); err != nil {
 		return nil, fmt.Errorf("decode generated export options plist: %w", err)
 	}
-	if err := validateExportOptionsPayload(decoded, opts.SigningStyle); err != nil {
+	if err := validateExportOptionsPayload(decoded, opts.Method, opts.SigningStyle); err != nil {
 		return nil, fmt.Errorf("validate generated export options plist: %w", err)
 	}
 
@@ -174,7 +176,7 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	result := &ExportOptionsGenerateResult{
 		Path:         opts.OutputPath,
 		ArchivePath:  opts.ArchivePath,
-		Method:       exportOptionsMethodAppStoreConnect,
+		Method:       opts.Method,
 		Destination:  opts.Destination,
 		SigningStyle: opts.SigningStyle,
 		TeamID:       teamID,
@@ -199,11 +201,29 @@ func NormalizeExportOptionsSigningStyle(value string) (string, error) {
 	}
 }
 
+// NormalizeExportOptionsMethod validates the public method enum shared by
+// export-options generation callers.
+func NormalizeExportOptionsMethod(value string) (string, error) {
+	method := strings.ToLower(strings.TrimSpace(value))
+	switch method {
+	case exportOptionsMethodAppStoreConnect, exportOptionsMethodReleaseTesting:
+		return method, nil
+	case "ad-hoc":
+		return method, fmt.Errorf("--method must be one of: app-store-connect, release-testing; use release-testing instead of deprecated ad-hoc")
+	default:
+		return method, fmt.Errorf("--method must be one of: app-store-connect, release-testing")
+	}
+}
+
 func normalizeExportOptionsGenerateOptions(opts ExportOptionsGenerateOptions) ExportOptionsGenerateOptions {
 	opts.ArchivePath = normalizeDirectoryPath(opts.ArchivePath)
 	opts.OutputPath = strings.TrimSpace(opts.OutputPath)
 	if opts.OutputPath != "" {
 		opts.OutputPath = filepath.Clean(opts.OutputPath)
+	}
+	opts.Method = strings.ToLower(strings.TrimSpace(opts.Method))
+	if opts.Method == "" {
+		opts.Method = exportOptionsMethodAppStoreConnect
 	}
 	opts.Destination = strings.ToLower(strings.TrimSpace(opts.Destination))
 	if opts.Destination == "" {
@@ -227,6 +247,9 @@ func validateExportOptionsGenerateOptions(opts ExportOptionsGenerateOptions) err
 	if opts.OutputPath == "" {
 		return fmt.Errorf("--output-path is required")
 	}
+	if _, err := NormalizeExportOptionsMethod(opts.Method); err != nil {
+		return err
+	}
 	switch opts.Destination {
 	case exportOptionsDestinationExport, exportOptionsDestinationUpload:
 	default:
@@ -234,6 +257,9 @@ func validateExportOptionsGenerateOptions(opts ExportOptionsGenerateOptions) err
 	}
 	if _, err := NormalizeExportOptionsSigningStyle(opts.SigningStyle); err != nil {
 		return err
+	}
+	if opts.Method == exportOptionsMethodReleaseTesting && opts.Destination != exportOptionsDestinationExport {
+		return fmt.Errorf("release-testing requires destination=export")
 	}
 	return nil
 }
@@ -285,9 +311,9 @@ func buildExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID string,
 	return buildPlatformExportOptionsPayload(opts, teamID, manual)
 }
 
-func validateExportOptionsPayload(payload map[string]any, signingStyle string) error {
-	if method := exportOptionsString(payload["method"]); method != exportOptionsMethodAppStoreConnect {
-		return fmt.Errorf("export options method must be %q", exportOptionsMethodAppStoreConnect)
+func validateExportOptionsPayload(payload map[string]any, method, signingStyle string) error {
+	if got := exportOptionsString(payload["method"]); got != method {
+		return fmt.Errorf("export options method must be %q", method)
 	}
 	destination := exportOptionsString(payload["destination"])
 	if destination != exportOptionsDestinationExport && destination != exportOptionsDestinationUpload {

--- a/internal/xcode/export_options_darwin.go
+++ b/internal/xcode/export_options_darwin.go
@@ -22,6 +22,8 @@ import (
 
 var bitriseStdoutCaptureMu sync.Mutex
 
+var readArchiveExportInfoFn = readArchiveExportInfo
+
 // buildPlatformExportOptionsPayload uses Bitrise's current typed v2 model on
 // macOS, where xcodebuild and local signing asset resolution are available.
 func buildPlatformExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID string, manual manualExportOptions) map[string]any {
@@ -60,16 +62,12 @@ func generateManualExportOptions(ctx context.Context, archivePath, teamID, metho
 	if platform != "IOS" && platform != "TV_OS" {
 		return manualExportOptions{}, fmt.Errorf("manual signing export options generation only supports iOS and tvOS archives; archive platform is %s", platform)
 	}
-	archive, err := xcarchive.NewIosArchive(archivePath)
-	if err != nil {
-		return manualExportOptions{}, fmt.Errorf("read iOS archive: %w", err)
-	}
-	archiveInfo, err := exportoptionsgenerator.ReadArchiveExportInfo(archive)
-	if err != nil {
-		return manualExportOptions{}, fmt.Errorf("read archive export information: %w", err)
-	}
 	var generated legacyexportoptions.ExportOptions
 	if _, err := captureBitriseStdout(func() error {
+		archiveInfo, err := readArchiveExportInfoFn(archivePath)
+		if err != nil {
+			return err
+		}
 		generator := exportoptionsgenerator.New(
 			xcodeversion.NewXcodeVersionProvider(command.NewFactory(env.NewRepository())),
 			log.NewLogger(),
@@ -89,6 +87,18 @@ func generateManualExportOptions(ctx context.Context, archivePath, teamID, metho
 		return manualExportOptions{}, err
 	}
 	return manualExportOptionsFromHash(generated.Hash())
+}
+
+func readArchiveExportInfo(archivePath string) (exportoptionsgenerator.ArchiveInfo, error) {
+	archive, err := xcarchive.NewIosArchive(archivePath)
+	if err != nil {
+		return exportoptionsgenerator.ArchiveInfo{}, fmt.Errorf("read iOS archive: %w", err)
+	}
+	archiveInfo, err := exportoptionsgenerator.ReadArchiveExportInfo(archive)
+	if err != nil {
+		return exportoptionsgenerator.ArchiveInfo{}, fmt.Errorf("read archive export information: %w", err)
+	}
+	return archiveInfo, nil
 }
 
 func manualExportOptionsResolverOptions(teamID, method string) exportoptionsgenerator.Opts {

--- a/internal/xcode/export_options_darwin.go
+++ b/internal/xcode/export_options_darwin.go
@@ -25,6 +25,18 @@ var bitriseStdoutCaptureMu sync.Mutex
 // buildPlatformExportOptionsPayload uses Bitrise's current typed v2 model on
 // macOS, where xcodebuild and local signing asset resolution are available.
 func buildPlatformExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID string, manual manualExportOptions) map[string]any {
+	if opts.Method == exportOptionsMethodReleaseTesting {
+		model := exportoptions.NewNonAppStoreOptions(exportoptions.MethodReleaseTesting)
+		model.TeamID = teamID
+		model.Destination = exportoptions.Destination(opts.Destination)
+		model.SigningStyle = exportoptions.SigningStyle(opts.SigningStyle)
+		if opts.SigningStyle == exportOptionsSigningStyleManual {
+			model.SigningCertificate = manual.SigningCertificate
+			model.BundleIDProvisioningProfileMapping = cloneProvisioningProfiles(manual.ProvisioningProfiles)
+			model.ICloudContainerEnvironment = exportoptions.ICloudContainerEnvironment(manual.ICloudContainerEnvironment)
+		}
+		return model.Hash()
+	}
 	model := exportoptions.NewAppStoreConnectOptions(exportoptions.MethodAppStoreConnect)
 	model.TeamID = teamID
 	model.Destination = exportoptions.Destination(opts.Destination)
@@ -37,7 +49,7 @@ func buildPlatformExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID
 	return model.Hash()
 }
 
-func generateManualExportOptions(ctx context.Context, archivePath, teamID string) (manualExportOptions, error) {
+func generateManualExportOptions(ctx context.Context, archivePath, teamID, method string) (manualExportOptions, error) {
 	if err := contextError(ctx); err != nil {
 		return manualExportOptions{}, err
 	}
@@ -63,19 +75,41 @@ func generateManualExportOptions(ctx context.Context, archivePath, teamID string
 			log.NewLogger(),
 		)
 		var generateErr error
+		exportMethod := manualExportOptionsResolverMethod(method)
 		generated, generateErr = generator.GenerateApplicationExportOptions(
 			exportoptionsgenerator.ExportProductApp,
 			archiveInfo,
 			// Bitrise v2's generator currently exposes these v1 argument types.
-			legacyexportoptions.MethodAppStoreConnect,
+			exportMethod,
 			legacyexportoptions.SigningStyleManual,
-			exportoptionsgenerator.Opts{TeamID: teamID},
+			manualExportOptionsResolverOptions(teamID, method),
 		)
 		return generateErr
 	}); err != nil {
 		return manualExportOptions{}, err
 	}
 	return manualExportOptionsFromHash(generated.Hash())
+}
+
+func manualExportOptionsResolverOptions(teamID, method string) exportoptionsgenerator.Opts {
+	opts := exportoptionsgenerator.Opts{TeamID: teamID}
+	if method == exportOptionsMethodReleaseTesting {
+		// Distribution profiles carry production entitlements. Bitrise requires
+		// this value for non-App-Store CloudKit archives instead of inferring it.
+		opts.ContainerEnvironment = "Production"
+	}
+	return opts
+}
+
+// manualExportOptionsResolverMethod adapts ASC's current public Xcode method
+// name to the pinned resolver's profile classification. Bitrise still labels
+// installed ad hoc profiles as MethodAdHoc and filters by exact equality, even
+// though the final ExportOptions.plist must use MethodReleaseTesting.
+func manualExportOptionsResolverMethod(method string) legacyexportoptions.Method {
+	if method == exportOptionsMethodReleaseTesting {
+		return legacyexportoptions.MethodAdHoc
+	}
+	return legacyexportoptions.MethodAppStoreConnect
 }
 
 // captureBitriseStdout contains upstream status prints so structured CLI

--- a/internal/xcode/export_options_darwin_test.go
+++ b/internal/xcode/export_options_darwin_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	legacyexportoptions "github.com/bitrise-io/go-xcode/exportoptions"
+	"github.com/bitrise-io/go-xcode/v2/exportoptionsgenerator"
 	"howett.net/plist"
 )
 
@@ -47,6 +48,28 @@ func TestCaptureBitriseStdout(t *testing.T) {
 	}
 	if !strings.Contains(captured, "Checking if project uses CloudKit") || !strings.Contains(captured, "profile diagnostic") {
 		t.Fatalf("captureBitriseStdout() output = %q", captured)
+	}
+}
+
+func TestGenerateManualExportOptionsCapturesArchiveReaderStdout(t *testing.T) {
+	archivePath := writeExportOptionsTestArchive(t, "TEAM123")
+	wantErr := errors.New("archive reader sentinel")
+	originalReader := readArchiveExportInfoFn
+	originalStdout := os.Stdout
+	captured := false
+	readArchiveExportInfoFn = func(string) (exportoptionsgenerator.ArchiveInfo, error) {
+		captured = os.Stdout != originalStdout
+		fmt.Fprint(os.Stdout, "Fetching entitlements from executable")
+		return exportoptionsgenerator.ArchiveInfo{}, wantErr
+	}
+	t.Cleanup(func() { readArchiveExportInfoFn = originalReader })
+
+	_, err := generateManualExportOptions(t.Context(), archivePath, "TEAM123", exportOptionsMethodReleaseTesting)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("generateManualExportOptions() error = %v, want %v", err, wantErr)
+	}
+	if !captured {
+		t.Fatal("archive reader ran before Bitrise stdout capture was installed")
 	}
 }
 

--- a/internal/xcode/export_options_darwin_test.go
+++ b/internal/xcode/export_options_darwin_test.go
@@ -11,8 +11,29 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/v2/log"
+	legacyexportoptions "github.com/bitrise-io/go-xcode/exportoptions"
 	"howett.net/plist"
 )
+
+func TestManualExportOptionsResolverMethodUsesLegacyAdHocProfileClassification(t *testing.T) {
+	if got := manualExportOptionsResolverMethod(exportOptionsMethodReleaseTesting); got != legacyexportoptions.MethodAdHoc {
+		t.Fatalf("release-testing resolver method = %q, want %q", got, legacyexportoptions.MethodAdHoc)
+	}
+	if got := manualExportOptionsResolverMethod(exportOptionsMethodAppStoreConnect); got != legacyexportoptions.MethodAppStoreConnect {
+		t.Fatalf("app-store-connect resolver method = %q, want %q", got, legacyexportoptions.MethodAppStoreConnect)
+	}
+}
+
+func TestManualExportOptionsResolverOptionsUseProductionCloudKitForReleaseTesting(t *testing.T) {
+	releaseTesting := manualExportOptionsResolverOptions("TEAM123", exportOptionsMethodReleaseTesting)
+	if releaseTesting.TeamID != "TEAM123" || releaseTesting.ContainerEnvironment != "Production" {
+		t.Fatalf("release-testing resolver options = %#v, want team and Production CloudKit", releaseTesting)
+	}
+	appStore := manualExportOptionsResolverOptions("TEAM123", exportOptionsMethodAppStoreConnect)
+	if appStore.TeamID != "TEAM123" || appStore.ContainerEnvironment != "" {
+		t.Fatalf("app-store-connect resolver options = %#v, want team and implied CloudKit environment", appStore)
+	}
+}
 
 func TestCaptureBitriseStdout(t *testing.T) {
 	wantErr := errors.New("generator sentinel")
@@ -43,7 +64,7 @@ func TestGenerateManualExportOptionsRejectsMacOSArchiveClearly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = generateManualExportOptions(t.Context(), archivePath, "TEAM123")
+	_, err = generateManualExportOptions(t.Context(), archivePath, "TEAM123", exportOptionsMethodAppStoreConnect)
 	if err == nil || !strings.Contains(err.Error(), "only supports iOS and tvOS archives") || !strings.Contains(err.Error(), "MAC_OS") {
 		t.Fatalf("expected clear macOS archive rejection, got %v", err)
 	}

--- a/internal/xcode/export_options_portable.go
+++ b/internal/xcode/export_options_portable.go
@@ -12,6 +12,18 @@ import (
 // buildPlatformExportOptionsPayload uses the stable v1 typed model on hosts
 // without Xcode. This keeps automatic ExportOptions generation portable.
 func buildPlatformExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID string, manual manualExportOptions) map[string]any {
+	if opts.Method == exportOptionsMethodReleaseTesting {
+		model := exportoptions.NewNonAppStoreOptions(exportoptions.MethodReleaseTesting)
+		model.TeamID = teamID
+		model.Destination = exportoptions.Destination(opts.Destination)
+		model.SigningStyle = exportoptions.SigningStyle(opts.SigningStyle)
+		if opts.SigningStyle == exportOptionsSigningStyleManual {
+			model.SigningCertificate = manual.SigningCertificate
+			model.BundleIDProvisioningProfileMapping = cloneProvisioningProfiles(manual.ProvisioningProfiles)
+			model.ICloudContainerEnvironment = exportoptions.ICloudContainerEnvironment(manual.ICloudContainerEnvironment)
+		}
+		return model.Hash()
+	}
 	model := exportoptions.NewAppStoreConnectOptions(exportoptions.MethodAppStoreConnect)
 	model.TeamID = teamID
 	model.Destination = exportoptions.Destination(opts.Destination)
@@ -24,6 +36,6 @@ func buildPlatformExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID
 	return model.Hash()
 }
 
-func generateManualExportOptions(context.Context, string, string) (manualExportOptions, error) {
+func generateManualExportOptions(context.Context, string, string, string) (manualExportOptions, error) {
 	return manualExportOptions{}, fmt.Errorf("manual signing export options generation is only supported on macOS because it requires Xcode signing assets")
 }

--- a/internal/xcode/export_options_portable_test.go
+++ b/internal/xcode/export_options_portable_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGenerateManualExportOptions_IsUnsupportedOutsideMacOS(t *testing.T) {
-	_, err := generateManualExportOptions(context.Background(), "Demo.xcarchive", "TEAM123")
+	_, err := generateManualExportOptions(context.Background(), "Demo.xcarchive", "TEAM123", exportOptionsMethodAppStoreConnect)
 	if err == nil || !strings.Contains(err.Error(), "only supported on macOS") {
 		t.Fatalf("expected clear unsupported-platform error, got %v", err)
 	}

--- a/internal/xcode/export_options_test.go
+++ b/internal/xcode/export_options_test.go
@@ -75,6 +75,98 @@ func TestNormalizeExportOptionsSigningStyle(t *testing.T) {
 	}
 }
 
+func TestNormalizeExportOptionsMethod(t *testing.T) {
+	for _, tc := range []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{input: "", want: "", wantErr: true},
+		{input: " app-store-connect ", want: "app-store-connect"},
+		{input: "release-testing", want: "release-testing"},
+		{input: "ad-hoc", want: "ad-hoc", wantErr: true},
+		{input: "enterprise", want: "enterprise", wantErr: true},
+	} {
+		got, err := NormalizeExportOptionsMethod(tc.input)
+		if got != tc.want || (err != nil) != tc.wantErr {
+			t.Fatalf("NormalizeExportOptionsMethod(%q) = %q, %v; want %q, error=%v", tc.input, got, err, tc.want, tc.wantErr)
+		}
+	}
+}
+
+func TestGenerateExportOptions_ReleaseTestingWritesModernMethod(t *testing.T) {
+	archivePath := writeExportOptionsTestArchive(t, "TEAM123")
+	outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")
+
+	result, err := GenerateExportOptions(context.Background(), ExportOptionsGenerateOptions{
+		ArchivePath:  archivePath,
+		OutputPath:   outputPath,
+		Method:       "release-testing",
+		Destination:  "export",
+		SigningStyle: "automatic",
+	})
+	if err != nil {
+		t.Fatalf("GenerateExportOptions() error: %v", err)
+	}
+	if result.Method != "release-testing" {
+		t.Fatalf("result method = %q, want release-testing", result.Method)
+	}
+	if payload := readExportOptionsTestPlist(t, outputPath); payload["method"] != "release-testing" {
+		t.Fatalf("plist method = %#v, want release-testing", payload["method"])
+	}
+}
+
+func TestGenerateExportOptions_ReleaseTestingRejectsUploadDestination(t *testing.T) {
+	archivePath := writeExportOptionsTestArchive(t, "TEAM123")
+	outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")
+
+	_, err := GenerateExportOptions(context.Background(), ExportOptionsGenerateOptions{
+		ArchivePath: archivePath,
+		OutputPath:  outputPath,
+		Method:      "release-testing",
+		Destination: "upload",
+	})
+	if err == nil || !strings.Contains(err.Error(), "release-testing") || !strings.Contains(err.Error(), "destination=export") {
+		t.Fatalf("expected release-testing destination error, got %v", err)
+	}
+	if _, statErr := os.Stat(outputPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("invalid release-testing options created output: %v", statErr)
+	}
+}
+
+func TestGenerateExportOptions_ManualReleaseTestingPassesMethodToResolver(t *testing.T) {
+	archivePath := writeExportOptionsTestArchive(t, "TEAM123")
+	outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")
+
+	originalGenerator := manualExportOptionsGeneratorFn
+	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID, method string) (manualExportOptions, error) {
+		if method != exportOptionsMethodReleaseTesting {
+			t.Fatalf("manual generator method = %q, want release-testing", method)
+		}
+		return manualExportOptions{
+			TeamID:             teamID,
+			SigningCertificate: "Apple Distribution: Example (TEAM123)",
+			ProvisioningProfiles: map[string]string{
+				"com.example.demo": "adhoc-profile-uuid",
+			},
+		}, nil
+	}
+	t.Cleanup(func() { manualExportOptionsGeneratorFn = originalGenerator })
+
+	result, err := GenerateExportOptions(context.Background(), ExportOptionsGenerateOptions{
+		ArchivePath:  archivePath,
+		OutputPath:   outputPath,
+		Method:       "release-testing",
+		SigningStyle: "manual",
+	})
+	if err != nil {
+		t.Fatalf("GenerateExportOptions() error: %v", err)
+	}
+	if result.Method != "release-testing" || result.ProvisioningProfiles["com.example.demo"] != "adhoc-profile-uuid" {
+		t.Fatalf("unexpected release-testing manual result: %#v", result)
+	}
+}
+
 func TestGenerateExportOptions_ExplicitTeamOverridesArchiveTeam(t *testing.T) {
 	archivePath := writeExportOptionsTestArchive(t, "ARCHIVE123")
 	outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")
@@ -474,7 +566,7 @@ func TestGenerateExportOptions_ManualSigningRejectsExistingOutputBeforeLookup(t 
 	}
 
 	originalGenerator := manualExportOptionsGeneratorFn
-	manualExportOptionsGeneratorFn = func(context.Context, string, string) (manualExportOptions, error) {
+	manualExportOptionsGeneratorFn = func(context.Context, string, string, string) (manualExportOptions, error) {
 		t.Fatal("manual signing lookup must not run for an unusable output destination")
 		return manualExportOptions{}, nil
 	}
@@ -618,6 +710,11 @@ func TestGenerateExportOptions_RejectsInvalidDestinationAndSigningStyleBeforeWri
 			errorHint: "signing",
 			opts:      ExportOptionsGenerateOptions{Destination: "export", SigningStyle: "invalid"},
 		},
+		{
+			name:      "method",
+			errorHint: "method",
+			opts:      ExportOptionsGenerateOptions{Method: "ad-hoc", Destination: "export", SigningStyle: "automatic"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")
@@ -643,7 +740,7 @@ func TestGenerateExportOptions_ManualGeneratorOutputIsValidatedBeforeReplacingOu
 	}
 
 	originalGenerator := manualExportOptionsGeneratorFn
-	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID string) (manualExportOptions, error) {
+	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID, _ string) (manualExportOptions, error) {
 		return manualExportOptions{
 			TeamID:               teamID,
 			SigningCertificate:   "Apple Distribution",
@@ -681,7 +778,7 @@ func TestGenerateExportOptions_ManualSigningPreflightsOutputParentBeforeLookup(t
 	t.Cleanup(func() { preflightExportOptionsParentFn = originalPreflight })
 
 	originalGenerator := manualExportOptionsGeneratorFn
-	manualExportOptionsGeneratorFn = func(context.Context, string, string) (manualExportOptions, error) {
+	manualExportOptionsGeneratorFn = func(context.Context, string, string, string) (manualExportOptions, error) {
 		t.Fatal("manual signing lookup ran before output-parent preflight")
 		return manualExportOptions{}, nil
 	}
@@ -721,7 +818,10 @@ func TestGenerateExportOptions_ManualSigningWritesResolvedCertificateAndProfiles
 	outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")
 
 	originalGenerator := manualExportOptionsGeneratorFn
-	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID string) (manualExportOptions, error) {
+	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID, method string) (manualExportOptions, error) {
+		if method != exportOptionsMethodAppStoreConnect {
+			t.Fatalf("manual generator method = %q, want app-store-connect", method)
+		}
 		if teamID != "TEAM123" {
 			t.Fatalf("manual generator team ID = %q, want archive team", teamID)
 		}
@@ -776,7 +876,7 @@ func TestGenerateExportOptions_ManualSigningRejectsGeneratorTeamMismatch(t *test
 	outputPath := filepath.Join(t.TempDir(), "ExportOptions.plist")
 
 	originalGenerator := manualExportOptionsGeneratorFn
-	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID string) (manualExportOptions, error) {
+	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID, _ string) (manualExportOptions, error) {
 		if teamID != "ARCHIVE123" {
 			t.Fatalf("manual generator team ID = %q, want archive team", teamID)
 		}
@@ -806,7 +906,7 @@ func TestGenerateExportOptions_ManualSigningRejectsGeneratorTeamMismatch(t *test
 func TestGenerateExportOptions_ManualOutputIsDeterministic(t *testing.T) {
 	archivePath := writeExportOptionsTestArchive(t, "TEAM123")
 	originalGenerator := manualExportOptionsGeneratorFn
-	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID string) (manualExportOptions, error) {
+	manualExportOptionsGeneratorFn = func(_ context.Context, _ string, teamID, _ string) (manualExportOptions, error) {
 		return manualExportOptions{
 			TeamID:             teamID,
 			SigningCertificate: "Apple Distribution: Example (TEAM123)",


### PR DESCRIPTION
## Summary

- add modern `release-testing` generation to `asc xcode export-options generate`
- thread the same method through implicit `asc xcode export` generation
- preserve `app-store-connect` as the default and reject Xcode's deprecated `ad-hoc` spelling with migration guidance
- resolve installed ad hoc profiles through the pinned Bitrise library while still emitting modern `release-testing` plists
- support distribution-profile CloudKit exports with the Production container environment

This is the first reviewable slice of the agent-native registered-device distribution design in `docs/design/agent-native-ad-hoc-distribution.md`. It intentionally stops at creating a signed local IPA; inspection, OTA bundle preparation, endpoint-driven publishing, signing reconciliation, and orchestration will be separate PRs.

## Public contract

```bash
asc xcode export-options generate \
  --archive-path .asc/artifacts/App.xcarchive \
  --method release-testing \
  --signing-style manual

asc xcode export \
  --archive-path .asc/artifacts/App.xcarchive \
  --ipa-path .asc/artifacts/App.ipa \
  --method release-testing \
  --signing-style manual
```

`release-testing` requires `destination=export`, conflicts with `--wait`, and cannot be combined with an explicit `--export-options` file. Existing invocations remain unchanged.

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 make test`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest`
- `make build`
- built-binary invalid-method stdout/stderr and exit-code check
- independent full-diff review, including regressions for Bitrise's legacy ad hoc profile classification and non-App-Store CloudKit behavior

The host-wide active developer directory remains CommandLineTools, so commands that need Xcode were run with an explicit Xcode 26.6 `DEVELOPER_DIR`. A real SmolLens archive identified the expected missing ad hoc-profile prerequisite; no account mutation is part of this PR.

## Compatibility and risk

- additive flag; the default stays `app-store-connect`
- explicit plists remain authoritative
- no App Store Connect or Developer Portal mutations
- no stable behavior is removed or deprecated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental support for generating Xcode export options and IPAs with the `release-testing` method for local installation on registered devices.
  * Added a `--method` option, defaulting to App Store Connect, with method-specific output paths and provisioning profile details.
  * Added validation for unsupported methods, incompatible destinations, deprecated `ad-hoc`, conflicting export options, and `--wait` usage.

* **Documentation**
  * Documented release-testing workflows, CLI options, defaults, limitations, validation, and compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->