### PR TITLE
fix: require introductory-offer territory and deprecate ALL alias

### DIFF
--- a/cmd/exit_codes.go
+++ b/cmd/exit_codes.go
@@ -40,7 +40,7 @@ func ExitCodeFromError(err error) int {
 	}
 
 	// Usage errors
-	if errors.Is(err, flag.ErrHelp) {
+	if errors.Is(err, flag.ErrHelp) || shared.IsReportedUsageError(err) {
 		return ExitUsage
 	}
 

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -50,6 +50,11 @@ func TestExitCodeFromError(t *testing.T) {
 			expected: ExitUsage,
 		},
 		{
+			name:     "reported usage error returns usage",
+			err:      shared.NewReportedUsageError(shared.UsageErrorInvalidValue, "invalid selector"),
+			expected: ExitUsage,
+		},
+		{
 			name:     "ErrMissingAuth returns auth failure",
 			err:      shared.ErrMissingAuth,
 			expected: ExitAuth,

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -157,7 +157,7 @@ func validationFailureContext(analysis invocationAnalysis, err error) telemetry.
 }
 
 func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int) telemetry.EventContext {
-	if errors.Is(err, flag.ErrHelp) || analysis.shape == telemetry.InvocationShapeUnknownChild {
+	if errors.Is(err, flag.ErrHelp) || shared.IsReportedUsageError(err) || analysis.shape == telemetry.InvocationShapeUnknownChild {
 		return validationFailureContext(analysis, err)
 	}
 

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -117,6 +117,22 @@ func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 			wantOutcome: telemetry.OutcomeExpectedNegative,
 		},
 		{
+			name:        "reported missing usage failure",
+			err:         shared.NewReportedUsageError(shared.UsageErrorMissingRequired, "--territory is required"),
+			exitCode:    ExitUsage,
+			wantKind:    telemetry.ErrorKindMissingRequired,
+			wantStage:   telemetry.FailureStageValidation,
+			wantOutcome: telemetry.OutcomeUsageError,
+		},
+		{
+			name:        "reported invalid usage failure",
+			err:         shared.NewReportedUsageError(shared.UsageErrorInvalidValue, "invalid value for --territory"),
+			exitCode:    ExitUsage,
+			wantKind:    telemetry.ErrorKindInvalidValue,
+			wantStage:   telemetry.FailureStageValidation,
+			wantOutcome: telemetry.OutcomeUsageError,
+		},
+		{
 			name:        "API conflict",
 			err:         errors.New("conflict"),
 			exitCode:    ExitConflict,

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -297,6 +297,60 @@ func TestRun_ValidateMissingRequiredFlagsReturnsUsage(t *testing.T) {
 	}
 }
 
+func TestRun_IntroductoryOfferSelectorReportedUsageEmitsUsageTelemetry(t *testing.T) {
+	resetReportFlags(t)
+	for _, key := range []string{
+		"ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
+		"ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_B64", "ASC_STRICT_AUTH",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	for _, test := range []struct {
+		name     string
+		selector []string
+		wantKind telemetry.ErrorKind
+	}{
+		{name: "missing", wantKind: telemetry.ErrorKindMissingRequired},
+		{name: "conflicting", selector: []string{"--territory", "USA", "--all-territories"}, wantKind: telemetry.ErrorKindInvalidValue},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			originalEmitTelemetry := emitTelemetry
+			t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+			var gotExitCode int
+			var gotContext telemetry.EventContext
+			emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+				gotExitCode = exitCode
+				gotContext = eventContext
+			}
+
+			args := []string{
+				"subscriptions", "offers", "introductory", "create",
+				"--subscription-id", "8000000001",
+				"--offer-duration", "ONE_MONTH",
+				"--offer-mode", "FREE_TRIAL",
+				"--number-of-periods", "1",
+			}
+			args = append(args, test.selector...)
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+			if stdout != "" || !strings.Contains(stderr, "For help:\n  asc subscriptions offers introductory create --help") {
+				t.Fatalf("stdout=%q stderr=%q", stdout, stderr)
+			}
+			if gotExitCode != ExitUsage || gotContext.ErrorKind != test.wantKind ||
+				gotContext.FailureStage != telemetry.FailureStageValidation ||
+				gotContext.OutcomeKind != telemetry.OutcomeUsageError {
+				t.Fatalf("unexpected telemetry: exit=%d context=%+v", gotExitCode, gotContext)
+			}
+		})
+	}
+}
+
 func TestRun_AuthLoginInvalidKeyTypeEmitsFailureParameter(t *testing.T) {
 	resetReportFlags(t)
 	tempDir := t.TempDir()

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -895,6 +895,7 @@ Offer discounted pricing to new subscribers.
 # Create introductory offer
 asc subscriptions offers introductory create \
   --subscription-id "SUB_ID" \
+  --territory "USA" \
   --offer-duration ONE_MONTH \
   --offer-mode FREE_TRIAL \
   --number-of-periods 1
@@ -910,7 +911,7 @@ asc subscriptions offers introductory create \
 # Preview all-territory introductory offer creation without mutating ASC
 asc subscriptions offers introductory create \
   --subscription-id "SUB_ID" \
-  --territory ALL \
+  --all-territories \
   --dry-run \
   --offer-duration ONE_MONTH \
   --offer-mode FREE_TRIAL \

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -948,7 +948,7 @@ asc subscriptions offers introductory delete \
 * Header alias: `price_point` -> `price_point_id`
 * Territory values may be 3-letter ASC IDs, 2-letter country codes, or English territory names
 * Row values override command-level defaults, so a territory-only CSV can inherit a shared offer shape from flags
-* Use `create --all-territories` when every current subscription availability territory should receive the same free-trial shape
+* Use `create --all-territories` when every current subscription availability territory should receive the same offer shape
 
 **Offer Types:**
 

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -891,6 +891,10 @@ asc subscriptions versions images delete --id "IMAGE_ID" --confirm
 
 Offer discounted pricing to new subscribers.
 
+`--territory ALL` remains accepted as a deprecated compatibility spelling for
+`--all-territories` and prints a migration warning. Use `--all-territories` in
+new scripts; combining both spellings is invalid.
+
 ```bash  theme={null}
 # Create introductory offer
 asc subscriptions offers introductory create \
@@ -944,7 +948,7 @@ asc subscriptions offers introductory delete \
 * Header alias: `price_point` -> `price_point_id`
 * Territory values may be 3-letter ASC IDs, 2-letter country codes, or English territory names
 * Row values override command-level defaults, so a territory-only CSV can inherit a shared offer shape from flags
-* Use `create --all-territories` or `create --territory ALL` when every current subscription availability territory should receive the same free-trial shape
+* Use `create --all-territories` when every current subscription availability territory should receive the same free-trial shape
 
 **Offer Types:**
 

--- a/docs/design/subscription-introductory-offer-territory-selector.md
+++ b/docs/design/subscription-introductory-offer-territory-selector.md
@@ -1,0 +1,53 @@
+# Subscription introductory-offer territory selector
+
+## Decision
+
+`asc subscriptions offers introductory create` requires exactly one territory
+mode before authentication or HTTP:
+
+```text
+(--territory "USA" | --all-territories)
+```
+
+`--territory` accepts alpha-2, alpha-3, or exact English country names and is
+normalized to the canonical App Store Connect territory ID. An explicitly
+blank value is invalid. Combining a concrete territory with
+`--all-territories` is invalid.
+
+The shipped `--territory ALL` spelling remains a deprecated compatibility alias
+for `--all-territories`. It emits a migration warning and is omitted from
+examples. Combining the alias with `--all-territories` is also invalid.
+
+## API contract
+
+The command uses `POST /v1/subscriptionIntroductoryOffers` with
+`SubscriptionIntroductoryOfferCreateRequest` and returns
+`SubscriptionIntroductoryOfferResponse`. OpenAPI requires the attributes and
+subscription relationship but marks the territory relationship optional. This
+CLI intentionally applies a stricter workflow contract because App Store
+Connect rejects practical create requests that omit a territory.
+
+Single-territory mode preserves the normalized territory relationship and an
+optional subscription price-point relationship. All-territories mode preserves
+the existing availability lookup, existing-offer reconciliation, per-territory
+create requests, summary output, dry-run behavior, and partial-failure handling.
+The lower-level API client remains unchanged because it follows the OpenAPI
+schema and has callers outside this command.
+
+## Compatibility and verification
+
+Valid concrete and all-territories invocations keep their existing request and
+output behavior. Missing, blank, conflicting, and invalid selectors return exit
+code 2 with empty stdout and one precise stderr diagnostic before client setup.
+The deprecated ALL alias remains accepted with a direct replacement warning.
+
+RED-GREEN coverage includes every validation edge, canonicalization, the
+single-create relationship payload, bulk payloads, the alias transition, live
+help, generated command documentation, and built-binary stdout, stderr, and
+exit behavior. No live mutation is needed because the provider failure is
+reproduced and the exact request schema is available offline.
+
+Removing `--territory ALL` immediately was rejected because it would break a
+stable spelling. Allowing the provider to reject missing selectors was rejected
+because it spends authentication and network work on a locally detectable
+invalid workflow.

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -3,6 +3,8 @@ package cmdtest
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -409,6 +411,23 @@ func TestCanonicalWrapperErrorsUseCanonicalPaths(t *testing.T) {
 				t.Fatalf("expected empty stderr, got %q", stderr)
 			}
 		})
+	}
+}
+
+func TestSubscriptionsDocsOnlyMentionDeprecatedIntroductoryOfferAliasInMigrationNote(t *testing.T) {
+	docsPath := filepath.Join("..", "..", "..", "commands", "subscriptions.mdx")
+	docs, err := os.ReadFile(docsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docsPath, err)
+	}
+
+	content := string(docs)
+	const deprecatedAlias = "--territory ALL"
+	if got := strings.Count(content, deprecatedAlias); got != 1 {
+		t.Fatalf("expected subscriptions docs to mention deprecated alias once in the migration note, got %d occurrences", got)
+	}
+	if !strings.Contains(content, "`--territory ALL` remains accepted as a deprecated compatibility spelling") {
+		t.Fatal("expected subscriptions docs to retain the deprecated alias migration note")
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_canonical_help_test.go
+++ b/internal/cli/cmdtest/subscriptions_canonical_help_test.go
@@ -212,6 +212,19 @@ func TestSubscriptionsHelpShowsCanonicalCommerceSubcommands(t *testing.T) {
 		t.Fatalf("expected introductory offer view help to drop the unsupported id-only invocation, got %q", introductoryViewUsage)
 	}
 
+	introductoryCreateCmd := findSubcommand(root, "subscriptions", "offers", "introductory", "create")
+	if introductoryCreateCmd == nil {
+		t.Fatal("expected subscriptions offers introductory create command")
+		return
+	}
+	introductoryCreateUsage := introductoryCreateCmd.UsageFunc(introductoryCreateCmd)
+	if !strings.Contains(introductoryCreateUsage, `(--territory "USA" | --all-territories)`) {
+		t.Fatalf("expected introductory offer create help to require one territory selector, got %q", introductoryCreateUsage)
+	}
+	if strings.Contains(introductoryCreateUsage, `--territory ALL`) {
+		t.Fatalf("expected introductory offer create help to omit the deprecated ALL alias, got %q", introductoryCreateUsage)
+	}
+
 	offerCodesCmd := findSubcommand(root, "subscriptions", "offers", "offer-codes")
 	if offerCodesCmd == nil {
 		t.Fatal("expected subscriptions offers offer-codes command")

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -42,11 +42,21 @@ func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) 
 		var payload struct {
 			Data struct {
 				Relationships struct {
+					Subscription struct {
+						Data struct {
+							ID string `json:"id"`
+						} `json:"data"`
+					} `json:"subscription"`
 					Territory struct {
 						Data struct {
 							ID string `json:"id"`
 						} `json:"data"`
 					} `json:"territory"`
+					SubscriptionPricePoint struct {
+						Data struct {
+							ID string `json:"id"`
+						} `json:"data"`
+					} `json:"subscriptionPricePoint"`
 				} `json:"relationships"`
 			} `json:"data"`
 		}
@@ -55,6 +65,12 @@ func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) 
 		}
 		if got := payload.Data.Relationships.Territory.Data.ID; got != "USA" {
 			t.Fatalf("expected normalized territory USA, got %q", got)
+		}
+		if got := payload.Data.Relationships.Subscription.Data.ID; got != "8000000001" {
+			t.Fatalf("expected subscription relationship 8000000001, got %q", got)
+		}
+		if got := payload.Data.Relationships.SubscriptionPricePoint.Data.ID; got != "price-1" {
+			t.Fatalf("expected price point relationship price-1, got %q", got)
 		}
 
 		return jsonHTTPResponse(http.StatusCreated, `{"data":{"type":"subscriptionIntroductoryOffers","id":"intro-1","attributes":{"duration":"ONE_MONTH","offerMode":"FREE_TRIAL","numberOfPeriods":1}}}`), nil
@@ -70,6 +86,7 @@ func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) 
 		"--offer-mode", "FREE_TRIAL",
 		"--number-of-periods", "1",
 		"--territory", "US",
+		"--price-point", "price-1",
 	}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
@@ -77,6 +94,166 @@ func TestSubscriptionsIntroductoryOffersCreateNormalizesTerritory(t *testing.T) 
 		t.Fatalf("run error: %v", err)
 	}
 }
+
+func TestSubscriptionsIntroductoryOffersCreateRequiresExactlyOneTerritorySelectorBeforeAuth(t *testing.T) {
+	isolateIntroductoryOfferCreateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("validation must happen before HTTP: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	baseArgs := []string{
+		"subscriptions", "offers", "introductory", "create",
+		"--subscription-id", "8000000001",
+		"--offer-duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--number-of-periods", "1",
+	}
+	tests := []struct {
+		name       string
+		additional []string
+		wantErr    string
+	}{
+		{
+			name:    "missing selector",
+			wantErr: "exactly one of --territory or --all-territories is required",
+		},
+		{
+			name:       "blank territory",
+			additional: []string{"--territory", "   "},
+			wantErr:    "invalid value for --territory: cannot be empty",
+		},
+		{
+			name:       "both selectors",
+			additional: []string{"--territory", "USA", "--all-territories"},
+			wantErr:    "exactly one of --territory or --all-territories is required",
+		},
+		{
+			name:       "deprecated all alias and canonical selector",
+			additional: []string{"--territory", "ALL", "--all-territories"},
+			wantErr:    "exactly one of --territory or --all-territories is required",
+		},
+		{
+			name:       "invalid territory",
+			additional: []string{"--territory", "Atlantis"},
+			wantErr:    `territory "Atlantis" could not be mapped to an App Store Connect territory ID`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := append(append([]string{}, baseArgs...), test.additional...)
+			stdout, stderr, runErr := runRootCommand(t, args)
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected usage error, got %v", runErr)
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitUsage)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			wantStderr := "Error: " + test.wantErr + "\n" + subscriptionIntroductoryOfferCreateSelectorGuidanceForTest + "\n"
+			if stderr != wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
+			}
+			if strings.Contains(stderr, "missing authentication") {
+				t.Fatalf("validation must happen before authentication, got %q", stderr)
+			}
+			if strings.Contains(stderr, "DESCRIPTION") || strings.Contains(stderr, "FLAGS") {
+				t.Fatalf("selector failure must not dump full help, got %q", stderr)
+			}
+		})
+	}
+}
+
+func isolateIntroductoryOfferCreateAuth(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	for _, key := range []string{
+		"ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
+		"ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_B64", "ASC_STRICT_AUTH",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateSelectorFailuresAreConciseAtTopLevel(t *testing.T) {
+	isolateIntroductoryOfferCreateAuth(t)
+
+	baseArgs := []string{
+		"subscriptions", "offers", "introductory", "create",
+		"--subscription-id", "8000000001",
+		"--offer-duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--number-of-periods", "1",
+	}
+	tests := []struct {
+		name       string
+		additional []string
+		wantErr    string
+	}{
+		{name: "missing selector", wantErr: "exactly one of --territory or --all-territories is required"},
+		{name: "blank territory", additional: []string{"--territory", "   "}, wantErr: "invalid value for --territory: cannot be empty"},
+		{name: "both selectors", additional: []string{"--territory", "USA", "--all-territories"}, wantErr: "exactly one of --territory or --all-territories is required"},
+		{name: "invalid territory", additional: []string{"--territory", "Atlantis"}, wantErr: `territory "Atlantis" could not be mapped to an App Store Connect territory ID`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := append(append([]string{}, baseArgs...), test.additional...)
+			var exitCode int
+			stdout, stderr := captureOutput(t, func() {
+				exitCode = rootcmd.Run(args, "1.2.3")
+			})
+			if exitCode != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", exitCode, rootcmd.ExitUsage)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			wantStderr := "Error: " + test.wantErr + "\n" + subscriptionIntroductoryOfferCreateSelectorGuidanceForTest + "\n"
+			if stderr != wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
+			}
+		})
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateNonSelectorValidationKeepsFullHelp(t *testing.T) {
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--subscription-id", "8000000001",
+			"--territory", "USA",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+		}, "1.2.3")
+	})
+	if exitCode != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d", exitCode, rootcmd.ExitUsage)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.HasPrefix(stderr, "Error: --offer-duration is required\n") ||
+		!strings.Contains(stderr, "DESCRIPTION\n") || !strings.Contains(stderr, "FLAGS\n") {
+		t.Fatalf("expected non-selector validation to retain full help, got %q", stderr)
+	}
+}
+
+const subscriptionIntroductoryOfferCreateSelectorGuidanceForTest = `Try:
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --territory "USA" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --all-territories --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+For help:
+  asc subscriptions offers introductory create --help
+`
 
 func TestSubscriptionsIntroductoryOffersCreateSelectorAndPostShareOperationTimeout(t *testing.T) {
 	setupAuth(t)
@@ -238,7 +415,7 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesDryRunSummarizesAvai
 	}
 }
 
-func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesCreatesPerAvailabilityTerritory(t *testing.T) {
+func TestSubscriptionsIntroductoryOffersCreateDeprecatedAllAliasCreatesPerAvailabilityTerritory(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
@@ -311,8 +488,9 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesCreatesPerAvailabili
 			t.Fatalf("run error: %v", err)
 		}
 	})
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	wantWarning := "Warning: `--territory ALL` is deprecated. Use `--all-territories`.\n"
+	if stderr != wantWarning {
+		t.Fatalf("expected stderr %q, got %q", wantWarning, stderr)
 	}
 	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
 		t.Fatalf("parse JSON summary: %v", err)
@@ -621,7 +799,7 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesRejectsConcreteTerri
 				"--all-territories",
 				"--territory", "USA",
 			},
-			wantErr: "Error: --territory and --all-territories are mutually exclusive",
+			wantErr: "Error: exactly one of --territory or --all-territories is required",
 		},
 		{
 			name: "all territories and price point",

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 type cancelOnCloseBody struct {
@@ -147,8 +148,8 @@ func TestSubscriptionsIntroductoryOffersCreateRequiresExactlyOneTerritorySelecto
 		t.Run(test.name, func(t *testing.T) {
 			args := append(append([]string{}, baseArgs...), test.additional...)
 			stdout, stderr, runErr := runRootCommand(t, args)
-			if !errors.Is(runErr, flag.ErrHelp) {
-				t.Fatalf("expected usage error, got %v", runErr)
+			if errors.Is(runErr, flag.ErrHelp) || !shared.IsReportedUsageError(runErr) {
+				t.Fatalf("expected reported usage error without flag.ErrHelp, got %v", runErr)
 			}
 			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
 				t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitUsage)
@@ -156,7 +157,7 @@ func TestSubscriptionsIntroductoryOffersCreateRequiresExactlyOneTerritorySelecto
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			wantStderr := "Error: " + test.wantErr + "\n" + subscriptionIntroductoryOfferCreateSelectorGuidanceForTest + "\n"
+			wantStderr := "Error: " + test.wantErr + "\n" + subscriptionIntroductoryOfferCreateSelectorGuidanceForTest
 			if stderr != wantStderr {
 				t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
 			}
@@ -217,7 +218,7 @@ func TestSubscriptionsIntroductoryOffersCreateSelectorFailuresAreConciseAtTopLev
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			wantStderr := "Error: " + test.wantErr + "\n" + subscriptionIntroductoryOfferCreateSelectorGuidanceForTest + "\n"
+			wantStderr := "Error: " + test.wantErr + "\n" + subscriptionIntroductoryOfferCreateSelectorGuidanceForTest
 			if stderr != wantStderr {
 				t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
 			}
@@ -784,9 +785,10 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesPartialFailureReturn
 
 func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesRejectsConcreteTerritoryAndPricePoint(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
+		name         string
+		args         []string
+		wantErr      string
+		wantReported bool
 	}{
 		{
 			name: "all territories and concrete territory",
@@ -799,7 +801,8 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesRejectsConcreteTerri
 				"--all-territories",
 				"--territory", "USA",
 			},
-			wantErr: "Error: exactly one of --territory or --all-territories is required",
+			wantErr:      "Error: exactly one of --territory or --all-territories is required",
+			wantReported: true,
 		},
 		{
 			name: "all territories and price point",
@@ -826,7 +829,11 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesRejectsConcreteTerri
 					t.Fatalf("parse error: %v", err)
 				}
 				err := root.Run(context.Background())
-				if !errors.Is(err, flag.ErrHelp) {
+				if test.wantReported {
+					if errors.Is(err, flag.ErrHelp) || !shared.IsReportedUsageError(err) {
+						t.Fatalf("expected reported usage error, got %v", err)
+					}
+				} else if !errors.Is(err, flag.ErrHelp) {
 					t.Fatalf("expected flag.ErrHelp, got %v", err)
 				}
 			})

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -15,6 +15,14 @@ type ReportedError interface {
 	Reported() bool
 }
 
+// ReportedUsageError marks an already-printed usage failure without wrapping
+// flag.ErrHelp. This lets commands provide concise corrective guidance while
+// preserving usage exit and telemetry semantics without triggering full help.
+type ReportedUsageError interface {
+	ReportedError
+	UsageErrorKind() UsageErrorKind
+}
+
 // ValidationFailure marks an error as a command/domain validation result rather
 // than a generic runtime failure. It intentionally carries no command-specific
 // value so telemetry can classify the stage without increasing cardinality.
@@ -25,6 +33,11 @@ type ValidationFailure interface {
 
 type reportedError struct {
 	err error
+}
+
+type reportedUsageError struct {
+	kind    UsageErrorKind
+	message string
 }
 
 type validationError struct {
@@ -56,6 +69,15 @@ func (e classifiedUsageError) Error() string {
 	return e.message
 }
 func (e classifiedUsageError) Unwrap() error { return flag.ErrHelp }
+func (e classifiedUsageError) UsageErrorKind() UsageErrorKind {
+	return e.kind
+}
+
+func (e reportedUsageError) Error() string  { return e.message }
+func (e reportedUsageError) Reported() bool { return true }
+func (e reportedUsageError) UsageErrorKind() UsageErrorKind {
+	return e.kind
+}
 
 func (e reportedError) Error() string {
 	return e.err.Error()
@@ -95,6 +117,24 @@ func NewReportedError(err error) error {
 		return nil
 	}
 	return reportedError{err: err}
+}
+
+// NewReportedUsageError classifies an already-printed usage failure without
+// wrapping flag.ErrHelp, which would cause ffcli to print the command's full
+// usage page. The returned error maps to usage exit code 2.
+func NewReportedUsageError(kind UsageErrorKind, message string) error {
+	trimmed := strings.TrimSpace(message)
+	if kind != UsageErrorMissingRequired && kind != UsageErrorInvalidValue && kind != UsageErrorOther {
+		kind = classifyUsageMessage(trimmed)
+	}
+	return reportedUsageError{kind: kind, message: trimmed}
+}
+
+// IsReportedUsageError reports whether err is an already-printed usage
+// failure that must not trigger ffcli's full help renderer.
+func IsReportedUsageError(err error) bool {
+	var reportedUsage ReportedUsageError
+	return errors.As(err, &reportedUsage)
 }
 
 // NewValidationError wraps an error that represents local/domain validation.
@@ -156,9 +196,9 @@ func MissingRequiredUsageError(parameters ...string) error {
 }
 
 func ClassifyUsageError(err error) UsageErrorKind {
-	var classified classifiedUsageError
+	var classified interface{ UsageErrorKind() UsageErrorKind }
 	if errors.As(err, &classified) {
-		return classified.kind
+		return classified.UsageErrorKind()
 	}
 	return ""
 }

--- a/internal/cli/shared/errors_test.go
+++ b/internal/cli/shared/errors_test.go
@@ -26,3 +26,31 @@ func TestUsageErrorPreservesValidationMessage(t *testing.T) {
 		t.Fatalf("UsageError() stderr = %q", stderr)
 	}
 }
+
+func TestNewReportedUsageErrorPreservesUsageClassificationWithoutHelp(t *testing.T) {
+	err := NewReportedUsageError(UsageErrorInvalidValue, "invalid value for --territory")
+
+	if err.Error() != "invalid value for --territory" {
+		t.Fatalf("NewReportedUsageError().Error() = %q", err.Error())
+	}
+	if errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("reported usage error must not unwrap to flag.ErrHelp: %v", err)
+	}
+	if !IsReportedUsageError(err) {
+		t.Fatalf("IsReportedUsageError() = false for %T", err)
+	}
+	var reported ReportedError
+	if !errors.As(err, &reported) || !reported.Reported() {
+		t.Fatalf("expected ReportedError marker, got %T", err)
+	}
+	if got := ClassifyUsageError(err); got != UsageErrorInvalidValue {
+		t.Fatalf("ClassifyUsageError() = %q, want %q", got, UsageErrorInvalidValue)
+	}
+}
+
+func TestNewReportedUsageErrorNormalizesUnknownKind(t *testing.T) {
+	err := NewReportedUsageError(UsageErrorKind("unknown"), "--app is required")
+	if got := ClassifyUsageError(err); got != UsageErrorMissingRequired {
+		t.Fatalf("ClassifyUsageError() = %q, want %q", got, UsageErrorMissingRequired)
+	}
+}

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -270,13 +270,6 @@ func SubscriptionsIntroductoryOffersCreateCommand() *ffcli.Command {
 	dryRun := fs.Bool("dry-run", false, "Resolve territories and print summary without creating offers")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue creating offers after a territory fails")
 	output := shared.BindOutputFlags(fs)
-	conciseSelectorUsage := false
-	usageFunc := func(command *ffcli.Command) string {
-		if conciseSelectorUsage {
-			return subscriptionIntroductoryOfferCreateSelectorGuidance
-		}
-		return shared.DefaultUsageFunc(command)
-	}
 
 	return &ffcli.Command{
 		Name:       "create",
@@ -292,7 +285,7 @@ Examples:
 Timeouts:
   An explicit ASC_TIMEOUT caps the full create operation. Without an override, the operation uses a 5m fallback while individual requests retain the standard request timeout.`,
 		FlagSet:   fs,
-		UsageFunc: usageFunc,
+		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
@@ -343,12 +336,20 @@ Timeouts:
 			})
 			territoryID := strings.TrimSpace(*territory)
 			if territoryProvided && territoryID == "" {
-				conciseSelectorUsage = true
-				return shared.UsageError("invalid value for --territory: cannot be empty")
+				return subscriptionIntroductoryOfferSelectorUsageError(
+					shared.UsageErrorInvalidValue,
+					"invalid value for --territory: cannot be empty",
+				)
 			}
 			if territoryProvided == *allTerritories {
-				conciseSelectorUsage = true
-				return shared.UsageError("exactly one of --territory or --all-territories is required")
+				kind := shared.UsageErrorMissingRequired
+				if territoryProvided {
+					kind = shared.UsageErrorInvalidValue
+				}
+				return subscriptionIntroductoryOfferSelectorUsageError(
+					kind,
+					"exactly one of --territory or --all-territories is required",
+				)
 			}
 
 			legacyAllTerritories := territoryProvided && strings.EqualFold(territoryID, "ALL")
@@ -363,8 +364,7 @@ Timeouts:
 			} else if territoryProvided {
 				territoryID, err = ascterritory.Normalize(territoryID)
 				if err != nil {
-					conciseSelectorUsage = true
-					return shared.UsageError(err.Error())
+					return subscriptionIntroductoryOfferSelectorUsageError(shared.UsageErrorInvalidValue, err.Error())
 				}
 			}
 
@@ -423,6 +423,11 @@ Timeouts:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func subscriptionIntroductoryOfferSelectorUsageError(kind shared.UsageErrorKind, message string) error {
+	fmt.Fprintf(os.Stderr, "Error: %s\n%s", strings.TrimSpace(message), subscriptionIntroductoryOfferCreateSelectorGuidance)
+	return shared.NewReportedUsageError(kind, message)
 }
 
 type subscriptionIntroductoryOfferCreateBulkSummary struct {

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -20,6 +20,13 @@ import (
 
 const subscriptionIntroductoryOfferCreateTimeout = 5 * time.Minute
 
+const subscriptionIntroductoryOfferCreateSelectorGuidance = `Try:
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --territory "USA" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --all-territories --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+For help:
+  asc subscriptions offers introductory create --help
+`
+
 // SubscriptionsIntroductoryOffersCommand returns the introductory offers command group.
 func SubscriptionsIntroductoryOffersCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("introductory-offers", flag.ExitOnError)
@@ -31,9 +38,9 @@ func SubscriptionsIntroductoryOffersCommand() *ffcli.Command {
 		LongHelp: `Manage subscription introductory offers.
 
 Examples:
-  asc subscriptions introductory-offers list --subscription-id "SUB_ID"
-  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
-  asc subscriptions introductory-offers import --subscription-id "SUB_ID" --input "./offers.csv" --offer-duration ONE_WEEK --offer-mode FREE_TRIAL --number-of-periods 1 --confirm`,
+  asc subscriptions offers introductory list --subscription-id "SUB_ID"
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --territory "USA" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers introductory import --subscription-id "SUB_ID" --input "./offers.csv" --offer-duration ONE_WEEK --offer-mode FREE_TRIAL --number-of-periods 1 --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -257,28 +264,35 @@ func SubscriptionsIntroductoryOffersCreateCommand() *ffcli.Command {
 	numberOfPeriods := fs.Int("number-of-periods", 0, "Number of periods (required)")
 	startDate := fs.String("start-date", "", "Start date (YYYY-MM-DD)")
 	endDate := fs.String("end-date", "", "End date (YYYY-MM-DD)")
-	territory := fs.String("territory", "", "Territory input for price override (accepts alpha-2, alpha-3, or exact English country name)")
+	territory := fs.String("territory", "", "Territory for the offer (accepts alpha-2, alpha-3, or exact English country name; required unless --all-territories)")
 	allTerritories := fs.Bool("all-territories", false, "Create introductory offers for all current subscription availability territories")
 	pricePoint := fs.String("price-point", "", "Subscription price point ID")
 	dryRun := fs.Bool("dry-run", false, "Resolve territories and print summary without creating offers")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue creating offers after a territory fails")
 	output := shared.BindOutputFlags(fs)
+	conciseSelectorUsage := false
+	usageFunc := func(command *ffcli.Command) string {
+		if conciseSelectorUsage {
+			return subscriptionIntroductoryOfferCreateSelectorGuidance
+		}
+		return shared.DefaultUsageFunc(command)
+	}
 
 	return &ffcli.Command{
 		Name:       "create",
-		ShortUsage: "asc subscriptions introductory-offers create [flags]",
+		ShortUsage: `asc subscriptions offers introductory create --subscription-id "SUB_ID" (--territory "USA" | --all-territories) [flags]`,
 		ShortHelp:  "Create an introductory offer.",
 		LongHelp: `Create an introductory offer.
 
 Examples:
-  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
-  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --all-territories --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
-  asc subscriptions introductory-offers create --subscription-id "SUB_ID" --territory ALL --dry-run --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --territory "USA" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --all-territories --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --all-territories --dry-run --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
 
 Timeouts:
   An explicit ASC_TIMEOUT caps the full create operation. Without an override, the operation uses a 5m fallback while individual requests retain the standard request timeout.`,
 		FlagSet:   fs,
-		UsageFunc: shared.DefaultUsageFunc,
+		UsageFunc: usageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
@@ -321,24 +335,36 @@ Timeouts:
 				}
 			}
 
+			territoryProvided := false
+			fs.Visit(func(parsed *flag.Flag) {
+				if parsed.Name == "territory" {
+					territoryProvided = true
+				}
+			})
 			territoryID := strings.TrimSpace(*territory)
-			useAllTerritories := *allTerritories || strings.EqualFold(territoryID, "ALL")
-			if *allTerritories && territoryID != "" && !strings.EqualFold(territoryID, "ALL") {
-				fmt.Fprintln(os.Stderr, "Error: --territory and --all-territories are mutually exclusive")
-				return flag.ErrHelp
+			if territoryProvided && territoryID == "" {
+				conciseSelectorUsage = true
+				return shared.UsageError("invalid value for --territory: cannot be empty")
 			}
+			if territoryProvided == *allTerritories {
+				conciseSelectorUsage = true
+				return shared.UsageError("exactly one of --territory or --all-territories is required")
+			}
+
+			legacyAllTerritories := territoryProvided && strings.EqualFold(territoryID, "ALL")
+			useAllTerritories := *allTerritories || legacyAllTerritories
 			if useAllTerritories && strings.TrimSpace(*pricePoint) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --price-point cannot be used with --all-territories or --territory ALL")
 				return flag.ErrHelp
 			}
-			if territoryID != "" {
-				if useAllTerritories {
-					territoryID = ""
-				} else {
-					territoryID, err = ascterritory.Normalize(territoryID)
-					if err != nil {
-						return shared.UsageError(err.Error())
-					}
+			if legacyAllTerritories {
+				fmt.Fprintln(os.Stderr, "Warning: `--territory ALL` is deprecated. Use `--all-territories`.")
+				territoryID = ""
+			} else if territoryProvided {
+				territoryID, err = ascterritory.Normalize(territoryID)
+				if err != nil {
+					conciseSelectorUsage = true
+					return shared.UsageError(err.Error())
 				}
 			}
 


### PR DESCRIPTION
## Summary

- require exactly one of `--territory` or `--all-territories` before authentication or HTTP
- reject blank, invalid, and conflicting territory selectors with concise corrective guidance and exit code 2
- keep `--territory ALL` as a deprecated compatibility alias while moving examples to `--all-territories`
- preserve concrete-territory normalization, optional price-point relationships, and bulk creation behavior

## Contract

The OpenAPI create schema marks the territory relationship optional, but practical provider requests without one fail. The command now applies a stricter workflow contract while leaving the lower-level API client unchanged.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- normal pre-commit hook
- built-binary checks for missing, blank, conflicting, and invalid selectors: exit 2, empty stdout, concise stderr, no authentication or HTTP

No live mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introductory-offer creation now requires either a specific territory or the all-territories option.
  * Added clearer guidance, examples, validation messages, and usage information for territory selection.
  * Existing `--territory ALL` commands remain supported with a deprecation warning and cannot be combined with `--all-territories`.
  * Territory examples now explicitly distinguish USA and all-territory usage.

* **Documentation**
  * Added design documentation covering territory selection, validation, compatibility, and request behavior.

* **Tests**
  * Expanded coverage for selector validation, help output, warnings, usage errors, and all-territory creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->