### PR TITLE
fix: keep unknown command errors concise

### DIFF
--- a/cmd/ads_blackbox_test.go
+++ b/cmd/ads_blackbox_test.go
@@ -25,7 +25,7 @@ func TestAdsUsageErrorsExitTwoWithBuiltBinary(t *testing.T) {
 		{
 			name:       "unexpected endpoint arg",
 			args:       []string{"ads", "campaigns", "--output", "json", "unexpected"},
-			wantStderr: "unexpected argument(s): unexpected",
+			wantStderr: "unknown command `asc ads campaigns unexpected`",
 		},
 		{
 			name:       "missing destructive confirm",

--- a/cmd/blackbox_test.go
+++ b/cmd/blackbox_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"sync"
@@ -29,4 +31,57 @@ func buildASCBlackboxBinary(t *testing.T) string {
 	}
 
 	return ascBlackboxBinaryPath
+}
+
+func TestUnknownInputRecoveryWithBuiltBinary(t *testing.T) {
+	binaryPath := buildASCBlackboxBinary(t)
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name: "unknown command",
+			args: []string{"builds", "lsit"},
+			wantStderr: "Error: unknown command `asc builds lsit`\n" +
+				"Try:\n" +
+				"  asc builds list\n" +
+				"For help:\n" +
+				"  asc builds --help\n",
+		},
+		{
+			name: "unknown flag",
+			args: []string{"builds", "list", "--ap", "PRIVATE_VALUE"},
+			wantStderr: "Error: unknown flag `--ap` for `asc builds list`\n" +
+				"Try:\n" +
+				"  --app\n" +
+				"For help:\n" +
+				"  asc builds list --help\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.Command(binaryPath, test.args...)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			command.Stdout = &stdout
+			command.Stderr = &stderr
+
+			err := command.Run()
+			var exitError *exec.ExitError
+			if !errors.As(err, &exitError) || exitError.ExitCode() != ExitUsage {
+				t.Fatalf("exit error = %v, want exit %d", err, ExitUsage)
+			}
+			if stdout.String() != "" {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if stderr.String() != test.wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), test.wantStderr)
+			}
+			if bytes.Contains(stderr.Bytes(), []byte("PRIVATE_VALUE")) {
+				t.Fatalf("stderr leaked a following argument: %q", stderr.String())
+			}
+		})
+	}
 }

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -80,15 +80,75 @@ func shapeForCommand(command *ffcli.Command, sawFlag bool) telemetry.InvocationS
 	return telemetry.InvocationShapeBareGroup
 }
 
-func shouldRejectUnknownChild(root *ffcli.Command, analysis invocationAnalysis, commandName string) bool {
-	if analysis.shape != telemetry.InvocationShapeUnknownChild || analysis.command == nil || analysis.command == root {
+func shouldRenderConciseUnknownChild(root *ffcli.Command, analysis invocationAnalysis, commandName string) bool {
+	if analysis.shape != telemetry.InvocationShapeUnknownChild || analysis.command == nil {
 		return false
 	}
+	if analysis.command != root && commandName == "asc snitch" {
+		return false
+	}
+	return analysis.command == root || !preservesLegacyChild(analysis, commandName)
+}
 
-	// Snitch intentionally accepts a positional report description before its
-	// optional flush subcommand. Normalized view/edit commands and a few removed
-	// commands also handle legacy children to print precise migration guidance.
-	return commandName != "asc snitch" && !preservesLegacyChild(analysis, commandName)
+func printConciseUnknownCommand(analysis invocationAnalysis, commandName string) {
+	unknown := shared.SanitizeTerminal(analysis.unknownToken)
+	fmt.Fprintf(os.Stderr, "Error: unknown command `%s %s`\n", commandName, unknown)
+
+	candidates := visibleSubcommandNames(analysis.command)
+	suggestions := suggest.Commands(analysis.unknownToken, candidates)
+	if len(suggestions) > 2 {
+		suggestions = suggestions[:2]
+	}
+	if len(suggestions) > 0 {
+		fmt.Fprintln(os.Stderr, "Try:")
+		for _, suggestion := range suggestions {
+			fmt.Fprintf(os.Stderr, "  %s %s\n", commandName, shared.SanitizeTerminal(suggestion))
+		}
+	}
+	fmt.Fprintln(os.Stderr, "For help:")
+	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
+}
+
+func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
+	flagName := strings.SplitN(analysis.unknownToken, "=", 2)[0]
+	fmt.Fprintf(
+		os.Stderr,
+		"Error: unknown flag `%s` for `%s`\n",
+		shared.SanitizeTerminal(flagName),
+		commandName,
+	)
+
+	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
+	candidates := make([]string, 0, len(visibleFlags))
+	for _, item := range visibleFlags {
+		candidates = append(candidates, item.Name)
+	}
+	suggestions := suggest.Flags(strings.TrimLeft(flagName, "-"), candidates)
+	if len(suggestions) > 2 {
+		suggestions = suggestions[:2]
+	}
+	if len(suggestions) > 0 {
+		fmt.Fprintln(os.Stderr, "Try:")
+		for _, suggestion := range suggestions {
+			fmt.Fprintf(os.Stderr, "  --%s\n", shared.SanitizeTerminal(suggestion))
+		}
+	}
+	fmt.Fprintln(os.Stderr, "For help:")
+	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
+}
+
+func visibleSubcommandNames(command *ffcli.Command) []string {
+	if command == nil {
+		return nil
+	}
+	names := make([]string, 0, len(command.Subcommands))
+	for _, subcommand := range command.Subcommands {
+		if subcommand == nil || strings.HasPrefix(strings.TrimSpace(subcommand.ShortHelp), "DEPRECATED:") {
+			continue
+		}
+		names = append(names, subcommand.Name)
+	}
+	return names
 }
 
 func preservesLegacyChild(analysis invocationAnalysis, commandName string) bool {
@@ -277,19 +337,6 @@ func hasDefinedFlags(flagSet *flag.FlagSet) bool {
 	return found
 }
 
-func printUnknownFlagSuggestion(analysis invocationAnalysis) {
-	if !analysis.unknownFlag || analysis.command == nil || analysis.command.FlagSet == nil {
-		return
-	}
-	input := strings.TrimLeft(strings.SplitN(analysis.unknownToken, "=", 2)[0], "-")
-	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
-	candidates := make([]string, 0, len(visibleFlags))
-	for _, f := range visibleFlags {
-		candidates = append(candidates, f.Name)
-	}
-	printFlagSuggestions(input, candidates)
-}
-
 func printUnknownSubcommandSuggestion(analysis invocationAnalysis, commandName string) {
 	if analysis.shape != telemetry.InvocationShapeUnknownChild || analysis.command == nil || analysis.command.Name == "asc" {
 		return
@@ -313,10 +360,6 @@ func isRemovedReviewItemDetailInvocation(analysis invocationAnalysis, commandNam
 func printSuggestions(input string, candidates []string, prefix string) {
 	suggestions := suggest.Commands(input, candidates)
 	printSuggestionList(suggestions, prefix)
-}
-
-func printFlagSuggestions(input string, candidates []string) {
-	printSuggestionList(suggest.Flags(input, candidates), "--")
 }
 
 func printSuggestionList(suggestions []string, prefix string) {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -170,7 +170,9 @@ func visibleSubcommandNames(command *ffcli.Command) []string {
 
 func isDeprecatedFlagHelp(help string) bool {
 	normalized := strings.ToLower(strings.TrimSpace(help))
-	return strings.HasPrefix(normalized, "deprecated") || strings.HasPrefix(normalized, "[deprecated")
+	return strings.HasPrefix(normalized, "deprecated") ||
+		strings.HasPrefix(normalized, "[deprecated") ||
+		strings.HasSuffix(normalized, " (deprecated)")
 }
 
 func isDeprecatedCommandHelp(help string) bool {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -121,7 +121,7 @@ func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
 	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
 	candidates := make([]string, 0, len(visibleFlags))
 	for _, item := range visibleFlags {
-		if strings.HasPrefix(strings.TrimSpace(item.Usage), "DEPRECATED:") {
+		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(item.Usage)), "DEPRECATED:") {
 			continue
 		}
 		candidates = append(candidates, item.Name)

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -121,6 +121,9 @@ func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
 	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
 	candidates := make([]string, 0, len(visibleFlags))
 	for _, item := range visibleFlags {
+		if strings.HasPrefix(strings.TrimSpace(item.Usage), "DEPRECATED:") {
+			continue
+		}
 		candidates = append(candidates, item.Name)
 	}
 	suggestions := suggest.Flags(strings.TrimLeft(flagName, "-"), candidates)

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -91,8 +91,7 @@ func shouldRenderConciseUnknownChild(root *ffcli.Command, analysis invocationAna
 }
 
 func printConciseUnknownCommand(analysis invocationAnalysis, commandName string) {
-	unknown := shared.SanitizeTerminal(analysis.unknownToken)
-	fmt.Fprintf(os.Stderr, "Error: unknown command `%s %s`\n", commandName, unknown)
+	fmt.Fprintf(os.Stderr, "Error: %s\n", unknownCommandError(analysis, commandName))
 
 	candidates := visibleSubcommandNames(analysis.command)
 	suggestions := suggest.Commands(analysis.unknownToken, candidates)
@@ -110,13 +109,8 @@ func printConciseUnknownCommand(analysis invocationAnalysis, commandName string)
 }
 
 func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
-	flagName := strings.SplitN(analysis.unknownToken, "=", 2)[0]
-	fmt.Fprintf(
-		os.Stderr,
-		"Error: unknown flag `%s` for `%s`\n",
-		shared.SanitizeTerminal(flagName),
-		commandName,
-	)
+	flagName := unknownFlagName(analysis)
+	fmt.Fprintf(os.Stderr, "Error: %s\n", unknownFlagError(analysis, commandName))
 
 	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
 	candidates := make([]string, 0, len(visibleFlags))
@@ -138,6 +132,26 @@ func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
 	}
 	fmt.Fprintln(os.Stderr, "For help:")
 	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
+}
+
+func unknownCommandError(analysis invocationAnalysis, commandName string) error {
+	return fmt.Errorf(
+		"unknown command `%s %s`",
+		commandName,
+		shared.SanitizeTerminal(analysis.unknownToken),
+	)
+}
+
+func unknownFlagName(analysis invocationAnalysis) string {
+	return strings.SplitN(analysis.unknownToken, "=", 2)[0]
+}
+
+func unknownFlagError(analysis invocationAnalysis, commandName string) error {
+	return fmt.Errorf(
+		"unknown flag `%s` for `%s`",
+		shared.SanitizeTerminal(unknownFlagName(analysis)),
+		commandName,
+	)
 }
 
 func visibleSubcommandNames(command *ffcli.Command) []string {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -22,6 +23,8 @@ type invocationAnalysis struct {
 	unknownToken string
 	unknownFlag  bool
 }
+
+var deprecatedHelpMarker = regexp.MustCompile(`(?i)(^|[^[:alnum:]_-])deprecated([^[:alnum:]_-]|$)`)
 
 func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
 	current := root
@@ -115,7 +118,7 @@ func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
 	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
 	candidates := make([]string, 0, len(visibleFlags))
 	for _, item := range visibleFlags {
-		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(item.Usage)), "DEPRECATED:") {
+		if isDeprecatedHelp(item.Usage) {
 			continue
 		}
 		candidates = append(candidates, item.Name)
@@ -160,12 +163,16 @@ func visibleSubcommandNames(command *ffcli.Command) []string {
 	}
 	names := make([]string, 0, len(command.Subcommands))
 	for _, subcommand := range command.Subcommands {
-		if subcommand == nil || strings.HasPrefix(strings.TrimSpace(subcommand.ShortHelp), "DEPRECATED:") {
+		if subcommand == nil || isDeprecatedHelp(subcommand.ShortHelp) || isDeprecatedHelp(subcommand.LongHelp) {
 			continue
 		}
 		names = append(names, subcommand.Name)
 	}
 	return names
+}
+
+func isDeprecatedHelp(help string) bool {
+	return deprecatedHelpMarker.MatchString(help)
 }
 
 func preservesLegacyChild(analysis invocationAnalysis, commandName string) bool {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -23,8 +22,6 @@ type invocationAnalysis struct {
 	unknownToken string
 	unknownFlag  bool
 }
-
-var deprecatedHelpMarker = regexp.MustCompile(`(?i)(^|[^[:alnum:]_-])deprecated([^[:alnum:]_-]|$)`)
 
 func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
 	current := root
@@ -118,7 +115,7 @@ func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
 	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
 	candidates := make([]string, 0, len(visibleFlags))
 	for _, item := range visibleFlags {
-		if isDeprecatedHelp(item.Usage) {
+		if isDeprecatedFlagHelp(item.Usage) {
 			continue
 		}
 		candidates = append(candidates, item.Name)
@@ -163,7 +160,7 @@ func visibleSubcommandNames(command *ffcli.Command) []string {
 	}
 	names := make([]string, 0, len(command.Subcommands))
 	for _, subcommand := range command.Subcommands {
-		if subcommand == nil || isDeprecatedHelp(subcommand.ShortHelp) || isDeprecatedHelp(subcommand.LongHelp) {
+		if subcommand == nil || isDeprecatedCommandHelp(subcommand.ShortHelp) {
 			continue
 		}
 		names = append(names, subcommand.Name)
@@ -171,8 +168,16 @@ func visibleSubcommandNames(command *ffcli.Command) []string {
 	return names
 }
 
-func isDeprecatedHelp(help string) bool {
-	return deprecatedHelpMarker.MatchString(help)
+func isDeprecatedFlagHelp(help string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(help))
+	return strings.HasPrefix(normalized, "deprecated") || strings.HasPrefix(normalized, "[deprecated")
+}
+
+func isDeprecatedCommandHelp(help string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(help))
+	return strings.HasPrefix(normalized, "deprecated") ||
+		strings.HasPrefix(normalized, "manage deprecated ") ||
+		strings.HasSuffix(normalized, "(deprecated by apple).")
 }
 
 func preservesLegacyChild(analysis invocationAnalysis, commandName string) bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -63,6 +63,9 @@ func Run(args []string, versionInfo string) int {
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
 		exitCode := ExitUsage
+		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
+			writeUsageJUnitReport(getCommandName(root, args))
+		}
 		emitImmediateTelemetry(args, root, versionInfo, exitCode, parseFailureContext(analysis))
 		return exitCode
 	}
@@ -92,6 +95,7 @@ func Run(args []string, versionInfo string) int {
 	commandName := getCommandName(root, args)
 	if shouldRenderConciseUnknownChild(root, analysis, commandName) {
 		printConciseUnknownCommand(analysis, commandName)
+		writeUsageJUnitReport(commandName)
 		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, flag.ErrHelp))
 		return ExitUsage
 	}
@@ -496,6 +500,15 @@ func isBoolFlag(f *flag.Flag) bool {
 	}
 	v, ok := f.Value.(boolFlag)
 	return ok && v.IsBoolFlag()
+}
+
+func writeUsageJUnitReport(commandName string) {
+	if shared.ReportFormat() != shared.ReportFormatJUnit || shared.ReportFile() == "" {
+		return
+	}
+	if err := writeJUnitReport(commandName, flag.ErrHelp, 0); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", err)
+	}
 }
 
 // writeJUnitReport writes a JUnit XML report if --report junit --report-file is configured.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -69,7 +69,10 @@ func Run(args []string, versionInfo string) int {
 		// including NoExecError cases that do not write flag output.
 		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
 			commandName := getCommandName(root, args)
-			writeUsageJUnitReport(commandName, unknownFlagError(analysis, commandName))
+			if err := writeUsageJUnitReport(commandName, unknownFlagError(analysis, commandName)); err != nil {
+				printUsageJUnitReportFailure(commandName, versionInfo, analysis, err)
+				return ExitError
+			}
 		}
 		emitImmediateTelemetry(args, root, versionInfo, parseFailureContext(analysis))
 		return ExitUsage
@@ -100,7 +103,10 @@ func Run(args []string, versionInfo string) int {
 	commandName := getCommandName(root, args)
 	if shouldRenderConciseUnknownChild(root, analysis, commandName) {
 		printConciseUnknownCommand(analysis, commandName)
-		writeUsageJUnitReport(commandName, unknownCommandError(analysis, commandName))
+		if err := writeUsageJUnitReport(commandName, unknownCommandError(analysis, commandName)); err != nil {
+			printUsageJUnitReportFailure(commandName, versionInfo, analysis, err)
+			return ExitError
+		}
 		emitImmediateTelemetry(args, root, versionInfo, validationFailureContext(analysis, flag.ErrHelp))
 		return ExitUsage
 	}
@@ -506,13 +512,21 @@ func isBoolFlag(f *flag.Flag) bool {
 	return ok && v.IsBoolFlag()
 }
 
-func writeUsageJUnitReport(commandName string, usageErr error) {
+func writeUsageJUnitReport(commandName string, usageErr error) error {
 	if shared.ReportFormat() != shared.ReportFormatJUnit || shared.ReportFile() == "" {
-		return
+		return nil
 	}
-	if err := writeJUnitReport(commandName, usageErr, 0); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", err)
-	}
+	return writeJUnitReport(commandName, usageErr, 0)
+}
+
+func printUsageJUnitReportFailure(commandName, versionInfo string, analysis invocationAnalysis, err error) {
+	fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", err)
+	emitTelemetry(commandName, versionInfo, 0, ExitError, telemetry.EventContext{
+		InvocationShape: analysis.shape,
+		ErrorKind:       telemetry.ErrorKindOther,
+		FailureStage:    telemetry.FailureStageExecution,
+		OutcomeKind:     telemetry.OutcomeInternalError,
+	})
 }
 
 // writeJUnitReport writes a JUnit XML report if --report junit --report-file is configured.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -216,6 +216,13 @@ func recoverCIReportFlags(root *ffcli.Command, args []string) {
 		}
 
 		if next, consumed := consumeFlagToken(root.FlagSet, token, args, index); consumed {
+			if !hasInlineValue {
+				if item := root.FlagSet.Lookup(name); item != nil && isBoolFlag(item) && next < len(args) {
+					if _, err := strconv.ParseBool(strings.TrimSpace(args[next])); err == nil {
+						next++
+					}
+				}
+			}
 			index = next
 			continue
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,6 +55,11 @@ func Run(args []string, versionInfo string) int {
 			fmt.Fprint(os.Stderr, parseOutput.String())
 			return ExitSuccess
 		}
+		if err := shared.ValidateReportFlags(); err != nil {
+			fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
+			emitImmediateTelemetry(args, root, versionInfo, validationFailureContext(analysis, err))
+			return ExitUsage
+		}
 		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
 			printConciseUnknownFlag(analysis, getCommandName(root, args))
 		} else {
@@ -62,18 +67,17 @@ func Run(args []string, versionInfo string) int {
 		}
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
-		exitCode := ExitUsage
 		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
 			writeUsageJUnitReport(getCommandName(root, args))
 		}
-		emitImmediateTelemetry(args, root, versionInfo, exitCode, parseFailureContext(analysis))
-		return exitCode
+		emitImmediateTelemetry(args, root, versionInfo, parseFailureContext(analysis))
+		return ExitUsage
 	}
 
 	// Validate CI report flags after parsing
 	if err := shared.ValidateReportFlags(); err != nil {
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
-		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, err))
+		emitImmediateTelemetry(args, root, versionInfo, validationFailureContext(analysis, err))
 		return ExitUsage
 	}
 
@@ -96,7 +100,7 @@ func Run(args []string, versionInfo string) int {
 	if shouldRenderConciseUnknownChild(root, analysis, commandName) {
 		printConciseUnknownCommand(analysis, commandName)
 		writeUsageJUnitReport(commandName)
-		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, flag.ErrHelp))
+		emitImmediateTelemetry(args, root, versionInfo, validationFailureContext(analysis, flag.ErrHelp))
 		return ExitUsage
 	}
 
@@ -310,10 +314,9 @@ func emitImmediateTelemetry(
 	args []string,
 	root *ffcli.Command,
 	versionInfo string,
-	exitCode int,
 	eventContext telemetry.EventContext,
 ) {
-	emitTelemetry(getCommandName(root, args), versionInfo, 0, exitCode, eventContext)
+	emitTelemetry(getCommandName(root, args), versionInfo, 0, ExitUsage, eventContext)
 }
 
 func prepareFlagParsing(command *ffcli.Command, args []string, output *bytes.Buffer) func() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -61,8 +61,14 @@ func Run(args []string, versionInfo string) int {
 			emitImmediateTelemetry(args, root, versionInfo, validationFailureContext(analysis, err))
 			return ExitUsage
 		}
+		badFlagSyntax := parseErr.Error()
+		if firstLine, _, _ := strings.Cut(parseOutput.String(), "\n"); strings.HasPrefix(firstLine, "bad flag syntax:") {
+			badFlagSyntax = firstLine
+		}
 		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
 			printConciseUnknownFlag(analysis, getCommandName(root, args))
+		} else if strings.HasPrefix(badFlagSyntax, "bad flag syntax:") {
+			fmt.Fprintf(os.Stderr, "Error: %s\nFor help:\n  asc --help\n", shared.SanitizeTerminal(badFlagSyntax))
 		} else {
 			printParseFailure(parseErr, parseOutput.String(), analysis)
 		}
@@ -196,7 +202,16 @@ func recoverCIReportFlags(root *ffcli.Command, args []string) {
 			return
 		}
 
-		trimmed := strings.TrimLeft(token, "-")
+		trimmed := ""
+		switch {
+		case strings.HasPrefix(token, "--") && !strings.HasPrefix(token, "---"):
+			trimmed = token[2:]
+		case strings.HasPrefix(token, "-") && !strings.HasPrefix(token, "--"):
+			trimmed = token[1:]
+		default:
+			index++
+			continue
+		}
 		name, value, hasInlineValue := strings.Cut(trimmed, "=")
 		if name == "report" || name == "report-file" {
 			if !hasInlineValue {
@@ -227,6 +242,12 @@ func recoverCIReportFlags(root *ffcli.Command, args []string) {
 			continue
 		}
 		index++
+		if index < len(args) {
+			next := args[index]
+			if next != "" && !strings.HasPrefix(next, "-") && findDirectSubcommand(root, next) == nil {
+				index++
+			}
+		}
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -68,7 +68,8 @@ func Run(args []string, versionInfo string) int {
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
 		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
-			writeUsageJUnitReport(getCommandName(root, args))
+			commandName := getCommandName(root, args)
+			writeUsageJUnitReport(commandName, unknownFlagError(analysis, commandName))
 		}
 		emitImmediateTelemetry(args, root, versionInfo, parseFailureContext(analysis))
 		return ExitUsage
@@ -99,7 +100,7 @@ func Run(args []string, versionInfo string) int {
 	commandName := getCommandName(root, args)
 	if shouldRenderConciseUnknownChild(root, analysis, commandName) {
 		printConciseUnknownCommand(analysis, commandName)
-		writeUsageJUnitReport(commandName)
+		writeUsageJUnitReport(commandName, unknownCommandError(analysis, commandName))
 		emitImmediateTelemetry(args, root, versionInfo, validationFailureContext(analysis, flag.ErrHelp))
 		return ExitUsage
 	}
@@ -505,11 +506,11 @@ func isBoolFlag(f *flag.Flag) bool {
 	return ok && v.IsBoolFlag()
 }
 
-func writeUsageJUnitReport(commandName string) {
+func writeUsageJUnitReport(commandName string, usageErr error) {
 	if shared.ReportFormat() != shared.ReportFormatJUnit || shared.ReportFile() == "" {
 		return
 	}
-	if err := writeJUnitReport(commandName, flag.ErrHelp, 0); err != nil {
+	if err := writeJUnitReport(commandName, usageErr, 0); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to write JUnit report: %v\n", err)
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,11 +55,14 @@ func Run(args []string, versionInfo string) int {
 			fmt.Fprint(os.Stderr, parseOutput.String())
 			return ExitSuccess
 		}
-		printParseFailure(parseErr, parseOutput.String(), analysis)
+		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
+			printConciseUnknownFlag(analysis, getCommandName(root, args))
+		} else {
+			printParseFailure(parseErr, parseOutput.String(), analysis)
+		}
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
 		exitCode := ExitUsage
-		printUnknownFlagSuggestion(analysis)
 		emitImmediateTelemetry(args, root, versionInfo, exitCode, parseFailureContext(analysis))
 		return exitCode
 	}
@@ -87,11 +90,9 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	commandName := getCommandName(root, args)
-	if shouldRejectUnknownChild(root, analysis, commandName) {
-		runErr := shared.UsageErrorf("unexpected argument(s): %s", shared.SanitizeTerminal(analysis.unknownToken))
-		fmt.Fprint(os.Stderr, analysis.command.UsageFunc(analysis.command))
-		printUnknownSubcommandSuggestion(analysis, commandName)
-		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, runErr))
+	if shouldRenderConciseUnknownChild(root, analysis, commandName) {
+		printConciseUnknownCommand(analysis, commandName)
+		emitImmediateTelemetry(args, root, versionInfo, ExitUsage, validationFailureContext(analysis, flag.ErrHelp))
 		return ExitUsage
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,6 +55,7 @@ func Run(args []string, versionInfo string) int {
 			fmt.Fprint(os.Stderr, parseOutput.String())
 			return ExitSuccess
 		}
+		recoverCIReportFlags(root, args)
 		if err := shared.ValidateReportFlags(); err != nil {
 			fmt.Fprint(os.Stderr, errfmt.FormatStderr(err))
 			emitImmediateTelemetry(args, root, versionInfo, validationFailureContext(analysis, err))
@@ -179,6 +180,47 @@ func Run(args []string, versionInfo string) int {
 		InvocationShape: analysis.shape,
 	})
 	return ExitSuccess
+}
+
+func recoverCIReportFlags(root *ffcli.Command, args []string) {
+	if root == nil {
+		return
+	}
+	for index := 0; index < len(args); {
+		token := args[index]
+		if token == "" {
+			index++
+			continue
+		}
+		if token == "--" || findDirectSubcommand(root, token) != nil || !strings.HasPrefix(token, "-") || token == "-" {
+			return
+		}
+
+		trimmed := strings.TrimLeft(token, "-")
+		name, value, hasInlineValue := strings.Cut(trimmed, "=")
+		if name == "report" || name == "report-file" {
+			if !hasInlineValue {
+				if index+1 >= len(args) {
+					return
+				}
+				index++
+				value = args[index]
+			}
+			if name == "report" {
+				shared.SetReportFormat(value)
+			} else {
+				shared.SetReportFile(value)
+			}
+			index++
+			continue
+		}
+
+		if next, consumed := consumeFlagToken(root.FlagSet, token, args, index); consumed {
+			index = next
+			continue
+		}
+		index++
+	}
 }
 
 // normalizeSpacedBooleanFlags preserves the CLI's liberal support for both

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1340,6 +1340,26 @@ func TestRun_UnknownFlagDoesNotSuggestDeprecatedAlias(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownFlagDoesNotSuggestSuffixDeprecatedAlias(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"iap", "localizations", "list", "--idd", "IAP_ID"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Try:\n  --iap-id\n") {
+		t.Fatalf("expected canonical --iap-id suggestion, got %q", stderr)
+	}
+	if strings.Contains(stderr, "Try:\n  --id\n") {
+		t.Fatalf("deprecated --id alias must not be suggested, got %q", stderr)
+	}
+}
+
 func TestRun_UnknownCommandDoesNotSuggestDeprecatedSurface(t *testing.T) {
 	resetReportFlags(t)
 
@@ -1362,6 +1382,7 @@ func TestDeprecatedHelpDetectionUsesLifecycleMarkers(t *testing.T) {
 		"DEPRECATED: use --app",
 		"Deprecated alias for --app",
 		"[deprecated, ignored] Previously used this flag",
+		"In-app purchase ID, product ID, or exact current name (deprecated)",
 	} {
 		if !isDeprecatedFlagHelp(help) {
 			t.Fatalf("isDeprecatedFlagHelp(%q) = false, want true", help)
@@ -1369,7 +1390,6 @@ func TestDeprecatedHelpDetectionUsesLifecycleMarkers(t *testing.T) {
 	}
 	for _, help := range []string{
 		"Sparse fields: kidsAgeBand (deprecated by Apple; prefer age-rating data)",
-		"In-app purchase ID, product ID, or exact current name (deprecated)",
 		"not-deprecated compatibility surface",
 	} {
 		if isDeprecatedFlagHelp(help) {

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -266,6 +266,78 @@ func TestRun_BareGroupWritesJUnitReport(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownChildWritesJUnitReport(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "junit.xml")
+
+	captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--report", "junit",
+			"--report-file", reportPath,
+			"builds", "lsit",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+
+	var suite struct {
+		Failures  int `xml:"failures,attr"`
+		TestCases []struct {
+			Name string `xml:"name,attr"`
+		} `xml:"testcase"`
+	}
+	if err := xml.Unmarshal(data, &suite); err != nil {
+		t.Fatalf("xml.Unmarshal() error: %v", err)
+	}
+	if suite.Failures != 1 {
+		t.Fatalf("failures = %d, want 1", suite.Failures)
+	}
+	if len(suite.TestCases) != 1 || suite.TestCases[0].Name != "asc builds" {
+		t.Fatalf("unexpected testcase payload: %+v", suite.TestCases)
+	}
+}
+
+func TestRun_UnknownFlagWritesJUnitReport(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "junit.xml")
+
+	captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--report", "junit",
+			"--report-file", reportPath,
+			"builds", "list", "--ap", "APP_ID",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+
+	var suite struct {
+		Failures  int `xml:"failures,attr"`
+		TestCases []struct {
+			Name string `xml:"name,attr"`
+		} `xml:"testcase"`
+	}
+	if err := xml.Unmarshal(data, &suite); err != nil {
+		t.Fatalf("xml.Unmarshal() error: %v", err)
+	}
+	if suite.Failures != 1 {
+		t.Fatalf("failures = %d, want 1", suite.Failures)
+	}
+	if len(suite.TestCases) != 1 || suite.TestCases[0].Name != "asc builds list" {
+		t.Fatalf("unexpected testcase payload: %+v", suite.TestCases)
+	}
+}
+
 func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	resetReportFlags(t)
 	t.Setenv("ASC_APP_ID", "")
@@ -1055,6 +1127,25 @@ func TestRun_UnknownFlagDoesNotSuggestHiddenCompatibilityFlag(t *testing.T) {
 		if strings.HasPrefix(line, "  --") && strings.Contains(line, "--name") {
 			t.Fatalf("hidden compatibility flag must not be suggested, got %q", stderr)
 		}
+	}
+}
+
+func TestRun_UnknownFlagDoesNotSuggestDeprecatedFlag(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"testflight", "beta-details", "update", "--external-testin", "true",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if strings.Contains(stderr, "Try:\n  --external-testing\n") {
+		t.Fatalf("deprecated flag must not be suggested, got %q", stderr)
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1254,6 +1254,57 @@ func TestRun_UnknownFlagDoesNotSuggestMixedCaseDeprecatedFlag(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownFlagDoesNotSuggestDeprecatedAlias(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"apps", "public", "view", "--idd", "APP_ID"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if strings.Contains(stderr, "Try:\n  --id\n") {
+		t.Fatalf("deprecated alias must not be suggested, got %q", stderr)
+	}
+}
+
+func TestRun_UnknownCommandDoesNotSuggestDeprecatedSurface(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"iap", "imagez"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if strings.Contains(stderr, "asc iap images") {
+		t.Fatalf("deprecated command must not be suggested, got %q", stderr)
+	}
+}
+
+func TestIsDeprecatedHelpUsesStandaloneMarker(t *testing.T) {
+	for _, help := range []string{
+		"DEPRECATED: use --app",
+		"Deprecated alias for --app",
+		"Manage deprecated product-scoped images.",
+	} {
+		if !isDeprecatedHelp(help) {
+			t.Fatalf("isDeprecatedHelp(%q) = false, want true", help)
+		}
+	}
+	for _, help := range []string{"Manage current images.", "not-deprecated compatibility surface"} {
+		if isDeprecatedHelp(help) {
+			t.Fatalf("isDeprecatedHelp(%q) = true, want false", help)
+		}
+	}
+}
+
 func TestRun_UnknownGroupFlagIsNotClassifiedAsBareGroup(t *testing.T) {
 	resetReportFlags(t)
 	originalEmitTelemetry := emitTelemetry

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -148,6 +148,64 @@ func TestRun_InvalidReportFormatWinsOverUnknownFlag(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownFlagBetweenCompleteReportOptionsWritesJUnit(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "result.xml")
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--report", "junit",
+			"--bogus",
+			"--report-file", reportPath,
+			"builds", "list",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	want := "Error: unknown flag `--bogus` for `asc`\nFor help:\n  asc --help\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !strings.Contains(string(data), "unknown flag `--bogus` for `asc`") {
+		t.Fatalf("report does not identify the unknown flag: %s", data)
+	}
+}
+
+func TestRun_InvalidReportFormatAfterUnknownFlagStillWins(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "result.xml")
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--bogus",
+			"--report", "xml",
+			"--report-file", reportPath,
+			"builds", "list",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	want := "Error: --report must be \"junit\" if specified, got \"xml\"\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if _, err := os.Stat(reportPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid report format must not write a report, stat error = %v", err)
+	}
+}
+
 func TestRun_ParseErrorEmitsTelemetry(t *testing.T) {
 	resetReportFlags(t)
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -711,20 +711,159 @@ func TestRun_PublishManagedExportPassthroughEmitsUsageContext(t *testing.T) {
 	}
 }
 
-func TestRun_UnknownNestedSubcommandSuggestsRealSubcommand(t *testing.T) {
+func TestRun_UnknownCommandsReturnConciseRecovery(t *testing.T) {
 	resetReportFlags(t)
 
-	stdout, stderr := captureCommandOutput(t, func() {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name: "root typo",
+			args: []string{"builts"},
+			wantStderr: "Error: unknown command `asc builts`\n" +
+				"Try:\n" +
+				"  asc builds\n" +
+				"For help:\n" +
+				"  asc --help\n",
+		},
+		{
+			name: "nested typo",
+			args: []string{"builds", "lsit"},
+			wantStderr: "Error: unknown command `asc builds lsit`\n" +
+				"Try:\n" +
+				"  asc builds list\n" +
+				"For help:\n" +
+				"  asc builds --help\n",
+		},
+		{
+			name: "deep nested typo",
+			args: []string{"xcode-cloud", "workflows", "lsit", "--app", "APP_ID"},
+			wantStderr: "Error: unknown command `asc xcode-cloud workflows lsit`\n" +
+				"Try:\n" +
+				"  asc xcode-cloud workflows list\n" +
+				"For help:\n" +
+				"  asc xcode-cloud workflows --help\n",
+		},
+		{
+			name: "no close match",
+			args: []string{"builds", "qqqqq"},
+			wantStderr: "Error: unknown command `asc builds qqqqq`\n" +
+				"For help:\n" +
+				"  asc builds --help\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if stderr != test.wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, test.wantStderr)
+			}
+			for _, fullHelpSection := range []string{"DESCRIPTION", "USAGE", "SUBCOMMANDS"} {
+				if strings.Contains(stderr, fullHelpSection) {
+					t.Fatalf("stderr contains full help section %q: %q", fullHelpSection, stderr)
+				}
+			}
+		})
+	}
+}
+
+func TestRun_ConciseUnknownCommandPreservesTelemetryClassification(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var calls int
+	var commandName string
+	var exitCode int
+	var eventContext telemetry.EventContext
+	emitTelemetry = func(command, _ string, _ time.Duration, code int, context telemetry.EventContext) {
+		calls++
+		commandName = command
+		exitCode = code
+		eventContext = context
+	}
+
+	_, _ = captureCommandOutput(t, func() {
 		if code := Run([]string{"builds", "lsit"}, "1.0.0"); code != ExitUsage {
 			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
 		}
 	})
 
-	if stdout != "" {
-		t.Fatalf("expected empty stdout, got %q", stdout)
+	if calls != 1 || commandName != "asc builds" || exitCode != ExitUsage {
+		t.Fatalf("telemetry calls=%d command=%q exit=%d", calls, commandName, exitCode)
 	}
-	if !strings.Contains(stderr, "Did you mean: list") {
-		t.Fatalf("expected list suggestion, got %q", stderr)
+	if eventContext.InvocationShape != telemetry.InvocationShapeUnknownChild ||
+		eventContext.ErrorKind != telemetry.ErrorKindOther ||
+		eventContext.FailureStage != telemetry.FailureStageValidation ||
+		eventContext.OutcomeKind != telemetry.OutcomeUsageError ||
+		eventContext.FailureParameter != "" {
+		t.Fatalf("unexpected telemetry context: %+v", eventContext)
+	}
+}
+
+func TestRun_UnknownCommandSuggestionsAreBoundedAndTerminalSafe(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"app"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if got := strings.Count(stderr, "\n  asc app-"); got != 2 {
+		t.Fatalf("suggestion count = %d, want 2; stderr=%q", got, stderr)
+	}
+
+	_, hostileStderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"bad\x1b[31m\r\ncommand"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if strings.ContainsAny(hostileStderr, "\x1b\r") {
+		t.Fatalf("stderr contains terminal control characters: %q", hostileStderr)
+	}
+	firstLine, _, _ := strings.Cut(hostileStderr, "\n")
+	if firstLine != "Error: unknown command `asc bad[31m  command`" {
+		t.Fatalf("unknown command line = %q", firstLine)
+	}
+}
+
+func TestRun_UnknownFlagReturnsConciseRecovery(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"builds", "list", "--ap", "SECRET_VALUE"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	want := "Error: unknown flag `--ap` for `asc builds list`\n" +
+		"Try:\n" +
+		"  --app\n" +
+		"For help:\n" +
+		"  asc builds list --help\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if strings.Contains(stderr, "SECRET_VALUE") {
+		t.Fatalf("stderr leaked a following argument: %q", stderr)
 	}
 }
 
@@ -760,8 +899,11 @@ func TestRun_UnknownHybridSubcommandReturnsUsageBeforeAuth(t *testing.T) {
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if !strings.Contains(stderr, "SUBCOMMANDS") {
-				t.Fatalf("expected command help, got %q", stderr)
+			if !strings.Contains(stderr, "For help:\n") {
+				t.Fatalf("expected concise help pointer, got %q", stderr)
+			}
+			if strings.Contains(stderr, "SUBCOMMANDS") {
+				t.Fatalf("did not expect full command help, got %q", stderr)
 			}
 			if strings.Contains(stderr, "missing authentication") {
 				t.Fatalf("expected unknown child validation before auth resolution, got %q", stderr)
@@ -836,13 +978,13 @@ func TestRun_UnknownFlagSuggestsRealFlagAndEmitsContext(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Unknown flag: --buid-id") {
+	if !strings.Contains(stderr, "Error: unknown flag `--buid-id` for `asc versions attach-build`") {
 		t.Fatalf("expected normalized unknown flag diagnostic, got %q", stderr)
 	}
 	if strings.Contains(stderr, "flag provided but not defined") {
 		t.Fatalf("did not expect raw Go flag diagnostic, got %q", stderr)
 	}
-	if !strings.Contains(stderr, "Did you mean: --build-id") {
+	if !strings.Contains(stderr, "Try:\n  --build-id\n") {
 		t.Fatalf("expected --build-id suggestion, got %q", stderr)
 	}
 	if gotContext.InvocationShape != telemetry.InvocationShapeLeaf ||
@@ -867,12 +1009,12 @@ func TestRun_UnknownIdentifierFlagsSuggestCommandSpecificFlags(t *testing.T) {
 		{
 			name:           "generic version ID",
 			args:           []string{"versions", "app-clip-default-experience", "view", "--id", "VERSION_ID"},
-			wantSuggestion: "Did you mean: --version-id?",
+			wantSuggestion: "Try:\n  --version-id\n",
 		},
 		{
 			name:           "qualified subscription ID",
 			args:           []string{"subscriptions", "groups", "view", "--subscription-id", "SUBSCRIPTION_ID"},
-			wantSuggestion: "Did you mean: --id?",
+			wantSuggestion: "Try:\n  --id\n",
 		},
 	}
 
@@ -906,11 +1048,11 @@ func TestRun_UnknownFlagDoesNotSuggestHiddenCompatibilityFlag(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Unknown flag: --nam") {
+	if !strings.Contains(stderr, "Error: unknown flag `--nam` for `asc iap setup`") {
 		t.Fatalf("expected normalized unknown flag diagnostic, got %q", stderr)
 	}
 	for _, line := range strings.Split(stderr, "\n") {
-		if strings.HasPrefix(line, "Did you mean: ") && strings.Contains(line, "--name") {
+		if strings.HasPrefix(line, "  --") && strings.Contains(line, "--name") {
 			t.Fatalf("hidden compatibility flag must not be suggested, got %q", stderr)
 		}
 	}
@@ -985,7 +1127,7 @@ func TestRun_RemovedTopLevelCommandsReturnUnknown(t *testing.T) {
 					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
 				}
 			})
-			if !strings.Contains(stderr, "Unknown command: "+test.arg) {
+			if !strings.Contains(stderr, "Error: unknown command `asc "+test.arg+"`") {
 				t.Fatalf("expected unknown command in stderr, got %q", stderr)
 			}
 		})

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -106,6 +106,48 @@ func TestRun_ReportFlagValidationErrorEmitsTelemetry(t *testing.T) {
 	}
 }
 
+func TestRun_InvalidReportFormatWinsOverUnknownFlag(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "result.xml")
+
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+	var calls int
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		calls++
+		gotContext = eventContext
+	}
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--report", "xml",
+			"--report-file", reportPath,
+			"builds", "list", "--ap", "PRIVATE_VALUE",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	want := "Error: --report must be \"junit\" if specified, got \"xml\"\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if strings.Contains(stderr, "PRIVATE_VALUE") {
+		t.Fatalf("stderr leaked a following argument: %q", stderr)
+	}
+	if _, err := os.Stat(reportPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid report format must not write a report, stat error = %v", err)
+	}
+	if calls != 1 || gotContext.FailureStage != telemetry.FailureStageValidation ||
+		gotContext.OutcomeKind != telemetry.OutcomeUsageError {
+		t.Fatalf("unexpected telemetry: calls=%d context=%+v", calls, gotContext)
+	}
+}
+
 func TestRun_ParseErrorEmitsTelemetry(t *testing.T) {
 	resetReportFlags(t)
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -330,7 +330,10 @@ func TestRun_UnknownChildWritesJUnitReport(t *testing.T) {
 	var suite struct {
 		Failures  int `xml:"failures,attr"`
 		TestCases []struct {
-			Name string `xml:"name,attr"`
+			Name    string `xml:"name,attr"`
+			Failure struct {
+				Message string `xml:"message,attr"`
+			} `xml:"failure"`
 		} `xml:"testcase"`
 	}
 	if err := xml.Unmarshal(data, &suite); err != nil {
@@ -342,6 +345,9 @@ func TestRun_UnknownChildWritesJUnitReport(t *testing.T) {
 	if len(suite.TestCases) != 1 || suite.TestCases[0].Name != "asc builds" {
 		t.Fatalf("unexpected testcase payload: %+v", suite.TestCases)
 	}
+	if suite.TestCases[0].Failure.Message != "unknown command `asc builds lsit`" {
+		t.Fatalf("failure message = %q", suite.TestCases[0].Failure.Message)
+	}
 }
 
 func TestRun_UnknownFlagWritesJUnitReport(t *testing.T) {
@@ -352,7 +358,7 @@ func TestRun_UnknownFlagWritesJUnitReport(t *testing.T) {
 		if code := Run([]string{
 			"--report", "junit",
 			"--report-file", reportPath,
-			"builds", "list", "--ap", "APP_ID",
+			"builds", "list", "--ap=PRIVATE_VALUE",
 		}, "1.0.0"); code != ExitUsage {
 			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
 		}
@@ -366,7 +372,10 @@ func TestRun_UnknownFlagWritesJUnitReport(t *testing.T) {
 	var suite struct {
 		Failures  int `xml:"failures,attr"`
 		TestCases []struct {
-			Name string `xml:"name,attr"`
+			Name    string `xml:"name,attr"`
+			Failure struct {
+				Message string `xml:"message,attr"`
+			} `xml:"failure"`
 		} `xml:"testcase"`
 	}
 	if err := xml.Unmarshal(data, &suite); err != nil {
@@ -377,6 +386,33 @@ func TestRun_UnknownFlagWritesJUnitReport(t *testing.T) {
 	}
 	if len(suite.TestCases) != 1 || suite.TestCases[0].Name != "asc builds list" {
 		t.Fatalf("unexpected testcase payload: %+v", suite.TestCases)
+	}
+	if suite.TestCases[0].Failure.Message != "unknown flag `--ap` for `asc builds list`" {
+		t.Fatalf("failure message = %q", suite.TestCases[0].Failure.Message)
+	}
+	if strings.Contains(string(data), "PRIVATE_VALUE") {
+		t.Fatalf("report leaked an inline flag value: %s", data)
+	}
+}
+
+func TestUnknownInputJUnitErrorsAreTerminalSafe(t *testing.T) {
+	commandErr := unknownCommandError(
+		invocationAnalysis{unknownToken: "bad\x1b[31m\r\n"},
+		"asc builds",
+	)
+	if got, want := commandErr.Error(), "unknown command `asc builds bad[31m  `"; got != want {
+		t.Fatalf("unknown command error = %q, want %q", got, want)
+	}
+	if strings.ContainsAny(commandErr.Error(), "\x1b\r\n") {
+		t.Fatalf("unknown command report error contains terminal controls: %q", commandErr)
+	}
+
+	flagErr := unknownFlagError(
+		invocationAnalysis{unknownToken: "--ap=PRIVATE_VALUE\x1b[31m"},
+		"asc builds list",
+	)
+	if got, want := flagErr.Error(), "unknown flag `--ap` for `asc builds list`"; got != want {
+		t.Fatalf("unknown flag error = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1288,20 +1288,65 @@ func TestRun_UnknownCommandDoesNotSuggestDeprecatedSurface(t *testing.T) {
 	}
 }
 
-func TestIsDeprecatedHelpUsesStandaloneMarker(t *testing.T) {
+func TestDeprecatedHelpDetectionUsesLifecycleMarkers(t *testing.T) {
 	for _, help := range []string{
 		"DEPRECATED: use --app",
 		"Deprecated alias for --app",
-		"Manage deprecated product-scoped images.",
+		"[deprecated, ignored] Previously used this flag",
 	} {
-		if !isDeprecatedHelp(help) {
-			t.Fatalf("isDeprecatedHelp(%q) = false, want true", help)
+		if !isDeprecatedFlagHelp(help) {
+			t.Fatalf("isDeprecatedFlagHelp(%q) = false, want true", help)
 		}
 	}
-	for _, help := range []string{"Manage current images.", "not-deprecated compatibility surface"} {
-		if isDeprecatedHelp(help) {
-			t.Fatalf("isDeprecatedHelp(%q) = true, want false", help)
+	for _, help := range []string{
+		"Sparse fields: kidsAgeBand (deprecated by Apple; prefer age-rating data)",
+		"In-app purchase ID, product ID, or exact current name (deprecated)",
+		"not-deprecated compatibility surface",
+	} {
+		if isDeprecatedFlagHelp(help) {
+			t.Fatalf("isDeprecatedFlagHelp(%q) = true, want false", help)
 		}
+	}
+
+	for _, help := range []string{
+		"DEPRECATED: use `asc iap versions images`.",
+		"Manage deprecated product-scoped images.",
+		"Manage subscription availability (deprecated by Apple).",
+	} {
+		if !isDeprecatedCommandHelp(help) {
+			t.Fatalf("isDeprecatedCommandHelp(%q) = false, want true", help)
+		}
+	}
+	for _, help := range []string{
+		"Submit a version that replaces a deprecated resource.",
+		"Manage current images.",
+		"not-deprecated compatibility surface",
+	} {
+		if isDeprecatedCommandHelp(help) {
+			t.Fatalf("isDeprecatedCommandHelp(%q) = true, want false", help)
+		}
+	}
+}
+
+func TestRun_DeprecationMentionsRemainSuggestionCandidates(t *testing.T) {
+	resetReportFlags(t)
+
+	_, commandStderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"iap", "versions", "subimt"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if !strings.Contains(commandStderr, "Try:\n  asc iap versions submit\n") {
+		t.Fatalf("stable command with deprecation context must remain suggestible, got %q", commandStderr)
+	}
+
+	_, flagStderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"apps", "list", "--app-info-field", "kidsAgeBand"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if !strings.Contains(flagStderr, "Try:\n  --app-info-fields\n") {
+		t.Fatalf("stable flag with deprecation context must remain suggestible, got %q", flagStderr)
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -179,6 +179,38 @@ func TestRun_UnknownFlagBetweenCompleteReportOptionsWritesJUnit(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownFlagBeforeSpacedBooleanAndReportOptionsWritesJUnit(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "result.xml")
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--bogus",
+			"--strict-auth", "false",
+			"--report", "junit",
+			"--report-file", reportPath,
+			"builds", "list",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	want := "Error: unknown flag `--bogus` for `asc`\nFor help:\n  asc --help\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !strings.Contains(string(data), "unknown flag `--bogus` for `asc`") {
+		t.Fatalf("report does not identify the unknown flag: %s", data)
+	}
+}
+
 func TestRun_InvalidReportFormatAfterUnknownFlagStillWins(t *testing.T) {
 	resetReportFlags(t)
 	reportPath := filepath.Join(t.TempDir(), "result.xml")

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -211,6 +211,55 @@ func TestRun_UnknownFlagBeforeSpacedBooleanAndReportOptionsWritesJUnit(t *testin
 	}
 }
 
+func TestRun_UnknownFlagWithValueBeforeReportOptionsWritesJUnit(t *testing.T) {
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "result.xml")
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--profiel", "ci",
+			"--report", "junit",
+			"--report-file", reportPath,
+			"builds", "list",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	want := "Error: unknown flag `--profiel` for `asc`\nTry:\n  --profile\nFor help:\n  asc --help\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !strings.Contains(string(data), "unknown flag `--profiel` for `asc`") {
+		t.Fatalf("report does not identify the unknown flag: %s", data)
+	}
+}
+
+func TestRun_MalformedTripleDashReportPreservesParseError(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"---report", "xml"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	want := "Error: bad flag syntax: ---report\nFor help:\n  asc --help\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+}
+
 func TestRun_InvalidReportFormatAfterUnknownFlagStillWins(t *testing.T) {
 	resetReportFlags(t)
 	reportPath := filepath.Join(t.TempDir(), "result.xml")
@@ -1133,8 +1182,9 @@ func TestRun_UnknownCommandSuggestionsAreBoundedAndTerminalSafe(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
 	}
-	if got := strings.Count(stderr, "\n  asc app-"); got != 2 {
-		t.Fatalf("suggestion count = %d, want 2; stderr=%q", got, stderr)
+	tryBlock, _, found := strings.Cut(strings.TrimPrefix(stderr, "Error: unknown command `asc app`\nTry:\n"), "For help:\n")
+	if !found || strings.Count(strings.TrimSpace(tryBlock), "\n") != 1 {
+		t.Fatalf("suggestion count is not 2; stderr=%q", stderr)
 	}
 
 	_, hostileStderr := captureCommandOutput(t, func() {
@@ -1148,6 +1198,23 @@ func TestRun_UnknownCommandSuggestionsAreBoundedAndTerminalSafe(t *testing.T) {
 	firstLine, _, _ := strings.Cut(hostileStderr, "\n")
 	if firstLine != "Error: unknown command `asc bad[31m  command`" {
 		t.Fatalf("unknown command line = %q", firstLine)
+	}
+}
+
+func TestRun_UnknownCommandRanksClosestPrefixBeforeSuggestionLimit(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"buil"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "Try:\n  asc builds\n") {
+		t.Fatalf("closest prefix was truncated from suggestions: %q", stderr)
 	}
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -395,6 +395,75 @@ func TestRun_UnknownFlagWritesJUnitReport(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownInputReportWriteFailureReturnsExitError(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantPrefix string
+	}{
+		{
+			name:       "unknown command",
+			args:       []string{"builds", "lsit"},
+			wantPrefix: "Error: unknown command `asc builds lsit`\n",
+		},
+		{
+			name:       "unknown flag",
+			args:       []string{"builds", "list", "--ap", "PRIVATE_VALUE"},
+			wantPrefix: "Error: unknown flag `--ap` for `asc builds list`\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resetReportFlags(t)
+			reportPath := filepath.Join(t.TempDir(), "junit.xml")
+			if err := os.WriteFile(reportPath, []byte("existing"), 0o600); err != nil {
+				t.Fatalf("WriteFile() error: %v", err)
+			}
+
+			originalEmitTelemetry := emitTelemetry
+			t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+			var calls int
+			var gotCommand string
+			var gotExit int
+			var gotContext telemetry.EventContext
+			emitTelemetry = func(command, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+				calls++
+				gotCommand = command
+				gotExit = exitCode
+				gotContext = eventContext
+			}
+
+			args := append([]string{
+				"--report", "junit",
+				"--report-file", reportPath,
+			}, test.args...)
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(args, "1.0.0"); code != ExitError {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitError)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.HasPrefix(stderr, test.wantPrefix) || !strings.Contains(stderr, "Error: failed to write JUnit report:") {
+				t.Fatalf("unexpected stderr: %q", stderr)
+			}
+			if strings.Contains(stderr, "PRIVATE_VALUE") {
+				t.Fatalf("stderr leaked a following argument: %q", stderr)
+			}
+			if calls != 1 || gotExit != ExitError || gotContext.FailureStage != telemetry.FailureStageExecution ||
+				gotContext.ErrorKind != telemetry.ErrorKindOther || gotContext.OutcomeKind != telemetry.OutcomeInternalError {
+				t.Fatalf("unexpected telemetry: calls=%d command=%q exit=%d context=%+v", calls, gotCommand, gotExit, gotContext)
+			}
+			if !strings.HasPrefix(gotCommand, "asc builds") {
+				t.Fatalf("telemetry command = %q, want canonical builds path", gotCommand)
+			}
+		})
+	}
+}
+
 func TestUnknownInputJUnitErrorsAreTerminalSafe(t *testing.T) {
 	commandErr := unknownCommandError(
 		invocationAnalysis{unknownToken: "bad\x1b[31m\r\n"},

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1149,6 +1149,33 @@ func TestRun_UnknownFlagDoesNotSuggestDeprecatedFlag(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownFlagDoesNotSuggestMixedCaseDeprecatedFlag(t *testing.T) {
+	resetReportFlags(t)
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"web", "apps", "create", "--two-factor-cod", "PRIVATE_VALUE",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	want := "Error: unknown flag `--two-factor-cod` for `asc web apps create`\n" +
+		"Try:\n" +
+		"  --two-factor-code-command\n" +
+		"For help:\n" +
+		"  asc web apps create --help\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if strings.Contains(stderr, "PRIVATE_VALUE") {
+		t.Fatalf("stderr leaked a following argument: %q", stderr)
+	}
+}
+
 func TestRun_UnknownGroupFlagIsNotClassifiedAsBareGroup(t *testing.T) {
 	resetReportFlags(t)
 	originalEmitTelemetry := emitTelemetry

--- a/cmd/terminal_diagnostic_test.go
+++ b/cmd/terminal_diagnostic_test.go
@@ -19,7 +19,7 @@ func TestRun_UnknownCommandSanitizesUnicodeTerminalControlsAndInvalidUTF8(t *tes
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
 	}
-	assertSafeTerminalDiagnostic(t, stderr, "Unknown command: evil31m \ufffdtail\n")
+	assertSafeTerminalDiagnostic(t, stderr, "Error: unknown command `asc evil31m \ufffdtail`\n")
 }
 
 func TestRun_UnknownFlagSanitizesUnicodeTerminalControlsAndInvalidUTF8(t *testing.T) {
@@ -35,7 +35,7 @@ func TestRun_UnknownFlagSanitizesUnicodeTerminalControlsAndInvalidUTF8(t *testin
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
 	}
-	assertSafeTerminalDiagnostic(t, stderr, "Unknown flag: --evil31m \ufffdtail\n")
+	assertSafeTerminalDiagnostic(t, stderr, "Error: unknown flag `--evil31m \ufffdtail` for `asc builds list`\n")
 }
 
 func assertSafeTerminalDiagnostic(t *testing.T, stderr, wantLine string) {

--- a/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
+++ b/internal/cli/cmdtest/analytics_request_reuse_existing_test.go
@@ -79,7 +79,7 @@ func TestAnalyticsRequestReuseExistingRejectsInvalidBoolExitCode(t *testing.T) {
 				"--app", "app-1",
 				"--access-type", "ONGOING",
 			},
-			wantErr: "Unknown flag: --reuse-existing",
+			wantErr: "Error: unknown flag `--reuse-existing` for `asc`",
 		},
 	}
 

--- a/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
+++ b/internal/cli/cmdtest/review_deprecated_surface_removal_test.go
@@ -73,7 +73,7 @@ func TestReviewRemovedItemCommandsProvideMigrationGuidance(t *testing.T) {
 		{
 			name:       "ordinary typo",
 			args:       []string{"review", "items", "lits"},
-			wantStderr: "Error: unexpected argument(s): lits\n" + items.UsageFunc(items) + "Did you mean: list?\n",
+			wantStderr: "Error: unknown command `asc review items lits`\nTry:\n  asc review items list\nFor help:\n  asc review items --help\n",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -167,7 +167,7 @@ func TestReviewItemsGroupRejectsUnknownSubcommands(t *testing.T) {
 		{
 			name:    "legacy get spelling",
 			args:    []string{"review", "items", "get", "--id", "ITEM_ID"},
-			wantErr: "Error: unexpected argument(s): get",
+			wantErr: "Error: unknown command `asc review items get`",
 		},
 		{
 			name:    "removed view spelling",
@@ -177,7 +177,7 @@ func TestReviewItemsGroupRejectsUnknownSubcommands(t *testing.T) {
 		{
 			name:    "unknown child",
 			args:    []string{"review", "items", "nope"},
-			wantErr: "Error: unexpected argument(s): nope",
+			wantErr: "Error: unknown command `asc review items nope`",
 		},
 	}
 

--- a/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
+++ b/internal/cli/cmdtest/subscriptions_monthly_commitment_test.go
@@ -127,7 +127,7 @@ func TestSubscriptionsPricingMonthlyCommitmentUsageExitCodes(t *testing.T) {
 		{
 			name:    "subcommand flag before subcommand returns usage",
 			args:    []string{"subscriptions", "pricing", "monthly-commitment", "--subscription-id", "sub-1", "enable", "--price", "9.99", "--price-territory", "Norway", "--territories", "Norway"},
-			wantErr: "Unknown flag: --subscription-id",
+			wantErr: "Error: unknown flag `--subscription-id` for `asc subscriptions pricing monthly-commitment`",
 		},
 		{
 			name:    "mixed flag order invalid price territory returns usage",

--- a/internal/cli/cmdtest/validate_blackbox_test.go
+++ b/internal/cli/cmdtest/validate_blackbox_test.go
@@ -11,12 +11,12 @@ func TestValidateRemovedRemediationFlagsReturnUsageExitCode(t *testing.T) {
 		{
 			name:    "next removed",
 			args:    []string{"validate", "--app", "app-1", "--version-id", "ver-1", "--next"},
-			wantErr: "Unknown flag: --next",
+			wantErr: "Error: unknown flag `--next` for `asc validate`",
 		},
 		{
 			name:    "fix-plan removed",
 			args:    []string{"validate", "--app", "app-1", "--version-id", "ver-1", "--fix-plan"},
-			wantErr: "Unknown flag: --fix-plan",
+			wantErr: "Error: unknown flag `--fix-plan` for `asc validate`",
 		},
 	}
 

--- a/internal/cli/cmdtest/web_apps_compatibility_test.go
+++ b/internal/cli/cmdtest/web_apps_compatibility_test.go
@@ -66,7 +66,7 @@ func TestWebAppsCompatibilityInvalidBooleanExitCodes(t *testing.T) {
 				"web", "apps", "compatibility", "edit",
 				"--app", "app-1",
 			},
-			wantStderr: "Unknown flag: --ios-app-on-mac",
+			wantStderr: "Error: unknown flag `--ios-app-on-mac` for `asc`",
 		},
 	}
 

--- a/internal/cli/cmdtest/web_review_iaps_test.go
+++ b/internal/cli/cmdtest/web_review_iaps_test.go
@@ -311,7 +311,7 @@ func TestWebReviewIAPsAttachInvalidValueExitCodes(t *testing.T) {
 		{
 			name:       "subcommand flag before attach rejected",
 			args:       []string{"web", "review", "iaps", "--app", "123456789", "attach", "--iap-id", "9000000001", "--confirm"},
-			wantStderr: "Unknown flag: --app",
+			wantStderr: "Error: unknown flag `--app` for `asc web review iaps`",
 		},
 	}
 

--- a/internal/cli/shared/suggest/suggest.go
+++ b/internal/cli/shared/suggest/suggest.go
@@ -28,7 +28,7 @@ func Commands(input string, candidates []string) []string {
 
 		// Strong signal: prefix relationship.
 		if strings.HasPrefix(name, in) || strings.HasPrefix(in, name) {
-			collected = append(collected, candidate{name: name, score: 0, dist: 0})
+			collected = append(collected, candidate{name: name, score: 0, dist: levenshtein(in, name)})
 			continue
 		}
 

--- a/internal/cli/shared/suggest/suggest.go
+++ b/internal/cli/shared/suggest/suggest.go
@@ -93,7 +93,9 @@ func Flags(input string, candidates []string) []string {
 		if name == "" || name == in {
 			continue
 		}
-		if strings.HasSuffix(name, "-"+in) || strings.HasSuffix(in, "-"+name) {
+		identifierTypo := strings.HasSuffix(name, "-id") &&
+			(withinThreshold(in, levenshtein(in, "id")) || isAdjacentTransposition(in, "id"))
+		if strings.HasSuffix(name, "-"+in) || strings.HasSuffix(in, "-"+name) || identifierTypo {
 			if _, ok := seen[name]; !ok {
 				suffixMatches = append(suffixMatches, name)
 			}

--- a/internal/cli/shared/suggest/suggest_test.go
+++ b/internal/cli/shared/suggest/suggest_test.go
@@ -66,6 +66,13 @@ func TestFlagsMatchesIdentifierShorthand(t *testing.T) {
 	}
 }
 
+func TestFlagsSuggestsQualifiedIdentifierForTypoOfID(t *testing.T) {
+	got := Flags("idd", []string{"app", "iap-id", "limit", "next"})
+	if len(got) == 0 || got[0] != "iap-id" {
+		t.Fatalf("Flags() = %v, want iap-id first", got)
+	}
+}
+
 func TestFlagsCapsSuggestionsAcrossMatchingStrategies(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cli/shared/suggest/suggest_test.go
+++ b/internal/cli/shared/suggest/suggest_test.go
@@ -12,6 +12,14 @@ func TestCommandsPrefixSuggestion(t *testing.T) {
 	}
 }
 
+func TestCommandsRanksClosestPrefixBeforeSpecializedGroups(t *testing.T) {
+	got := Commands("buil", []string{"build-bundles", "build-localizations", "builds"})
+	want := []string{"builds", "build-bundles", "build-localizations"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Commands() = %v, want %v", got, want)
+	}
+}
+
 func TestCommandsEditDistanceSuggestion(t *testing.T) {
 	got := Commands("revews", []string{"reviews", "crashes", "apps"})
 	if len(got) == 0 || got[0] != "reviews" {
@@ -84,7 +92,7 @@ func TestFlagsCapsSuggestionsAcrossMatchingStrategies(t *testing.T) {
 			name:       "direct matches return at cap",
 			input:      "app",
 			candidates: []string{"appstore", "application", "apple", "build-app"},
-			want:       []string{"apple", "application", "appstore"},
+			want:       []string{"apple", "appstore", "application"},
 		},
 		{
 			name:       "suffix matches top up to cap",


### PR DESCRIPTION
## Summary

- replace full help dumps for unknown command paths with a concise error, up to two registered suggestions, and the relevant parent `--help` command
- apply the same compact contract to unknown flags without echoing following argument values
- preserve explicit help, bare command-group help, command-local validation, removed-command migration guidance, telemetry classification, usage exit code 2, and requested JUnit reports
- exclude hidden and deprecated commands and flags from generic suggestions

## Examples

```text
Error: unknown command `asc builds lsit`
Try:
  asc builds list
For help:
  asc builds --help
```

```text
Error: unknown flag `--ap` for `asc builds list`
Try:
  --app
For help:
  asc builds list --help
```

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- normal pre-commit hook with `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer`
- built-binary stdout/stderr/exit checks for unknown commands and flags
- JUnit regression tests for both concise early-return paths

## Merge note

PR #1993 touches the same dispatcher files. Its three semantic command-path mappings must be evaluated before this generic renderer when the branches are combined, then use `writeUsageJUnitReport` before their early return. The restack must include a semantic-mapping JUnit regression. A temporary integration verified the required ordering and both original test sets together; one mechanical conflict in `cmd/run.go` requires restacking or a small conflict resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unknown-command and unknown-flag errors with concise, consistent guidance.
  * Added sanitized suggestions and help instructions while preventing accidental argument disclosure.
  * Standardized diagnostics for deprecated and removed commands and flags.
  * Preserved appropriate exit statuses, telemetry, and configured usage reports for invalid input.

* **Tests**
  * Expanded coverage for command and flag recovery, output formatting, hidden or deprecated options, and argument-value protection.
  * Added built-binary integration coverage for unknown input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->