### PR TITLE
feat(distribute): prepare verified ad hoc bundles

### DIFF
--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -44,7 +44,7 @@ var rootUsageGroups = []rootCommandGroup{
 		title: "TESTFLIGHT & BUILD COMMANDS",
 		commands: []string{
 			"testflight", "feedback", "crashes", "builds", "build-bundles",
-			"build-localizations", "xcode",
+			"build-localizations", "xcode", "distribute",
 			"sandbox",
 		},
 	},

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -89,6 +89,7 @@ asc <subcommand> [flags]
 - `build-bundles` - Manage build bundles and App Clip data.
 - `build-localizations` - Manage build release notes localizations.
 - `xcode` - Local Xcode build/archive/export helpers (macOS only).
+- `distribute` - Inspect and prepare local iOS distribution artifacts. [experimental]
 - `sandbox` - Manage sandbox testers in App Store Connect.
 
 ### Review and Release

--- a/docs/design/agent-native-ad-hoc-distribution.md
+++ b/docs/design/agent-native-ad-hoc-distribution.md
@@ -17,7 +17,121 @@ The complete workflow is planned as separate reviewable changes:
 5. Sync and install the private signing identity under explicit local control.
 6. Compose the stages into a resumable run with a durable receipt.
 
-The first change in this stack owns only item 1.
+The first change in this stack owns only item 1. The second change owns only
+local inspection and preparation from item 2; publishing remains a separate
+network-facing boundary.
+
+## PR 2 public contract
+
+The experimental `distribute` family begins with two provider-neutral local
+commands:
+
+```text
+asc distribute inspect --ipa ./App.ipa [--include-devices] [--output json|table|markdown]
+asc distribute prepare --ipa ./App.ipa [--output-dir DIR] [--title TITLE] \
+  [--channel CHANNEL] [--source-revision REVISION] [--source-url URL] \
+  [--output json|table|markdown]
+```
+
+`inspect` opens the IPA once without following a symlink, validates every ZIP
+member name, rejects encrypted members, duplicate paths, an ambiguous main app,
+and oversized selected metadata, then reports app, artifact, provisioning
+profile, certificate, and metadata-preparation facts. Raw device UDIDs are
+omitted unless the caller explicitly requests `--include-devices`; deterministic
+device-set and certificate fingerprints are safe to pass between agents.
+
+`prepare` applies the same inspection and requires an unexpired ad hoc profile
+whose bundle identifier matches the main app and contains at least one device.
+It writes a deterministic descriptor followed by the unchanged IPA in this
+layout:
+
+```text
+bundle.json
+payload/app.ipa
+```
+
+The default path is
+`.asc/distribution/<safe-bundle-id>/<version>-<build>-<first-12-ipa-sha256>`.
+The descriptor contains no timestamp, absolute input path, raw device UDID, URL
+manifest, or storage-provider setting. An existing byte-for-byte-equivalent
+bundle is reported as reused. Any other existing destination is a conflict and
+is never overwritten. A new bundle is assembled in an unpredictable sibling
+directory and published with no-replace semantics so `bundle.json` is never a
+receipt for a partial bundle.
+
+Both commands print data to stdout, diagnostics to stderr, and use exit code 2
+for invalid flags or missing required flags. IPA or preparation validation
+failures use the ordinary non-zero command error. This is an additive
+experimental surface and requires no migration.
+
+### PR 2 security and verification
+
+An IPA is treated as an untrusted ZIP, never extracted wholesale. Member names
+must be canonical relative slash paths without traversal, backslashes, NUL or
+control characters. The archive has fixed overall-size, entry, and
+declared-expansion limits;
+the main `Info.plist` is capped at 4 MiB and the embedded provisioning profile at
+16 MiB, with both advertised-size and streamed-size enforcement. Preparation
+uses rooted, no-follow reads and writes, copies from the already-open IPA file,
+writes the descriptor last in staging, and refuses replacement at publication.
+
+RED-GREEN coverage includes the complete JSON schema, explicit device
+disclosure, ad hoc/development/enterprise/App Store classification, expired and
+mismatched profiles, missing metadata, malicious ZIP paths, duplicate and
+ambiguous app members, compressed-size limit bypasses, deterministic default
+paths, exact reuse, conflict/no-overwrite behavior, table/Markdown rendering,
+help/registration, built-binary stdout/stderr and exit behavior, command-doc
+generation, and the repository validation gate.
+
+Keeping install manifests out of preparation avoids pretending that URLs exist
+before a publisher assigns them. Extracting the IPA to a directory would make
+symlink and traversal handling much broader without adding needed metadata.
+Using a mutable channel directory as the bundle identity would be convenient
+for humans but would prevent safe retries and verifiable agent handoffs; channel
+is therefore descriptor metadata rather than an output-path key.
+
+The preparation result is `metadataEligible`; there is deliberately no generic
+`eligible` or `installable` boolean. Inspection and the persisted descriptor
+separately report profile CMS integrity, Apple profile trust, and the scoped
+`complete-main-app-code-resources-entitlements-and-profile-certificate-binding`
+verification. On macOS the
+complete main app is safely materialized into private bounded staging,
+`codesign --deep --strict` verifies its resource envelope and nested code, and
+each architecture's leaf signer certificate must occur in the embedded profile.
+Signed team, application identifier, debugging state, and other entitlements
+must be permitted by that profile. This does not claim project-wide verification
+when embedded targets exist; those IPAs remain blocked. Profile trust requires
+the expected Apple provisioning signer and a chain to an exact pinned Apple
+root. The verifier does not use the host root store and fails closed when a
+recognized root is not carried in the CMS; supporting a newly introduced Apple
+root requires a CLI update. CMS signature integrity alone is not Apple
+authenticity. `prepare` refuses to write unless profile integrity, Apple trust,
+and the exact complete-main-app signature scope are all `verified`.
+
+Profile certificate fingerprints are explicitly named
+`profileCertificateSha256Fingerprints`: they prove which certificates the
+embedded profile permits, not which identity signed the IPA. An IPA containing
+extensions, watch apps, or App Clips reports those target metadata paths but is
+not marked eligible in this change; a later signing slice must validate every
+target/profile pair before preparation claims project-wide readiness.
+
+IPA processing is copied once from the already-open input into a private
+snapshot so parsing, hashing, and publishing bind the same bytes. It is capped
+at 8 GiB before ZIP parsing; selected metadata and the complete materialized
+main app have expanded-size limits. Provenance text, IPA metadata, and ZIP member names are
+bounded and reject control, Unicode format, and bidirectional-control characters.
+`--source-url` must
+be an absolute HTTPS URL with no user information, query, or fragment so a
+deterministic descriptor cannot become a credential or signed-URL sink.
+
+This boundary matches current production patterns without inheriting their
+storage implementation: Blockstream separates local caller-URL bundle
+generation from upload; Mattermost uses immutable PR, merge, and commit object
+paths; Onym records structured build metadata and caps its index; ipa-server
+generates the complete web-install surface across providers. Retention,
+encryption, serialization, immutable object keys, channel indexes, comments,
+and final install URLs remain publishing concerns rather than local preparation
+concerns.
 
 ## Placement and current behavior
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudrankriyam/App-Store-Connect-CLI
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/1Password/srp v0.2.0

--- a/internal/cli/cmdtest/distribute_test.go
+++ b/internal/cli/cmdtest/distribute_test.go
@@ -6,17 +6,16 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
 	"errors"
 	"flag"
-	"fmt"
 	"io"
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -81,8 +80,15 @@ func TestDistributeInspectJSONPrivacyAndExplicitDisclosure(t *testing.T) {
 	if !result.Preparation.MetadataEligible || result.Signing.DeviceCount != 1 || result.App.BundleID != "com.example.demo" {
 		t.Fatalf("unexpected inspection: %#v", result)
 	}
-	if result.Signing.CodeSignatureVerification.Status != distribution.CodeSignatureInvalid {
+	wantCodeSignatureStatus := distribution.CodeSignatureInvalid
+	if runtime.GOOS != "darwin" {
+		wantCodeSignatureStatus = distribution.CodeSignatureNotVerified
+	}
+	if result.Signing.CodeSignatureVerification.Status != wantCodeSignatureStatus {
 		t.Fatalf("unexpected signer verification: %#v", result.Signing.CodeSignatureVerification)
+	}
+	if runtime.GOOS != "darwin" && result.Signing.CodeSignatureVerification.Reason != "complete main-app code-signature verification is available only on macOS" {
+		t.Fatalf("unexpected portable signer verification: %#v", result.Signing.CodeSignatureVerification)
 	}
 
 	stdout, stderr, runErr = runRootCommand(t, []string{"distribute", "inspect", "--ipa", ipa, "--include-devices", "--output", "json"})
@@ -96,19 +102,23 @@ func TestDistributeInspectJSONPrivacyAndExplicitDisclosure(t *testing.T) {
 
 func TestDistributeInspectTableAndMarkdownDeviceDisclosure(t *testing.T) {
 	ipa := writeDistributionIPA(t, "private-device-udid")
-	ipaData, err := os.ReadFile(ipa)
-	if err != nil {
-		t.Fatal(err)
-	}
-	digest := fmt.Sprintf("%x", sha256.Sum256(ipaData))
 	for _, format := range []string{"table", "markdown"} {
 		t.Run(format, func(t *testing.T) {
 			stdout, stderr, runErr := runRootCommand(t, []string{"distribute", "inspect", "--ipa", ipa, "--output", format})
 			if runErr != nil || stderr != "" {
 				t.Fatalf("run error=%v stderr=%q", runErr, stderr)
 			}
-			if want := expectedDistributeInspectHumanOutput(format, digest, false); stdout != want {
-				t.Fatalf("default %s output:\n%s\nwant:\n%s", format, stdout, want)
+			rows := parseDistributeInspectHumanRows(t, format, stdout)
+			if rows["Bundle ID"] != "com.example.demo" || rows["Devices"] != "1" {
+				t.Fatalf("unexpected default %s rows: %#v", format, rows)
+			}
+			if value, exists := rows["Device UDIDs"]; exists {
+				t.Fatalf("default %s output disclosed Device UDIDs row %q: %#v", format, value, rows)
+			}
+			for field, value := range rows {
+				if strings.Contains(value, "private-device-udid") {
+					t.Fatalf("default %s output leaked UDID in %q row: %#v", format, field, rows)
+				}
 			}
 
 			stdout, stderr, runErr = runRootCommand(t, []string{
@@ -117,51 +127,38 @@ func TestDistributeInspectTableAndMarkdownDeviceDisclosure(t *testing.T) {
 			if runErr != nil || stderr != "" {
 				t.Fatalf("run with --include-devices error=%v stderr=%q", runErr, stderr)
 			}
-			if want := expectedDistributeInspectHumanOutput(format, digest, true); stdout != want {
-				t.Fatalf("public %s output:\n%s\nwant:\n%s", format, stdout, want)
+			rows = parseDistributeInspectHumanRows(t, format, stdout)
+			if rows["Devices"] != "1" || rows["Device UDIDs"] != "private-device-udid" {
+				t.Fatalf("public %s output omitted exact Device UDIDs row: %#v", format, rows)
 			}
 		})
 	}
 }
 
-func expectedDistributeInspectHumanOutput(format, digest string, includeDevices bool) string {
-	rows := [][]string{
-		{"Metadata Eligible", "true"},
-		{"Code Signature", "invalid"},
-		{"Profile Integrity", "verified"},
-		{"Profile Trust", "invalid"},
-		{"Bundle ID", "com.example.demo"},
-		{"Title", "Demo"},
-		{"Version", "1.0"},
-		{"Build", "7"},
-		{"Profile Class", "ad-hoc"},
-		{"Profile UUID", "fixture-profile"},
-		{"Team ID", "TEAM123"},
-		{"Devices", "1"},
-	}
-	if includeDevices {
-		rows = append(rows, []string{"Device UDIDs", "private-device-udid"})
-	}
-	rows = append(rows, []string{"IPA SHA-256", digest}, []string{"Issues", ""})
-
-	var output strings.Builder
+func parseDistributeInspectHumanRows(t *testing.T, format, output string) map[string]string {
+	t.Helper()
+	delimiter := "│"
 	if format == "markdown" {
-		output.WriteString("| Field             | Value                                                            |\n")
-		output.WriteString("|:------------------|:-----------------------------------------------------------------|\n")
-		for _, row := range rows {
-			fmt.Fprintf(&output, "| %-17s | %-64s |\n", row[0], row[1])
+		delimiter = "|"
+	}
+	rows := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, delimiter) || !strings.HasSuffix(line, delimiter) {
+			continue
 		}
-		return output.String()
+		cells := strings.Split(strings.Trim(line, delimiter), delimiter)
+		if len(cells) != 2 {
+			t.Fatalf("malformed %s row %q", format, line)
+		}
+		field := strings.TrimSpace(cells[0])
+		value := strings.TrimSpace(cells[1])
+		if field == "Field" || strings.HasPrefix(field, ":-") {
+			continue
+		}
+		rows[field] = value
 	}
-
-	output.WriteString("┌───────────────────┬──────────────────────────────────────────────────────────────────┐\n")
-	output.WriteString("│       Field       │                              Value                               │\n")
-	output.WriteString("├───────────────────┼──────────────────────────────────────────────────────────────────┤\n")
-	for _, row := range rows {
-		fmt.Fprintf(&output, "│ %-17s │ %-64s │\n", row[0], row[1])
-	}
-	output.WriteString("└───────────────────┴──────────────────────────────────────────────────────────────────┘\n")
-	return output.String()
+	return rows
 }
 
 func TestDistributePrepareFailsClosedForUnverifiedFixture(t *testing.T) {

--- a/internal/cli/cmdtest/distribute_test.go
+++ b/internal/cli/cmdtest/distribute_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -92,19 +94,74 @@ func TestDistributeInspectJSONPrivacyAndExplicitDisclosure(t *testing.T) {
 	}
 }
 
-func TestDistributeInspectTableAndMarkdown(t *testing.T) {
-	ipa := writeDistributionIPA(t, "device")
+func TestDistributeInspectTableAndMarkdownDeviceDisclosure(t *testing.T) {
+	ipa := writeDistributionIPA(t, "private-device-udid")
+	ipaData, err := os.ReadFile(ipa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := fmt.Sprintf("%x", sha256.Sum256(ipaData))
 	for _, format := range []string{"table", "markdown"} {
 		t.Run(format, func(t *testing.T) {
 			stdout, stderr, runErr := runRootCommand(t, []string{"distribute", "inspect", "--ipa", ipa, "--output", format})
 			if runErr != nil || stderr != "" {
 				t.Fatalf("run error=%v stderr=%q", runErr, stderr)
 			}
-			if !strings.Contains(stdout, "Bundle ID") || !strings.Contains(stdout, "com.example.demo") {
-				t.Fatalf("unexpected %s: %s", format, stdout)
+			if want := expectedDistributeInspectHumanOutput(format, digest, false); stdout != want {
+				t.Fatalf("default %s output:\n%s\nwant:\n%s", format, stdout, want)
+			}
+
+			stdout, stderr, runErr = runRootCommand(t, []string{
+				"distribute", "inspect", "--ipa", ipa, "--include-devices", "--output", format,
+			})
+			if runErr != nil || stderr != "" {
+				t.Fatalf("run with --include-devices error=%v stderr=%q", runErr, stderr)
+			}
+			if want := expectedDistributeInspectHumanOutput(format, digest, true); stdout != want {
+				t.Fatalf("public %s output:\n%s\nwant:\n%s", format, stdout, want)
 			}
 		})
 	}
+}
+
+func expectedDistributeInspectHumanOutput(format, digest string, includeDevices bool) string {
+	rows := [][]string{
+		{"Metadata Eligible", "true"},
+		{"Code Signature", "invalid"},
+		{"Profile Integrity", "verified"},
+		{"Profile Trust", "invalid"},
+		{"Bundle ID", "com.example.demo"},
+		{"Title", "Demo"},
+		{"Version", "1.0"},
+		{"Build", "7"},
+		{"Profile Class", "ad-hoc"},
+		{"Profile UUID", "fixture-profile"},
+		{"Team ID", "TEAM123"},
+		{"Devices", "1"},
+	}
+	if includeDevices {
+		rows = append(rows, []string{"Device UDIDs", "private-device-udid"})
+	}
+	rows = append(rows, []string{"IPA SHA-256", digest}, []string{"Issues", ""})
+
+	var output strings.Builder
+	if format == "markdown" {
+		output.WriteString("| Field             | Value                                                            |\n")
+		output.WriteString("|:------------------|:-----------------------------------------------------------------|\n")
+		for _, row := range rows {
+			fmt.Fprintf(&output, "| %-17s | %-64s |\n", row[0], row[1])
+		}
+		return output.String()
+	}
+
+	output.WriteString("┌───────────────────┬──────────────────────────────────────────────────────────────────┐\n")
+	output.WriteString("│       Field       │                              Value                               │\n")
+	output.WriteString("├───────────────────┼──────────────────────────────────────────────────────────────────┤\n")
+	for _, row := range rows {
+		fmt.Fprintf(&output, "│ %-17s │ %-64s │\n", row[0], row[1])
+	}
+	output.WriteString("└───────────────────┴──────────────────────────────────────────────────────────────────┘\n")
+	return output.String()
 }
 
 func TestDistributePrepareFailsClosedForUnverifiedFixture(t *testing.T) {

--- a/internal/cli/cmdtest/distribute_test.go
+++ b/internal/cli/cmdtest/distribute_test.go
@@ -1,0 +1,219 @@
+package cmdtest
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mozilla.org/pkcs7"
+	"howett.net/plist"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/distribution"
+)
+
+func TestDistributeCommandsAreRegisteredWithAgentOrientedFlags(t *testing.T) {
+	root := RootCommand("1.2.3")
+	inspect := findSubcommand(root, "distribute", "inspect")
+	prepare := findSubcommand(root, "distribute", "prepare")
+	if inspect == nil || prepare == nil {
+		t.Fatalf("distribute commands missing: inspect=%v prepare=%v", inspect, prepare)
+	}
+	for _, name := range []string{"ipa", "include-devices", "output"} {
+		if inspect.FlagSet.Lookup(name) == nil {
+			t.Errorf("inspect --%s missing", name)
+		}
+	}
+	for _, name := range []string{"ipa", "output-dir", "title", "channel", "source-revision", "source-url", "output"} {
+		if prepare.FlagSet.Lookup(name) == nil {
+			t.Errorf("prepare --%s missing", name)
+		}
+	}
+}
+
+func TestDistributeInspectRequiresIPAAndRejectsInvalidOutput(t *testing.T) {
+	assertUsageExit(t, []string{"distribute", "inspect"}, "--ipa is required")
+	assertUsageExit(t, []string{"distribute", "inspect", "--ipa", "missing.ipa", "--output", "yaml"}, "unsupported format")
+	assertUsageExit(t, []string{"distribute", "inspect", "unexpected", "--ipa", "missing.ipa"}, "does not accept positional arguments")
+}
+
+func TestDistributePrepareRejectsCredentialSourceURLBeforeFilesystemAccess(t *testing.T) {
+	assertUsageExit(t, []string{
+		"distribute", "prepare", "--ipa", "missing.ipa", "--source-url", "https://token@example.com/revision",
+	}, "user information is not allowed")
+	assertUsageExit(t, []string{
+		"distribute", "prepare", "--ipa", "missing.ipa", "--source-url", "https://example.com/revision?token=secret",
+	}, "query and fragment are not allowed")
+	assertUsageExit(t, []string{"distribute", "prepare", "unexpected", "--ipa", "missing.ipa"}, "does not accept positional arguments")
+}
+
+func TestDistributeInspectJSONPrivacyAndExplicitDisclosure(t *testing.T) {
+	ipa := writeDistributionIPA(t, "private-device-udid")
+	stdout, stderr, runErr := runRootCommand(t, []string{"distribute", "inspect", "--output", "json", "--ipa", ipa})
+	if runErr != nil {
+		t.Fatalf("run error = %v; stderr=%s", runErr, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if strings.Contains(stdout, "private-device-udid") {
+		t.Fatalf("default inspect leaked UDID: %s", stdout)
+	}
+	var result distribution.Inspection
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if !result.Preparation.MetadataEligible || result.Signing.DeviceCount != 1 || result.App.BundleID != "com.example.demo" {
+		t.Fatalf("unexpected inspection: %#v", result)
+	}
+	if result.Signing.CodeSignatureVerification.Status != distribution.CodeSignatureInvalid {
+		t.Fatalf("unexpected signer verification: %#v", result.Signing.CodeSignatureVerification)
+	}
+
+	stdout, stderr, runErr = runRootCommand(t, []string{"distribute", "inspect", "--ipa", ipa, "--include-devices", "--output", "json"})
+	if runErr != nil || stderr != "" {
+		t.Fatalf("run error=%v stderr=%q", runErr, stderr)
+	}
+	if !strings.Contains(stdout, "private-device-udid") {
+		t.Fatalf("explicit inspect omitted UDID: %s", stdout)
+	}
+}
+
+func TestDistributeInspectTableAndMarkdown(t *testing.T) {
+	ipa := writeDistributionIPA(t, "device")
+	for _, format := range []string{"table", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			stdout, stderr, runErr := runRootCommand(t, []string{"distribute", "inspect", "--ipa", ipa, "--output", format})
+			if runErr != nil || stderr != "" {
+				t.Fatalf("run error=%v stderr=%q", runErr, stderr)
+			}
+			if !strings.Contains(stdout, "Bundle ID") || !strings.Contains(stdout, "com.example.demo") {
+				t.Fatalf("unexpected %s: %s", format, stdout)
+			}
+		})
+	}
+}
+
+func TestDistributePrepareFailsClosedForUnverifiedFixture(t *testing.T) {
+	ipa := writeDistributionIPA(t, "private-device-udid")
+	outputDir := filepath.Join(t.TempDir(), "bundle")
+	args := []string{
+		"distribute", "prepare", "--ipa", ipa, "--output-dir", outputDir,
+		"--title", "Preview", "--channel", "pull-request-7", "--source-revision", "abcdef", "--output", "json",
+	}
+	stdout, stderr, runErr := runRootCommand(t, args)
+	if runErr == nil || !strings.Contains(runErr.Error(), "complete main-app signature verification") {
+		t.Fatalf("run error=%v stderr=%q", runErr, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout=%q", stdout)
+	}
+	if _, err := os.Stat(outputDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unverified prepare created output: %v", err)
+	}
+}
+
+func TestDistributeInspectRejectsSymlinkIPA(t *testing.T) {
+	ipa := writeDistributionIPA(t, "device")
+	link := filepath.Join(t.TempDir(), "linked.ipa")
+	if err := os.Symlink(ipa, link); err != nil {
+		t.Fatal(err)
+	}
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"distribute", "inspect", "--ipa", link, "--output", "json"}); err != nil {
+			t.Fatal(err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil || errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected runtime symlink error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func writeDistributionIPA(t *testing.T, device string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Add(-time.Hour)
+	template := &x509.Certificate{SerialNumber: big.NewInt(7), Subject: pkix.Name{CommonName: "Fixture"}, NotBefore: now, NotAfter: now.Add(365 * 24 * time.Hour), KeyUsage: x509.KeyUsageDigitalSignature}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profilePlist, err := plist.Marshal(map[string]any{
+		"UUID": "fixture-profile", "TeamIdentifier": []string{"TEAM123"}, "ApplicationIdentifierPrefix": []string{"SEED123"},
+		"Platform":           []string{"iOS", "visionOS"},
+		"ProvisionedDevices": []string{device}, "ExpirationDate": now.Add(48 * time.Hour), "DeveloperCertificates": [][]byte{der},
+		"Entitlements": map[string]any{"application-identifier": "SEED123.com.example.demo", "com.apple.developer.team-identifier": "TEAM123", "get-task-allow": false},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed, err := pkcs7.NewSignedData(profilePlist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := signed.AddSigner(cert, key, pkcs7.SignerInfoConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	profile, err := signed.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	infoPlist, err := plist.Marshal(map[string]any{
+		"CFBundleIdentifier": "com.example.demo", "CFBundleDisplayName": "Demo", "CFBundleShortVersionString": "1.0", "CFBundleVersion": "7", "MinimumOSVersion": "17.0",
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "App.ipa")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := zip.NewWriter(file)
+	for name, data := range map[string][]byte{
+		"Payload/Demo.app/Info.plist":               infoPlist,
+		"Payload/Demo.app/embedded.mobileprovision": profile,
+	} {
+		entry, err := archive.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/cli/cmdtest/distribute_test.go
+++ b/internal/cli/cmdtest/distribute_test.go
@@ -250,6 +250,7 @@ func writeDistributionIPA(t *testing.T, device string) string {
 	}
 	infoPlist, err := plist.Marshal(map[string]any{
 		"CFBundleIdentifier": "com.example.demo", "CFBundleDisplayName": "Demo", "CFBundleShortVersionString": "1.0", "CFBundleVersion": "7", "MinimumOSVersion": "17.0",
+		"DTPlatformName": "iphoneos", "CFBundleSupportedPlatforms": []string{"iPhoneOS"},
 	}, plist.XMLFormat)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/cmdtest/distribute_test.go
+++ b/internal/cli/cmdtest/distribute_test.go
@@ -58,6 +58,9 @@ func TestDistributePrepareRejectsCredentialSourceURLBeforeFilesystemAccess(t *te
 	assertUsageExit(t, []string{
 		"distribute", "prepare", "--ipa", "missing.ipa", "--source-url", "https://example.com/revision?token=secret",
 	}, "query and fragment are not allowed")
+	assertUsageExit(t, []string{
+		"distribute", "prepare", "--ipa", "missing.ipa", "--source-url", "https://:443/path",
+	}, "must be an absolute HTTPS URL")
 	assertUsageExit(t, []string{"distribute", "prepare", "unexpected", "--ipa", "missing.ipa"}, "does not accept positional arguments")
 }
 
@@ -80,10 +83,7 @@ func TestDistributeInspectJSONPrivacyAndExplicitDisclosure(t *testing.T) {
 	if !result.Preparation.MetadataEligible || result.Signing.DeviceCount != 1 || result.App.BundleID != "com.example.demo" {
 		t.Fatalf("unexpected inspection: %#v", result)
 	}
-	wantCodeSignatureStatus := distribution.CodeSignatureInvalid
-	if runtime.GOOS != "darwin" {
-		wantCodeSignatureStatus = distribution.CodeSignatureNotVerified
-	}
+	wantCodeSignatureStatus := expectedDistributionFixtureCodeSignatureStatus()
 	if result.Signing.CodeSignatureVerification.Status != wantCodeSignatureStatus {
 		t.Fatalf("unexpected signer verification: %#v", result.Signing.CodeSignatureVerification)
 	}
@@ -109,7 +109,9 @@ func TestDistributeInspectTableAndMarkdownDeviceDisclosure(t *testing.T) {
 				t.Fatalf("run error=%v stderr=%q", runErr, stderr)
 			}
 			rows := parseDistributeInspectHumanRows(t, format, stdout)
-			if rows["Bundle ID"] != "com.example.demo" || rows["Devices"] != "1" {
+			if rows["Bundle ID"] != "com.example.demo" ||
+				rows["Code Signature"] != string(expectedDistributionFixtureCodeSignatureStatus()) ||
+				rows["Devices"] != "1" {
 				t.Fatalf("unexpected default %s rows: %#v", format, rows)
 			}
 			if value, exists := rows["Device UDIDs"]; exists {
@@ -133,6 +135,13 @@ func TestDistributeInspectTableAndMarkdownDeviceDisclosure(t *testing.T) {
 			}
 		})
 	}
+}
+
+func expectedDistributionFixtureCodeSignatureStatus() distribution.CodeSignatureVerificationStatus {
+	if runtime.GOOS == "darwin" {
+		return distribution.CodeSignatureInvalid
+	}
+	return distribution.CodeSignatureNotVerified
 }
 
 func parseDistributeInspectHumanRows(t *testing.T, format, output string) map[string]string {

--- a/internal/cli/cmdtest/distribute_test.go
+++ b/internal/cli/cmdtest/distribute_test.go
@@ -93,7 +93,7 @@ func TestDistributeInspectJSONPrivacyAndExplicitDisclosure(t *testing.T) {
 }
 
 func TestDistributeInspectTableAndMarkdown(t *testing.T) {
-	ipa := writeDistributionIPA(t, "device")
+	ipa := writeDistributionIPA(t, "private-device-udid")
 	for _, format := range []string{"table", "markdown"} {
 		t.Run(format, func(t *testing.T) {
 			stdout, stderr, runErr := runRootCommand(t, []string{"distribute", "inspect", "--ipa", ipa, "--output", format})
@@ -102,6 +102,19 @@ func TestDistributeInspectTableAndMarkdown(t *testing.T) {
 			}
 			if !strings.Contains(stdout, "Bundle ID") || !strings.Contains(stdout, "com.example.demo") {
 				t.Fatalf("unexpected %s: %s", format, stdout)
+			}
+			if strings.Contains(stdout, "private-device-udid") {
+				t.Fatalf("default %s inspect leaked UDID: %s", format, stdout)
+			}
+
+			stdout, stderr, runErr = runRootCommand(t, []string{
+				"distribute", "inspect", "--ipa", ipa, "--include-devices", "--output", format,
+			})
+			if runErr != nil || stderr != "" {
+				t.Fatalf("include devices run error=%v stderr=%q", runErr, stderr)
+			}
+			if !strings.Contains(stdout, "private-device-udid") {
+				t.Fatalf("explicit %s inspect omitted UDID: %s", format, stdout)
 			}
 		})
 	}

--- a/internal/cli/distribute/distribute.go
+++ b/internal/cli/distribute/distribute.go
@@ -79,7 +79,7 @@ Examples:
 				return fmt.Errorf("distribute inspect: %w", err)
 			}
 			defer file.Close()
-			result, err := distribution.InspectIPA(file, size, distribution.InspectOptions{IncludeDevices: *includeDevices})
+			result, err := distribution.InspectIPAContext(ctx, file, size, distribution.InspectOptions{IncludeDevices: *includeDevices})
 			if err != nil {
 				return fmt.Errorf("distribute inspect: %w", err)
 			}
@@ -146,7 +146,7 @@ Examples:
 			defer file.Close()
 			prepareOptions.Root = root
 			prepareOptions.OutputDir = relativeOutput
-			result, err := distribution.PrepareIPA(file, size, prepareOptions)
+			result, err := distribution.PrepareIPAContext(ctx, file, size, prepareOptions)
 			if err != nil {
 				return fmt.Errorf("distribute prepare: %w", err)
 			}

--- a/internal/cli/distribute/distribute.go
+++ b/internal/cli/distribute/distribute.go
@@ -65,6 +65,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if len(args) != 0 {
 				return shared.UsageError("distribute inspect does not accept positional arguments")
 			}
@@ -79,9 +82,12 @@ Examples:
 				return fmt.Errorf("distribute inspect: %w", err)
 			}
 			defer file.Close()
-			result, err := distribution.InspectIPA(file, size, distribution.InspectOptions{IncludeDevices: *includeDevices})
+			result, err := distribution.InspectIPAContext(ctx, file, size, distribution.InspectOptions{IncludeDevices: *includeDevices})
 			if err != nil {
 				return fmt.Errorf("distribute inspect: %w", err)
+			}
+			if err := ctx.Err(); err != nil {
+				return err
 			}
 			return printInspection(result, *output.Output, *output.Pretty)
 		},
@@ -120,6 +126,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if len(args) != 0 {
 				return shared.UsageError("distribute prepare does not accept positional arguments")
 			}
@@ -146,9 +155,12 @@ Examples:
 			defer file.Close()
 			prepareOptions.Root = root
 			prepareOptions.OutputDir = relativeOutput
-			result, err := distribution.PrepareIPA(file, size, prepareOptions)
+			result, err := distribution.PrepareIPAContext(ctx, file, size, prepareOptions)
 			if err != nil {
 				return fmt.Errorf("distribute prepare: %w", err)
+			}
+			if err := ctx.Err(); err != nil {
+				return err
 			}
 			return printPrepareResult(result, *output.Output, *output.Pretty)
 		},
@@ -164,6 +176,7 @@ func openIPA(pathValue string) (*os.File, int64, error) {
 	if err != nil {
 		return nil, 0, fmt.Errorf("open IPA root: %w", err)
 	}
+	defer root.Close()
 	file, err := root.OpenFile(filepath.Base(absolute))
 	if err != nil {
 		return nil, 0, fmt.Errorf("open IPA: %w", err)

--- a/internal/cli/distribute/distribute.go
+++ b/internal/cli/distribute/distribute.go
@@ -231,7 +231,7 @@ func renderInspection(result distribution.Inspection, markdown bool) error {
 	if markdown {
 		render = asc.RenderMarkdown
 	}
-	render([]string{"Field", "Value"}, [][]string{
+	rows := [][]string{
 		{"Metadata Eligible", fmt.Sprintf("%t", result.Preparation.MetadataEligible)},
 		{"Code Signature", string(result.Signing.CodeSignatureVerification.Status)},
 		{"Profile Integrity", string(result.Signing.ProfileIntegrityVerification.Status)},
@@ -244,9 +244,16 @@ func renderInspection(result distribution.Inspection, markdown bool) error {
 		{"Profile UUID", result.Signing.ProfileUUID},
 		{"Team ID", result.Signing.TeamID},
 		{"Devices", fmt.Sprintf("%d", result.Signing.DeviceCount)},
-		{"IPA SHA-256", result.Artifact.SHA256},
-		{"Issues", strings.Join(result.Preparation.Issues, "; ")},
-	})
+	}
+	if len(result.Signing.Devices) > 0 {
+		rows = append(rows, []string{"Device UDIDs", strings.Join(result.Signing.Devices, ", ")})
+	}
+	rows = append(
+		rows,
+		[]string{"IPA SHA-256", result.Artifact.SHA256},
+		[]string{"Issues", strings.Join(result.Preparation.Issues, "; ")},
+	)
+	render([]string{"Field", "Value"}, rows)
 	return nil
 }
 

--- a/internal/cli/distribute/distribute.go
+++ b/internal/cli/distribute/distribute.go
@@ -1,0 +1,275 @@
+package distribute
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/distribution"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+)
+
+// DistributeCommand returns the experimental local distribution command group.
+func DistributeCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("distribute", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "distribute",
+		ShortUsage: "asc distribute <subcommand> [flags]",
+		ShortHelp:  "Inspect and prepare local iOS distribution artifacts. [experimental]",
+		LongHelp: `Inspect and prepare provider-neutral iOS release-testing artifacts.
+
+This experimental command family performs local, deterministic work only. It
+does not access App Store Connect, a keychain, a storage provider, or a network.
+
+Examples:
+  asc distribute inspect --ipa "./App.ipa" --output json
+  asc distribute prepare --ipa "./App.ipa" --channel "pull-request-42"`,
+		FlagSet: fs,
+		Subcommands: []*ffcli.Command{
+			inspectCommand(),
+			prepareCommand(),
+		},
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec:      func(context.Context, []string) error { return flag.ErrHelp },
+	}
+}
+
+func inspectCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("inspect", flag.ExitOnError)
+	ipaPath := fs.String("ipa", "", "Path to the IPA to inspect")
+	includeDevices := fs.Bool("include-devices", false, "Include raw registered-device UDIDs in inspection output")
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name:       "inspect",
+		ShortUsage: "asc distribute inspect --ipa PATH [--include-devices] [flags]",
+		ShortHelp:  "Inspect an IPA for release-testing distribution readiness.",
+		LongHelp: `Inspect an IPA without persistent extraction or access to Apple services.
+
+Verification uses bounded private temporary materialization and removes it when
+the command exits.
+
+Raw device UDIDs are omitted by default. Use --include-devices only when the
+consumer explicitly needs the registered-device list.
+
+Examples:
+  asc distribute inspect --ipa "./App.ipa"
+  asc distribute inspect --ipa "./App.ipa" --include-devices --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) != 0 {
+				return shared.UsageError("distribute inspect does not accept positional arguments")
+			}
+			if strings.TrimSpace(*ipaPath) == "" {
+				return shared.UsageError("--ipa is required")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			file, size, err := openIPA(*ipaPath)
+			if err != nil {
+				return fmt.Errorf("distribute inspect: %w", err)
+			}
+			defer file.Close()
+			result, err := distribution.InspectIPA(file, size, distribution.InspectOptions{IncludeDevices: *includeDevices})
+			if err != nil {
+				return fmt.Errorf("distribute inspect: %w", err)
+			}
+			return printInspection(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func prepareCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("prepare", flag.ExitOnError)
+	ipaPath := fs.String("ipa", "", "Path to the IPA to prepare")
+	outputDir := fs.String("output-dir", "", "Exact output bundle directory (default: deterministic path under .asc/distribution)")
+	title := fs.String("title", "", "Override the app title in bundle metadata")
+	channel := fs.String("channel", "", "Logical build channel recorded as provenance")
+	sourceRevision := fs.String("source-revision", "", "Source revision recorded as provenance")
+	sourceURL := fs.String("source-url", "", "Absolute HTTPS source URL without credentials")
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name:       "prepare",
+		ShortUsage: "asc distribute prepare --ipa PATH [--output-dir DIR] [flags]",
+		ShortHelp:  "Prepare an immutable provider-neutral distribution bundle.",
+		LongHelp: `Prepare a metadata-valid ad hoc IPA as bundle.json plus payload/app.ipa.
+
+The command records separate bounded checks for provisioning-profile CMS
+integrity, Apple profile trust, and the main executable's signature/profile
+certificate binding. On macOS it verifies the complete main app, nested code,
+resource seal, signed entitlements, and signer/profile certificate binding.
+Preparation fails closed before writing unless every required check is verified.
+
+The command never overwrites a bundle. An exactly equivalent destination is
+reused; any incomplete or different destination is a conflict. No install URL,
+web page, object-store credential, or raw device UDID is written.
+
+Examples:
+  asc distribute prepare --ipa "./App.ipa"
+  asc distribute prepare --ipa "./App.ipa" --channel "pull-request-42" --source-revision "abc123"
+  asc distribute prepare --ipa "./App.ipa" --output-dir "./artifacts/install-bundle"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) != 0 {
+				return shared.UsageError("distribute prepare does not accept positional arguments")
+			}
+			if strings.TrimSpace(*ipaPath) == "" {
+				return shared.UsageError("--ipa is required")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			prepareOptions := distribution.PrepareOptions{
+				Title: *title, Channel: *channel, SourceRevision: *sourceRevision, SourceURL: *sourceURL,
+			}
+			if err := distribution.ValidatePrepareOptions(prepareOptions); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			root, relativeOutput, err := resolveOutput(*outputDir)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			file, size, err := openIPA(*ipaPath)
+			if err != nil {
+				return fmt.Errorf("distribute prepare: %w", err)
+			}
+			defer file.Close()
+			prepareOptions.Root = root
+			prepareOptions.OutputDir = relativeOutput
+			result, err := distribution.PrepareIPA(file, size, prepareOptions)
+			if err != nil {
+				return fmt.Errorf("distribute prepare: %w", err)
+			}
+			return printPrepareResult(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func openIPA(pathValue string) (*os.File, int64, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(pathValue))
+	if err != nil {
+		return nil, 0, fmt.Errorf("resolve IPA path: %w", err)
+	}
+	root, err := rootfs.New(filepath.Dir(absolute))
+	if err != nil {
+		return nil, 0, fmt.Errorf("open IPA root: %w", err)
+	}
+	file, err := root.OpenFile(filepath.Base(absolute))
+	if err != nil {
+		return nil, 0, fmt.Errorf("open IPA: %w", err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("inspect IPA: %w", err)
+	}
+	return file, info.Size(), nil
+}
+
+func resolveOutput(requested string) (string, string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		cwd, err := os.Getwd()
+		return cwd, "", err
+	}
+	if !filepath.IsAbs(requested) {
+		if err := rootfs.ValidateRelative(requested); err != nil {
+			return "", "", fmt.Errorf("invalid --output-dir: %w", err)
+		}
+		cwd, err := os.Getwd()
+		return cwd, filepath.Clean(requested), err
+	}
+	absolute := filepath.Clean(requested)
+	ancestor := filepath.Dir(absolute)
+	for {
+		info, err := os.Lstat(ancestor)
+		if err == nil {
+			if !info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+				return "", "", fmt.Errorf("invalid --output-dir: existing parent %q is not a directory", ancestor)
+			}
+			physical, err := filepath.EvalSymlinks(ancestor)
+			if err != nil {
+				return "", "", fmt.Errorf("resolve --output-dir parent: %w", err)
+			}
+			relative, err := filepath.Rel(ancestor, absolute)
+			if err != nil {
+				return "", "", fmt.Errorf("resolve --output-dir: %w", err)
+			}
+			return physical, relative, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", "", fmt.Errorf("inspect --output-dir parent: %w", err)
+		}
+		next := filepath.Dir(ancestor)
+		if next == ancestor {
+			return "", "", fmt.Errorf("invalid --output-dir: no existing parent")
+		}
+		ancestor = next
+	}
+}
+
+func printInspection(result distribution.Inspection, format string, pretty bool) error {
+	return shared.PrintOutputWithRenderers(
+		result, format, pretty,
+		func() error { return renderInspection(result, false) },
+		func() error { return renderInspection(result, true) },
+	)
+}
+
+func renderInspection(result distribution.Inspection, markdown bool) error {
+	render := asc.RenderTable
+	if markdown {
+		render = asc.RenderMarkdown
+	}
+	render([]string{"Field", "Value"}, [][]string{
+		{"Metadata Eligible", fmt.Sprintf("%t", result.Preparation.MetadataEligible)},
+		{"Code Signature", string(result.Signing.CodeSignatureVerification.Status)},
+		{"Profile Integrity", string(result.Signing.ProfileIntegrityVerification.Status)},
+		{"Profile Trust", string(result.Signing.ProfileTrustVerification.Status)},
+		{"Bundle ID", result.App.BundleID},
+		{"Title", result.App.Title},
+		{"Version", result.App.Version},
+		{"Build", result.App.BuildNumber},
+		{"Profile Class", string(result.Signing.ProfileClass)},
+		{"Profile UUID", result.Signing.ProfileUUID},
+		{"Team ID", result.Signing.TeamID},
+		{"Devices", fmt.Sprintf("%d", result.Signing.DeviceCount)},
+		{"IPA SHA-256", result.Artifact.SHA256},
+		{"Issues", strings.Join(result.Preparation.Issues, "; ")},
+	})
+	return nil
+}
+
+func printPrepareResult(result distribution.PrepareResult, format string, pretty bool) error {
+	return shared.PrintOutputWithRenderers(
+		result, format, pretty,
+		func() error { return renderPrepareResult(result, false) },
+		func() error { return renderPrepareResult(result, true) },
+	)
+}
+
+func renderPrepareResult(result distribution.PrepareResult, markdown bool) error {
+	render := asc.RenderTable
+	if markdown {
+		render = asc.RenderMarkdown
+	}
+	render([]string{"Field", "Value"}, [][]string{
+		{"Bundle Path", result.BundlePath},
+		{"Reused", fmt.Sprintf("%t", result.Reused)},
+		{"Bundle ID", result.Descriptor.App.BundleID},
+		{"Version", result.Descriptor.App.Version},
+		{"Build", result.Descriptor.App.BuildNumber},
+		{"IPA SHA-256", result.Descriptor.Artifact.SHA256},
+	})
+	return nil
+}

--- a/internal/cli/distribute/distribute_test.go
+++ b/internal/cli/distribute/distribute_test.go
@@ -1,9 +1,13 @@
 package distribute
 
 import (
+	"context"
+	"errors"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/distribution"
 )
@@ -132,6 +136,24 @@ func TestRenderInspectionDeviceDisclosure(t *testing.T) {
 			})
 			if output != test.wantPrivate {
 				t.Fatalf("private %s renderer output:\n%s\nwant:\n%s", test.name, output, test.wantPrivate)
+			}
+		})
+	}
+}
+
+func TestDistributionCommandsHonorAlreadyCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for _, command := range []struct {
+		name string
+		cmd  *ffcli.Command
+	}{
+		{name: "inspect", cmd: inspectCommand()},
+		{name: "prepare", cmd: prepareCommand()},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			if err := command.cmd.Exec(ctx, nil); !errors.Is(err, context.Canceled) {
+				t.Fatalf("Exec() error = %v, want context.Canceled", err)
 			}
 		})
 	}

--- a/internal/cli/distribute/distribute_test.go
+++ b/internal/cli/distribute/distribute_test.go
@@ -1,12 +1,32 @@
 package distribute
 
 import (
+	"context"
+	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/distribution"
 )
+
+func TestInspectCommandPropagatesCancellation(t *testing.T) {
+	ipaPath := filepath.Join(t.TempDir(), "App.ipa")
+	if err := os.WriteFile(ipaPath, []byte("not a zip"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := inspectCommand()
+	if err := command.Parse([]string{"--ipa", ipaPath, "--output", "json"}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := command.Run(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("inspect command error = %v, want context.Canceled", err)
+	}
+}
 
 func TestRenderInspectionDeviceDisclosure(t *testing.T) {
 	result := distribution.Inspection{

--- a/internal/cli/distribute/distribute_test.go
+++ b/internal/cli/distribute/distribute_test.go
@@ -1,0 +1,163 @@
+package distribute
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/distribution"
+)
+
+func TestRenderInspectionDeviceDisclosure(t *testing.T) {
+	result := distribution.Inspection{
+		App:      distribution.App{BundleID: "com.example.demo", Title: "Demo", Version: "1.0", BuildNumber: "7"},
+		Artifact: distribution.Artifact{SHA256: "artifact-sha256"},
+		Signing: distribution.Signing{
+			ProfileClass:                 distribution.ProfileClassAdHoc,
+			ProfileUUID:                  "profile-uuid",
+			TeamID:                       "TEAM123",
+			DeviceCount:                  2,
+			Devices:                      []string{"device-0001", "device-0002"},
+			CodeSignatureVerification:    distribution.CodeSignatureVerification{Status: distribution.CodeSignatureVerified},
+			ProfileIntegrityVerification: distribution.CodeSignatureVerification{Status: distribution.CodeSignatureVerified},
+			ProfileTrustVerification:     distribution.CodeSignatureVerification{Status: distribution.CodeSignatureVerified},
+		},
+		Preparation: distribution.Preparation{MetadataEligible: true, Issues: []string{}},
+	}
+
+	for _, test := range []struct {
+		name        string
+		markdown    bool
+		wantPublic  string
+		wantPrivate string
+	}{
+		{
+			name: "table",
+			wantPublic: `┌───────────────────┬──────────────────────────┐
+│       Field       │          Value           │
+├───────────────────┼──────────────────────────┤
+│ Metadata Eligible │ true                     │
+│ Code Signature    │ verified                 │
+│ Profile Integrity │ verified                 │
+│ Profile Trust     │ verified                 │
+│ Bundle ID         │ com.example.demo         │
+│ Title             │ Demo                     │
+│ Version           │ 1.0                      │
+│ Build             │ 7                        │
+│ Profile Class     │ ad-hoc                   │
+│ Profile UUID      │ profile-uuid             │
+│ Team ID           │ TEAM123                  │
+│ Devices           │ 2                        │
+│ Device UDIDs      │ device-0001, device-0002 │
+│ IPA SHA-256       │ artifact-sha256          │
+│ Issues            │                          │
+└───────────────────┴──────────────────────────┘
+`,
+			wantPrivate: `┌───────────────────┬──────────────────┐
+│       Field       │      Value       │
+├───────────────────┼──────────────────┤
+│ Metadata Eligible │ true             │
+│ Code Signature    │ verified         │
+│ Profile Integrity │ verified         │
+│ Profile Trust     │ verified         │
+│ Bundle ID         │ com.example.demo │
+│ Title             │ Demo             │
+│ Version           │ 1.0              │
+│ Build             │ 7                │
+│ Profile Class     │ ad-hoc           │
+│ Profile UUID      │ profile-uuid     │
+│ Team ID           │ TEAM123          │
+│ Devices           │ 2                │
+│ IPA SHA-256       │ artifact-sha256  │
+│ Issues            │                  │
+└───────────────────┴──────────────────┘
+`,
+		},
+		{
+			name:     "markdown",
+			markdown: true,
+			wantPublic: `| Field             | Value                    |
+|:------------------|:-------------------------|
+| Metadata Eligible | true                     |
+| Code Signature    | verified                 |
+| Profile Integrity | verified                 |
+| Profile Trust     | verified                 |
+| Bundle ID         | com.example.demo         |
+| Title             | Demo                     |
+| Version           | 1.0                      |
+| Build             | 7                        |
+| Profile Class     | ad-hoc                   |
+| Profile UUID      | profile-uuid             |
+| Team ID           | TEAM123                  |
+| Devices           | 2                        |
+| Device UDIDs      | device-0001, device-0002 |
+| IPA SHA-256       | artifact-sha256          |
+| Issues            |                          |
+`,
+			wantPrivate: `| Field             | Value            |
+|:------------------|:-----------------|
+| Metadata Eligible | true             |
+| Code Signature    | verified         |
+| Profile Integrity | verified         |
+| Profile Trust     | verified         |
+| Bundle ID         | com.example.demo |
+| Title             | Demo             |
+| Version           | 1.0              |
+| Build             | 7                |
+| Profile Class     | ad-hoc           |
+| Profile UUID      | profile-uuid     |
+| Team ID           | TEAM123          |
+| Devices           | 2                |
+| IPA SHA-256       | artifact-sha256  |
+| Issues            |                  |
+`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			output := captureStdout(t, func() {
+				if err := renderInspection(result, test.markdown); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if output != test.wantPublic {
+				t.Fatalf("public %s renderer output:\n%s\nwant:\n%s", test.name, output, test.wantPublic)
+			}
+
+			privateResult := result
+			privateResult.Signing.Devices = nil
+			output = captureStdout(t, func() {
+				if err := renderInspection(privateResult, test.markdown); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if output != test.wantPrivate {
+				t.Fatalf("private %s renderer output:\n%s\nwant:\n%s", test.name, output, test.wantPrivate)
+			}
+		})
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = original })
+
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = original
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
+}

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -165,6 +165,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `release` - Run high-level App Store release workflows.
 - `workflow` - Run multi-step automation workflows.
 - `xcode` - Produce deterministic `.xcarchive` and `.ipa` artifacts with local Xcode build/export helpers (macOS only).
+- `distribute` - Inspect and prepare provider-neutral iOS release-testing bundles (experimental).
 - `versions` - Manage App Store versions.
 - `product-pages` - Manage custom product pages and product page experiments.
 - `routing-coverage` - Manage routing app coverage files.

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/completion"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/devices"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/diffcmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/distribute"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/docs"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/encryption"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/eula"
@@ -153,6 +154,7 @@ func NewCatalog(version string) *Catalog {
 		commandFactory("release", "Run high-level App Store release workflows.", release.ReleaseCommand),
 		commandFactory("workflow", "Run multi-step automation workflows.", workflow.WorkflowCommand),
 		commandFactory("xcode", "Local Xcode build/archive/export helpers (macOS only).", xcode.XcodeCommand),
+		commandFactory("distribute", "Inspect and prepare local iOS distribution artifacts. [experimental]", distribute.DistributeCommand),
 		commandFactory("versions", "Manage App Store versions.", versions.VersionsCommand),
 		commandFactory("product-pages", "Manage custom product pages and product page experiments.", productpages.ProductPagesCommand),
 		commandFactory("routing-coverage", "Manage routing app coverage files.", routingcoverage.RoutingCoverageCommand),

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -509,8 +509,13 @@ func syncPullCommand() *ffcli.Command {
 			if err := os.MkdirAll(outDir, 0o755); err != nil {
 				return fmt.Errorf("signing sync pull: create output dir: %w", err)
 			}
+			outputRoot, err := rootfs.New(outDir)
+			if err != nil {
+				return fmt.Errorf("signing sync pull: create output root: %w", err)
+			}
+			defer outputRoot.Close()
 
-			decrypted, err := prepareDecryptedSigningFiles(store, encryptedFiles, pass, outDir)
+			decrypted, err := prepareDecryptedSigningFilesInRoot(store, encryptedFiles, pass, outputRoot)
 			if err != nil {
 				return fmt.Errorf("signing sync pull: %w", err)
 			}
@@ -519,7 +524,7 @@ func syncPullCommand() *ffcli.Command {
 			var sensitiveFiles []string
 			identityPresent := false
 			for _, file := range decrypted {
-				if err := writeDecryptedOutputFile(outDir, file.RelativePath, file.Plaintext, file.Sensitive); err != nil {
+				if err := writeDecryptedOutputFileInRoot(outputRoot, file.RelativePath, file.Plaintext, file.Sensitive); err != nil {
 					return fmt.Errorf("signing sync pull: %w", err)
 				}
 
@@ -548,6 +553,15 @@ func syncPullCommand() *ffcli.Command {
 }
 
 func prepareDecryptedSigningFiles(store *signingpkg.GitStore, encryptedFiles []string, password, outDir string) ([]decryptedSigningFile, error) {
+	root, err := rootfs.New(outDir)
+	if err != nil {
+		return nil, fmt.Errorf("create output root: %w", err)
+	}
+	defer root.Close()
+	return prepareDecryptedSigningFilesInRoot(store, encryptedFiles, password, root)
+}
+
+func prepareDecryptedSigningFilesInRoot(store *signingpkg.GitStore, encryptedFiles []string, password string, root rootfs.Root) ([]decryptedSigningFile, error) {
 	if len(encryptedFiles) > maxEncryptedSigningFiles {
 		return nil, fmt.Errorf("encrypted signing repository contains %d files; limit is %d", len(encryptedFiles), maxEncryptedSigningFiles)
 	}
@@ -606,10 +620,6 @@ func prepareDecryptedSigningFiles(store *signingpkg.GitStore, encryptedFiles []s
 	}
 	decrypted = filtered
 
-	root, err := rootfs.New(outDir)
-	if err != nil {
-		return nil, fmt.Errorf("create output root: %w", err)
-	}
 	for _, file := range decrypted {
 		if file.Sensitive {
 			err = root.CheckCreateNewFile(file.RelativePath)
@@ -825,6 +835,12 @@ func writeDecryptedOutputFile(outDir, relPath string, plaintext []byte, sensitiv
 	if err != nil {
 		return fmt.Errorf("create output root: %w", err)
 	}
+	defer root.Close()
+	return writeDecryptedOutputFileInRoot(root, relPath, plaintext, sensitive)
+}
+
+func writeDecryptedOutputFileInRoot(root rootfs.Root, relPath string, plaintext []byte, sensitive bool) error {
+	var err error
 	if sensitive {
 		err = root.CreateNewFile(relPath, plaintext, 0o600)
 	} else {

--- a/internal/cli/web/web_review.go
+++ b/internal/cli/web/web_review.go
@@ -511,7 +511,7 @@ func newDownloadRoot(outDir string) (rootfs.Root, string, error) {
 	}
 	root, err := rootfs.New(absolute)
 	if err != nil {
-		return rootfs.Root{}, "", fmt.Errorf("failed to resolve output directory %q: %w", outDir, err)
+		return rootfs.Root{}, "", fmt.Errorf("failed to create output directory %q: %w", outDir, err)
 	}
 	return root, ".", nil
 }
@@ -673,6 +673,7 @@ func downloadAttachmentsForShow(
 	if err != nil {
 		return nil, nil, err
 	}
+	defer root.Close()
 	if err := root.MkdirAll(prefix, 0o755); err != nil {
 		return nil, nil, fmt.Errorf("failed to create output directory %q: %w", outDir, err)
 	}

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -213,7 +213,7 @@ func validateSignedMainAppEntitlements(entitlementsData []byte, bundleID string,
 		return fmt.Errorf("inspected CFBundleIdentifier is missing")
 	}
 	profileApplicationID, _ := profile.Entitlements["application-identifier"].(string)
-	if strings.TrimSpace(teamIdentifier) != teamID || !entitlementValuePermits(profileApplicationID, appIdentifier) {
+	if teamIdentifier != teamID || !entitlementValuePermits(profileApplicationID, appIdentifier) {
 		return fmt.Errorf("signed main-app entitlements do not match the embedded profile team and application identifier")
 	}
 	if appIdentifier != applicationIdentifierPrefix+"."+bundleID {
@@ -456,7 +456,6 @@ func entitlementValuePermits(profileValue, signedValue any) bool {
 	profileString, profileIsString := profileValue.(string)
 	signedString, signedIsString := signedValue.(string)
 	if profileIsString && signedIsString {
-		profileString, signedString = strings.TrimSpace(profileString), strings.TrimSpace(signedString)
 		if strings.HasSuffix(profileString, "*") {
 			prefix := strings.TrimSuffix(profileString, "*")
 			return strings.HasPrefix(signedString, prefix) && len(signedString) > len(prefix)

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -257,8 +257,9 @@ func enumerateMachOFiles(appPath string) ([]string, error) {
 		var magic [4]byte
 		_, readErr := io.ReadFull(file, magic[:])
 		isMachO := false
+		var classificationErr error
 		if readErr == nil {
-			isMachO = isMachOFile(file, magic, info.Size())
+			isMachO, classificationErr = classifyMachOFile(file, magic, info.Size())
 		}
 		closeErr := file.Close()
 		if readErr != nil && !errors.Is(readErr, io.ErrUnexpectedEOF) && !errors.Is(readErr, io.EOF) {
@@ -266,6 +267,9 @@ func enumerateMachOFiles(appPath string) ([]string, error) {
 		}
 		if closeErr != nil {
 			return closeErr
+		}
+		if classificationErr != nil {
+			return fmt.Errorf("classify Mach-O file %q: %w", candidate, classificationErr)
 		}
 		if isMachO {
 			result = append(result, candidate)
@@ -279,49 +283,60 @@ func enumerateMachOFiles(appPath string) ([]string, error) {
 	return result, nil
 }
 
-func isMachOFile(file *os.File, magic [4]byte, fileSize int64) bool {
+func classifyMachOFile(file *os.File, magic [4]byte, fileSize int64) (bool, error) {
 	switch magic {
 	case [4]byte{0xfe, 0xed, 0xfa, 0xce}, [4]byte{0xce, 0xfa, 0xed, 0xfe},
 		[4]byte{0xfe, 0xed, 0xfa, 0xcf}, [4]byte{0xcf, 0xfa, 0xed, 0xfe}:
-		return isValidThinMachO(file, fileSize)
+		return isLoadableThinMachO(file, fileSize), nil
 	case [4]byte{0xca, 0xfe, 0xba, 0xbe}:
-		return isValidFatMachO(file, fileSize, binary.BigEndian, 20)
+		return classifyFatMachO(file, fileSize, binary.BigEndian, 20)
 	case [4]byte{0xbe, 0xba, 0xfe, 0xca}:
-		return isValidFatMachO(file, fileSize, binary.LittleEndian, 20)
+		return classifyFatMachO(file, fileSize, binary.LittleEndian, 20)
 	case [4]byte{0xca, 0xfe, 0xba, 0xbf}:
-		return isValidFatMachO(file, fileSize, binary.BigEndian, 32)
+		return classifyFatMachO(file, fileSize, binary.BigEndian, 32)
 	case [4]byte{0xbf, 0xba, 0xfe, 0xca}:
-		return isValidFatMachO(file, fileSize, binary.LittleEndian, 32)
+		return classifyFatMachO(file, fileSize, binary.LittleEndian, 32)
+	default:
+		return false, nil
+	}
+}
+
+func isLoadableThinMachO(file *os.File, fileSize int64) bool {
+	if fileSize <= 0 {
+		return false
+	}
+	image, err := macho.NewFile(io.NewSectionReader(file, 0, fileSize))
+	return err == nil && isLoadableMachOImage(image)
+}
+
+func isLoadableMachOImage(file *macho.File) bool {
+	switch file.Type {
+	case macho.TypeExec, macho.TypeDylib, macho.TypeBundle:
+		return true
 	default:
 		return false
 	}
 }
 
-func isValidThinMachO(file *os.File, fileSize int64) bool {
-	if fileSize <= 0 {
-		return false
-	}
-	_, err := macho.NewFile(io.NewSectionReader(file, 0, fileSize))
-	return err == nil
-}
-
-func isValidFatMachO(file *os.File, fileSize int64, order binary.ByteOrder, archHeaderSize int64) bool {
+func classifyFatMachO(file *os.File, fileSize int64, order binary.ByteOrder, archHeaderSize int64) (bool, error) {
 	var countBytes [4]byte
 	if _, err := file.ReadAt(countBytes[:], 4); err != nil {
-		return false
+		return false, nil
 	}
 	architectureCount := order.Uint32(countBytes[:])
 	if architectureCount == 0 || architectureCount > 64 {
-		return false
+		return false, nil
 	}
 	tableEnd := int64(8) + int64(architectureCount)*archHeaderSize
 	if tableEnd > fileSize {
-		return false
+		return false, nil
 	}
 	header := make([]byte, archHeaderSize)
+	hasLoadableSlice := false
+	hasNonLoadableSlice := false
 	for index := uint32(0); index < architectureCount; index++ {
 		if _, err := file.ReadAt(header, int64(8)+int64(index)*archHeaderSize); err != nil {
-			return false
+			return false, nil
 		}
 		var offset, size uint64
 		if archHeaderSize == 20 {
@@ -332,14 +347,25 @@ func isValidFatMachO(file *os.File, fileSize int64, order binary.ByteOrder, arch
 			size = order.Uint64(header[16:24])
 		}
 		if offset < uint64(tableEnd) || size == 0 || offset > uint64(fileSize) || size > uint64(fileSize)-offset {
-			return false
+			return false, nil
 		}
 		slice, err := macho.NewFile(io.NewSectionReader(file, int64(offset), int64(size)))
-		if err != nil || uint32(slice.Cpu) != order.Uint32(header[:4]) {
-			return false
+		if err != nil {
+			return false, fmt.Errorf("fat Mach-O contains a malformed architecture slice")
+		}
+		if uint32(slice.Cpu) != order.Uint32(header[:4]) {
+			return false, fmt.Errorf("fat Mach-O architecture header does not match its slice")
+		}
+		if isLoadableMachOImage(slice) {
+			hasLoadableSlice = true
+		} else {
+			hasNonLoadableSlice = true
+		}
+		if hasLoadableSlice && hasNonLoadableSlice {
+			return false, fmt.Errorf("fat Mach-O mixes loadable and non-loadable image types")
 		}
 	}
-	return true
+	return hasLoadableSlice, nil
 }
 
 func codeObjectFingerprints(ctx context.Context, directory string, objectIndex int, codePath string) ([]string, error) {

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
+	"debug/macho"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -40,6 +42,11 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 		return result
 	}
 	if err := validateExecutableName(strings.TrimSpace(executable)); err != nil {
+		result.Status, result.Reason = CodeSignatureInvalid, err.Error()
+		return result
+	}
+	teamID := onlyTrimmed(profile.TeamIdentifier)
+	if err := validateTeamIdentifier(teamID); err != nil {
 		result.Status, result.Reason = CodeSignatureInvalid, err.Error()
 		return result
 	}
@@ -153,7 +160,7 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 		}
 	}
 	mainFingerprintSet := stringSet(mainFingerprints)
-	teamRequirement := `anchor apple generic and certificate leaf[subject.OU] = "` + onlyTrimmed(profile.TeamIdentifier) + `"`
+	teamRequirement := `anchor apple generic and certificate leaf[subject.OU] = "` + teamID + `"`
 	for index, codePath := range codePaths {
 		if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "--verify", "--strict", "--all-architectures", "-R="+teamRequirement, codePath); err != nil {
 			result.Status, result.Reason = CodeSignatureInvalid, "nested signed code does not satisfy the main app signing-team requirement"
@@ -209,6 +216,10 @@ func enumerateMachOFiles(appPath string) ([]string, error) {
 		}
 		var magic [4]byte
 		_, readErr := io.ReadFull(file, magic[:])
+		isMachO := false
+		if readErr == nil {
+			isMachO = isMachOFile(file, magic, info.Size())
+		}
 		closeErr := file.Close()
 		if readErr != nil && !errors.Is(readErr, io.ErrUnexpectedEOF) && !errors.Is(readErr, io.EOF) {
 			return readErr
@@ -216,7 +227,7 @@ func enumerateMachOFiles(appPath string) ([]string, error) {
 		if closeErr != nil {
 			return closeErr
 		}
-		if isMachOMagic(magic) {
+		if isMachO {
 			result = append(result, candidate)
 		}
 		return nil
@@ -228,16 +239,59 @@ func enumerateMachOFiles(appPath string) ([]string, error) {
 	return result, nil
 }
 
-func isMachOMagic(magic [4]byte) bool {
+func isMachOFile(file *os.File, magic [4]byte, fileSize int64) bool {
 	switch magic {
 	case [4]byte{0xfe, 0xed, 0xfa, 0xce}, [4]byte{0xce, 0xfa, 0xed, 0xfe},
-		[4]byte{0xfe, 0xed, 0xfa, 0xcf}, [4]byte{0xcf, 0xfa, 0xed, 0xfe},
-		[4]byte{0xca, 0xfe, 0xba, 0xbe}, [4]byte{0xbe, 0xba, 0xfe, 0xca},
-		[4]byte{0xca, 0xfe, 0xba, 0xbf}, [4]byte{0xbf, 0xba, 0xfe, 0xca}:
+		[4]byte{0xfe, 0xed, 0xfa, 0xcf}, [4]byte{0xcf, 0xfa, 0xed, 0xfe}:
 		return true
+	case [4]byte{0xca, 0xfe, 0xba, 0xbe}:
+		return isValidFatMachO(file, fileSize, binary.BigEndian, 20)
+	case [4]byte{0xbe, 0xba, 0xfe, 0xca}:
+		return isValidFatMachO(file, fileSize, binary.LittleEndian, 20)
+	case [4]byte{0xca, 0xfe, 0xba, 0xbf}:
+		return isValidFatMachO(file, fileSize, binary.BigEndian, 32)
+	case [4]byte{0xbf, 0xba, 0xfe, 0xca}:
+		return isValidFatMachO(file, fileSize, binary.LittleEndian, 32)
 	default:
 		return false
 	}
+}
+
+func isValidFatMachO(file *os.File, fileSize int64, order binary.ByteOrder, archHeaderSize int64) bool {
+	var countBytes [4]byte
+	if _, err := file.ReadAt(countBytes[:], 4); err != nil {
+		return false
+	}
+	architectureCount := order.Uint32(countBytes[:])
+	if architectureCount == 0 || architectureCount > 64 {
+		return false
+	}
+	tableEnd := int64(8) + int64(architectureCount)*archHeaderSize
+	if tableEnd > fileSize {
+		return false
+	}
+	header := make([]byte, archHeaderSize)
+	for index := uint32(0); index < architectureCount; index++ {
+		if _, err := file.ReadAt(header, int64(8)+int64(index)*archHeaderSize); err != nil {
+			return false
+		}
+		var offset, size uint64
+		if archHeaderSize == 20 {
+			offset = uint64(order.Uint32(header[8:12]))
+			size = uint64(order.Uint32(header[12:16]))
+		} else {
+			offset = order.Uint64(header[8:16])
+			size = order.Uint64(header[16:24])
+		}
+		if offset < uint64(tableEnd) || size == 0 || offset > uint64(fileSize) || size > uint64(fileSize)-offset {
+			return false
+		}
+		slice, err := macho.NewFile(io.NewSectionReader(file, int64(offset), int64(size)))
+		if err != nil || uint32(slice.Cpu) != order.Uint32(header[:4]) {
+			return false
+		}
+	}
+	return true
 }
 
 func codeObjectFingerprints(ctx context.Context, directory string, objectIndex int, codePath string) ([]string, error) {
@@ -408,6 +462,18 @@ func validateExecutableName(value string) error {
 	for _, r := range value {
 		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.In(r, unicode.Bidi_Control) {
 			return fmt.Errorf("CFBundleExecutable contains control or formatting characters")
+		}
+	}
+	return nil
+}
+
+func validateTeamIdentifier(value string) error {
+	if value == "" || len(value) > 32 {
+		return fmt.Errorf("embedded profile team identifier is not a single safe value")
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+			return fmt.Errorf("embedded profile team identifier contains unsupported characters")
 		}
 	}
 	return nil

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -197,6 +197,10 @@ func validateSignedMainAppEntitlements(entitlementsData []byte, bundleID string,
 	if err := validateTeamIdentifier(teamID); err != nil {
 		return err
 	}
+	applicationIdentifierPrefix := onlyTrimmed(profile.ApplicationIdentifierPrefix)
+	if applicationIdentifierPrefix == "" {
+		return fmt.Errorf("embedded profile application identifier prefix is not a single value")
+	}
 	bundleID = strings.TrimSpace(bundleID)
 	if bundleID == "" {
 		return fmt.Errorf("inspected CFBundleIdentifier is missing")
@@ -205,7 +209,7 @@ func validateSignedMainAppEntitlements(entitlementsData []byte, bundleID string,
 	if strings.TrimSpace(teamIdentifier) != teamID || !entitlementValuePermits(profileApplicationID, appIdentifier) {
 		return fmt.Errorf("signed main-app entitlements do not match the embedded profile team and application identifier")
 	}
-	if appIdentifier != teamID+"."+bundleID {
+	if appIdentifier != applicationIdentifierPrefix+"."+bundleID {
 		return fmt.Errorf("signed main-app application identifier does not match inspected CFBundleIdentifier")
 	}
 	if profileDebug, ok := profile.Entitlements["get-task-allow"].(bool); !ok {

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
@@ -34,10 +35,22 @@ const (
 	mainCodeSignatureScope          = "complete-main-app-code-resources-entitlements-and-profile-certificate-binding"
 )
 
-var runCodeSignTool = runBoundedTool
+var (
+	runCodeSignTool               = runBoundedTool
+	duringMaterializationForTest  func(string)
+	duringMaterializedCopyForTest func()
+)
 
 func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleID string, profile parsedProfile) CodeSignatureVerification {
+	return verifyMainAppCodeSignatureContext(context.Background(), members, appDir, executable, bundleID, profile)
+}
+
+func verifyMainAppCodeSignatureContext(ctx context.Context, members []*zip.File, appDir, executable, bundleID string, profile parsedProfile) CodeSignatureVerification {
 	result := CodeSignatureVerification{Status: CodeSignatureNotVerified, Scope: mainCodeSignatureScope}
+	if err := contextError(ctx); err != nil {
+		result.Reason = err.Error()
+		return result
+	}
 	if runtime.GOOS != "darwin" {
 		result.Reason = "complete main-app code-signature verification is available only on macOS"
 		return result
@@ -77,12 +90,11 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleI
 		return result
 	}
 	defer app.Close()
-	if err := materializeMainApp(app, members, appDir); err != nil {
+	if err := materializeMainAppContext(ctx, app, members, appDir); err != nil {
 		result.Status, result.Reason = CodeSignatureInvalid, "could not safely materialize the complete bounded main app: "+err.Error()
 		return result
 	}
 	appPath := path.Join(directory, "Verify.app")
-	ctx := context.Background()
 	if _, err := runCodeSignInvocation(ctx, "/usr/bin/codesign", "--verify", "--deep", "--strict", "--all-architectures", "--verbose=4", appPath); err != nil {
 		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
 			result.Reason = "codesign is unavailable"
@@ -92,7 +104,7 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleI
 		return result
 	}
 	mainExecutablePath := filepath.Join(appPath, executable)
-	codePaths, err := enumerateMachOFiles(appPath)
+	codePaths, err := enumerateMachOFilesContext(ctx, appPath)
 	if err != nil {
 		result.Status, result.Reason = CodeSignatureInvalid, "could not enumerate nested signed code: "+err.Error()
 		return result
@@ -125,6 +137,10 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleI
 	mainFingerprintSet := stringSet(mainFingerprints)
 	teamRequirement := `anchor apple generic and certificate leaf[subject.OU] = "` + teamID + `"`
 	for index, codePath := range codePaths {
+		if err := contextError(ctx); err != nil {
+			result.Reason = err.Error()
+			return result
+		}
 		if _, err := runCodeSignInvocation(ctx, "/usr/bin/codesign", "--verify", "--strict", "--all-architectures", "-R="+teamRequirement, codePath); err != nil {
 			result.Status, result.Reason = CodeSignatureInvalid, "nested signed code does not satisfy the main app signing-team requirement"
 			return result
@@ -232,8 +248,15 @@ func validateSignedMainAppEntitlements(entitlementsData []byte, bundleID string,
 }
 
 func enumerateMachOFiles(appPath string) ([]string, error) {
+	return enumerateMachOFilesContext(context.Background(), appPath)
+}
+
+func enumerateMachOFilesContext(ctx context.Context, appPath string) ([]string, error) {
 	var result []string
 	err := filepath.WalkDir(appPath, func(candidate string, entry os.DirEntry, walkErr error) error {
+		if err := contextError(ctx); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -488,10 +511,16 @@ func entitlementList(value any) ([]any, bool) {
 	}
 }
 
-func materializeMainApp(destination *os.Root, members []*zip.File, appDir string) error {
+func materializeMainAppContext(ctx context.Context, destination *os.Root, members []*zip.File, appDir string) error {
 	prefix := appDir + "/"
 	var total int64
 	for _, member := range members {
+		if duringMaterializationForTest != nil {
+			duringMaterializationForTest(member.Name)
+		}
+		if err := contextError(ctx); err != nil {
+			return err
+		}
 		if !strings.HasPrefix(member.Name, prefix) {
 			continue
 		}
@@ -512,7 +541,7 @@ func materializeMainApp(destination *os.Root, members []*zip.File, appDir string
 		if err := destination.MkdirAll(path.Dir(relative), 0o700); err != nil {
 			return err
 		}
-		if err := copyZipMemberToNewFile(destination, relative, member, int64(member.UncompressedSize64)); err != nil {
+		if err := copyZipMemberToNewFileContext(ctx, destination, relative, member, int64(member.UncompressedSize64)); err != nil {
 			return err
 		}
 	}
@@ -596,7 +625,7 @@ func validateArchitecture(value string) error {
 	return nil
 }
 
-func copyZipMemberToNewFile(root *os.Root, name string, member *zip.File, limit int64) error {
+func copyZipMemberToNewFileContext(ctx context.Context, root *os.Root, name string, member *zip.File, limit int64) error {
 	reader, err := member.Open()
 	if err != nil {
 		return err
@@ -606,7 +635,7 @@ func copyZipMemberToNewFile(root *os.Root, name string, member *zip.File, limit 
 	if err != nil {
 		return err
 	}
-	written, copyErr := io.Copy(file, io.LimitReader(reader, limit+1))
+	written, copyErr := copyWithContext(ctx, file, io.LimitReader(reader, limit+1), duringMaterializedCopyForTest)
 	closeErr := file.Close()
 	if copyErr != nil {
 		return copyErr
@@ -621,12 +650,18 @@ func copyZipMemberToNewFile(root *os.Root, name string, member *zip.File, limit 
 }
 
 func runCodeSignInvocation(parent context.Context, name string, args ...string) ([]byte, error) {
+	if err := contextError(parent); err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithTimeout(parent, codeSignInvocationTimeout)
 	defer cancel()
 	return runCodeSignTool(ctx, name, args...)
 }
 
 func runBoundedTool(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
 	command := exec.CommandContext(ctx, name, args...)
 	pipe, err := command.StdoutPipe()
 	if err != nil {
@@ -636,8 +671,13 @@ func runBoundedTool(ctx context.Context, name string, args ...string) ([]byte, e
 	if err := command.Start(); err != nil {
 		return nil, err
 	}
-	output, readErr := io.ReadAll(io.LimitReader(pipe, maxToolOutputBytes+1))
+	var outputBuffer bytes.Buffer
+	_, readErr := copyWithContext(ctx, &outputBuffer, io.LimitReader(pipe, maxToolOutputBytes+1), nil)
 	waitErr := command.Wait()
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	output := outputBuffer.Bytes()
 	if len(output) > maxToolOutputBytes {
 		return nil, fmt.Errorf("tool output exceeded %d bytes", maxToolOutputBytes)
 	}

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -197,9 +197,9 @@ func validateSignedMainAppEntitlements(entitlementsData []byte, bundleID string,
 	if err := validateTeamIdentifier(teamID); err != nil {
 		return err
 	}
-	applicationIdentifierPrefix := onlyTrimmed(profile.ApplicationIdentifierPrefix)
-	if applicationIdentifierPrefix == "" {
-		return fmt.Errorf("embedded profile application identifier prefix is not a single value")
+	applicationIdentifierPrefix := declaredSingle(profile.ApplicationIdentifierPrefix)
+	if err := validateApplicationIdentifierPrefix(applicationIdentifierPrefix); err != nil {
+		return err
 	}
 	bundleID = strings.TrimSpace(bundleID)
 	if bundleID == "" {
@@ -541,6 +541,18 @@ func validateTeamIdentifier(value string) error {
 	for _, r := range value {
 		if (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
 			return fmt.Errorf("embedded profile team identifier contains unsupported characters")
+		}
+	}
+	return nil
+}
+
+func validateApplicationIdentifierPrefix(value string) error {
+	if value == "" || len(value) > 32 {
+		return fmt.Errorf("embedded profile application identifier prefix is not a single safe value")
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+			return fmt.Errorf("embedded profile application identifier prefix contains unsupported characters")
 		}
 	}
 	return nil

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -1,0 +1,474 @@
+package distribution
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
+	"howett.net/plist"
+)
+
+const (
+	maxMainAppExpandedBytes int64 = 4 << 30
+	maxToolOutputBytes            = 1 << 20
+	mainCodeSignatureScope        = "complete-main-app-code-resources-entitlements-and-profile-certificate-binding"
+)
+
+var runCodeSignTool = runBoundedTool
+
+func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File, executable string, profile parsedProfile) CodeSignatureVerification {
+	result := CodeSignatureVerification{Status: CodeSignatureNotVerified, Scope: mainCodeSignatureScope}
+	if runtime.GOOS != "darwin" {
+		result.Reason = "complete main-app code-signature verification is available only on macOS"
+		return result
+	}
+	if err := validateExecutableName(strings.TrimSpace(executable)); err != nil {
+		result.Status, result.Reason = CodeSignatureInvalid, err.Error()
+		return result
+	}
+	directory, err := os.MkdirTemp("", ".asc-distribute-codesign-")
+	if err != nil {
+		result.Reason = "could not create a private code-signature verification directory"
+		return result
+	}
+	defer os.RemoveAll(directory)
+	if err := os.Chmod(directory, 0o700); err != nil {
+		result.Reason = "could not secure the code-signature verification directory"
+		return result
+	}
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		result.Reason = "could not open the code-signature verification directory"
+		return result
+	}
+	defer root.Close()
+	if err := root.Mkdir("Verify.app", 0o700); err != nil {
+		result.Reason = "could not create the code-signature verification app"
+		return result
+	}
+	app, err := root.OpenRoot("Verify.app")
+	if err != nil {
+		result.Reason = "could not open the code-signature verification app"
+		return result
+	}
+	defer app.Close()
+	if err := materializeMainApp(app, members, appDir); err != nil {
+		result.Status, result.Reason = CodeSignatureInvalid, "could not safely materialize the complete bounded main app: "+err.Error()
+		return result
+	}
+	appPath := path.Join(directory, "Verify.app")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "--verify", "--deep", "--strict", "--all-architectures", "--verbose=4", appPath); err != nil {
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+			result.Reason = "codesign is unavailable"
+			return result
+		}
+		result.Status, result.Reason = CodeSignatureInvalid, "codesign rejected the complete main app"
+		return result
+	}
+	entitlementsData, err := runCodeSignTool(ctx, "/usr/bin/codesign", "-d", "--entitlements", ":-", appPath)
+	if err != nil {
+		result.Status, result.Reason = CodeSignatureInvalid, "could not extract signed main-app entitlements"
+		return result
+	}
+	var entitlements map[string]any
+	if err := decodeBoundedPlist(entitlementsData, &entitlements); err != nil {
+		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app entitlements are invalid"
+		return result
+	}
+	appIdentifier, ok := entitlements["application-identifier"].(string)
+	if !ok || strings.TrimSpace(appIdentifier) == "" {
+		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app application identifier is missing"
+		return result
+	}
+	teamIdentifier, ok := entitlements["com.apple.developer.team-identifier"].(string)
+	if !ok || strings.TrimSpace(teamIdentifier) == "" {
+		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app team identifier is missing"
+		return result
+	}
+	profileApplicationID, _ := profile.Entitlements["application-identifier"].(string)
+	if strings.TrimSpace(teamIdentifier) != onlyTrimmed(profile.TeamIdentifier) || !entitlementValuePermits(profileApplicationID, appIdentifier) {
+		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app entitlements do not match the embedded profile team and application identifier"
+		return result
+	}
+	if profileDebug, ok := profile.Entitlements["get-task-allow"].(bool); !ok {
+		result.Status, result.Reason = CodeSignatureInvalid, "embedded profile get-task-allow entitlement is missing or invalid"
+		return result
+	} else if signedDebug, exists := entitlements["get-task-allow"]; exists {
+		debug, ok := signedDebug.(bool)
+		if !ok || debug != profileDebug {
+			result.Status, result.Reason = CodeSignatureInvalid, "signed get-task-allow entitlement is not permitted by the embedded profile"
+			return result
+		}
+	} else if profileDebug {
+		result.Status, result.Reason = CodeSignatureInvalid, "signed get-task-allow entitlement is missing for a development profile"
+		return result
+	}
+	for key, signedValue := range entitlements {
+		profileValue, exists := profile.Entitlements[key]
+		if !exists || !entitlementValuePermits(profileValue, signedValue) {
+			result.Status, result.Reason = CodeSignatureInvalid, "signed main-app entitlement is not permitted by the embedded profile: "+key
+			return result
+		}
+	}
+
+	codePaths, err := enumerateMachOFiles(appPath)
+	if err != nil {
+		result.Status, result.Reason = CodeSignatureInvalid, "could not enumerate nested signed code: "+err.Error()
+		return result
+	}
+	mainExecutablePath := filepath.Join(appPath, executable)
+	if !containsPath(codePaths, mainExecutablePath) {
+		result.Status, result.Reason = CodeSignatureInvalid, "CFBundleExecutable is not a Mach-O file in the main app"
+		return result
+	}
+	allowed := certificateFingerprintSet(profile.DeveloperCertificates)
+	mainFingerprints, err := codeObjectFingerprints(ctx, directory, 0, mainExecutablePath)
+	if err != nil {
+		result.Status, result.Reason = codeVerificationFailure(err, "main executable")
+		return result
+	}
+	for _, fingerprint := range mainFingerprints {
+		if _, ok := allowed[fingerprint]; !ok {
+			result.Status, result.Reason = CodeSignatureInvalid, "main executable signer is not permitted by the embedded profile"
+			return result
+		}
+	}
+	mainFingerprintSet := stringSet(mainFingerprints)
+	teamRequirement := `anchor apple generic and certificate leaf[subject.OU] = "` + onlyTrimmed(profile.TeamIdentifier) + `"`
+	for index, codePath := range codePaths {
+		if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "--verify", "--strict", "--all-architectures", "-R="+teamRequirement, codePath); err != nil {
+			result.Status, result.Reason = CodeSignatureInvalid, "nested signed code does not satisfy the main app signing-team requirement"
+			return result
+		}
+		if codePath == mainExecutablePath {
+			continue
+		}
+		fingerprints, err := codeObjectFingerprints(ctx, directory, index+1, codePath)
+		if err != nil {
+			result.Status, result.Reason = codeVerificationFailure(err, "nested signed code")
+			return result
+		}
+		for _, fingerprint := range fingerprints {
+			if _, ok := allowed[fingerprint]; !ok {
+				result.Status, result.Reason = CodeSignatureInvalid, "nested signed code signer is not permitted by the embedded profile"
+				return result
+			}
+			if _, ok := mainFingerprintSet[fingerprint]; !ok {
+				result.Status, result.Reason = CodeSignatureInvalid, "nested signed code signer differs from the main executable signer"
+				return result
+			}
+		}
+	}
+	result.Status = CodeSignatureVerified
+	result.Reason = "complete main app, every nested Mach-O code object, signed entitlements, and profile certificate binding verified"
+	result.SignerCertificateSHA256Fingerprints = canonicalSet(mainFingerprints)
+	return result
+}
+
+func enumerateMachOFiles(appPath string) ([]string, error) {
+	var result []string
+	err := filepath.WalkDir(appPath, func(candidate string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symbolic link found in materialized app")
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("non-regular file found in materialized app")
+		}
+		file, err := os.Open(candidate)
+		if err != nil {
+			return err
+		}
+		var magic [4]byte
+		_, readErr := io.ReadFull(file, magic[:])
+		closeErr := file.Close()
+		if readErr != nil && !errors.Is(readErr, io.ErrUnexpectedEOF) && !errors.Is(readErr, io.EOF) {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if isMachOMagic(magic) {
+			result = append(result, candidate)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func isMachOMagic(magic [4]byte) bool {
+	switch magic {
+	case [4]byte{0xfe, 0xed, 0xfa, 0xce}, [4]byte{0xce, 0xfa, 0xed, 0xfe},
+		[4]byte{0xfe, 0xed, 0xfa, 0xcf}, [4]byte{0xcf, 0xfa, 0xed, 0xfe},
+		[4]byte{0xca, 0xfe, 0xba, 0xbe}, [4]byte{0xbe, 0xba, 0xfe, 0xca},
+		[4]byte{0xca, 0xfe, 0xba, 0xbf}, [4]byte{0xbf, 0xba, 0xfe, 0xca}:
+		return true
+	default:
+		return false
+	}
+}
+
+func codeObjectFingerprints(ctx context.Context, directory string, objectIndex int, codePath string) ([]string, error) {
+	archOutput, err := runCodeSignTool(ctx, "/usr/bin/lipo", "-archs", codePath)
+	if err != nil {
+		return nil, err
+	}
+	architectures := strings.Fields(string(archOutput))
+	if len(architectures) == 0 || len(architectures) > 64 {
+		return nil, fmt.Errorf("invalid architecture list")
+	}
+	var fingerprints []string
+	for architectureIndex, architecture := range architectures {
+		if err := validateArchitecture(architecture); err != nil {
+			return nil, err
+		}
+		prefix := path.Join(directory, fmt.Sprintf("certificate-%d-%d-", objectIndex, architectureIndex))
+		if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "-d", "-a", architecture, "--extract-certificates="+prefix, codePath); err != nil {
+			return nil, err
+		}
+		leaf, err := os.ReadFile(prefix + "0")
+		if err != nil {
+			return nil, err
+		}
+		fingerprint, err := certificateFingerprint(leaf)
+		if err != nil {
+			return nil, err
+		}
+		fingerprints = append(fingerprints, fingerprint)
+	}
+	return canonicalSet(fingerprints), nil
+}
+
+func codeVerificationFailure(err error, subject string) (CodeSignatureVerificationStatus, string) {
+	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+		return CodeSignatureNotVerified, "required code-signature tooling is unavailable"
+	}
+	return CodeSignatureInvalid, "could not verify " + subject + " architectures and signer certificates"
+}
+
+func stringSet(values []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func containsPath(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func entitlementValuePermits(profileValue, signedValue any) bool {
+	profileString, profileIsString := profileValue.(string)
+	signedString, signedIsString := signedValue.(string)
+	if profileIsString && signedIsString {
+		profileString, signedString = strings.TrimSpace(profileString), strings.TrimSpace(signedString)
+		if strings.HasSuffix(profileString, "*") {
+			prefix := strings.TrimSuffix(profileString, "*")
+			return strings.HasPrefix(signedString, prefix) && len(signedString) > len(prefix)
+		}
+		return signedString == profileString
+	}
+	profileList, profileIsList := entitlementList(profileValue)
+	signedList, signedIsList := entitlementList(signedValue)
+	if profileIsList && signedIsList {
+		for _, signedItem := range signedList {
+			permitted := false
+			for _, profileItem := range profileList {
+				if entitlementValuePermits(profileItem, signedItem) {
+					permitted = true
+					break
+				}
+			}
+			if !permitted {
+				return false
+			}
+		}
+		return true
+	}
+	return reflect.DeepEqual(profileValue, signedValue)
+}
+
+func entitlementList(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []string:
+		result := make([]any, len(typed))
+		for index, item := range typed {
+			result[index] = item
+		}
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+func materializeMainApp(destination *os.Root, members []*zip.File, appDir string) error {
+	prefix := appDir + "/"
+	var total int64
+	for _, member := range members {
+		if !strings.HasPrefix(member.Name, prefix) {
+			continue
+		}
+		relative := strings.TrimPrefix(member.Name, prefix)
+		if relative == "" {
+			continue
+		}
+		if member.FileInfo().IsDir() {
+			if err := destination.MkdirAll(strings.TrimSuffix(relative, "/"), 0o700); err != nil {
+				return err
+			}
+			continue
+		}
+		if member.UncompressedSize64 > uint64(maxMainAppExpandedBytes) || total > maxMainAppExpandedBytes-int64(member.UncompressedSize64) {
+			return fmt.Errorf("expanded main app exceeds %d bytes", maxMainAppExpandedBytes)
+		}
+		total += int64(member.UncompressedSize64)
+		if err := destination.MkdirAll(path.Dir(relative), 0o700); err != nil {
+			return err
+		}
+		if err := copyZipMemberToNewFile(destination, relative, member, int64(member.UncompressedSize64)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decodeBoundedPlist(data []byte, destination any) error {
+	if len(data) == 0 || len(data) > 4<<20 {
+		return fmt.Errorf("plist size is invalid")
+	}
+	if err := infoplist.ValidateStructure(data); err != nil {
+		return err
+	}
+	_, err := plist.Unmarshal(data, destination)
+	return err
+}
+
+func certificateFingerprintSet(certificates [][]byte) map[string]struct{} {
+	result := make(map[string]struct{}, len(certificates))
+	for _, certificate := range certificates {
+		if fingerprint, err := certificateFingerprint(certificate); err == nil {
+			result[fingerprint] = struct{}{}
+		}
+	}
+	return result
+}
+
+func certificateFingerprint(data []byte) (string, error) {
+	if _, err := x509.ParseCertificate(data); err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validateExecutableName(value string) error {
+	if value == "" || len(value) > 255 || path.Base(value) != value || value == "." || value == ".." {
+		return fmt.Errorf("CFBundleExecutable is not a single safe filename")
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.In(r, unicode.Bidi_Control) {
+			return fmt.Errorf("CFBundleExecutable contains control or formatting characters")
+		}
+	}
+	return nil
+}
+
+func validateArchitecture(value string) error {
+	if value == "" || len(value) > 64 {
+		return fmt.Errorf("invalid architecture")
+	}
+	for _, r := range value {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-' {
+			return fmt.Errorf("invalid architecture")
+		}
+	}
+	return nil
+}
+
+func copyZipMemberToNewFile(root *os.Root, name string, member *zip.File, limit int64) error {
+	reader, err := member.Open()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	file, err := secureopen.OpenNewFileNoFollowInRoot(root, name, 0o600)
+	if err != nil {
+		return err
+	}
+	written, copyErr := io.Copy(file, io.LimitReader(reader, limit+1))
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if written > limit {
+		return fmt.Errorf("expanded member exceeds %d bytes", limit)
+	}
+	return nil
+}
+
+func runBoundedTool(ctx context.Context, name string, args ...string) ([]byte, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	pipe, err := command.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	command.Stderr = io.Discard
+	if err := command.Start(); err != nil {
+		return nil, err
+	}
+	output, readErr := io.ReadAll(io.LimitReader(pipe, maxToolOutputBytes+1))
+	waitErr := command.Wait()
+	if len(output) > maxToolOutputBytes {
+		return nil, fmt.Errorf("tool output exceeded %d bytes", maxToolOutputBytes)
+	}
+	if readErr != nil {
+		return nil, readErr
+	}
+	if waitErr != nil {
+		return nil, waitErr
+	}
+	return output, nil
+}

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -36,7 +36,7 @@ const (
 
 var runCodeSignTool = runBoundedTool
 
-func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File, executable string, profile parsedProfile) CodeSignatureVerification {
+func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleID string, profile parsedProfile) CodeSignatureVerification {
 	result := CodeSignatureVerification{Status: CodeSignatureNotVerified, Scope: mainCodeSignatureScope}
 	if runtime.GOOS != "darwin" {
 		result.Reason = "complete main-app code-signature verification is available only on macOS"
@@ -101,7 +101,7 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 		result.Status, result.Reason = CodeSignatureInvalid, "CFBundleExecutable is not a Mach-O file in the main app"
 		return result
 	}
-	mainArchitectures, err := verifyMainExecutableEntitlements(ctx, mainExecutablePath, profile)
+	mainArchitectures, err := verifyMainExecutableEntitlements(ctx, mainExecutablePath, bundleID, profile)
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
 			result.Status, result.Reason = codeVerificationFailure(err, "main executable")
@@ -154,7 +154,7 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 	return result
 }
 
-func verifyMainExecutableEntitlements(ctx context.Context, codePath string, profile parsedProfile) ([]string, error) {
+func verifyMainExecutableEntitlements(ctx context.Context, codePath, bundleID string, profile parsedProfile) ([]string, error) {
 	architectures, err := codeObjectArchitectures(ctx, codePath)
 	if err != nil {
 		return nil, err
@@ -173,14 +173,14 @@ func verifyMainExecutableEntitlements(ctx context.Context, codePath string, prof
 		if err != nil {
 			return nil, fmt.Errorf("could not extract signed main-app entitlements for architecture %s: %w", architecture, err)
 		}
-		if err := validateSignedMainAppEntitlements(entitlementsData, profile); err != nil {
+		if err := validateSignedMainAppEntitlements(entitlementsData, bundleID, profile); err != nil {
 			return nil, err
 		}
 	}
 	return architectures, nil
 }
 
-func validateSignedMainAppEntitlements(entitlementsData []byte, profile parsedProfile) error {
+func validateSignedMainAppEntitlements(entitlementsData []byte, bundleID string, profile parsedProfile) error {
 	var entitlements map[string]any
 	if err := decodeBoundedPlist(entitlementsData, &entitlements); err != nil {
 		return fmt.Errorf("signed main-app entitlements are invalid")
@@ -193,9 +193,20 @@ func validateSignedMainAppEntitlements(entitlementsData []byte, profile parsedPr
 	if !ok || strings.TrimSpace(teamIdentifier) == "" {
 		return fmt.Errorf("signed main-app team identifier is missing")
 	}
+	teamID := onlyTrimmed(profile.TeamIdentifier)
+	if err := validateTeamIdentifier(teamID); err != nil {
+		return err
+	}
+	bundleID = strings.TrimSpace(bundleID)
+	if bundleID == "" {
+		return fmt.Errorf("inspected CFBundleIdentifier is missing")
+	}
 	profileApplicationID, _ := profile.Entitlements["application-identifier"].(string)
-	if strings.TrimSpace(teamIdentifier) != onlyTrimmed(profile.TeamIdentifier) || !entitlementValuePermits(profileApplicationID, appIdentifier) {
+	if strings.TrimSpace(teamIdentifier) != teamID || !entitlementValuePermits(profileApplicationID, appIdentifier) {
 		return fmt.Errorf("signed main-app entitlements do not match the embedded profile team and application identifier")
+	}
+	if appIdentifier != teamID+"."+bundleID {
+		return fmt.Errorf("signed main-app application identifier does not match inspected CFBundleIdentifier")
 	}
 	if profileDebug, ok := profile.Entitlements["get-task-allow"].(bool); !ok {
 		return fmt.Errorf("embedded profile get-task-allow entitlement is missing or invalid")

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	maxMainAppExpandedBytes int64 = 4 << 30
-	maxToolOutputBytes            = 1 << 20
-	mainCodeSignatureScope        = "complete-main-app-code-resources-entitlements-and-profile-certificate-binding"
+	maxMainAppExpandedBytes   int64 = 4 << 30
+	maxToolOutputBytes              = 1 << 20
+	codeSignInvocationTimeout       = 30 * time.Second
+	mainCodeSignatureScope          = "complete-main-app-code-resources-entitlements-and-profile-certificate-binding"
 )
 
 var runCodeSignTool = runBoundedTool
@@ -81,9 +82,8 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 		return result
 	}
 	appPath := path.Join(directory, "Verify.app")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "--verify", "--deep", "--strict", "--all-architectures", "--verbose=4", appPath); err != nil {
+	ctx := context.Background()
+	if _, err := runCodeSignInvocation(ctx, "/usr/bin/codesign", "--verify", "--deep", "--strict", "--all-architectures", "--verbose=4", appPath); err != nil {
 		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
 			result.Reason = "codesign is unavailable"
 			return result
@@ -125,7 +125,7 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 	mainFingerprintSet := stringSet(mainFingerprints)
 	teamRequirement := `anchor apple generic and certificate leaf[subject.OU] = "` + teamID + `"`
 	for index, codePath := range codePaths {
-		if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "--verify", "--strict", "--all-architectures", "-R="+teamRequirement, codePath); err != nil {
+		if _, err := runCodeSignInvocation(ctx, "/usr/bin/codesign", "--verify", "--strict", "--all-architectures", "-R="+teamRequirement, codePath); err != nil {
 			result.Status, result.Reason = CodeSignatureInvalid, "nested signed code does not satisfy the main app signing-team requirement"
 			return result
 		}
@@ -160,7 +160,7 @@ func verifyMainExecutableEntitlements(ctx context.Context, codePath string, prof
 		return nil, err
 	}
 	for _, architecture := range architectures {
-		entitlementsData, err := runCodeSignTool(
+		entitlementsData, err := runCodeSignInvocation(
 			ctx,
 			"/usr/bin/codesign",
 			"-d",
@@ -268,7 +268,7 @@ func isMachOFile(file *os.File, magic [4]byte, fileSize int64) bool {
 	switch magic {
 	case [4]byte{0xfe, 0xed, 0xfa, 0xce}, [4]byte{0xce, 0xfa, 0xed, 0xfe},
 		[4]byte{0xfe, 0xed, 0xfa, 0xcf}, [4]byte{0xcf, 0xfa, 0xed, 0xfe}:
-		return true
+		return isValidThinMachO(file, fileSize)
 	case [4]byte{0xca, 0xfe, 0xba, 0xbe}:
 		return isValidFatMachO(file, fileSize, binary.BigEndian, 20)
 	case [4]byte{0xbe, 0xba, 0xfe, 0xca}:
@@ -280,6 +280,14 @@ func isMachOFile(file *os.File, magic [4]byte, fileSize int64) bool {
 	default:
 		return false
 	}
+}
+
+func isValidThinMachO(file *os.File, fileSize int64) bool {
+	if fileSize <= 0 {
+		return false
+	}
+	_, err := macho.NewFile(io.NewSectionReader(file, 0, fileSize))
+	return err == nil
 }
 
 func isValidFatMachO(file *os.File, fileSize int64, order binary.ByteOrder, archHeaderSize int64) bool {
@@ -328,7 +336,7 @@ func codeObjectFingerprints(ctx context.Context, directory string, objectIndex i
 }
 
 func codeObjectArchitectures(ctx context.Context, codePath string) ([]string, error) {
-	archOutput, err := runCodeSignTool(ctx, "/usr/bin/lipo", "-archs", codePath)
+	archOutput, err := runCodeSignInvocation(ctx, "/usr/bin/lipo", "-archs", codePath)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +361,7 @@ func codeObjectFingerprintsForArchitectures(ctx context.Context, directory strin
 	var fingerprints []string
 	for architectureIndex, architecture := range architectures {
 		prefix := path.Join(directory, fmt.Sprintf("certificate-%d-%d-", objectIndex, architectureIndex))
-		if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "-d", "-a", architecture, "--extract-certificates="+prefix, codePath); err != nil {
+		if _, err := runCodeSignInvocation(ctx, "/usr/bin/codesign", "-d", "-a", architecture, "--extract-certificates="+prefix, codePath); err != nil {
 			return nil, err
 		}
 		leaf, err := os.ReadFile(prefix + "0")
@@ -557,6 +565,12 @@ func copyZipMemberToNewFile(root *os.Root, name string, member *zip.File, limit 
 		return fmt.Errorf("expanded member exceeds %d bytes", limit)
 	}
 	return nil
+}
+
+func runCodeSignInvocation(parent context.Context, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(parent, codeSignInvocationTimeout)
+	defer cancel()
+	return runCodeSignTool(ctx, name, args...)
 }
 
 func runBoundedTool(ctx context.Context, name string, args ...string) ([]byte, error) {

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -91,64 +91,27 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 		result.Status, result.Reason = CodeSignatureInvalid, "codesign rejected the complete main app"
 		return result
 	}
-	entitlementsData, err := runCodeSignTool(ctx, "/usr/bin/codesign", "-d", "--entitlements", ":-", appPath)
-	if err != nil {
-		result.Status, result.Reason = CodeSignatureInvalid, "could not extract signed main-app entitlements"
-		return result
-	}
-	var entitlements map[string]any
-	if err := decodeBoundedPlist(entitlementsData, &entitlements); err != nil {
-		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app entitlements are invalid"
-		return result
-	}
-	appIdentifier, ok := entitlements["application-identifier"].(string)
-	if !ok || strings.TrimSpace(appIdentifier) == "" {
-		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app application identifier is missing"
-		return result
-	}
-	teamIdentifier, ok := entitlements["com.apple.developer.team-identifier"].(string)
-	if !ok || strings.TrimSpace(teamIdentifier) == "" {
-		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app team identifier is missing"
-		return result
-	}
-	profileApplicationID, _ := profile.Entitlements["application-identifier"].(string)
-	if strings.TrimSpace(teamIdentifier) != onlyTrimmed(profile.TeamIdentifier) || !entitlementValuePermits(profileApplicationID, appIdentifier) {
-		result.Status, result.Reason = CodeSignatureInvalid, "signed main-app entitlements do not match the embedded profile team and application identifier"
-		return result
-	}
-	if profileDebug, ok := profile.Entitlements["get-task-allow"].(bool); !ok {
-		result.Status, result.Reason = CodeSignatureInvalid, "embedded profile get-task-allow entitlement is missing or invalid"
-		return result
-	} else if signedDebug, exists := entitlements["get-task-allow"]; exists {
-		debug, ok := signedDebug.(bool)
-		if !ok || debug != profileDebug {
-			result.Status, result.Reason = CodeSignatureInvalid, "signed get-task-allow entitlement is not permitted by the embedded profile"
-			return result
-		}
-	} else if profileDebug {
-		result.Status, result.Reason = CodeSignatureInvalid, "signed get-task-allow entitlement is missing for a development profile"
-		return result
-	}
-	for key, signedValue := range entitlements {
-		profileValue, exists := profile.Entitlements[key]
-		if !exists || !entitlementValuePermits(profileValue, signedValue) {
-			result.Status, result.Reason = CodeSignatureInvalid, "signed main-app entitlement is not permitted by the embedded profile: "+key
-			return result
-		}
-	}
-
+	mainExecutablePath := filepath.Join(appPath, executable)
 	codePaths, err := enumerateMachOFiles(appPath)
 	if err != nil {
 		result.Status, result.Reason = CodeSignatureInvalid, "could not enumerate nested signed code: "+err.Error()
 		return result
 	}
-	mainExecutablePath := filepath.Join(appPath, executable)
 	if !containsPath(codePaths, mainExecutablePath) {
 		result.Status, result.Reason = CodeSignatureInvalid, "CFBundleExecutable is not a Mach-O file in the main app"
 		return result
 	}
+	mainArchitectures, err := verifyMainExecutableEntitlements(ctx, mainExecutablePath, profile)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+			result.Status, result.Reason = codeVerificationFailure(err, "main executable")
+		} else {
+			result.Status, result.Reason = CodeSignatureInvalid, err.Error()
+		}
+		return result
+	}
 	allowed := certificateFingerprintSet(profile.DeveloperCertificates)
-	mainFingerprints, err := codeObjectFingerprints(ctx, directory, 0, mainExecutablePath)
+	mainFingerprints, err := codeObjectFingerprintsForArchitectures(ctx, directory, 0, mainExecutablePath, mainArchitectures)
 	if err != nil {
 		result.Status, result.Reason = codeVerificationFailure(err, "main executable")
 		return result
@@ -189,6 +152,68 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir string, _ *zip.File,
 	result.Reason = "complete main app, every nested Mach-O code object, signed entitlements, and profile certificate binding verified"
 	result.SignerCertificateSHA256Fingerprints = canonicalSet(mainFingerprints)
 	return result
+}
+
+func verifyMainExecutableEntitlements(ctx context.Context, codePath string, profile parsedProfile) ([]string, error) {
+	architectures, err := codeObjectArchitectures(ctx, codePath)
+	if err != nil {
+		return nil, err
+	}
+	for _, architecture := range architectures {
+		entitlementsData, err := runCodeSignTool(
+			ctx,
+			"/usr/bin/codesign",
+			"-d",
+			"-a",
+			architecture,
+			"--entitlements",
+			":-",
+			codePath,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("could not extract signed main-app entitlements for architecture %s: %w", architecture, err)
+		}
+		if err := validateSignedMainAppEntitlements(entitlementsData, profile); err != nil {
+			return nil, err
+		}
+	}
+	return architectures, nil
+}
+
+func validateSignedMainAppEntitlements(entitlementsData []byte, profile parsedProfile) error {
+	var entitlements map[string]any
+	if err := decodeBoundedPlist(entitlementsData, &entitlements); err != nil {
+		return fmt.Errorf("signed main-app entitlements are invalid")
+	}
+	appIdentifier, ok := entitlements["application-identifier"].(string)
+	if !ok || strings.TrimSpace(appIdentifier) == "" {
+		return fmt.Errorf("signed main-app application identifier is missing")
+	}
+	teamIdentifier, ok := entitlements["com.apple.developer.team-identifier"].(string)
+	if !ok || strings.TrimSpace(teamIdentifier) == "" {
+		return fmt.Errorf("signed main-app team identifier is missing")
+	}
+	profileApplicationID, _ := profile.Entitlements["application-identifier"].(string)
+	if strings.TrimSpace(teamIdentifier) != onlyTrimmed(profile.TeamIdentifier) || !entitlementValuePermits(profileApplicationID, appIdentifier) {
+		return fmt.Errorf("signed main-app entitlements do not match the embedded profile team and application identifier")
+	}
+	if profileDebug, ok := profile.Entitlements["get-task-allow"].(bool); !ok {
+		return fmt.Errorf("embedded profile get-task-allow entitlement is missing or invalid")
+	} else if signedDebug, exists := entitlements["get-task-allow"]; exists {
+		debug, ok := signedDebug.(bool)
+		if !ok || debug != profileDebug {
+			return fmt.Errorf("signed get-task-allow entitlement is not permitted by the embedded profile")
+		}
+	} else if profileDebug {
+		return fmt.Errorf("signed get-task-allow entitlement is missing for a development profile")
+	}
+	for key, signedValue := range entitlements {
+		profileValue, exists := profile.Entitlements[key]
+		if !exists || !entitlementValuePermits(profileValue, signedValue) {
+			return fmt.Errorf("signed main-app entitlement is not permitted by the embedded profile: %s", key)
+		}
+	}
+	return nil
 }
 
 func enumerateMachOFiles(appPath string) ([]string, error) {
@@ -295,6 +320,14 @@ func isValidFatMachO(file *os.File, fileSize int64, order binary.ByteOrder, arch
 }
 
 func codeObjectFingerprints(ctx context.Context, directory string, objectIndex int, codePath string) ([]string, error) {
+	architectures, err := codeObjectArchitectures(ctx, codePath)
+	if err != nil {
+		return nil, err
+	}
+	return codeObjectFingerprintsForArchitectures(ctx, directory, objectIndex, codePath, architectures)
+}
+
+func codeObjectArchitectures(ctx context.Context, codePath string) ([]string, error) {
 	archOutput, err := runCodeSignTool(ctx, "/usr/bin/lipo", "-archs", codePath)
 	if err != nil {
 		return nil, err
@@ -303,11 +336,22 @@ func codeObjectFingerprints(ctx context.Context, directory string, objectIndex i
 	if len(architectures) == 0 || len(architectures) > 64 {
 		return nil, fmt.Errorf("invalid architecture list")
 	}
-	var fingerprints []string
-	for architectureIndex, architecture := range architectures {
+	seen := make(map[string]struct{}, len(architectures))
+	for _, architecture := range architectures {
 		if err := validateArchitecture(architecture); err != nil {
 			return nil, err
 		}
+		if _, exists := seen[architecture]; exists {
+			return nil, fmt.Errorf("duplicate architecture")
+		}
+		seen[architecture] = struct{}{}
+	}
+	return architectures, nil
+}
+
+func codeObjectFingerprintsForArchitectures(ctx context.Context, directory string, objectIndex int, codePath string, architectures []string) ([]string, error) {
+	var fingerprints []string
+	for architectureIndex, architecture := range architectures {
 		prefix := path.Join(directory, fmt.Sprintf("certificate-%d-%d-", objectIndex, architectureIndex))
 		if _, err := runCodeSignTool(ctx, "/usr/bin/codesign", "-d", "-a", architecture, "--extract-certificates="+prefix, codePath); err != nil {
 			return nil, err

--- a/internal/distribution/codesign.go
+++ b/internal/distribution/codesign.go
@@ -36,8 +36,12 @@ const (
 
 var runCodeSignTool = runBoundedTool
 
-func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleID string, profile parsedProfile) CodeSignatureVerification {
+func verifyMainAppCodeSignature(ctx context.Context, members []*zip.File, appDir, executable, bundleID string, profile parsedProfile) CodeSignatureVerification {
 	result := CodeSignatureVerification{Status: CodeSignatureNotVerified, Scope: mainCodeSignatureScope}
+	if err := ctx.Err(); err != nil {
+		result.Reason = err.Error()
+		return result
+	}
 	if runtime.GOOS != "darwin" {
 		result.Reason = "complete main-app code-signature verification is available only on macOS"
 		return result
@@ -77,12 +81,11 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleI
 		return result
 	}
 	defer app.Close()
-	if err := materializeMainApp(app, members, appDir); err != nil {
+	if err := materializeMainApp(ctx, app, members, appDir); err != nil {
 		result.Status, result.Reason = CodeSignatureInvalid, "could not safely materialize the complete bounded main app: "+err.Error()
 		return result
 	}
 	appPath := path.Join(directory, "Verify.app")
-	ctx := context.Background()
 	if _, err := runCodeSignInvocation(ctx, "/usr/bin/codesign", "--verify", "--deep", "--strict", "--all-architectures", "--verbose=4", appPath); err != nil {
 		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
 			result.Reason = "codesign is unavailable"
@@ -92,7 +95,7 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleI
 		return result
 	}
 	mainExecutablePath := filepath.Join(appPath, executable)
-	codePaths, err := enumerateMachOFiles(appPath)
+	codePaths, err := enumerateMachOFiles(ctx, appPath)
 	if err != nil {
 		result.Status, result.Reason = CodeSignatureInvalid, "could not enumerate nested signed code: "+err.Error()
 		return result
@@ -125,6 +128,10 @@ func verifyMainAppCodeSignature(members []*zip.File, appDir, executable, bundleI
 	mainFingerprintSet := stringSet(mainFingerprints)
 	teamRequirement := `anchor apple generic and certificate leaf[subject.OU] = "` + teamID + `"`
 	for index, codePath := range codePaths {
+		if err := ctx.Err(); err != nil {
+			result.Reason = err.Error()
+			return result
+		}
 		if _, err := runCodeSignInvocation(ctx, "/usr/bin/codesign", "--verify", "--strict", "--all-architectures", "-R="+teamRequirement, codePath); err != nil {
 			result.Status, result.Reason = CodeSignatureInvalid, "nested signed code does not satisfy the main app signing-team requirement"
 			return result
@@ -231,9 +238,12 @@ func validateSignedMainAppEntitlements(entitlementsData []byte, bundleID string,
 	return nil
 }
 
-func enumerateMachOFiles(appPath string) ([]string, error) {
+func enumerateMachOFiles(ctx context.Context, appPath string) ([]string, error) {
 	var result []string
 	err := filepath.WalkDir(appPath, func(candidate string, entry os.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -488,10 +498,13 @@ func entitlementList(value any) ([]any, bool) {
 	}
 }
 
-func materializeMainApp(destination *os.Root, members []*zip.File, appDir string) error {
+func materializeMainApp(ctx context.Context, destination *os.Root, members []*zip.File, appDir string) error {
 	prefix := appDir + "/"
 	var total int64
 	for _, member := range members {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if !strings.HasPrefix(member.Name, prefix) {
 			continue
 		}
@@ -512,7 +525,7 @@ func materializeMainApp(destination *os.Root, members []*zip.File, appDir string
 		if err := destination.MkdirAll(path.Dir(relative), 0o700); err != nil {
 			return err
 		}
-		if err := copyZipMemberToNewFile(destination, relative, member, int64(member.UncompressedSize64)); err != nil {
+		if err := copyZipMemberToNewFile(ctx, destination, relative, member, int64(member.UncompressedSize64)); err != nil {
 			return err
 		}
 	}
@@ -596,7 +609,7 @@ func validateArchitecture(value string) error {
 	return nil
 }
 
-func copyZipMemberToNewFile(root *os.Root, name string, member *zip.File, limit int64) error {
+func copyZipMemberToNewFile(ctx context.Context, root *os.Root, name string, member *zip.File, limit int64) error {
 	reader, err := member.Open()
 	if err != nil {
 		return err
@@ -606,7 +619,7 @@ func copyZipMemberToNewFile(root *os.Root, name string, member *zip.File, limit 
 	if err != nil {
 		return err
 	}
-	written, copyErr := io.Copy(file, io.LimitReader(reader, limit+1))
+	written, copyErr := copyWithContext(ctx, file, io.LimitReader(reader, limit+1))
 	closeErr := file.Close()
 	if copyErr != nil {
 		return copyErr

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -328,6 +328,13 @@ func TestValidateSignedMainAppEntitlementsBindsExactBundleIdentifier(t *testing.
 			signedTeamID:         "OTHERTEAM",
 			wantError:            true,
 		},
+		{
+			name:                 "signed team entitlement has trailing whitespace",
+			profileApplicationID: "TEAM123.com.example.demo",
+			signedApplicationID:  "TEAM123.com.example.demo",
+			signedTeamID:         "TEAM123 ",
+			wantError:            true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			profile := entitlementTestProfile()
@@ -804,7 +811,13 @@ func TestEntitlementValuePermitsExactWildcardAndSubsetOnly(t *testing.T) {
 		{name: "terminal wildcard", profile: "TEAM.com.example.*", signed: "TEAM.com.example.app", want: true},
 		{name: "wildcard needs suffix", profile: "TEAM.com.example.*", signed: "TEAM.com.example.", want: false},
 		{name: "mismatched prefix", profile: "TEAM.com.example.*", signed: "OTHER.com.example.app", want: false},
+		{name: "signed exact leading whitespace", profile: "TEAM.com.example.app", signed: " TEAM.com.example.app", want: false},
+		{name: "signed exact trailing whitespace", profile: "TEAM.com.example.app", signed: "TEAM.com.example.app ", want: false},
+		{name: "signed wildcard leading whitespace", profile: "TEAM.com.example.*", signed: " TEAM.com.example.app", want: false},
+		{name: "profile exact whitespace is not normalized", profile: " TEAM.com.example.app", signed: "TEAM.com.example.app", want: false},
+		{name: "profile wildcard whitespace is not normalized", profile: " TEAM.com.example.*", signed: "TEAM.com.example.app", want: false},
 		{name: "list subset", profile: []any{"group.one", "group.two"}, signed: []any{"group.two"}, want: true},
+		{name: "list signed whitespace", profile: []any{"group.one"}, signed: []any{" group.one"}, want: false},
 		{name: "list extra", profile: []any{"group.one"}, signed: []any{"group.two"}, want: false},
 		{name: "bool mismatch", profile: false, signed: true, want: false},
 	}

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -403,6 +403,22 @@ func TestRunCodeSignInvocationUsesIndependentDeadlines(t *testing.T) {
 	}
 }
 
+func TestRunCodeSignInvocationPropagatesParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runCodeSignTool = func(toolCtx context.Context, _ string, _ ...string) ([]byte, error) {
+		if !errors.Is(toolCtx.Err(), context.Canceled) {
+			t.Fatalf("tool context error = %v, want context.Canceled", toolCtx.Err())
+		}
+		return nil, toolCtx.Err()
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+
+	if _, err := runCodeSignInvocation(ctx, "codesign", "--verify"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("runCodeSignInvocation() error = %v, want context.Canceled", err)
+	}
+}
+
 func TestInspectIPARejectsNestedCodeSignedByDifferentLeafEvenWhenDeepVerifyPasses(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("codesign verification is macOS-only")
@@ -526,7 +542,7 @@ func TestEnumerateMachOFilesIgnoresJavaClassMagicCollision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := enumerateMachOFiles(appPath)
+	got, err := enumerateMachOFiles(context.Background(), appPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +563,7 @@ func TestEnumerateMachOFilesIgnoresNonLoadableObjectFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := enumerateMachOFiles(appPath)
+	got, err := enumerateMachOFiles(context.Background(), appPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -576,7 +592,7 @@ func TestEnumerateMachOFilesIncludesOnlyLoadableThinImageTypes(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	got, err := enumerateMachOFiles(appPath)
+	got, err := enumerateMachOFiles(context.Background(), appPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -595,7 +611,7 @@ func TestEnumerateMachOFilesClassifiesFatImageTypesSafely(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(appPath, "Resource.o"), fatMachOWithTypes(1), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		got, err := enumerateMachOFiles(appPath)
+		got, err := enumerateMachOFiles(context.Background(), appPath)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -609,7 +625,7 @@ func TestEnumerateMachOFilesClassifiesFatImageTypesSafely(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(appPath, "Mixed"), fatMachOWithTypes(2, 1), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := enumerateMachOFiles(appPath); err == nil || !strings.Contains(err.Error(), "mixes loadable and non-loadable") {
+		if _, err := enumerateMachOFiles(context.Background(), appPath); err == nil || !strings.Contains(err.Error(), "mixes loadable and non-loadable") {
 			t.Fatalf("enumerateMachOFiles() error = %v, want mixed-type rejection", err)
 		}
 	})
@@ -622,7 +638,7 @@ func TestEnumerateMachOFilesClassifiesFatImageTypesSafely(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(appPath, "Malformed"), data, 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := enumerateMachOFiles(appPath); err == nil || !strings.Contains(err.Error(), "malformed architecture slice") {
+		if _, err := enumerateMachOFiles(context.Background(), appPath); err == nil || !strings.Contains(err.Error(), "malformed architecture slice") {
 			t.Fatalf("enumerateMachOFiles() error = %v, want malformed-slice rejection", err)
 		}
 	})
@@ -652,7 +668,7 @@ func TestVerifyMainAppCodeSignatureRejectsUnsafeTeamBeforeTools(t *testing.T) {
 	}
 	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
 
-	got := verifyMainAppCodeSignature(nil, "Payload/Demo.app", "Demo", "com.example.demo", parsedProfile{
+	got := verifyMainAppCodeSignature(context.Background(), nil, "Payload/Demo.app", "Demo", "com.example.demo", parsedProfile{
 		embeddedProfile: embeddedProfile{TeamIdentifier: []string{`TEAM" or true`}},
 	})
 	if got.Status != CodeSignatureInvalid || !strings.Contains(got.Reason, "unsupported characters") || called {
@@ -671,7 +687,7 @@ func TestVerifyMainAppCodeSignatureRejectsExpandedExecutableBeforeTools(t *testi
 		return nil, errors.New("unexpected")
 	}
 	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
-	got := verifyMainAppCodeSignature([]*zip.File{member}, "Payload/Demo.app", "Demo", "com.example.demo", parsedProfile{})
+	got := verifyMainAppCodeSignature(context.Background(), []*zip.File{member}, "Payload/Demo.app", "Demo", "com.example.demo", parsedProfile{})
 	if got.Status != CodeSignatureInvalid || called {
 		t.Fatalf("verification=%#v called=%t", got, called)
 	}

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -255,17 +255,25 @@ func TestVerifyMainExecutableEntitlementsRejectsInvalidLipoOutput(t *testing.T) 
 
 func TestValidateSignedMainAppEntitlementsBindsExactBundleIdentifier(t *testing.T) {
 	for _, test := range []struct {
-		name                 string
-		profileApplicationID string
-		signedApplicationID  any
-		signedTeamID         string
-		wantError            bool
+		name                        string
+		applicationIdentifierPrefix string
+		profileApplicationID        string
+		signedApplicationID         any
+		signedTeamID                string
+		wantError                   bool
 	}{
 		{
 			name:                 "exact profile and matching signed identifier",
 			profileApplicationID: "TEAM123.com.example.demo",
 			signedApplicationID:  "TEAM123.com.example.demo",
 			signedTeamID:         "TEAM123",
+		},
+		{
+			name:                        "legacy application prefix differs from team",
+			applicationIdentifierPrefix: "LEGACY123",
+			profileApplicationID:        "LEGACY123.com.example.demo",
+			signedApplicationID:         "LEGACY123.com.example.demo",
+			signedTeamID:                "TEAM123",
 		},
 		{
 			name:                 "wildcard profile and matching signed identifier",
@@ -304,6 +312,9 @@ func TestValidateSignedMainAppEntitlementsBindsExactBundleIdentifier(t *testing.
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			profile := entitlementTestProfile()
+			if test.applicationIdentifierPrefix != "" {
+				profile.ApplicationIdentifierPrefix = []string{test.applicationIdentifierPrefix}
+			}
 			profile.Entitlements["application-identifier"] = test.profileApplicationID
 			entitlements := map[string]any{
 				"com.apple.developer.team-identifier": test.signedTeamID,
@@ -545,7 +556,8 @@ func validExecutableIPA(t *testing.T) string {
 
 func entitlementTestProfile() parsedProfile {
 	return parsedProfile{embeddedProfile: embeddedProfile{
-		TeamIdentifier: []string{"TEAM123"},
+		TeamIdentifier:              []string{"TEAM123"},
+		ApplicationIdentifierPrefix: []string{"TEAM123"},
 		Entitlements: map[string]any{
 			"application-identifier":              "TEAM123.com.example.*",
 			"com.apple.developer.team-identifier": "TEAM123",

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -143,14 +143,14 @@ func TestVerifyMainExecutableEntitlementsQueriesEveryArchitectureOnce(t *testing
 		queries[architecture]++
 		entitlements := validMainEntitlements()
 		if architecture == "x86_64" {
-			entitlements["get-task-allow"] = true
+			entitlements["application-identifier"] = "TEAM123.com.example.other"
 		}
 		return plist.Marshal(entitlements, plist.XMLFormat)
 	}
 	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
 
-	_, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", profile)
-	if err == nil || !strings.Contains(err.Error(), "get-task-allow") {
+	_, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", "com.example.demo", profile)
+	if err == nil || !strings.Contains(err.Error(), "CFBundleIdentifier") {
 		t.Fatalf("verifyMainExecutableEntitlements() error = %v, want secondary-architecture mismatch", err)
 	}
 	if queries["arm64"] != 1 || queries["x86_64"] != 1 || len(queries) != 2 {
@@ -199,7 +199,7 @@ func TestVerifyMainExecutableEntitlementsFailsClosedPerSlice(t *testing.T) {
 			}
 			t.Cleanup(func() { runCodeSignTool = runBoundedTool })
 
-			_, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", entitlementTestProfile())
+			_, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", "com.example.demo", entitlementTestProfile())
 			if err == nil || !strings.Contains(err.Error(), test.wantReason) {
 				t.Fatalf("verifyMainExecutableEntitlements() error = %v, want %q", err, test.wantReason)
 			}
@@ -221,7 +221,7 @@ func TestVerifyMainExecutableEntitlementsPreservesThinBinaryBehavior(t *testing.
 	}
 	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
 
-	architectures, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", entitlementTestProfile())
+	architectures, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", "com.example.demo", entitlementTestProfile())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,11 +243,81 @@ func TestVerifyMainExecutableEntitlementsRejectsInvalidLipoOutput(t *testing.T) 
 			}
 			t.Cleanup(func() { runCodeSignTool = runBoundedTool })
 
-			if _, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", entitlementTestProfile()); err == nil {
+			if _, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", "com.example.demo", entitlementTestProfile()); err == nil {
 				t.Fatal("verifyMainExecutableEntitlements() error = nil, want invalid architecture rejection")
 			}
 			if codesignCalled {
 				t.Fatal("codesign was called with unvalidated lipo output")
+			}
+		})
+	}
+}
+
+func TestValidateSignedMainAppEntitlementsBindsExactBundleIdentifier(t *testing.T) {
+	for _, test := range []struct {
+		name                 string
+		profileApplicationID string
+		signedApplicationID  any
+		signedTeamID         string
+		wantError            bool
+	}{
+		{
+			name:                 "exact profile and matching signed identifier",
+			profileApplicationID: "TEAM123.com.example.demo",
+			signedApplicationID:  "TEAM123.com.example.demo",
+			signedTeamID:         "TEAM123",
+		},
+		{
+			name:                 "wildcard profile and matching signed identifier",
+			profileApplicationID: "TEAM123.com.example.*",
+			signedApplicationID:  "TEAM123.com.example.demo",
+			signedTeamID:         "TEAM123",
+		},
+		{
+			name:                 "wildcard profile different suffix",
+			profileApplicationID: "TEAM123.com.example.*",
+			signedApplicationID:  "TEAM123.com.example.other",
+			signedTeamID:         "TEAM123",
+			wantError:            true,
+		},
+		{
+			name:                 "team prefix ambiguity",
+			profileApplicationID: "TEAM123.*",
+			signedApplicationID:  "TEAM1234.com.example.demo",
+			signedTeamID:         "TEAM123",
+			wantError:            true,
+		},
+		{
+			name:                 "application identifier injection",
+			profileApplicationID: "TEAM123.*",
+			signedApplicationID:  `TEAM123.com.example.demo" or true`,
+			signedTeamID:         "TEAM123",
+			wantError:            true,
+		},
+		{
+			name:                 "missing signed identifier",
+			profileApplicationID: "TEAM123.*",
+			signedApplicationID:  nil,
+			signedTeamID:         "TEAM123",
+			wantError:            true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			profile := entitlementTestProfile()
+			profile.Entitlements["application-identifier"] = test.profileApplicationID
+			entitlements := map[string]any{
+				"com.apple.developer.team-identifier": test.signedTeamID,
+			}
+			if test.signedApplicationID != nil {
+				entitlements["application-identifier"] = test.signedApplicationID
+			}
+			data, err := plist.Marshal(entitlements, plist.XMLFormat)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = validateSignedMainAppEntitlements(data, "com.example.demo", profile)
+			if (err != nil) != test.wantError {
+				t.Fatalf("validateSignedMainAppEntitlements() error = %v, wantError=%t", err, test.wantError)
 			}
 		})
 	}
@@ -434,7 +504,7 @@ func TestVerifyMainAppCodeSignatureRejectsUnsafeTeamBeforeTools(t *testing.T) {
 	}
 	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
 
-	got := verifyMainAppCodeSignature(nil, "Payload/Demo.app", nil, "Demo", parsedProfile{
+	got := verifyMainAppCodeSignature(nil, "Payload/Demo.app", "Demo", "com.example.demo", parsedProfile{
 		embeddedProfile: embeddedProfile{TeamIdentifier: []string{`TEAM" or true`}},
 	})
 	if got.Status != CodeSignatureInvalid || !strings.Contains(got.Reason, "unsupported characters") || called {
@@ -453,7 +523,7 @@ func TestVerifyMainAppCodeSignatureRejectsExpandedExecutableBeforeTools(t *testi
 		return nil, errors.New("unexpected")
 	}
 	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
-	got := verifyMainAppCodeSignature([]*zip.File{member}, "Payload/Demo.app", nil, "Demo", parsedProfile{})
+	got := verifyMainAppCodeSignature([]*zip.File{member}, "Payload/Demo.app", "Demo", "com.example.demo", parsedProfile{})
 	if got.Status != CodeSignatureInvalid || called {
 		t.Fatalf("verification=%#v called=%t", got, called)
 	}

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -183,6 +184,67 @@ func TestInspectIPARejectsSignerOutsideEmbeddedProfile(t *testing.T) {
 	}
 }
 
+func TestEnumerateMachOFilesIgnoresJavaClassMagicCollision(t *testing.T) {
+	appPath := t.TempDir()
+	mainPath := filepath.Join(appPath, "Demo")
+	fatPath := filepath.Join(appPath, "Universal")
+	classPath := filepath.Join(appPath, "Resource.class")
+	malformedFatPath := filepath.Join(appPath, "MalformedUniversal")
+	if err := os.WriteFile(mainPath, fakeMachO("main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fatPath, validFatMachO(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(classPath, []byte{0xca, 0xfe, 0xba, 0xbe, 0x00, 0x00, 0x00, 0x3d}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(malformedFatPath, []byte{0xca, 0xfe, 0xba, 0xbe, 0x00, 0x00, 0x00, 0x01}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := enumerateMachOFiles(appPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{mainPath, fatPath}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("enumerateMachOFiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidateTeamIdentifierRejectsRequirementInjection(t *testing.T) {
+	for _, value := range []string{"TEAM123", "abc123", strings.Repeat("A", 32)} {
+		if err := validateTeamIdentifier(value); err != nil {
+			t.Fatalf("validateTeamIdentifier(%q) = %v", value, err)
+		}
+	}
+	for _, value := range []string{"", `TEAM" or true`, "TEAM 123", "TÉAM123", strings.Repeat("A", 33)} {
+		if err := validateTeamIdentifier(value); err == nil {
+			t.Fatalf("validateTeamIdentifier(%q) unexpectedly succeeded", value)
+		}
+	}
+}
+
+func TestVerifyMainAppCodeSignatureRejectsUnsafeTeamBeforeTools(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codesign verification is macOS-only")
+	}
+	called := false
+	runCodeSignTool = func(context.Context, string, ...string) ([]byte, error) {
+		called = true
+		return nil, errors.New("unexpected")
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+
+	got := verifyMainAppCodeSignature(nil, "Payload/Demo.app", nil, "Demo", parsedProfile{
+		embeddedProfile: embeddedProfile{TeamIdentifier: []string{`TEAM" or true`}},
+	})
+	if got.Status != CodeSignatureInvalid || !strings.Contains(got.Reason, "unsupported characters") || called {
+		t.Fatalf("verification=%#v called=%t", got, called)
+	}
+}
+
 func TestVerifyMainAppCodeSignatureRejectsExpandedExecutableBeforeTools(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("codesign verification is macOS-only")
@@ -216,6 +278,26 @@ func validExecutableIPA(t *testing.T) string {
 
 func fakeMachO(payload string) []byte {
 	return append([]byte{0xcf, 0xfa, 0xed, 0xfe}, []byte(payload)...)
+}
+
+func validFatMachO() []byte {
+	return []byte{
+		0xca, 0xfe, 0xba, 0xbe, // FAT_MAGIC
+		0x00, 0x00, 0x00, 0x01, // one architecture
+		0x01, 0x00, 0x00, 0x0c, // CPU_TYPE_ARM64
+		0x00, 0x00, 0x00, 0x00, // CPU subtype
+		0x00, 0x00, 0x00, 0x1c, // slice offset
+		0x00, 0x00, 0x00, 0x20, // slice size
+		0x00, 0x00, 0x00, 0x02, // alignment
+		0xcf, 0xfa, 0xed, 0xfe, // MH_MAGIC_64
+		0x0c, 0x00, 0x00, 0x01, // CPU_TYPE_ARM64
+		0x00, 0x00, 0x00, 0x00, // CPU subtype
+		0x02, 0x00, 0x00, 0x00, // MH_EXECUTE
+		0x00, 0x00, 0x00, 0x00, // no load commands
+		0x00, 0x00, 0x00, 0x00, // load command size
+		0x00, 0x00, 0x00, 0x00, // flags
+		0x00, 0x00, 0x00, 0x00, // reserved
+	}
 }
 
 func TestValidateExecutableNameRejectsTraversalAndFormatting(t *testing.T) {

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -1,0 +1,251 @@
+package distribution
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mozilla.org/pkcs7"
+	"howett.net/plist"
+)
+
+func TestInspectIPAVerifiesEveryMainExecutableArchitectureAgainstProfile(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codesign verification is macOS-only")
+	}
+	profile := signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
+	message, err := pkcs7.Parse(profile)
+	if err != nil || len(message.Certificates) == 0 {
+		t.Fatalf("parse fixture profile: %v", err)
+	}
+	leaf := message.Certificates[0].Raw
+	var extracted int
+	var verified, listed bool
+	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		switch name {
+		case "/usr/bin/lipo":
+			if len(args) != 2 || args[0] != "-archs" {
+				t.Fatalf("unexpected lipo args: %#v", args)
+			}
+			listed = true
+			return []byte("arm64 x86_64\n"), nil
+		case "/usr/bin/codesign":
+			if len(args) > 1 && args[0] == "--verify" && args[1] == "--deep" {
+				want := []string{"--verify", "--deep", "--strict", "--all-architectures", "--verbose=4"}
+				if len(args) != len(want)+1 || strings.Join(args[:len(want)], "\x00") != strings.Join(want, "\x00") {
+					t.Fatalf("unexpected codesign verify args: %#v", args)
+				}
+				verified = true
+			}
+			if len(args) > 0 && args[0] == "-d" && len(args) > 3 && args[1] == "--entitlements" && args[2] == ":-" {
+				return plist.Marshal(map[string]any{
+					"application-identifier":              "TEAM123.com.example.demo",
+					"com.apple.developer.team-identifier": "TEAM123",
+				}, plist.XMLFormat)
+			}
+			for _, argument := range args {
+				if strings.HasPrefix(argument, "--extract-certificates=") {
+					prefix := strings.TrimPrefix(argument, "--extract-certificates=")
+					if err := os.WriteFile(prefix+"0", leaf, 0o600); err != nil {
+						return nil, err
+					}
+					extracted++
+				}
+			}
+			return nil, nil
+		default:
+			t.Fatalf("unexpected tool %q", name)
+			return nil, nil
+		}
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+	path := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistBytes(t, map[string]any{
+			"CFBundleIdentifier": "com.example.demo", "CFBundleName": "Demo",
+			"CFBundleShortVersionString": "1.0", "CFBundleVersion": "1", "CFBundleExecutable": "Demo",
+		}),
+		"Payload/Demo.app/Demo":                     fakeMachO("main"),
+		"Payload/Demo.app/Frameworks/Shared.dylib":  fakeMachO("nested"),
+		"Payload/Demo.app/embedded.mobileprovision": profile,
+	})
+	got := inspectPath(t, path, false)
+	if got.Signing.CodeSignatureVerification.Status != CodeSignatureVerified || extracted != 4 || !verified || !listed {
+		t.Fatalf("verification=%#v extracted=%d", got.Signing.CodeSignatureVerification, extracted)
+	}
+	if len(got.Signing.CodeSignatureVerification.SignerCertificateSHA256Fingerprints) != 1 {
+		t.Fatalf("fingerprints=%#v", got.Signing.CodeSignatureVerification.SignerCertificateSHA256Fingerprints)
+	}
+}
+
+func TestInspectIPARejectsNestedCodeSignedByDifferentLeafEvenWhenDeepVerifyPasses(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codesign verification is macOS-only")
+	}
+	profile := signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
+	message, err := pkcs7.Parse(profile)
+	if err != nil || len(message.Certificates) == 0 {
+		t.Fatalf("parse fixture profile: %v", err)
+	}
+	mainLeaf := message.Certificates[0].Raw
+	otherProfile := signedProfile(t, profileFixture{BundleID: "com.example.other", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
+	otherMessage, err := pkcs7.Parse(otherProfile)
+	if err != nil || len(otherMessage.Certificates) == 0 {
+		t.Fatalf("parse other profile: %v", err)
+	}
+	otherLeaf := otherMessage.Certificates[0].Raw
+	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "/usr/bin/lipo" {
+			return []byte("arm64\n"), nil
+		}
+		if len(args) > 3 && args[1] == "--entitlements" && args[2] == ":-" {
+			return plist.Marshal(map[string]any{
+				"application-identifier":              "TEAM123.com.example.demo",
+				"com.apple.developer.team-identifier": "TEAM123",
+			}, plist.XMLFormat)
+		}
+		for _, argument := range args {
+			if strings.HasPrefix(argument, "--extract-certificates=") {
+				leaf := mainLeaf
+				if strings.Contains(args[len(args)-1], "Shared.dylib") {
+					leaf = otherLeaf
+				}
+				return nil, os.WriteFile(strings.TrimPrefix(argument, "--extract-certificates=")+"0", leaf, 0o600)
+			}
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+	path := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistBytes(t, map[string]any{
+			"CFBundleIdentifier": "com.example.demo", "CFBundleName": "Demo",
+			"CFBundleShortVersionString": "1.0", "CFBundleVersion": "1", "CFBundleExecutable": "Demo",
+		}),
+		"Payload/Demo.app/Demo":                     fakeMachO("main"),
+		"Payload/Demo.app/Frameworks/Shared.dylib":  fakeMachO("nested"),
+		"Payload/Demo.app/embedded.mobileprovision": profile,
+	})
+	got := inspectPath(t, path, false)
+	if got.Signing.CodeSignatureVerification.Status != CodeSignatureInvalid || !strings.Contains(got.Signing.CodeSignatureVerification.Reason, "nested signed code signer") {
+		t.Fatalf("verification=%#v", got.Signing.CodeSignatureVerification)
+	}
+}
+
+func TestInspectIPACodeSignToolAbsenceIsExplicitlyNotVerified(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codesign verification is macOS-only")
+	}
+	runCodeSignTool = func(context.Context, string, ...string) ([]byte, error) { return nil, exec.ErrNotFound }
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+	path := validExecutableIPA(t)
+	got := inspectPath(t, path, false)
+	if got.Signing.CodeSignatureVerification.Status != CodeSignatureNotVerified {
+		t.Fatalf("verification=%#v", got.Signing.CodeSignatureVerification)
+	}
+}
+
+func TestInspectIPARejectsSignerOutsideEmbeddedProfile(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codesign verification is macOS-only")
+	}
+	otherProfile := signedProfile(t, profileFixture{BundleID: "com.example.other", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
+	message, err := pkcs7.Parse(otherProfile)
+	if err != nil || len(message.Certificates) == 0 {
+		t.Fatalf("parse other profile: %v", err)
+	}
+	otherLeaf := message.Certificates[0].Raw
+	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "/usr/bin/lipo" {
+			return []byte("arm64\n"), nil
+		}
+		for _, argument := range args {
+			if strings.HasPrefix(argument, "--extract-certificates=") {
+				return nil, os.WriteFile(strings.TrimPrefix(argument, "--extract-certificates=")+"0", otherLeaf, 0o600)
+			}
+		}
+		if len(args) > 3 && args[1] == "--entitlements" && args[2] == ":-" {
+			return plist.Marshal(map[string]any{
+				"application-identifier":              "TEAM123.com.example.demo",
+				"com.apple.developer.team-identifier": "TEAM123",
+			}, plist.XMLFormat)
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+	got := inspectPath(t, validExecutableIPA(t), false)
+	if got.Signing.CodeSignatureVerification.Status != CodeSignatureInvalid {
+		t.Fatalf("verification=%#v", got.Signing.CodeSignatureVerification)
+	}
+}
+
+func TestVerifyMainAppCodeSignatureRejectsExpandedExecutableBeforeTools(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codesign verification is macOS-only")
+	}
+	member := &zip.File{FileHeader: zip.FileHeader{Name: "Payload/Demo.app/Demo", UncompressedSize64: uint64(maxMainAppExpandedBytes + 1)}}
+	called := false
+	runCodeSignTool = func(context.Context, string, ...string) ([]byte, error) {
+		called = true
+		return nil, errors.New("unexpected")
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+	got := verifyMainAppCodeSignature([]*zip.File{member}, "Payload/Demo.app", nil, "Demo", parsedProfile{})
+	if got.Status != CodeSignatureInvalid || called {
+		t.Fatalf("verification=%#v called=%t", got, called)
+	}
+}
+
+func validExecutableIPA(t *testing.T) string {
+	t.Helper()
+	return writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistBytes(t, map[string]any{
+			"CFBundleIdentifier": "com.example.demo", "CFBundleName": "Demo",
+			"CFBundleShortVersionString": "1.0", "CFBundleVersion": "1", "CFBundleExecutable": "Demo",
+		}),
+		"Payload/Demo.app/Demo": fakeMachO("main"),
+		"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{
+			BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour),
+		}),
+	})
+}
+
+func fakeMachO(payload string) []byte {
+	return append([]byte{0xcf, 0xfa, 0xed, 0xfe}, []byte(payload)...)
+}
+
+func TestValidateExecutableNameRejectsTraversalAndFormatting(t *testing.T) {
+	for _, value := range []string{"../Demo", "PlugIns/Demo", "Demo\u202Eipa", strings.Repeat("a", 256)} {
+		if err := validateExecutableName(value); err == nil {
+			t.Fatalf("validateExecutableName(%q) unexpectedly succeeded", value)
+		}
+	}
+}
+
+func TestEntitlementValuePermitsExactWildcardAndSubsetOnly(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile any
+		signed  any
+		want    bool
+	}{
+		{name: "exact", profile: "TEAM.com.example.app", signed: "TEAM.com.example.app", want: true},
+		{name: "terminal wildcard", profile: "TEAM.com.example.*", signed: "TEAM.com.example.app", want: true},
+		{name: "wildcard needs suffix", profile: "TEAM.com.example.*", signed: "TEAM.com.example.", want: false},
+		{name: "mismatched prefix", profile: "TEAM.com.example.*", signed: "OTHER.com.example.app", want: false},
+		{name: "list subset", profile: []any{"group.one", "group.two"}, signed: []any{"group.two"}, want: true},
+		{name: "list extra", profile: []any{"group.one"}, signed: []any{"group.two"}, want: false},
+		{name: "bool mismatch", profile: false, signed: true, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := entitlementValuePermits(test.profile, test.signed); got != test.want {
+				t.Fatalf("entitlementValuePermits(%#v, %#v) = %t, want %t", test.profile, test.signed, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -379,6 +379,63 @@ func TestValidateSignedMainAppEntitlementsRejectsUnsafeProfilePrefix(t *testing.
 	}
 }
 
+func TestVerifyMainExecutableEntitlementsStopsBetweenArchitecturesOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls []string
+	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		if name == "/usr/bin/lipo" {
+			return []byte("arm64 x86_64 arm64e\n"), nil
+		}
+		cancel()
+		return nil, context.Canceled
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+	_, err := verifyMainExecutableEntitlements(ctx, "/tmp/Demo", "com.example.demo", parsedProfile{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("verifyMainExecutableEntitlements() error = %v, want context.Canceled", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("tool calls = %#v, want lipo and one architecture only", calls)
+	}
+}
+
+func TestMaterializeMainAppContextCancellationStopsBeforeLaterFiles(t *testing.T) {
+	path := writeOrderedIPA(t, []orderedZipEntry{
+		{Name: "Payload/Demo.app/Demo", Data: fakeMachO("main")},
+		{Name: "Payload/Demo.app/Frameworks/Later.dylib", Data: fakeMachO("later")},
+	})
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := t.TempDir()
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	duringMaterializedCopyForTest = cancel
+	t.Cleanup(func() { duringMaterializedCopyForTest = nil })
+	err = materializeMainAppContext(ctx, root, reader.File, "Payload/Demo.app")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("materializeMainAppContext() error = %v, want context.Canceled", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, "Frameworks", "Later.dylib")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("later nested code stat error = %v, want not found", err)
+	}
+}
+
 func TestRunCodeSignInvocationUsesIndependentDeadlines(t *testing.T) {
 	var deadlines []time.Time
 	runCodeSignTool = func(ctx context.Context, _ string, _ ...string) ([]byte, error) {

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -253,6 +253,30 @@ func TestVerifyMainExecutableEntitlementsRejectsInvalidLipoOutput(t *testing.T) 
 	}
 }
 
+func TestRunCodeSignInvocationUsesIndependentDeadlines(t *testing.T) {
+	var deadlines []time.Time
+	runCodeSignTool = func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("codesign invocation context has no deadline")
+		}
+		deadlines = append(deadlines, deadline)
+		return nil, nil
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+
+	if _, err := runCodeSignInvocation(context.Background(), "codesign", "--verify"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(2 * time.Millisecond)
+	if _, err := runCodeSignInvocation(context.Background(), "lipo", "-archs"); err != nil {
+		t.Fatal(err)
+	}
+	if len(deadlines) != 2 || !deadlines[1].After(deadlines[0]) {
+		t.Fatalf("invocation deadlines = %#v, want a fresh deadline for every tool call", deadlines)
+	}
+}
+
 func TestInspectIPARejectsNestedCodeSignedByDifferentLeafEvenWhenDeepVerifyPasses(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("codesign verification is macOS-only")
@@ -359,6 +383,7 @@ func TestEnumerateMachOFilesIgnoresJavaClassMagicCollision(t *testing.T) {
 	fatPath := filepath.Join(appPath, "Universal")
 	classPath := filepath.Join(appPath, "Resource.class")
 	malformedFatPath := filepath.Join(appPath, "MalformedUniversal")
+	thinMagicResourcePath := filepath.Join(appPath, "ThinMagicResource")
 	if err := os.WriteFile(mainPath, fakeMachO("main"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -369,6 +394,9 @@ func TestEnumerateMachOFilesIgnoresJavaClassMagicCollision(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(malformedFatPath, []byte{0xca, 0xfe, 0xba, 0xbe, 0x00, 0x00, 0x00, 0x01}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(thinMagicResourcePath, []byte{0xcf, 0xfa, 0xed, 0xfe, 'n', 'o', 't', '-', 'm', 'a', 'c', 'h', 'o'}, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -480,7 +508,17 @@ func requireEntitlementDisplayArgs(t *testing.T, args []string, codePath string)
 }
 
 func fakeMachO(payload string) []byte {
-	return append([]byte{0xcf, 0xfa, 0xed, 0xfe}, []byte(payload)...)
+	header := []byte{
+		0xcf, 0xfa, 0xed, 0xfe, // MH_MAGIC_64
+		0x0c, 0x00, 0x00, 0x01, // CPU_TYPE_ARM64
+		0x00, 0x00, 0x00, 0x00, // CPU subtype
+		0x02, 0x00, 0x00, 0x00, // MH_EXECUTE
+		0x00, 0x00, 0x00, 0x00, // no load commands
+		0x00, 0x00, 0x00, 0x00, // load command size
+		0x00, 0x00, 0x00, 0x00, // flags
+		0x00, 0x00, 0x00, 0x00, // reserved
+	}
+	return append(header, []byte(payload)...)
 }
 
 func validFatMachO() []byte {

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -44,7 +44,7 @@ func TestInspectIPAVerifiesEveryMainExecutableArchitectureAgainstProfile(t *test
 				}
 				verified = true
 			}
-			if len(args) > 0 && args[0] == "-d" && len(args) > 3 && args[1] == "--entitlements" && args[2] == ":-" {
+			if len(args) == 6 && args[0] == "-d" && args[1] == "-a" && args[3] == "--entitlements" && args[4] == ":-" {
 				return plist.Marshal(map[string]any{
 					"application-identifier":              "TEAM123.com.example.demo",
 					"com.apple.developer.team-identifier": "TEAM123",
@@ -84,6 +84,175 @@ func TestInspectIPAVerifiesEveryMainExecutableArchitectureAgainstProfile(t *test
 	}
 }
 
+func TestInspectIPARejectsEntitlementMismatchInSecondaryArchitecture(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codesign verification is macOS-only")
+	}
+	profile := signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
+	message, err := pkcs7.Parse(profile)
+	if err != nil || len(message.Certificates) == 0 {
+		t.Fatalf("parse fixture profile: %v", err)
+	}
+	leaf := message.Certificates[0].Raw
+	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "/usr/bin/lipo" {
+			return []byte("arm64 x86_64\n"), nil
+		}
+		if len(args) == 6 && args[0] == "-d" && args[1] == "-a" && args[3] == "--entitlements" && args[4] == ":-" {
+			entitlements := map[string]any{
+				"application-identifier":              "TEAM123.com.example.demo",
+				"com.apple.developer.team-identifier": "TEAM123",
+			}
+			for index, argument := range args {
+				if argument == "-a" && index+1 < len(args) && args[index+1] == "x86_64" {
+					entitlements["get-task-allow"] = true
+				}
+			}
+			return plist.Marshal(entitlements, plist.XMLFormat)
+		}
+		for _, argument := range args {
+			if strings.HasPrefix(argument, "--extract-certificates=") {
+				return nil, os.WriteFile(strings.TrimPrefix(argument, "--extract-certificates=")+"0", leaf, 0o600)
+			}
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+	path := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistBytes(t, map[string]any{
+			"CFBundleIdentifier": "com.example.demo", "CFBundleName": "Demo",
+			"CFBundleShortVersionString": "1.0", "CFBundleVersion": "1", "CFBundleExecutable": "Demo",
+		}),
+		"Payload/Demo.app/Demo":                     fakeMachO("main"),
+		"Payload/Demo.app/embedded.mobileprovision": profile,
+	})
+	got := inspectPath(t, path, false)
+	if got.Signing.CodeSignatureVerification.Status != CodeSignatureInvalid || !strings.Contains(got.Signing.CodeSignatureVerification.Reason, "get-task-allow") {
+		t.Fatalf("verification=%#v", got.Signing.CodeSignatureVerification)
+	}
+}
+
+func TestVerifyMainExecutableEntitlementsQueriesEveryArchitectureOnce(t *testing.T) {
+	profile := entitlementTestProfile()
+	queries := make(map[string]int)
+	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "/usr/bin/lipo" {
+			return []byte("arm64 x86_64\n"), nil
+		}
+		architecture := requireEntitlementDisplayArgs(t, args, "/tmp/Demo")
+		queries[architecture]++
+		entitlements := validMainEntitlements()
+		if architecture == "x86_64" {
+			entitlements["get-task-allow"] = true
+		}
+		return plist.Marshal(entitlements, plist.XMLFormat)
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+
+	_, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", profile)
+	if err == nil || !strings.Contains(err.Error(), "get-task-allow") {
+		t.Fatalf("verifyMainExecutableEntitlements() error = %v, want secondary-architecture mismatch", err)
+	}
+	if queries["arm64"] != 1 || queries["x86_64"] != 1 || len(queries) != 2 {
+		t.Fatalf("entitlement architecture queries = %#v, want each architecture exactly once", queries)
+	}
+}
+
+func TestVerifyMainExecutableEntitlementsFailsClosedPerSlice(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		secondary  func() ([]byte, error)
+		wantReason string
+	}{
+		{
+			name:       "extraction failure",
+			secondary:  func() ([]byte, error) { return nil, errors.New("codesign failed") },
+			wantReason: "could not extract signed main-app entitlements for architecture x86_64",
+		},
+		{
+			name:       "malformed plist",
+			secondary:  func() ([]byte, error) { return []byte("not a plist"), nil },
+			wantReason: "signed main-app entitlements are invalid",
+		},
+		{
+			name: "missing required entitlement",
+			secondary: func() ([]byte, error) {
+				return plist.Marshal(map[string]any{
+					"com.apple.developer.team-identifier": "TEAM123",
+				}, plist.XMLFormat)
+			},
+			wantReason: "signed main-app application identifier is missing",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var queried []string
+			runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if name == "/usr/bin/lipo" {
+					return []byte("arm64 x86_64\n"), nil
+				}
+				architecture := requireEntitlementDisplayArgs(t, args, "/tmp/Demo")
+				queried = append(queried, architecture)
+				if architecture == "x86_64" {
+					return test.secondary()
+				}
+				return plist.Marshal(validMainEntitlements(), plist.XMLFormat)
+			}
+			t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+
+			_, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", entitlementTestProfile())
+			if err == nil || !strings.Contains(err.Error(), test.wantReason) {
+				t.Fatalf("verifyMainExecutableEntitlements() error = %v, want %q", err, test.wantReason)
+			}
+			if strings.Join(queried, ",") != "arm64,x86_64" {
+				t.Fatalf("queried architectures = %#v, want both slices once", queried)
+			}
+		})
+	}
+}
+
+func TestVerifyMainExecutableEntitlementsPreservesThinBinaryBehavior(t *testing.T) {
+	var queried []string
+	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "/usr/bin/lipo" {
+			return []byte("arm64\n"), nil
+		}
+		queried = append(queried, requireEntitlementDisplayArgs(t, args, "/tmp/Demo"))
+		return plist.Marshal(validMainEntitlements(), plist.XMLFormat)
+	}
+	t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+
+	architectures, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", entitlementTestProfile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(architectures, ",") != "arm64" || strings.Join(queried, ",") != "arm64" {
+		t.Fatalf("architectures=%#v queried=%#v, want one arm64 slice", architectures, queried)
+	}
+}
+
+func TestVerifyMainExecutableEntitlementsRejectsInvalidLipoOutput(t *testing.T) {
+	for _, output := range []string{"arm64 bad;architecture\n", "arm64 arm64\n"} {
+		t.Run(strings.TrimSpace(output), func(t *testing.T) {
+			codesignCalled := false
+			runCodeSignTool = func(_ context.Context, name string, _ ...string) ([]byte, error) {
+				if name == "/usr/bin/lipo" {
+					return []byte(output), nil
+				}
+				codesignCalled = true
+				return nil, nil
+			}
+			t.Cleanup(func() { runCodeSignTool = runBoundedTool })
+
+			if _, err := verifyMainExecutableEntitlements(context.Background(), "/tmp/Demo", entitlementTestProfile()); err == nil {
+				t.Fatal("verifyMainExecutableEntitlements() error = nil, want invalid architecture rejection")
+			}
+			if codesignCalled {
+				t.Fatal("codesign was called with unvalidated lipo output")
+			}
+		})
+	}
+}
+
 func TestInspectIPARejectsNestedCodeSignedByDifferentLeafEvenWhenDeepVerifyPasses(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("codesign verification is macOS-only")
@@ -104,7 +273,7 @@ func TestInspectIPARejectsNestedCodeSignedByDifferentLeafEvenWhenDeepVerifyPasse
 		if name == "/usr/bin/lipo" {
 			return []byte("arm64\n"), nil
 		}
-		if len(args) > 3 && args[1] == "--entitlements" && args[2] == ":-" {
+		if len(args) == 6 && args[0] == "-d" && args[1] == "-a" && args[3] == "--entitlements" && args[4] == ":-" {
 			return plist.Marshal(map[string]any{
 				"application-identifier":              "TEAM123.com.example.demo",
 				"com.apple.developer.team-identifier": "TEAM123",
@@ -169,7 +338,7 @@ func TestInspectIPARejectsSignerOutsideEmbeddedProfile(t *testing.T) {
 				return nil, os.WriteFile(strings.TrimPrefix(argument, "--extract-certificates=")+"0", otherLeaf, 0o600)
 			}
 		}
-		if len(args) > 3 && args[1] == "--entitlements" && args[2] == ":-" {
+		if len(args) == 6 && args[0] == "-d" && args[1] == "-a" && args[3] == "--entitlements" && args[4] == ":-" {
 			return plist.Marshal(map[string]any{
 				"application-identifier":              "TEAM123.com.example.demo",
 				"com.apple.developer.team-identifier": "TEAM123",
@@ -274,6 +443,40 @@ func validExecutableIPA(t *testing.T) string {
 			BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour),
 		}),
 	})
+}
+
+func entitlementTestProfile() parsedProfile {
+	return parsedProfile{embeddedProfile: embeddedProfile{
+		TeamIdentifier: []string{"TEAM123"},
+		Entitlements: map[string]any{
+			"application-identifier":              "TEAM123.com.example.*",
+			"com.apple.developer.team-identifier": "TEAM123",
+			"get-task-allow":                      false,
+		},
+	}}
+}
+
+func validMainEntitlements() map[string]any {
+	return map[string]any{
+		"application-identifier":              "TEAM123.com.example.demo",
+		"com.apple.developer.team-identifier": "TEAM123",
+	}
+}
+
+func requireEntitlementDisplayArgs(t *testing.T, args []string, codePath string) string {
+	t.Helper()
+	if len(args) != 6 ||
+		args[0] != "-d" ||
+		args[1] != "-a" ||
+		args[3] != "--entitlements" ||
+		args[4] != ":-" ||
+		args[5] != codePath {
+		t.Fatalf("unexpected codesign entitlement args: %#v", args)
+	}
+	if err := validateArchitecture(args[2]); err != nil {
+		t.Fatalf("unvalidated architecture argument %q: %v", args[2], err)
+	}
+	return args[2]
 }
 
 func fakeMachO(payload string) []byte {

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -134,6 +134,8 @@ func TestInspectIPARejectsEntitlementMismatchInSecondaryArchitecture(t *testing.
 
 func TestVerifyMainExecutableEntitlementsQueriesEveryArchitectureOnce(t *testing.T) {
 	profile := entitlementTestProfile()
+	profile.ApplicationIdentifierPrefix = []string{"LEGACY123"}
+	profile.Entitlements["application-identifier"] = "LEGACY123.com.example.*"
 	queries := make(map[string]int)
 	runCodeSignTool = func(_ context.Context, name string, args ...string) ([]byte, error) {
 		if name == "/usr/bin/lipo" {
@@ -142,8 +144,9 @@ func TestVerifyMainExecutableEntitlementsQueriesEveryArchitectureOnce(t *testing
 		architecture := requireEntitlementDisplayArgs(t, args, "/tmp/Demo")
 		queries[architecture]++
 		entitlements := validMainEntitlements()
+		entitlements["application-identifier"] = "LEGACY123.com.example.demo"
 		if architecture == "x86_64" {
-			entitlements["application-identifier"] = "TEAM123.com.example.other"
+			entitlements["application-identifier"] = "LEGACY123.com.example.other"
 		}
 		return plist.Marshal(entitlements, plist.XMLFormat)
 	}
@@ -276,6 +279,14 @@ func TestValidateSignedMainAppEntitlementsBindsExactBundleIdentifier(t *testing.
 			signedTeamID:                "TEAM123",
 		},
 		{
+			name:                        "legacy signed identifier incorrectly uses team",
+			applicationIdentifierPrefix: "LEGACY123",
+			profileApplicationID:        "LEGACY123.com.example.*",
+			signedApplicationID:         "TEAM123.com.example.demo",
+			signedTeamID:                "TEAM123",
+			wantError:                   true,
+		},
+		{
 			name:                 "wildcard profile and matching signed identifier",
 			profileApplicationID: "TEAM123.com.example.*",
 			signedApplicationID:  "TEAM123.com.example.demo",
@@ -309,6 +320,13 @@ func TestValidateSignedMainAppEntitlementsBindsExactBundleIdentifier(t *testing.
 			signedTeamID:         "TEAM123",
 			wantError:            true,
 		},
+		{
+			name:                 "wrong signed team entitlement",
+			profileApplicationID: "TEAM123.com.example.demo",
+			signedApplicationID:  "TEAM123.com.example.demo",
+			signedTeamID:         "OTHERTEAM",
+			wantError:            true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			profile := entitlementTestProfile()
@@ -329,6 +347,32 @@ func TestValidateSignedMainAppEntitlementsBindsExactBundleIdentifier(t *testing.
 			err = validateSignedMainAppEntitlements(data, "com.example.demo", profile)
 			if (err != nil) != test.wantError {
 				t.Fatalf("validateSignedMainAppEntitlements() error = %v, wantError=%t", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateSignedMainAppEntitlementsRejectsUnsafeProfilePrefix(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		prefixes []string
+	}{
+		{name: "missing", prefixes: []string{}},
+		{name: "ambiguous", prefixes: []string{"TEAM123", "LEGACY123"}},
+		{name: "duplicate declarations", prefixes: []string{"TEAM123", "TEAM123"}},
+		{name: "unsupported characters", prefixes: []string{`TEAM"123`}},
+		{name: "excessive length", prefixes: []string{strings.Repeat("A", 33)}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			profile := entitlementTestProfile()
+			profile.ApplicationIdentifierPrefix = test.prefixes
+			data, err := plist.Marshal(validMainEntitlements(), plist.XMLFormat)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = validateSignedMainAppEntitlements(data, "com.example.demo", profile)
+			if err == nil || !strings.Contains(err.Error(), "application identifier prefix") {
+				t.Fatalf("validateSignedMainAppEntitlements() error = %v, want safe single prefix rejection", err)
 			}
 		})
 	}

--- a/internal/distribution/codesign_test.go
+++ b/internal/distribution/codesign_test.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"archive/zip"
 	"context"
+	"encoding/binary"
 	"errors"
 	"os"
 	"os/exec"
@@ -535,6 +536,98 @@ func TestEnumerateMachOFilesIgnoresJavaClassMagicCollision(t *testing.T) {
 	}
 }
 
+func TestEnumerateMachOFilesIgnoresNonLoadableObjectFile(t *testing.T) {
+	appPath := t.TempDir()
+	mainPath := filepath.Join(appPath, "Demo")
+	objectPath := filepath.Join(appPath, "Resource.o")
+	if err := os.WriteFile(mainPath, fakeMachO("main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(objectPath, fakeMachOType("resource", 1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := enumerateMachOFiles(appPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != mainPath {
+		t.Fatalf("enumerateMachOFiles() = %#v, want only %q", got, mainPath)
+	}
+}
+
+func TestEnumerateMachOFilesIncludesOnlyLoadableThinImageTypes(t *testing.T) {
+	appPath := t.TempDir()
+	want := []string{
+		filepath.Join(appPath, "Bundle"),
+		filepath.Join(appPath, "Dylib"),
+		filepath.Join(appPath, "Executable"),
+	}
+	for _, fixture := range []struct {
+		name     string
+		fileType byte
+	}{
+		{name: "Executable", fileType: 2},
+		{name: "Dylib", fileType: 6},
+		{name: "Bundle", fileType: 8},
+		{name: "ObjectResource", fileType: 1},
+	} {
+		if err := os.WriteFile(filepath.Join(appPath, fixture.name), fakeMachOType(fixture.name, fixture.fileType), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := enumerateMachOFiles(appPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("enumerateMachOFiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestEnumerateMachOFilesClassifiesFatImageTypesSafely(t *testing.T) {
+	t.Run("fat object is a resource", func(t *testing.T) {
+		appPath := t.TempDir()
+		mainPath := filepath.Join(appPath, "Demo")
+		if err := os.WriteFile(mainPath, fakeMachO("main"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(appPath, "Resource.o"), fatMachOWithTypes(1), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := enumerateMachOFiles(appPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0] != mainPath {
+			t.Fatalf("enumerateMachOFiles() = %#v, want only %q", got, mainPath)
+		}
+	})
+
+	t.Run("mixed loadable and object slices are rejected", func(t *testing.T) {
+		appPath := t.TempDir()
+		if err := os.WriteFile(filepath.Join(appPath, "Mixed"), fatMachOWithTypes(2, 1), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := enumerateMachOFiles(appPath); err == nil || !strings.Contains(err.Error(), "mixes loadable and non-loadable") {
+			t.Fatalf("enumerateMachOFiles() error = %v, want mixed-type rejection", err)
+		}
+	})
+
+	t.Run("malformed slice is rejected after valid fat header", func(t *testing.T) {
+		appPath := t.TempDir()
+		data := fatMachOWithTypes(2, 6)
+		secondSliceOffset := 8 + 2*20 + 32
+		clear(data[secondSliceOffset : secondSliceOffset+4])
+		if err := os.WriteFile(filepath.Join(appPath, "Malformed"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := enumerateMachOFiles(appPath); err == nil || !strings.Contains(err.Error(), "malformed architecture slice") {
+			t.Fatalf("enumerateMachOFiles() error = %v, want malformed-slice rejection", err)
+		}
+	})
+}
+
 func TestValidateTeamIdentifierRejectsRequirementInjection(t *testing.T) {
 	for _, value := range []string{"TEAM123", "abc123", strings.Repeat("A", 32)} {
 		if err := validateTeamIdentifier(value); err != nil {
@@ -634,11 +727,15 @@ func requireEntitlementDisplayArgs(t *testing.T, args []string, codePath string)
 }
 
 func fakeMachO(payload string) []byte {
+	return fakeMachOType(payload, 2)
+}
+
+func fakeMachOType(payload string, fileType byte) []byte {
 	header := []byte{
 		0xcf, 0xfa, 0xed, 0xfe, // MH_MAGIC_64
 		0x0c, 0x00, 0x00, 0x01, // CPU_TYPE_ARM64
 		0x00, 0x00, 0x00, 0x00, // CPU subtype
-		0x02, 0x00, 0x00, 0x00, // MH_EXECUTE
+		fileType, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, // no load commands
 		0x00, 0x00, 0x00, 0x00, // load command size
 		0x00, 0x00, 0x00, 0x00, // flags
@@ -648,23 +745,28 @@ func fakeMachO(payload string) []byte {
 }
 
 func validFatMachO() []byte {
-	return []byte{
-		0xca, 0xfe, 0xba, 0xbe, // FAT_MAGIC
-		0x00, 0x00, 0x00, 0x01, // one architecture
-		0x01, 0x00, 0x00, 0x0c, // CPU_TYPE_ARM64
-		0x00, 0x00, 0x00, 0x00, // CPU subtype
-		0x00, 0x00, 0x00, 0x1c, // slice offset
-		0x00, 0x00, 0x00, 0x20, // slice size
-		0x00, 0x00, 0x00, 0x02, // alignment
-		0xcf, 0xfa, 0xed, 0xfe, // MH_MAGIC_64
-		0x0c, 0x00, 0x00, 0x01, // CPU_TYPE_ARM64
-		0x00, 0x00, 0x00, 0x00, // CPU subtype
-		0x02, 0x00, 0x00, 0x00, // MH_EXECUTE
-		0x00, 0x00, 0x00, 0x00, // no load commands
-		0x00, 0x00, 0x00, 0x00, // load command size
-		0x00, 0x00, 0x00, 0x00, // flags
-		0x00, 0x00, 0x00, 0x00, // reserved
+	return fatMachOWithTypes(2)
+}
+
+func fatMachOWithTypes(fileTypes ...byte) []byte {
+	const (
+		architectureHeaderSize = 20
+		sliceSize              = 32
+	)
+	tableEnd := 8 + len(fileTypes)*architectureHeaderSize
+	data := make([]byte, tableEnd+len(fileTypes)*sliceSize)
+	copy(data[:4], []byte{0xca, 0xfe, 0xba, 0xbe})
+	binary.BigEndian.PutUint32(data[4:8], uint32(len(fileTypes)))
+	for index, fileType := range fileTypes {
+		headerOffset := 8 + index*architectureHeaderSize
+		sliceOffset := tableEnd + index*sliceSize
+		binary.BigEndian.PutUint32(data[headerOffset:headerOffset+4], 0x0100000c)
+		binary.BigEndian.PutUint32(data[headerOffset+8:headerOffset+12], uint32(sliceOffset))
+		binary.BigEndian.PutUint32(data[headerOffset+12:headerOffset+16], sliceSize)
+		binary.BigEndian.PutUint32(data[headerOffset+16:headerOffset+20], 2)
+		copy(data[sliceOffset:sliceOffset+sliceSize], fakeMachOType("", fileType))
 	}
+	return data
 }
 
 func TestValidateExecutableNameRejectsTraversalAndFormatting(t *testing.T) {

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -6,6 +6,7 @@ package distribution
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
@@ -114,6 +115,11 @@ type InspectOptions struct {
 	Now            time.Time
 }
 
+var (
+	duringZIPValidationForTest func(string)
+	duringZIPStreamReadForTest func()
+)
+
 type infoPlistPayload struct {
 	BundleID           string   `plist:"CFBundleIdentifier"`
 	Executable         string   `plist:"CFBundleExecutable"`
@@ -154,6 +160,13 @@ var appleProfileRootFingerprints = map[string]struct{}{
 // InspectIPA validates and reads deterministic metadata from an already-open
 // regular IPA file. The file must remain open for the duration of the call.
 func InspectIPA(file *os.File, size int64, options InspectOptions) (Inspection, error) {
+	return InspectIPAContext(context.Background(), file, size, options)
+}
+
+func InspectIPAContext(ctx context.Context, file *os.File, size int64, options InspectOptions) (Inspection, error) {
+	if err := contextError(ctx); err != nil {
+		return Inspection{}, err
+	}
 	if file == nil {
 		return Inspection{}, fmt.Errorf("IPA file is nil")
 	}
@@ -163,7 +176,7 @@ func InspectIPA(file *os.File, size int64, options InspectOptions) (Inspection, 
 	if size > MaxIPABytes {
 		return Inspection{}, fmt.Errorf("IPA size %d bytes exceeds supported limit of %d bytes", size, MaxIPABytes)
 	}
-	snapshot, digest, cleanup, err := snapshotIPA(file, size)
+	snapshot, digest, cleanup, err := snapshotIPAContext(ctx, file, size)
 	if err != nil {
 		return Inspection{}, err
 	}
@@ -171,10 +184,13 @@ func InspectIPA(file *os.File, size int64, options InspectOptions) (Inspection, 
 	if afterIPASnapshotForTest != nil {
 		afterIPASnapshotForTest()
 	}
-	return inspectSnapshot(snapshot, size, digest, options)
+	return inspectSnapshotContext(ctx, snapshot, size, digest, options)
 }
 
-func inspectSnapshot(file *os.File, size int64, digest string, options InspectOptions) (Inspection, error) {
+func inspectSnapshotContext(ctx context.Context, file *os.File, size int64, digest string, options InspectOptions) (Inspection, error) {
+	if err := contextError(ctx); err != nil {
+		return Inspection{}, err
+	}
 	reader, err := zip.NewReader(file, size)
 	if err != nil {
 		return Inspection{}, fmt.Errorf("open IPA ZIP: %w", err)
@@ -223,15 +239,25 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 	}
 	var expandedBytes uint64
 	for _, member := range reader.File {
-		if member.FileInfo().IsDir() {
-			continue
+		if duringZIPValidationForTest != nil {
+			duringZIPValidationForTest(member.Name)
+		}
+		if err := contextError(ctx); err != nil {
+			return Inspection{}, err
 		}
 		remaining := maxArchiveExpandedBytes - expandedBytes
-		opened, err := member.Open()
+		streamMember := member
+		if member.FileInfo().IsDir() {
+			regular := *member
+			regular.Name = strings.TrimSuffix(regular.Name, "/")
+			regular.SetMode(0o600)
+			streamMember = &regular
+		}
+		opened, err := streamMember.Open()
 		if err != nil {
 			return Inspection{}, fmt.Errorf("open IPA member %q: %w", member.Name, err)
 		}
-		written, readErr := io.Copy(io.Discard, io.LimitReader(opened, int64(remaining)+1))
+		written, readErr := copyWithContext(ctx, io.Discard, io.LimitReader(opened, int64(remaining)+1), duringZIPStreamReadForTest)
 		closeErr := opened.Close()
 		if written < 0 || uint64(written) > remaining {
 			return Inspection{}, fmt.Errorf("IPA expanded contents exceed %d bytes", maxArchiveExpandedBytes)
@@ -246,6 +272,9 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 		if uint64(written) != member.UncompressedSize64 {
 			return Inspection{}, fmt.Errorf("IPA member %q expanded size does not match its declaration", member.Name)
 		}
+		if member.FileInfo().IsDir() && written != 0 {
+			return Inspection{}, fmt.Errorf("IPA directory member %q contains data", member.Name)
+		}
 	}
 	if len(infoFiles) == 0 {
 		return Inspection{}, fmt.Errorf("IPA is missing Payload/*.app/Info.plist")
@@ -254,7 +283,7 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 		return Inspection{}, fmt.Errorf("IPA contains %d main apps; expected exactly one", len(infoFiles))
 	}
 
-	info, err := readInfoPlist(infoFiles[0])
+	info, err := readInfoPlistContext(ctx, infoFiles[0])
 	if err != nil {
 		return Inspection{}, err
 	}
@@ -310,7 +339,7 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 	if profileFile == nil {
 		result.Preparation.Issues = append(result.Preparation.Issues, "embedded provisioning profile is missing")
 	} else {
-		profile, err := readProfile(profileFile, effectiveNow(options.Now))
+		profile, err := readProfileContext(ctx, profileFile, effectiveNow(options.Now))
 		if err != nil {
 			return Inspection{}, err
 		}
@@ -341,7 +370,11 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 			result.Signing.Devices = devices
 		}
 		result.Preparation.Issues = preparationIssues(result, profile, effectiveNow(options.Now))
-		result.Signing.CodeSignatureVerification = verifyMainAppCodeSignature(reader.File, appDir, info.Executable, app.BundleID, profile)
+		verification := verifyMainAppCodeSignatureContext(ctx, reader.File, appDir, info.Executable, app.BundleID, profile)
+		if err := contextError(ctx); err != nil {
+			return Inspection{}, err
+		}
+		result.Signing.CodeSignatureVerification = verification
 	}
 	result.Preparation.MetadataEligible = len(result.Preparation.Issues) == 0
 	return result, nil
@@ -462,11 +495,11 @@ func isEmbeddedTargetInfoPlist(name string) bool {
 	return len(strings.Split(dir, "/")) > 2
 }
 
-func readInfoPlist(member *zip.File) (infoPlistPayload, error) {
+func readInfoPlistContext(ctx context.Context, member *zip.File) (infoPlistPayload, error) {
 	if err := infoplist.CheckDeclaredSize(member.UncompressedSize64); err != nil {
 		return infoPlistPayload{}, fmt.Errorf("read main app Info.plist: %w", err)
 	}
-	data, err := readZipMemberBounded(member, infoplist.MaxBytes)
+	data, err := readZipMemberBoundedContext(ctx, member, infoplist.MaxBytes)
 	if err != nil {
 		return infoPlistPayload{}, fmt.Errorf("read main app Info.plist: %w", err)
 	}
@@ -480,11 +513,11 @@ func readInfoPlist(member *zip.File) (infoPlistPayload, error) {
 	return result, nil
 }
 
-func readProfile(member *zip.File, now time.Time) (parsedProfile, error) {
+func readProfileContext(ctx context.Context, member *zip.File, now time.Time) (parsedProfile, error) {
 	if member.UncompressedSize64 > maxProfileBytes {
 		return parsedProfile{}, fmt.Errorf("embedded provisioning profile declared size exceeds %d bytes", maxProfileBytes)
 	}
-	data, err := readZipMemberBounded(member, maxProfileBytes)
+	data, err := readZipMemberBoundedContext(ctx, member, maxProfileBytes)
 	if err != nil {
 		return parsedProfile{}, fmt.Errorf("read embedded provisioning profile: %w", err)
 	}
@@ -582,16 +615,21 @@ func verifyAppleProfileTrust(profile *pkcs7.PKCS7, now time.Time, allowedRoots m
 	return CodeSignatureVerification{Status: CodeSignatureVerified, Reason: "Apple provisioning signer identity and chain verified to a pinned Apple root"}
 }
 
-func readZipMemberBounded(member *zip.File, limit int64) ([]byte, error) {
+func readZipMemberBoundedContext(ctx context.Context, member *zip.File, limit int64) ([]byte, error) {
 	reader, err := member.Open()
 	if err != nil {
 		return nil, err
 	}
 	defer reader.Close()
-	data, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	var destination bytes.Buffer
+	if limit < 1<<20 {
+		destination.Grow(int(limit))
+	}
+	_, err = copyWithContext(ctx, &destination, io.LimitReader(reader, limit+1), nil)
 	if err != nil {
 		return nil, err
 	}
+	data := destination.Bytes()
 	if int64(len(data)) > limit {
 		return nil, fmt.Errorf("expanded contents exceed %d bytes", limit)
 	}

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -183,7 +183,8 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 		return Inspection{}, fmt.Errorf("IPA contains %d entries; limit is %d", len(reader.File), maxArchiveEntries)
 	}
 
-	seen := make(map[string]struct{}, len(reader.File))
+	seen := make(map[string]bool, len(reader.File))
+	requiredDirectories := make(map[string]struct{}, len(reader.File))
 	var infoFiles []*zip.File
 	var embeddedTargets []string
 	var declaredExpandedBytes uint64
@@ -199,7 +200,19 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 		if _, exists := seen[key]; exists {
 			return Inspection{}, fmt.Errorf("IPA contains duplicate path %q", member.Name)
 		}
-		seen[key] = struct{}{}
+		isDirectory := member.FileInfo().IsDir()
+		if !isDirectory {
+			if _, required := requiredDirectories[key]; required {
+				return Inspection{}, fmt.Errorf("IPA regular member %q conflicts with a descendant path", member.Name)
+			}
+		}
+		for ancestor := path.Dir(key); ancestor != "."; ancestor = path.Dir(ancestor) {
+			if ancestorIsDirectory, exists := seen[ancestor]; exists && !ancestorIsDirectory {
+				return Inspection{}, fmt.Errorf("IPA regular member %q conflicts with descendant %q", ancestor, member.Name)
+			}
+			requiredDirectories[ancestor] = struct{}{}
+		}
+		seen[key] = isDirectory
 		if isMainAppMember(member.Name, "Info.plist") && !member.FileInfo().IsDir() {
 			infoFiles = append(infoFiles, member)
 		} else if isEmbeddedTargetInfoPlist(member.Name) && !member.FileInfo().IsDir() {
@@ -377,6 +390,30 @@ func validateAppMetadata(app App) error {
 			if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.In(r, unicode.Bidi_Control) {
 				return fmt.Errorf("invalid %s: control or formatting characters are not allowed", field.name)
 			}
+		}
+	}
+	if err := validateBundleIdentifier(app.BundleID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateBundleIdentifier(identifier string) error {
+	if identifier == "" {
+		return nil
+	}
+	for _, component := range strings.Split(identifier, ".") {
+		if component == "" {
+			return fmt.Errorf("invalid CFBundleIdentifier: components must not be empty")
+		}
+		for _, character := range []byte(component) {
+			if (character >= 'a' && character <= 'z') ||
+				(character >= 'A' && character <= 'Z') ||
+				(character >= '0' && character <= '9') ||
+				character == '-' {
+				continue
+			}
+			return fmt.Errorf("invalid CFBundleIdentifier: components may contain only ASCII letters, digits, and hyphens")
 		}
 	}
 	return nil

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -6,6 +6,7 @@ package distribution
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
@@ -154,6 +155,12 @@ var appleProfileRootFingerprints = map[string]struct{}{
 // InspectIPA validates and reads deterministic metadata from an already-open
 // regular IPA file. The file must remain open for the duration of the call.
 func InspectIPA(file *os.File, size int64, options InspectOptions) (Inspection, error) {
+	return InspectIPAContext(context.Background(), file, size, options)
+}
+
+// InspectIPAContext validates and reads deterministic metadata from an
+// already-open regular IPA file, stopping promptly when ctx is canceled.
+func InspectIPAContext(ctx context.Context, file *os.File, size int64, options InspectOptions) (Inspection, error) {
 	if file == nil {
 		return Inspection{}, fmt.Errorf("IPA file is nil")
 	}
@@ -163,7 +170,7 @@ func InspectIPA(file *os.File, size int64, options InspectOptions) (Inspection, 
 	if size > MaxIPABytes {
 		return Inspection{}, fmt.Errorf("IPA size %d bytes exceeds supported limit of %d bytes", size, MaxIPABytes)
 	}
-	snapshot, digest, cleanup, err := snapshotIPA(file, size)
+	snapshot, digest, cleanup, err := snapshotIPA(ctx, file, size)
 	if err != nil {
 		return Inspection{}, err
 	}
@@ -171,10 +178,13 @@ func InspectIPA(file *os.File, size int64, options InspectOptions) (Inspection, 
 	if afterIPASnapshotForTest != nil {
 		afterIPASnapshotForTest()
 	}
-	return inspectSnapshot(snapshot, size, digest, options)
+	return inspectSnapshot(ctx, snapshot, size, digest, options)
 }
 
-func inspectSnapshot(file *os.File, size int64, digest string, options InspectOptions) (Inspection, error) {
+func inspectSnapshot(ctx context.Context, file *os.File, size int64, digest string, options InspectOptions) (Inspection, error) {
+	if err := ctx.Err(); err != nil {
+		return Inspection{}, err
+	}
 	reader, err := zip.NewReader(file, size)
 	if err != nil {
 		return Inspection{}, fmt.Errorf("open IPA ZIP: %w", err)
@@ -189,6 +199,9 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 	var embeddedTargets []string
 	var declaredExpandedBytes uint64
 	for _, member := range reader.File {
+		if err := ctx.Err(); err != nil {
+			return Inspection{}, err
+		}
 		if err := validateArchiveMember(member); err != nil {
 			return Inspection{}, err
 		}
@@ -228,7 +241,7 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 		if err != nil {
 			return Inspection{}, fmt.Errorf("open IPA member %q: %w", member.Name, err)
 		}
-		written, readErr := io.Copy(io.Discard, io.LimitReader(opened, int64(remaining)+1))
+		written, readErr := copyWithContext(ctx, io.Discard, io.LimitReader(opened, int64(remaining)+1))
 		closeErr := opened.Close()
 		if written < 0 || uint64(written) > remaining {
 			return Inspection{}, fmt.Errorf("IPA expanded contents exceed %d bytes", maxArchiveExpandedBytes)
@@ -338,7 +351,10 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 			result.Signing.Devices = devices
 		}
 		result.Preparation.Issues = preparationIssues(result, profile, effectiveNow(options.Now))
-		result.Signing.CodeSignatureVerification = verifyMainAppCodeSignature(reader.File, appDir, info.Executable, app.BundleID, profile)
+		result.Signing.CodeSignatureVerification = verifyMainAppCodeSignature(ctx, reader.File, appDir, info.Executable, app.BundleID, profile)
+		if err := ctx.Err(); err != nil {
+			return Inspection{}, err
+		}
 	}
 	result.Preparation.MetadataEligible = len(result.Preparation.Issues) == 0
 	return result, nil

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -115,13 +115,15 @@ type InspectOptions struct {
 }
 
 type infoPlistPayload struct {
-	BundleID    string `plist:"CFBundleIdentifier"`
-	Executable  string `plist:"CFBundleExecutable"`
-	DisplayName string `plist:"CFBundleDisplayName"`
-	Name        string `plist:"CFBundleName"`
-	Version     string `plist:"CFBundleShortVersionString"`
-	Build       string `plist:"CFBundleVersion"`
-	MinimumOS   string `plist:"MinimumOSVersion"`
+	BundleID           string   `plist:"CFBundleIdentifier"`
+	Executable         string   `plist:"CFBundleExecutable"`
+	DisplayName        string   `plist:"CFBundleDisplayName"`
+	Name               string   `plist:"CFBundleName"`
+	Version            string   `plist:"CFBundleShortVersionString"`
+	Build              string   `plist:"CFBundleVersion"`
+	MinimumOS          string   `plist:"MinimumOSVersion"`
+	PlatformName       string   `plist:"DTPlatformName"`
+	SupportedPlatforms []string `plist:"CFBundleSupportedPlatforms"`
 }
 
 type embeddedProfile struct {
@@ -215,6 +217,9 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 	if err != nil {
 		return Inspection{}, err
 	}
+	if err := validateIOSPlatform(info); err != nil {
+		return Inspection{}, err
+	}
 	app := App{
 		BundleID:         strings.TrimSpace(info.BundleID),
 		Title:            firstNonempty(info.DisplayName, info.Name),
@@ -295,7 +300,7 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 			result.Signing.Devices = devices
 		}
 		result.Preparation.Issues = preparationIssues(result, profile, effectiveNow(options.Now))
-		result.Signing.CodeSignatureVerification = verifyMainAppCodeSignature(reader.File, appDir, infoFiles[0], info.Executable, profile)
+		result.Signing.CodeSignatureVerification = verifyMainAppCodeSignature(reader.File, appDir, info.Executable, app.BundleID, profile)
 	}
 	result.Preparation.MetadataEligible = len(result.Preparation.Issues) == 0
 	return result, nil
@@ -346,6 +351,22 @@ func validateAppMetadata(app App) error {
 			if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.In(r, unicode.Bidi_Control) {
 				return fmt.Errorf("invalid %s: control or formatting characters are not allowed", field.name)
 			}
+		}
+	}
+	return nil
+}
+
+func validateIOSPlatform(info infoPlistPayload) error {
+	platformName := strings.ToLower(strings.TrimSpace(info.PlatformName))
+	if platformName == "" && len(info.SupportedPlatforms) == 0 {
+		return fmt.Errorf("main app iOS platform metadata is missing")
+	}
+	if platformName != "" && platformName != "iphoneos" {
+		return fmt.Errorf("main app iOS platform metadata has unsupported DTPlatformName")
+	}
+	for _, platform := range info.SupportedPlatforms {
+		if strings.ToLower(strings.TrimSpace(platform)) != "iphoneos" {
+			return fmt.Errorf("main app iOS platform metadata contains an unsupported CFBundleSupportedPlatforms value")
 		}
 	}
 	return nil

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -223,9 +223,6 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 	}
 	var expandedBytes uint64
 	for _, member := range reader.File {
-		if member.FileInfo().IsDir() {
-			continue
-		}
 		remaining := maxArchiveExpandedBytes - expandedBytes
 		opened, err := member.Open()
 		if err != nil {

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -1,0 +1,631 @@
+// Package distribution inspects and prepares local iOS release-testing
+// artifacts. It deliberately contains no account, keychain, network, or
+// storage-provider operations.
+package distribution
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.mozilla.org/pkcs7"
+	"howett.net/plist"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+)
+
+const (
+	maxArchiveEntries       = 20_000
+	maxArchiveMemberNameLen = 4096
+	maxProfileBytes         = 16 << 20
+	// MaxIPABytes bounds synchronous inspection, hashing, and preparation work.
+	MaxIPABytes int64 = 8 << 30
+)
+
+type ProfileClass string
+
+const (
+	ProfileClassUnknown     ProfileClass = "unknown"
+	ProfileClassDevelopment ProfileClass = "development"
+	ProfileClassAdHoc       ProfileClass = "ad-hoc"
+	ProfileClassEnterprise  ProfileClass = "enterprise"
+	ProfileClassAppStore    ProfileClass = "app-store"
+)
+
+type App struct {
+	BundleID         string `json:"bundleId"`
+	Title            string `json:"title"`
+	Version          string `json:"version"`
+	BuildNumber      string `json:"buildNumber"`
+	MinimumOSVersion string `json:"minimumOSVersion,omitempty"`
+}
+
+type Artifact struct {
+	RelativePath string `json:"relativePath,omitempty"`
+	SizeBytes    int64  `json:"sizeBytes"`
+	SHA256       string `json:"sha256"`
+}
+
+type Signing struct {
+	ProfileClass                         ProfileClass              `json:"profileClass"`
+	ProfileUUID                          string                    `json:"profileUuid,omitempty"`
+	TeamID                               string                    `json:"teamId,omitempty"`
+	ExpiresAt                            string                    `json:"expiresAt,omitempty"`
+	DeviceCount                          int                       `json:"deviceCount"`
+	DeviceSetSHA256                      string                    `json:"deviceSetSha256,omitempty"`
+	ProfileCertificateSHA256Fingerprints []string                  `json:"profileCertificateSha256Fingerprints,omitempty"`
+	Devices                              []string                  `json:"devices,omitempty"`
+	ProfileIntegrityVerification         CodeSignatureVerification `json:"profileIntegrityVerification"`
+	ProfileTrustVerification             CodeSignatureVerification `json:"profileTrustVerification"`
+	CodeSignatureVerification            CodeSignatureVerification `json:"codeSignatureVerification"`
+}
+
+type Preparation struct {
+	MetadataEligible bool     `json:"metadataEligible"`
+	Issues           []string `json:"issues"`
+}
+
+type CodeSignatureVerificationStatus string
+
+const (
+	CodeSignatureVerified    CodeSignatureVerificationStatus = "verified"
+	CodeSignatureInvalid     CodeSignatureVerificationStatus = "invalid"
+	CodeSignatureNotVerified CodeSignatureVerificationStatus = "not-verified"
+)
+
+type CodeSignatureVerification struct {
+	Status                              CodeSignatureVerificationStatus `json:"status"`
+	Scope                               string                          `json:"scope,omitempty"`
+	Reason                              string                          `json:"reason,omitempty"`
+	SignerCertificateSHA256Fingerprints []string                        `json:"signerCertificateSha256Fingerprints,omitempty"`
+}
+
+type Source struct {
+	Channel  string `json:"channel,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	URL      string `json:"url,omitempty"`
+}
+
+type Inspection struct {
+	SchemaVersion      string      `json:"schemaVersion"`
+	Platform           string      `json:"platform"`
+	DistributionMethod string      `json:"distributionMethod"`
+	App                App         `json:"app"`
+	Artifact           Artifact    `json:"artifact"`
+	Signing            Signing     `json:"signing"`
+	Preparation        Preparation `json:"preparation"`
+	EmbeddedTargets    []string    `json:"embeddedTargets,omitempty"`
+}
+
+type InspectOptions struct {
+	IncludeDevices bool
+	Now            time.Time
+}
+
+type infoPlistPayload struct {
+	BundleID    string `plist:"CFBundleIdentifier"`
+	Executable  string `plist:"CFBundleExecutable"`
+	DisplayName string `plist:"CFBundleDisplayName"`
+	Name        string `plist:"CFBundleName"`
+	Version     string `plist:"CFBundleShortVersionString"`
+	Build       string `plist:"CFBundleVersion"`
+	MinimumOS   string `plist:"MinimumOSVersion"`
+}
+
+type embeddedProfile struct {
+	UUID                        string         `plist:"UUID"`
+	TeamIdentifier              []string       `plist:"TeamIdentifier"`
+	ApplicationIdentifierPrefix []string       `plist:"ApplicationIdentifierPrefix"`
+	ProvisionedDevices          []string       `plist:"ProvisionedDevices"`
+	ProvisionsAllDevices        bool           `plist:"ProvisionsAllDevices"`
+	ExpirationDate              time.Time      `plist:"ExpirationDate"`
+	Entitlements                map[string]any `plist:"Entitlements"`
+	DeveloperCertificates       [][]byte       `plist:"DeveloperCertificates"`
+	Platform                    []string       `plist:"Platform"`
+}
+
+type parsedProfile struct {
+	embeddedProfile
+	BundleID                 string
+	Class                    ProfileClass
+	ProfileTrustVerification CodeSignatureVerification
+}
+
+var appleProfileRootFingerprints = map[string]struct{}{
+	"b0b1730ecbc7ff4505142c49f1295e6eda6bcaed7e2c68c5be91b5a11001f024": {},
+	"c2b9b042dd57830e7d117dac55ac8ae19407d38e41d88f3215bc3a890444a050": {},
+	"63343abfb89a6a03ebb57e9b3f5fa7be7c4f5c756f3017b3a8c488c3653e9179": {},
+}
+
+// InspectIPA validates and reads deterministic metadata from an already-open
+// regular IPA file. The file must remain open for the duration of the call.
+func InspectIPA(file *os.File, size int64, options InspectOptions) (Inspection, error) {
+	if file == nil {
+		return Inspection{}, fmt.Errorf("IPA file is nil")
+	}
+	if size < 0 {
+		return Inspection{}, fmt.Errorf("IPA size is invalid")
+	}
+	if size > MaxIPABytes {
+		return Inspection{}, fmt.Errorf("IPA size %d bytes exceeds supported limit of %d bytes", size, MaxIPABytes)
+	}
+	snapshot, digest, cleanup, err := snapshotIPA(file, size)
+	if err != nil {
+		return Inspection{}, err
+	}
+	defer cleanup()
+	if afterIPASnapshotForTest != nil {
+		afterIPASnapshotForTest()
+	}
+	return inspectSnapshot(snapshot, size, digest, options)
+}
+
+func inspectSnapshot(file *os.File, size int64, digest string, options InspectOptions) (Inspection, error) {
+	reader, err := zip.NewReader(file, size)
+	if err != nil {
+		return Inspection{}, fmt.Errorf("open IPA ZIP: %w", err)
+	}
+	if len(reader.File) > maxArchiveEntries {
+		return Inspection{}, fmt.Errorf("IPA contains %d entries; limit is %d", len(reader.File), maxArchiveEntries)
+	}
+
+	seen := make(map[string]struct{}, len(reader.File))
+	var infoFiles []*zip.File
+	var embeddedTargets []string
+	for _, member := range reader.File {
+		if err := validateArchiveMember(member); err != nil {
+			return Inspection{}, err
+		}
+		key := strings.ToLower(strings.TrimSuffix(member.Name, "/"))
+		if _, exists := seen[key]; exists {
+			return Inspection{}, fmt.Errorf("IPA contains duplicate path %q", member.Name)
+		}
+		seen[key] = struct{}{}
+		if isMainAppMember(member.Name, "Info.plist") && !member.FileInfo().IsDir() {
+			infoFiles = append(infoFiles, member)
+		} else if isEmbeddedTargetInfoPlist(member.Name) && !member.FileInfo().IsDir() {
+			embeddedTargets = append(embeddedTargets, member.Name)
+		}
+	}
+	if len(infoFiles) == 0 {
+		return Inspection{}, fmt.Errorf("IPA is missing Payload/*.app/Info.plist")
+	}
+	if len(infoFiles) != 1 {
+		return Inspection{}, fmt.Errorf("IPA contains %d main apps; expected exactly one", len(infoFiles))
+	}
+
+	info, err := readInfoPlist(infoFiles[0])
+	if err != nil {
+		return Inspection{}, err
+	}
+	app := App{
+		BundleID:         strings.TrimSpace(info.BundleID),
+		Title:            firstNonempty(info.DisplayName, info.Name),
+		Version:          strings.TrimSpace(info.Version),
+		BuildNumber:      strings.TrimSpace(info.Build),
+		MinimumOSVersion: strings.TrimSpace(info.MinimumOS),
+	}
+	if err := validateAppMetadata(app); err != nil {
+		return Inspection{}, err
+	}
+	appDir := path.Dir(infoFiles[0].Name)
+	profileName := appDir + "/embedded.mobileprovision"
+	var profileFile *zip.File
+	for _, member := range reader.File {
+		if member.Name == profileName && !member.FileInfo().IsDir() {
+			profileFile = member
+			break
+		}
+	}
+
+	result := Inspection{
+		SchemaVersion:      "1",
+		Platform:           "IOS",
+		DistributionMethod: "release-testing",
+		App:                app,
+		Artifact:           Artifact{SizeBytes: size, SHA256: digest},
+		Signing: Signing{
+			ProfileClass: ProfileClassUnknown,
+			ProfileIntegrityVerification: CodeSignatureVerification{
+				Status: CodeSignatureNotVerified,
+				Reason: "embedded provisioning profile CMS integrity was not verified",
+			},
+			ProfileTrustVerification: CodeSignatureVerification{
+				Status: CodeSignatureNotVerified,
+				Reason: "Apple provisioning profile trust chain and issuance were not verified",
+			},
+			CodeSignatureVerification: CodeSignatureVerification{
+				Status: CodeSignatureNotVerified,
+				Scope:  mainCodeSignatureScope,
+				Reason: "Mach-O code signature and signer/profile certificate binding were not verified",
+			},
+		},
+		Preparation:     Preparation{Issues: []string{}},
+		EmbeddedTargets: canonicalSet(embeddedTargets),
+	}
+
+	if profileFile == nil {
+		result.Preparation.Issues = append(result.Preparation.Issues, "embedded provisioning profile is missing")
+	} else {
+		profile, err := readProfile(profileFile, effectiveNow(options.Now))
+		if err != nil {
+			return Inspection{}, err
+		}
+		devices := canonicalSet(profile.ProvisionedDevices)
+		certificates := certificateFingerprints(profile.DeveloperCertificates)
+		result.Signing = Signing{
+			ProfileClass:                         profile.Class,
+			ProfileUUID:                          strings.TrimSpace(profile.UUID),
+			TeamID:                               onlyTrimmed(profile.TeamIdentifier),
+			DeviceCount:                          len(devices),
+			DeviceSetSHA256:                      hashSet(devices),
+			ProfileCertificateSHA256Fingerprints: certificates,
+			ProfileIntegrityVerification: CodeSignatureVerification{
+				Status: CodeSignatureVerified,
+				Reason: "CMS signature integrity verified; signer trust was not evaluated",
+			},
+			ProfileTrustVerification: profile.ProfileTrustVerification,
+			CodeSignatureVerification: CodeSignatureVerification{
+				Status: CodeSignatureNotVerified,
+				Scope:  mainCodeSignatureScope,
+				Reason: "Mach-O code signature and signer/profile certificate binding were not verified",
+			},
+		}
+		if !profile.ExpirationDate.IsZero() {
+			result.Signing.ExpiresAt = profile.ExpirationDate.UTC().Format(time.RFC3339)
+		}
+		if options.IncludeDevices {
+			result.Signing.Devices = devices
+		}
+		result.Preparation.Issues = preparationIssues(result, profile, effectiveNow(options.Now))
+		result.Signing.CodeSignatureVerification = verifyMainAppCodeSignature(reader.File, appDir, infoFiles[0], info.Executable, profile)
+	}
+	result.Preparation.MetadataEligible = len(result.Preparation.Issues) == 0
+	return result, nil
+}
+
+func validateArchiveMember(member *zip.File) error {
+	name := member.Name
+	if name == "" || len(name) > maxArchiveMemberNameLen || !utf8.ValidString(name) || strings.Contains(name, `\`) {
+		return fmt.Errorf("IPA contains unsafe path %q", name)
+	}
+	for _, r := range name {
+		if r == 0 || unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.In(r, unicode.Bidi_Control) {
+			return fmt.Errorf("IPA contains unsafe path %q", name)
+		}
+	}
+	trimmed := strings.TrimSuffix(name, "/")
+	if trimmed == "" || path.IsAbs(name) || path.Clean(trimmed) != trimmed || strings.HasPrefix(trimmed, "../") || trimmed == ".." {
+		return fmt.Errorf("IPA contains non-canonical path %q", name)
+	}
+	if member.Flags&1 != 0 {
+		return fmt.Errorf("IPA contains encrypted member %q", name)
+	}
+	if member.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("IPA contains symbolic link %q", name)
+	}
+	if !member.FileInfo().IsDir() && !member.Mode().IsRegular() {
+		return fmt.Errorf("IPA contains non-regular member %q", name)
+	}
+	return nil
+}
+
+func validateAppMetadata(app App) error {
+	for _, field := range []struct {
+		name  string
+		value string
+		limit int
+	}{
+		{name: "CFBundleIdentifier", value: app.BundleID, limit: 255},
+		{name: "app title", value: app.Title, limit: 512},
+		{name: "CFBundleShortVersionString", value: app.Version, limit: 64},
+		{name: "CFBundleVersion", value: app.BuildNumber, limit: 64},
+		{name: "MinimumOSVersion", value: app.MinimumOSVersion, limit: 64},
+	} {
+		if len(field.value) > field.limit {
+			return fmt.Errorf("invalid %s: must be at most %d bytes", field.name, field.limit)
+		}
+		for _, r := range field.value {
+			if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.In(r, unicode.Bidi_Control) {
+				return fmt.Errorf("invalid %s: control or formatting characters are not allowed", field.name)
+			}
+		}
+	}
+	return nil
+}
+
+func isMainAppMember(name, base string) bool {
+	if path.Base(name) != base {
+		return false
+	}
+	dir := path.Dir(name)
+	return strings.HasSuffix(dir, ".app") && path.Dir(dir) == "Payload"
+}
+
+func isEmbeddedTargetInfoPlist(name string) bool {
+	if path.Base(name) != "Info.plist" || !strings.HasPrefix(name, "Payload/") {
+		return false
+	}
+	dir := path.Dir(name)
+	if !strings.HasSuffix(dir, ".appex") && !strings.HasSuffix(dir, ".app") {
+		return false
+	}
+	return len(strings.Split(dir, "/")) > 2
+}
+
+func readInfoPlist(member *zip.File) (infoPlistPayload, error) {
+	if err := infoplist.CheckDeclaredSize(member.UncompressedSize64); err != nil {
+		return infoPlistPayload{}, fmt.Errorf("read main app Info.plist: %w", err)
+	}
+	data, err := readZipMemberBounded(member, infoplist.MaxBytes)
+	if err != nil {
+		return infoPlistPayload{}, fmt.Errorf("read main app Info.plist: %w", err)
+	}
+	if err := infoplist.ValidateStructure(data); err != nil {
+		return infoPlistPayload{}, fmt.Errorf("decode main app Info.plist: %w", err)
+	}
+	var result infoPlistPayload
+	if _, err := plist.Unmarshal(data, &result); err != nil {
+		return infoPlistPayload{}, fmt.Errorf("decode main app Info.plist: %w", err)
+	}
+	return result, nil
+}
+
+func readProfile(member *zip.File, now time.Time) (parsedProfile, error) {
+	if member.UncompressedSize64 > maxProfileBytes {
+		return parsedProfile{}, fmt.Errorf("embedded provisioning profile declared size exceeds %d bytes", maxProfileBytes)
+	}
+	data, err := readZipMemberBounded(member, maxProfileBytes)
+	if err != nil {
+		return parsedProfile{}, fmt.Errorf("read embedded provisioning profile: %w", err)
+	}
+	p7, err := pkcs7.Parse(data)
+	if err != nil {
+		return parsedProfile{}, fmt.Errorf("embedded provisioning profile is not signed CMS data: %w", err)
+	}
+	if len(p7.Content) == 0 {
+		return parsedProfile{}, fmt.Errorf("embedded provisioning profile CMS content is empty")
+	}
+	if err := p7.Verify(); err != nil {
+		return parsedProfile{}, fmt.Errorf("verify embedded provisioning profile CMS signature integrity: %w", err)
+	}
+	trust := verifyAppleProfileTrust(p7, now, appleProfileRootFingerprints)
+	if err := infoplist.ValidateStructure(p7.Content); err != nil {
+		return parsedProfile{}, fmt.Errorf("validate embedded provisioning profile plist: %w", err)
+	}
+	var profile embeddedProfile
+	if _, err := plist.Unmarshal(p7.Content, &profile); err != nil {
+		return parsedProfile{}, fmt.Errorf("decode embedded provisioning profile: %w", err)
+	}
+	teamID := declaredSingle(profile.TeamIdentifier)
+	prefix := declaredSingle(profile.ApplicationIdentifierPrefix)
+	if teamID == "" || prefix == "" {
+		return parsedProfile{}, fmt.Errorf("embedded provisioning profile must declare exactly one team and application identifier prefix")
+	}
+	entitlementTeam, _ := profile.Entitlements["com.apple.developer.team-identifier"].(string)
+	if strings.TrimSpace(entitlementTeam) != teamID {
+		return parsedProfile{}, fmt.Errorf("embedded provisioning profile team identifier does not match its entitlement")
+	}
+	applicationID, _ := profile.Entitlements["application-identifier"].(string)
+	wantPrefix := prefix + "."
+	if !strings.HasPrefix(strings.TrimSpace(applicationID), wantPrefix) {
+		return parsedProfile{}, fmt.Errorf("embedded provisioning profile application identifier does not match its declared prefix")
+	}
+	profileBundleID := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(applicationID), wantPrefix))
+	if profileBundleID == "" {
+		return parsedProfile{}, fmt.Errorf("embedded provisioning profile bundle identifier is empty")
+	}
+	debugValue, hasDebugValue := profile.Entitlements["get-task-allow"]
+	debuggable, debugIsBool := debugValue.(bool)
+	class := ProfileClassUnknown
+	deviceCount := len(canonicalSet(profile.ProvisionedDevices))
+	switch {
+	case profile.ProvisionsAllDevices && deviceCount == 0:
+		class = ProfileClassEnterprise
+	case !profile.ProvisionsAllDevices && deviceCount > 0 && hasDebugValue && debugIsBool && debuggable:
+		class = ProfileClassDevelopment
+	case !profile.ProvisionsAllDevices && deviceCount > 0 && hasDebugValue && debugIsBool && !debuggable:
+		class = ProfileClassAdHoc
+	case !profile.ProvisionsAllDevices && deviceCount == 0 && hasDebugValue && debugIsBool && !debuggable:
+		class = ProfileClassAppStore
+	}
+	return parsedProfile{embeddedProfile: profile, BundleID: profileBundleID, Class: class, ProfileTrustVerification: trust}, nil
+}
+
+func verifyAppleProfileTrust(profile *pkcs7.PKCS7, now time.Time, allowedRoots map[string]struct{}) CodeSignatureVerification {
+	invalid := func(reason string) CodeSignatureVerification {
+		return CodeSignatureVerification{Status: CodeSignatureInvalid, Reason: reason}
+	}
+	if len(profile.Signers) != 1 {
+		return invalid("provisioning profile must contain exactly one CMS signer")
+	}
+	signer := profile.GetOnlySigner()
+	if signer == nil || signer.Subject.CommonName != "Apple iPhone OS Provisioning Profile Signing" ||
+		len(signer.Subject.Organization) != 1 || signer.Subject.Organization[0] != "Apple Inc." ||
+		signer.Issuer.CommonName != "Apple iPhone Certification Authority" {
+		return invalid("provisioning profile CMS signer is not the expected Apple provisioning signer")
+	}
+	pool := x509.NewCertPool()
+	foundPinnedRoot := false
+	for _, certificate := range profile.Certificates {
+		if !certificate.IsCA || (!bytes.Equal(certificate.RawSubject, certificate.RawIssuer) && certificate.Subject.String() != certificate.Issuer.String()) {
+			continue
+		}
+		sum := sha256.Sum256(certificate.Raw)
+		if _, ok := allowedRoots[hex.EncodeToString(sum[:])]; !ok {
+			continue
+		}
+		pool.AddCert(certificate)
+		foundPinnedRoot = true
+	}
+	if !foundPinnedRoot {
+		return invalid("provisioning profile chain does not contain a pinned Apple root")
+	}
+	if err := profile.VerifyWithChainAtTime(pool, now); err != nil {
+		return invalid("provisioning profile does not chain to a pinned Apple root")
+	}
+	return CodeSignatureVerification{Status: CodeSignatureVerified, Reason: "Apple provisioning signer identity and chain verified to a pinned Apple root"}
+}
+
+func readZipMemberBounded(member *zip.File, limit int64) ([]byte, error) {
+	reader, err := member.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("expanded contents exceed %d bytes", limit)
+	}
+	return data, nil
+}
+
+func preparationIssues(result Inspection, profile parsedProfile, now time.Time) []string {
+	issues := make([]string, 0)
+	if result.App.BundleID == "" {
+		issues = append(issues, "CFBundleIdentifier is missing")
+	}
+	if result.App.Title == "" {
+		issues = append(issues, "app title is missing")
+	}
+	if result.App.Version == "" {
+		issues = append(issues, "CFBundleShortVersionString is missing")
+	}
+	if result.App.BuildNumber == "" {
+		issues = append(issues, "CFBundleVersion is missing")
+	}
+	if profile.Class != ProfileClassAdHoc {
+		issues = append(issues, fmt.Sprintf("provisioning profile class is %s; expected ad-hoc", profile.Class))
+	}
+	if profile.ExpirationDate.IsZero() {
+		issues = append(issues, "provisioning profile expiration is missing")
+	} else if !profile.ExpirationDate.After(now) {
+		issues = append(issues, "provisioning profile is expired")
+	}
+	if len(canonicalSet(profile.ProvisionedDevices)) == 0 {
+		issues = append(issues, "provisioning profile contains no devices")
+	}
+	if !bundleMatches(profile.BundleID, result.App.BundleID) {
+		issues = append(issues, "provisioning profile bundle identifier does not match the app")
+	}
+	if strings.TrimSpace(profile.UUID) == "" {
+		issues = append(issues, "provisioning profile UUID is missing")
+	}
+	if len(certificateFingerprints(profile.DeveloperCertificates)) == 0 {
+		issues = append(issues, "provisioning profile contains no signing certificates")
+	}
+	if !containsFold(profile.Platform, "iOS") {
+		issues = append(issues, "provisioning profile does not include the iOS platform")
+	}
+	if len(result.EmbeddedTargets) > 0 {
+		issues = append(issues, "embedded targets require target-by-target signing validation before preparation")
+	}
+	return issues
+}
+
+func bundleMatches(profileBundleID, appBundleID string) bool {
+	profileBundleID = strings.TrimSpace(profileBundleID)
+	appBundleID = strings.TrimSpace(appBundleID)
+	if profileBundleID == appBundleID {
+		return appBundleID != ""
+	}
+	if strings.HasSuffix(profileBundleID, ".*") {
+		prefix := strings.TrimSuffix(profileBundleID, "*")
+		return strings.HasPrefix(appBundleID, prefix) && len(appBundleID) > len(prefix)
+	}
+	return false
+}
+
+func certificateFingerprints(certificates [][]byte) []string {
+	result := make([]string, 0, len(certificates))
+	for _, data := range certificates {
+		if _, err := x509.ParseCertificate(data); err != nil {
+			continue
+		}
+		sum := sha256.Sum256(data)
+		result = append(result, hex.EncodeToString(sum[:]))
+	}
+	return canonicalSet(result)
+}
+
+func canonicalSet(values []string) []string {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func hashSet(values []string) string {
+	values = canonicalSet(values)
+	if len(values) == 0 {
+		return ""
+	}
+	hash := sha256.New()
+	for _, value := range values {
+		_, _ = fmt.Fprintf(hash, "%d:", len(value))
+		_, _ = hash.Write([]byte(value))
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func onlyTrimmed(values []string) string {
+	values = canonicalSet(values)
+	if len(values) != 1 {
+		return ""
+	}
+	return values[0]
+}
+
+func declaredSingle(values []string) string {
+	if len(values) != 1 {
+		return ""
+	}
+	return strings.TrimSpace(values[0])
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonempty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func effectiveNow(now time.Time) time.Time {
+	if now.IsZero() {
+		return time.Now()
+	}
+	return now
+}

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -183,7 +183,8 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 		return Inspection{}, fmt.Errorf("IPA contains %d entries; limit is %d", len(reader.File), maxArchiveEntries)
 	}
 
-	seen := make(map[string]struct{}, len(reader.File))
+	seen := make(map[string]bool, len(reader.File))
+	hasDescendants := make(map[string]struct{}, len(reader.File))
 	var infoFiles []*zip.File
 	var embeddedTargets []string
 	var declaredExpandedBytes uint64
@@ -199,7 +200,21 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 		if _, exists := seen[key]; exists {
 			return Inspection{}, fmt.Errorf("IPA contains duplicate path %q", member.Name)
 		}
-		seen[key] = struct{}{}
+		isDirectory := member.FileInfo().IsDir()
+		for ancestor := path.Dir(key); ancestor != "."; ancestor = path.Dir(ancestor) {
+			if ancestorIsDirectory, exists := seen[ancestor]; exists && !ancestorIsDirectory {
+				return Inspection{}, fmt.Errorf("IPA contains file/directory path collision involving %q", member.Name)
+			}
+		}
+		if !isDirectory {
+			if _, exists := hasDescendants[key]; exists {
+				return Inspection{}, fmt.Errorf("IPA contains file/directory path collision involving %q", member.Name)
+			}
+		}
+		seen[key] = isDirectory
+		for ancestor := path.Dir(key); ancestor != "."; ancestor = path.Dir(ancestor) {
+			hasDescendants[ancestor] = struct{}{}
+		}
 		if isMainAppMember(member.Name, "Info.plist") && !member.FileInfo().IsDir() {
 			infoFiles = append(infoFiles, member)
 		} else if isEmbeddedTargetInfoPlist(member.Name) && !member.FileInfo().IsDir() {
@@ -359,6 +374,9 @@ func validateArchiveMember(member *zip.File) error {
 }
 
 func validateAppMetadata(app App) error {
+	if err := validateBundleIdentifier(app.BundleID); err != nil {
+		return err
+	}
 	for _, field := range []struct {
 		name  string
 		value string
@@ -376,6 +394,30 @@ func validateAppMetadata(app App) error {
 		for _, r := range field.value {
 			if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.In(r, unicode.Bidi_Control) {
 				return fmt.Errorf("invalid %s: control or formatting characters are not allowed", field.name)
+			}
+		}
+	}
+	return nil
+}
+
+func validateBundleIdentifier(value string) error {
+	if value == "" {
+		return nil
+	}
+	if len(value) > 255 {
+		return fmt.Errorf("invalid CFBundleIdentifier: must be at most 255 bytes")
+	}
+	for _, component := range strings.Split(value, ".") {
+		if component == "" {
+			return fmt.Errorf("invalid CFBundleIdentifier: components must not be empty")
+		}
+		for index := 0; index < len(component); index++ {
+			character := component[index]
+			if (character < 'a' || character > 'z') &&
+				(character < 'A' || character > 'Z') &&
+				(character < '0' || character > '9') &&
+				character != '-' {
+				return fmt.Errorf("invalid CFBundleIdentifier: only ASCII alphanumeric characters, hyphens, and periods are allowed")
 			}
 		}
 	}

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -549,6 +549,9 @@ func bundleMatches(profileBundleID, appBundleID string) bool {
 	if profileBundleID == appBundleID {
 		return appBundleID != ""
 	}
+	if profileBundleID == "*" {
+		return appBundleID != ""
+	}
 	if strings.HasSuffix(profileBundleID, ".*") {
 		prefix := strings.TrimSuffix(profileBundleID, "*")
 		return strings.HasPrefix(appBundleID, prefix) && len(appBundleID) > len(prefix)

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	maxArchiveEntries       = 20_000
-	maxArchiveMemberNameLen = 4096
-	maxProfileBytes         = 16 << 20
+	maxArchiveEntries              = 20_000
+	maxArchiveMemberNameLen        = 4096
+	maxArchiveExpandedBytes uint64 = 16 << 30
+	maxProfileBytes                = 16 << 20
 	// MaxIPABytes bounds synchronous inspection, hashing, and preparation work.
 	MaxIPABytes int64 = 8 << 30
 )
@@ -183,10 +184,15 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 	seen := make(map[string]struct{}, len(reader.File))
 	var infoFiles []*zip.File
 	var embeddedTargets []string
+	var declaredExpandedBytes uint64
 	for _, member := range reader.File {
 		if err := validateArchiveMember(member); err != nil {
 			return Inspection{}, err
 		}
+		if member.UncompressedSize64 > maxArchiveExpandedBytes-declaredExpandedBytes {
+			return Inspection{}, fmt.Errorf("IPA declared expansion exceeds %d bytes", maxArchiveExpandedBytes)
+		}
+		declaredExpandedBytes += member.UncompressedSize64
 		key := strings.ToLower(strings.TrimSuffix(member.Name, "/"))
 		if _, exists := seen[key]; exists {
 			return Inspection{}, fmt.Errorf("IPA contains duplicate path %q", member.Name)

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -206,6 +206,32 @@ func inspectSnapshot(file *os.File, size int64, digest string, options InspectOp
 			embeddedTargets = append(embeddedTargets, member.Name)
 		}
 	}
+	var expandedBytes uint64
+	for _, member := range reader.File {
+		if member.FileInfo().IsDir() {
+			continue
+		}
+		remaining := maxArchiveExpandedBytes - expandedBytes
+		opened, err := member.Open()
+		if err != nil {
+			return Inspection{}, fmt.Errorf("open IPA member %q: %w", member.Name, err)
+		}
+		written, readErr := io.Copy(io.Discard, io.LimitReader(opened, int64(remaining)+1))
+		closeErr := opened.Close()
+		if written < 0 || uint64(written) > remaining {
+			return Inspection{}, fmt.Errorf("IPA expanded contents exceed %d bytes", maxArchiveExpandedBytes)
+		}
+		expandedBytes += uint64(written)
+		if readErr != nil {
+			return Inspection{}, fmt.Errorf("validate IPA member %q compressed data: %w", member.Name, readErr)
+		}
+		if closeErr != nil {
+			return Inspection{}, fmt.Errorf("close IPA member %q: %w", member.Name, closeErr)
+		}
+		if uint64(written) != member.UncompressedSize64 {
+			return Inspection{}, fmt.Errorf("IPA member %q expanded size does not match its declaration", member.Name)
+		}
+	}
 	if len(infoFiles) == 0 {
 		return Inspection{}, fmt.Errorf("IPA is missing Payload/*.app/Info.plist")
 	}

--- a/internal/distribution/inspect.go
+++ b/internal/distribution/inspect.go
@@ -440,6 +440,12 @@ func readProfile(member *zip.File, now time.Time) (parsedProfile, error) {
 	if teamID == "" || prefix == "" {
 		return parsedProfile{}, fmt.Errorf("embedded provisioning profile must declare exactly one team and application identifier prefix")
 	}
+	if err := validateTeamIdentifier(teamID); err != nil {
+		return parsedProfile{}, err
+	}
+	if err := validateApplicationIdentifierPrefix(prefix); err != nil {
+		return parsedProfile{}, err
+	}
 	entitlementTeam, _ := profile.Entitlements["com.apple.developer.team-identifier"].(string)
 	if strings.TrimSpace(entitlementTeam) != teamID {
 		return parsedProfile{}, fmt.Errorf("embedded provisioning profile team identifier does not match its entitlement")

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -184,6 +184,61 @@ func TestInspectIPARejectsUnsafeAndAmbiguousArchives(t *testing.T) {
 	}
 }
 
+func TestInspectIPARejectsUnreadableNonMainMembers(t *testing.T) {
+	baseEntries := map[string][]byte{
+		"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"),
+		"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{
+			BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+		}),
+	}
+
+	t.Run("checksum failure", func(t *testing.T) {
+		entries := cloneByteMap(baseEntries)
+		entries["Symbols/resource.bin"] = bytes.Repeat([]byte("signed-resource"), 64)
+		path := writeIPA(t, entries)
+		file, err := os.OpenFile(path, os.O_RDWR, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := file.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		reader, err := zip.NewReader(file, info.Size())
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, member := range reader.File {
+			if member.Name != "Symbols/resource.bin" {
+				continue
+			}
+			offset, err := member.DataOffset()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var value [1]byte
+			if _, err := file.ReadAt(value[:], offset); err != nil {
+				t.Fatal(err)
+			}
+			value[0] ^= 0xff
+			if _, err := file.WriteAt(value[:], offset); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		assertInspectErrorContains(t, path, "Symbols/resource.bin")
+	})
+
+	t.Run("truncated stream", func(t *testing.T) {
+		path := writeIPAWithDeclaredRawEntries(t, baseEntries, []declaredRawZipEntry{
+			{Name: "Symbols/truncated.bin", UncompressedSize: 1},
+		})
+		assertInspectErrorContains(t, path, "Symbols/truncated.bin")
+	})
+}
+
 func TestInspectIPARejectsArchiveWideDeclaredExpansionFromCompressedNonMainMembers(t *testing.T) {
 	const archiveExpansionLimit = uint64(16 << 30)
 	baseEntries := map[string][]byte{
@@ -507,6 +562,30 @@ func clonePlistMap(value map[string]any) map[string]any {
 		result[key] = item
 	}
 	return result
+}
+
+func cloneByteMap(value map[string][]byte) map[string][]byte {
+	result := make(map[string][]byte, len(value))
+	for key, item := range value {
+		result[key] = item
+	}
+	return result
+}
+
+func assertInspectErrorContains(t *testing.T, path, want string) {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("InspectIPA() error = %v, want member %q rejection", err, want)
+	}
 }
 
 type profileFixture struct {

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -129,6 +129,55 @@ func TestInspectIPARejectsUnsafeAndAmbiguousArchives(t *testing.T) {
 	}
 }
 
+func TestInspectIPARejectsArchiveWideDeclaredExpansionFromCompressedNonMainMembers(t *testing.T) {
+	const archiveExpansionLimit = uint64(16 << 30)
+	baseEntries := map[string][]byte{
+		"Payload/Demo.app/Info.plist":               infoPlist(t, "com.example.demo"),
+		"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)}),
+	}
+	tests := []struct {
+		name     string
+		declared []declaredRawZipEntry
+	}{
+		{
+			name: "single highly compressed SwiftSupport member",
+			declared: []declaredRawZipEntry{
+				{Name: "SwiftSupport/libSwiftCore.dylib", UncompressedSize: archiveExpansionLimit},
+			},
+		},
+		{
+			name: "sum of non-main members",
+			declared: []declaredRawZipEntry{
+				{Name: "Symbols/part-1.bin", UncompressedSize: archiveExpansionLimit/2 + 1},
+				{Name: "Symbols/part-2.bin", UncompressedSize: archiveExpansionLimit/2 + 1},
+			},
+		},
+		{
+			name: "declared size arithmetic cannot overflow",
+			declared: []declaredRawZipEntry{
+				{Name: "SwiftSupport/overflow.bin", UncompressedSize: ^uint64(0)},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeIPAWithDeclaredRawEntries(t, baseEntries, test.declared)
+			file, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			info, err := file.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil || !strings.Contains(err.Error(), "declared expansion") {
+				t.Fatalf("InspectIPA() error = %v, want archive-wide declared expansion rejection", err)
+			}
+		})
+	}
+}
+
 func TestInspectIPATamperedProfileFailsCMSVerification(t *testing.T) {
 	profile := signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
 	profile[len(profile)/2] ^= 1
@@ -406,6 +455,52 @@ func writeIPA(t *testing.T, entries map[string][]byte) string {
 			t.Fatal(err)
 		}
 		if _, err := entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+type declaredRawZipEntry struct {
+	Name             string
+	UncompressedSize uint64
+}
+
+func writeIPAWithDeclaredRawEntries(t *testing.T, entries map[string][]byte, declaredEntries []declaredRawZipEntry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "App.ipa")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	for name, data := range entries {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, declared := range declaredEntries {
+		header := &zip.FileHeader{
+			Name:               declared.Name,
+			Method:             zip.Deflate,
+			CompressedSize64:   2,
+			UncompressedSize64: declared.UncompressedSize,
+		}
+		entry, err := writer.CreateRaw(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write([]byte{0x03, 0x00}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -314,6 +314,84 @@ func TestInspectIPARejectsUnsafeAppMetadataBeforeDescriptorUse(t *testing.T) {
 	}
 }
 
+func TestInspectIPARequiresMainAppIOSPlatformEvidence(t *testing.T) {
+	base := map[string]any{
+		"CFBundleIdentifier":         "com.example.demo",
+		"CFBundleName":               "Demo",
+		"CFBundleShortVersionString": "1.0",
+		"CFBundleVersion":            "1",
+	}
+	for _, test := range []struct {
+		name     string
+		metadata map[string]any
+	}{
+		{name: "visionOS", metadata: map[string]any{"DTPlatformName": "xros", "CFBundleSupportedPlatforms": []string{"XROS"}}},
+		{name: "tvOS", metadata: map[string]any{"DTPlatformName": "appletvos", "CFBundleSupportedPlatforms": []string{"AppleTVOS"}}},
+		{name: "macOS", metadata: map[string]any{"DTPlatformName": "macosx", "CFBundleSupportedPlatforms": []string{"MacOSX"}}},
+		{name: "simulator", metadata: map[string]any{"DTPlatformName": "iphonesimulator", "CFBundleSupportedPlatforms": []string{"iPhoneSimulator"}}},
+		{name: "contradictory fields", metadata: map[string]any{"DTPlatformName": "iphoneos", "CFBundleSupportedPlatforms": []string{"XROS"}}},
+		{name: "multiple platforms", metadata: map[string]any{"DTPlatformName": "iphoneos", "CFBundleSupportedPlatforms": []string{"iPhoneOS", "AppleTVOS"}}},
+		{name: "missing metadata", metadata: map[string]any{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			metadata := clonePlistMap(base)
+			for key, value := range test.metadata {
+				metadata[key] = value
+			}
+			path := writeIPA(t, map[string][]byte{
+				"Payload/Demo.app/Info.plist": plistBytesFormat(t, metadata, plist.XMLFormat),
+			})
+			file, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			info, err := file.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil || !strings.Contains(err.Error(), "iOS platform") {
+				t.Fatalf("InspectIPA() error = %v, want iOS platform rejection", err)
+			}
+		})
+	}
+}
+
+func TestInspectIPAAcceptsMainAppIOSPlatformEvidenceInXMLAndBinaryPlists(t *testing.T) {
+	metadata := map[string]any{
+		"CFBundleIdentifier":         "com.example.demo",
+		"CFBundleName":               "Demo",
+		"CFBundleShortVersionString": "1.0",
+		"CFBundleVersion":            "1",
+		"DTPlatformName":             "iphoneos",
+		"CFBundleSupportedPlatforms": []string{"iPhoneOS"},
+	}
+	for _, format := range []int{plist.XMLFormat, plist.BinaryFormat} {
+		path := writeIPA(t, map[string][]byte{
+			"Payload/Demo.app/Info.plist": plistBytesFormat(t, metadata, format),
+		})
+		got := inspectPath(t, path, false)
+		if got.Platform != "IOS" {
+			t.Fatalf("platform = %q, want IOS", got.Platform)
+		}
+	}
+}
+
+func TestInspectIPAUsesOnlyMainAppPlatformEvidence(t *testing.T) {
+	path := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"),
+		"Payload/Demo.app/PlugIns/Vision.appex/Info.plist": plistBytes(t, map[string]any{
+			"CFBundleIdentifier":         "com.example.demo.vision",
+			"DTPlatformName":             "xros",
+			"CFBundleSupportedPlatforms": []string{"XROS"},
+		}),
+	})
+	got := inspectPath(t, path, false)
+	if got.Platform != "IOS" {
+		t.Fatalf("platform = %q, want main-app IOS evidence", got.Platform)
+	}
+}
+
 func inspectPath(t *testing.T, path string, devices bool) Inspection {
 	t.Helper()
 	file, err := os.Open(path)
@@ -342,16 +420,46 @@ func validIPA(t *testing.T, devices []string, expires time.Time, debuggable bool
 
 func infoPlist(t *testing.T, bundleID string) []byte {
 	t.Helper()
-	return plistBytes(t, map[string]any{"CFBundleIdentifier": bundleID, "CFBundleName": "Demo", "CFBundleShortVersionString": "1.0", "CFBundleVersion": "1"})
+	return plistBytes(t, map[string]any{
+		"CFBundleIdentifier":         bundleID,
+		"CFBundleName":               "Demo",
+		"CFBundleShortVersionString": "1.0",
+		"CFBundleVersion":            "1",
+	})
 }
 
 func plistBytes(t *testing.T, value any) []byte {
 	t.Helper()
-	data, err := plist.Marshal(value, plist.XMLFormat)
+	if payload, ok := value.(map[string]any); ok {
+		payload = clonePlistMap(payload)
+		if _, hasBundleID := payload["CFBundleIdentifier"]; hasBundleID {
+			if _, hasPlatformName := payload["DTPlatformName"]; !hasPlatformName {
+				if _, hasSupportedPlatforms := payload["CFBundleSupportedPlatforms"]; !hasSupportedPlatforms {
+					payload["DTPlatformName"] = "iphoneos"
+					payload["CFBundleSupportedPlatforms"] = []string{"iPhoneOS"}
+				}
+			}
+		}
+		value = payload
+	}
+	return plistBytesFormat(t, value, plist.XMLFormat)
+}
+
+func plistBytesFormat(t *testing.T, value any, format int) []byte {
+	t.Helper()
+	data, err := plist.Marshal(value, format)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return data
+}
+
+func clonePlistMap(value map[string]any) map[string]any {
+	result := make(map[string]any, len(value))
+	for key, item := range value {
+		result[key] = item
+	}
+	return result
 }
 
 type profileFixture struct {

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -1,0 +1,427 @@
+package distribution
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mozilla.org/pkcs7"
+	"howett.net/plist"
+)
+
+func TestInspectIPAAdHocOmitsDevicesByDefault(t *testing.T) {
+	profile := signedProfile(t, profileFixture{
+		BundleID: "com.example.demo",
+		Devices:  []string{"device-b", "device-a"},
+		Expires:  time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+	})
+	path := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistBytes(t, map[string]any{
+			"CFBundleIdentifier":         "com.example.demo",
+			"CFBundleDisplayName":        "Demo",
+			"CFBundleShortVersionString": "1.2.3",
+			"CFBundleVersion":            "45",
+			"MinimumOSVersion":           "17.0",
+		}),
+		"Payload/Demo.app/embedded.mobileprovision": profile,
+	})
+
+	got := inspectPath(t, path, false)
+	if got.SchemaVersion != "1" || got.Platform != "IOS" || got.DistributionMethod != "release-testing" {
+		t.Fatalf("unexpected contract header: %#v", got)
+	}
+	if got.App.BundleID != "com.example.demo" || got.App.Title != "Demo" || got.App.BuildNumber != "45" {
+		t.Fatalf("unexpected app: %#v", got.App)
+	}
+	if got.Signing.ProfileClass != ProfileClassAdHoc || got.Signing.DeviceCount != 2 || len(got.Signing.Devices) != 0 {
+		t.Fatalf("unexpected signing result: %#v", got.Signing)
+	}
+	if got.Signing.DeviceSetSHA256 == "" || len(got.Signing.ProfileCertificateSHA256Fingerprints) != 1 {
+		t.Fatalf("missing deterministic fingerprints: %#v", got.Signing)
+	}
+	if !got.Preparation.MetadataEligible || len(got.Preparation.Issues) != 0 {
+		t.Fatalf("unexpected eligibility: %#v", got.Preparation)
+	}
+	if got.Signing.CodeSignatureVerification.Status != CodeSignatureInvalid {
+		t.Fatalf("unexpected code signature verification: %#v", got.Signing.CodeSignatureVerification)
+	}
+	if got.Signing.ProfileIntegrityVerification.Status != CodeSignatureVerified || got.Signing.ProfileTrustVerification.Status != CodeSignatureInvalid {
+		t.Fatalf("unexpected profile verification: %#v", got.Signing)
+	}
+	if got.Artifact.SHA256 == "" || got.Artifact.SizeBytes == 0 {
+		t.Fatalf("unexpected artifact: %#v", got.Artifact)
+	}
+}
+
+func TestInspectIPAIncludesSortedDevicesOnlyWhenRequested(t *testing.T) {
+	path := validIPA(t, []string{"device-b", "device-a"}, time.Now().Add(24*time.Hour), false)
+	got := inspectPath(t, path, true)
+	if len(got.Signing.Devices) != 2 || got.Signing.Devices[0] != "device-a" || got.Signing.Devices[1] != "device-b" {
+		t.Fatalf("devices = %#v", got.Signing.Devices)
+	}
+}
+
+func TestInspectIPAClassifiesProfiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		devices    []string
+		debuggable bool
+		enterprise bool
+		want       ProfileClass
+	}{
+		{name: "ad hoc", devices: []string{"one"}, want: ProfileClassAdHoc},
+		{name: "development", devices: []string{"one"}, debuggable: true, want: ProfileClassDevelopment},
+		{name: "enterprise", enterprise: true, want: ProfileClassEnterprise},
+		{name: "app store", want: ProfileClassAppStore},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeIPA(t, map[string][]byte{
+				"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"),
+				"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{
+					BundleID: "com.example.demo", Devices: test.devices, Debuggable: test.debuggable,
+					Enterprise: test.enterprise, Expires: time.Now().Add(24 * time.Hour),
+				}),
+			})
+			if got := inspectPath(t, path, false).Signing.ProfileClass; got != test.want {
+				t.Fatalf("class = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestInspectIPARejectsUnsafeAndAmbiguousArchives(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries map[string][]byte
+	}{
+		{name: "traversal", entries: map[string][]byte{"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"), "Payload/../evil": {1}}},
+		{name: "backslash", entries: map[string][]byte{"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"), `Payload\evil`: {1}}},
+		{name: "bidirectional control", entries: map[string][]byte{"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"), "Payload/evil\u202Eipa": {1}}},
+		{name: "oversized member name", entries: map[string][]byte{"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"), "Payload/" + strings.Repeat("a", maxArchiveMemberNameLen): {1}}},
+		{name: "ambiguous main app", entries: map[string][]byte{"Payload/A.app/Info.plist": infoPlist(t, "com.example.a"), "Payload/B.app/Info.plist": infoPlist(t, "com.example.b")}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeIPA(t, test.entries)
+			file, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			info, _ := file.Stat()
+			if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil {
+				t.Fatal("expected inspection error")
+			}
+		})
+	}
+}
+
+func TestInspectIPATamperedProfileFailsCMSVerification(t *testing.T) {
+	profile := signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
+	profile[len(profile)/2] ^= 1
+	path := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist":               infoPlist(t, "com.example.demo"),
+		"Payload/Demo.app/embedded.mobileprovision": profile,
+	})
+	file, _ := os.Open(path)
+	defer file.Close()
+	info, _ := file.Stat()
+	if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil {
+		t.Fatal("expected tampered profile to fail")
+	}
+}
+
+func TestVerifyAppleProfileTrustRequiresPinnedAppleIssuance(t *testing.T) {
+	profile, root := appleShapedCMS(t, false)
+	sum := sha256.Sum256(root.Raw)
+	allowed := map[string]struct{}{hex.EncodeToString(sum[:]): {}}
+	got := verifyAppleProfileTrust(profile, time.Now(), allowed)
+	if got.Status != CodeSignatureVerified {
+		t.Fatalf("Apple-shaped pinned chain status = %#v", got)
+	}
+
+	arbitrary := signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)})
+	message, err := pkcs7.Parse(arbitrary)
+	if err != nil || len(message.Certificates) == 0 {
+		t.Fatalf("parse arbitrary CMS: %v", err)
+	}
+	arbitrarySum := sha256.Sum256(message.Certificates[0].Raw)
+	got = verifyAppleProfileTrust(message, time.Now(), map[string]struct{}{hex.EncodeToString(arbitrarySum[:]): {}})
+	if got.Status != CodeSignatureInvalid {
+		t.Fatalf("arbitrary trusted signer status = %#v", got)
+	}
+
+	multiple, root := appleShapedCMS(t, true)
+	sum = sha256.Sum256(root.Raw)
+	got = verifyAppleProfileTrust(multiple, time.Now(), map[string]struct{}{hex.EncodeToString(sum[:]): {}})
+	if got.Status != CodeSignatureInvalid {
+		t.Fatalf("multiple signer status = %#v", got)
+	}
+}
+
+func TestInspectIPAReportsEmbeddedTargetAsNotReady(t *testing.T) {
+	path := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist":                      infoPlist(t, "com.example.demo"),
+		"Payload/Demo.app/embedded.mobileprovision":        signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Now().Add(time.Hour)}),
+		"Payload/Demo.app/PlugIns/Widget.appex/Info.plist": infoPlist(t, "com.example.demo.widget"),
+	})
+	got := inspectPath(t, path, false)
+	if got.Preparation.MetadataEligible || len(got.EmbeddedTargets) != 1 {
+		t.Fatalf("complex IPA was reported ready: %#v", got)
+	}
+}
+
+func TestInspectIPARejectsFileOverSupportedSizeBeforeZIPWork(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge.ipa")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(MaxIPABytes + 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectIPA(file, MaxIPABytes+1, InspectOptions{}); err == nil {
+		t.Fatal("expected IPA size limit rejection")
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInspectIPARejectsUnsafeAppMetadataBeforeDescriptorUse(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		value string
+	}{
+		{name: "bidirectional title", field: "CFBundleDisplayName", value: "Demo\u202Eipa"},
+		{name: "format control bundle identifier", field: "CFBundleIdentifier", value: "com.example.\u200Bdemo"},
+		{name: "oversized version", field: "CFBundleShortVersionString", value: strings.Repeat("1", 65)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metadata := map[string]any{
+				"CFBundleIdentifier":         "com.example.demo",
+				"CFBundleDisplayName":        "Demo",
+				"CFBundleShortVersionString": "1.0",
+				"CFBundleVersion":            "1",
+			}
+			metadata[test.field] = test.value
+			path := writeIPA(t, map[string][]byte{
+				"Payload/Demo.app/Info.plist": plistBytes(t, metadata),
+			})
+			file, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			info, err := file.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil {
+				t.Fatal("expected unsafe app metadata rejection")
+			}
+		})
+	}
+}
+
+func inspectPath(t *testing.T, path string, devices bool) Inspection {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := InspectIPA(file, info.Size(), InspectOptions{IncludeDevices: devices, Now: time.Date(2028, 1, 1, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("InspectIPA() error = %v", err)
+	}
+	return got
+}
+
+func validIPA(t *testing.T, devices []string, expires time.Time, debuggable bool) string {
+	t.Helper()
+	return writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist":               infoPlist(t, "com.example.demo"),
+		"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{BundleID: "com.example.demo", Devices: devices, Expires: expires, Debuggable: debuggable}),
+	})
+}
+
+func infoPlist(t *testing.T, bundleID string) []byte {
+	t.Helper()
+	return plistBytes(t, map[string]any{"CFBundleIdentifier": bundleID, "CFBundleName": "Demo", "CFBundleShortVersionString": "1.0", "CFBundleVersion": "1"})
+}
+
+func plistBytes(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := plist.Marshal(value, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+type profileFixture struct {
+	BundleID   string
+	Devices    []string
+	Expires    time.Time
+	Debuggable bool
+	Enterprise bool
+}
+
+func signedProfile(t *testing.T, fixture profileFixture) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Add(-time.Hour)
+	template := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "Test Profile Signer"}, NotBefore: now, NotAfter: now.Add(365 * 24 * time.Hour), KeyUsage: x509.KeyUsageDigitalSignature}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entitlements := map[string]any{"application-identifier": "TEAM123." + fixture.BundleID, "com.apple.developer.team-identifier": "TEAM123", "get-task-allow": fixture.Debuggable}
+	payload := map[string]any{
+		"UUID": "profile-uuid", "Name": "Test Profile", "TeamIdentifier": []string{"TEAM123"}, "ApplicationIdentifierPrefix": []string{"TEAM123"},
+		"Platform":           []string{"iOS"},
+		"ProvisionedDevices": fixture.Devices, "ProvisionsAllDevices": fixture.Enterprise,
+		"ExpirationDate": fixture.Expires, "Entitlements": entitlements, "DeveloperCertificates": [][]byte{der},
+	}
+	signed, err := pkcs7.NewSignedData(plistBytes(t, payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := signed.AddSigner(cert, key, pkcs7.SignerInfoConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := signed.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func appleShapedCMS(t *testing.T, multipleSigners bool) (*pkcs7.PKCS7, *x509.Certificate) {
+	t.Helper()
+	now := time.Now().Add(-time.Hour)
+	newKey := func() *ecdsa.PrivateKey {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return key
+	}
+	issue := func(serial int64, subject, issuer pkix.Name, public any, issuerCert *x509.Certificate, issuerKey *ecdsa.PrivateKey, ca bool) *x509.Certificate {
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(serial), Subject: subject, Issuer: issuer,
+			NotBefore: now, NotAfter: now.Add(24 * time.Hour), BasicConstraintsValid: true, IsCA: ca,
+			KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, issuerCert, public, issuerKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		certificate, err := x509.ParseCertificate(der)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return certificate
+	}
+	rootKey := newKey()
+	rootName := pkix.Name{CommonName: "Apple Root CA", Organization: []string{"Apple Inc."}}
+	rootTemplate := &x509.Certificate{SerialNumber: big.NewInt(100), Subject: rootName, Issuer: rootName, NotBefore: now, NotAfter: now.Add(24 * time.Hour), BasicConstraintsValid: true, IsCA: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intermediateKey := newKey()
+	intermediateName := pkix.Name{CommonName: "Apple iPhone Certification Authority", Organization: []string{"Apple Inc."}}
+	intermediate := issue(101, intermediateName, rootName, &intermediateKey.PublicKey, root, rootKey, true)
+	signerKey := newKey()
+	signerName := pkix.Name{CommonName: "Apple iPhone OS Provisioning Profile Signing", Organization: []string{"Apple Inc."}}
+	signer := issue(102, signerName, intermediateName, &signerKey.PublicKey, intermediate, intermediateKey, false)
+	signed, err := pkcs7.NewSignedData([]byte("fixture"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := signed.AddSigner(signer, signerKey, pkcs7.SignerInfoConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	if multipleSigners {
+		if err := signed.AddSigner(signer, signerKey, pkcs7.SignerInfoConfig{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	signed.AddCertificate(intermediate)
+	signed.AddCertificate(root)
+	data, err := signed.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, err := pkcs7.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return message, root
+}
+
+func writeIPA(t *testing.T, entries map[string][]byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "App.ipa")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	for name, data := range entries {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestHashSetDeterministic(t *testing.T) {
+	a := hashSet([]string{"b", "a", "a"})
+	b := hashSet([]string{"a", "b"})
+	if !bytes.Equal([]byte(a), []byte(b)) {
+		t.Fatalf("hashes differ: %q %q", a, b)
+	}
+}

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -54,8 +55,15 @@ func TestInspectIPAAdHocOmitsDevicesByDefault(t *testing.T) {
 	if !got.Preparation.MetadataEligible || len(got.Preparation.Issues) != 0 {
 		t.Fatalf("unexpected eligibility: %#v", got.Preparation)
 	}
-	if got.Signing.CodeSignatureVerification.Status != CodeSignatureInvalid {
+	wantCodeSignatureStatus := CodeSignatureInvalid
+	if runtime.GOOS != "darwin" {
+		wantCodeSignatureStatus = CodeSignatureNotVerified
+	}
+	if got.Signing.CodeSignatureVerification.Status != wantCodeSignatureStatus {
 		t.Fatalf("unexpected code signature verification: %#v", got.Signing.CodeSignatureVerification)
+	}
+	if runtime.GOOS != "darwin" && got.Signing.CodeSignatureVerification.Reason != "complete main-app code-signature verification is available only on macOS" {
+		t.Fatalf("unexpected portable code signature reason: %#v", got.Signing.CodeSignatureVerification)
 	}
 	if got.Signing.ProfileIntegrityVerification.Status != CodeSignatureVerified || got.Signing.ProfileTrustVerification.Status != CodeSignatureInvalid {
 		t.Fatalf("unexpected profile verification: %#v", got.Signing)

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -110,6 +110,53 @@ func TestInspectIPAClassifiesProfiles(t *testing.T) {
 	}
 }
 
+func TestInspectIPAValidatesApplicationIdentifierPrefixDeclaration(t *testing.T) {
+	t.Run("legacy prefix differs from team", func(t *testing.T) {
+		path := writeIPA(t, map[string][]byte{
+			"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"),
+			"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{
+				BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+				ApplicationIdentifierPrefixes: []string{"LEGACY123"},
+			}),
+		})
+		got := inspectPath(t, path, false)
+		if got.Signing.TeamID != "TEAM123" || !got.Preparation.MetadataEligible {
+			t.Fatalf("legacy profile inspection = %#v", got)
+		}
+	})
+
+	for _, test := range []struct {
+		name     string
+		prefixes []string
+	}{
+		{name: "missing", prefixes: []string{}},
+		{name: "ambiguous", prefixes: []string{"LEGACY123", "OTHER123"}},
+		{name: "malformed", prefixes: []string{`LEGACY"123`}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeIPA(t, map[string][]byte{
+				"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"),
+				"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{
+					BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+					ApplicationIdentifierPrefixes: test.prefixes,
+				}),
+			})
+			file, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			info, err := file.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil || !strings.Contains(err.Error(), "application identifier prefix") {
+				t.Fatalf("InspectIPA() error = %v, want prefix declaration rejection", err)
+			}
+		})
+	}
+}
+
 func TestInspectIPARejectsUnsafeAndAmbiguousArchives(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -463,11 +510,12 @@ func clonePlistMap(value map[string]any) map[string]any {
 }
 
 type profileFixture struct {
-	BundleID   string
-	Devices    []string
-	Expires    time.Time
-	Debuggable bool
-	Enterprise bool
+	BundleID                      string
+	Devices                       []string
+	Expires                       time.Time
+	Debuggable                    bool
+	Enterprise                    bool
+	ApplicationIdentifierPrefixes []string
 }
 
 func signedProfile(t *testing.T, fixture profileFixture) []byte {
@@ -486,9 +534,17 @@ func signedProfile(t *testing.T, fixture profileFixture) []byte {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entitlements := map[string]any{"application-identifier": "TEAM123." + fixture.BundleID, "com.apple.developer.team-identifier": "TEAM123", "get-task-allow": fixture.Debuggable}
+	prefixes := fixture.ApplicationIdentifierPrefixes
+	if prefixes == nil {
+		prefixes = []string{"TEAM123"}
+	}
+	applicationIdentifierPrefix := "TEAM123"
+	if len(prefixes) > 0 {
+		applicationIdentifierPrefix = prefixes[0]
+	}
+	entitlements := map[string]any{"application-identifier": applicationIdentifierPrefix + "." + fixture.BundleID, "com.apple.developer.team-identifier": "TEAM123", "get-task-allow": fixture.Debuggable}
 	payload := map[string]any{
-		"UUID": "profile-uuid", "Name": "Test Profile", "TeamIdentifier": []string{"TEAM123"}, "ApplicationIdentifierPrefix": []string{"TEAM123"},
+		"UUID": "profile-uuid", "Name": "Test Profile", "TeamIdentifier": []string{"TEAM123"}, "ApplicationIdentifierPrefix": prefixes,
 		"Platform":           []string{"iOS"},
 		"ProvisionedDevices": fixture.Devices, "ProvisionsAllDevices": fixture.Enterprise,
 		"ExpirationDate": fixture.Expires, "Entitlements": entitlements, "DeveloperCertificates": [][]byte{der},

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -272,38 +272,7 @@ func TestInspectIPARejectsUnreadableNonMainMembers(t *testing.T) {
 		entries := cloneByteMap(baseEntries)
 		entries["Symbols/resource.bin"] = bytes.Repeat([]byte("signed-resource"), 64)
 		path := writeIPA(t, entries)
-		file, err := os.OpenFile(path, os.O_RDWR, 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		info, err := file.Stat()
-		if err != nil {
-			t.Fatal(err)
-		}
-		reader, err := zip.NewReader(file, info.Size())
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, member := range reader.File {
-			if member.Name != "Symbols/resource.bin" {
-				continue
-			}
-			offset, err := member.DataOffset()
-			if err != nil {
-				t.Fatal(err)
-			}
-			var value [1]byte
-			if _, err := file.ReadAt(value[:], offset); err != nil {
-				t.Fatal(err)
-			}
-			value[0] ^= 0xff
-			if _, err := file.WriteAt(value[:], offset); err != nil {
-				t.Fatal(err)
-			}
-		}
-		if err := file.Close(); err != nil {
-			t.Fatal(err)
-		}
+		corruptZipMemberData(t, path, "Symbols/resource.bin")
 		assertInspectErrorContains(t, path, "Symbols/resource.bin")
 	})
 
@@ -312,6 +281,33 @@ func TestInspectIPARejectsUnreadableNonMainMembers(t *testing.T) {
 			{Name: "Symbols/truncated.bin", UncompressedSize: 1},
 		})
 		assertInspectErrorContains(t, path, "Symbols/truncated.bin")
+	})
+}
+
+func TestInspectIPARejectsUnreadableDirectoryMembers(t *testing.T) {
+	baseEntries := []orderedZipEntry{
+		{Name: "Payload/Demo.app/Info.plist", Data: infoPlist(t, "com.example.demo")},
+		{Name: "Payload/Demo.app/embedded.mobileprovision", Data: signedProfile(t, profileFixture{
+			BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+		})},
+	}
+
+	t.Run("checksum failure", func(t *testing.T) {
+		entries := append([]orderedZipEntry(nil), baseEntries...)
+		entries = append(entries, orderedZipEntry{Name: "SymbolsX", Data: []byte("directory-data")})
+		path := writeOrderedIPA(t, entries)
+		renameZipMember(t, path, "SymbolsX", "Symbols/")
+		corruptZipMemberData(t, path, "Symbols/")
+		assertInspectErrorContains(t, path, "Symbols/")
+	})
+
+	t.Run("truncated stream", func(t *testing.T) {
+		path := writeIPAWithDeclaredRawEntries(t, map[string][]byte{
+			baseEntries[0].Name: baseEntries[0].Data,
+			baseEntries[1].Name: baseEntries[1].Data,
+		}, []declaredRawZipEntry{{Name: "SymbolsX", UncompressedSize: 1}})
+		renameZipMember(t, path, "SymbolsX", "Symbols/")
+		assertInspectErrorContains(t, path, "Symbols/")
 	})
 }
 
@@ -944,6 +940,60 @@ func writeIPAWithDeclaredRawEntries(t *testing.T, entries map[string][]byte, dec
 		t.Fatal(err)
 	}
 	return path
+}
+
+func corruptZipMemberData(t *testing.T, path, memberName string) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range reader.File {
+		if member.Name != memberName {
+			continue
+		}
+		offset, err := member.DataOffset()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var value [1]byte
+		if _, err := file.ReadAt(value[:], offset); err != nil {
+			t.Fatal(err)
+		}
+		value[0] ^= 0xff
+		if _, err := file.WriteAt(value[:], offset); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	t.Fatalf("ZIP member %q not found", memberName)
+}
+
+func renameZipMember(t *testing.T, path, oldName, newName string) {
+	t.Helper()
+	if len(oldName) != len(newName) {
+		t.Fatal("ZIP member replacement names must have equal lengths")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replaced := bytes.ReplaceAll(data, []byte(oldName), []byte(newName))
+	if bytes.Equal(replaced, data) {
+		t.Fatalf("ZIP member %q not found", oldName)
+	}
+	if err := os.WriteFile(path, replaced, 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestHashSetDeterministic(t *testing.T) {

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -184,6 +184,80 @@ func TestInspectIPARejectsUnsafeAndAmbiguousArchives(t *testing.T) {
 	}
 }
 
+func TestInspectIPARejectsArchivePathPrefixCollisions(t *testing.T) {
+	info := infoPlist(t, "com.example.demo")
+	tests := []struct {
+		name    string
+		entries []orderedZipEntry
+	}{
+		{
+			name: "regular Payload before descendant",
+			entries: []orderedZipEntry{
+				{Name: "Payload", Data: []byte("file")},
+				{Name: "Payload/Demo.app/Info.plist", Data: info},
+			},
+		},
+		{
+			name: "regular app directory before Info plist",
+			entries: []orderedZipEntry{
+				{Name: "Payload/Demo.app", Data: []byte("file")},
+				{Name: "Payload/Demo.app/Info.plist", Data: info},
+			},
+		},
+		{
+			name: "descendant before regular app directory",
+			entries: []orderedZipEntry{
+				{Name: "Payload/Demo.app/Info.plist", Data: info},
+				{Name: "Payload/Demo.app", Data: []byte("file")},
+			},
+		},
+		{
+			name: "trailing slash alias changes kind",
+			entries: []orderedZipEntry{
+				{Name: "Payload/", Mode: os.ModeDir | 0o755},
+				{Name: "Payload", Data: []byte("file")},
+			},
+		},
+		{
+			name: "symlink ancestor",
+			entries: []orderedZipEntry{
+				{Name: "Payload", Data: []byte("outside"), Mode: os.ModeSymlink | 0o777},
+				{Name: "Payload/Demo.app/Info.plist", Data: info},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeOrderedIPA(t, test.entries)
+			assertInspectErrorContains(t, path, "Payload")
+		})
+	}
+}
+
+func TestInspectIPAAcceptsExplicitDirectoriesAndSimilarlyPrefixedSiblings(t *testing.T) {
+	path := writeOrderedIPA(t, []orderedZipEntry{
+		{Name: "Payload/", Mode: os.ModeDir | 0o755},
+		{Name: "Payload/Demo.app/", Mode: os.ModeDir | 0o755},
+		{Name: "Payload/Demo.application", Data: []byte("sibling")},
+		{Name: "Payload/Demo.app/Info.plist", Data: infoPlist(t, "com.example.demo")},
+		{Name: "Payload/Demo.app/embedded.mobileprovision", Data: signedProfile(t, profileFixture{
+			BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+		})},
+	})
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err != nil {
+		t.Fatalf("InspectIPA() error = %v, want valid explicit directories and sibling", err)
+	}
+}
+
 func TestInspectIPARejectsUnreadableNonMainMembers(t *testing.T) {
 	baseEntries := map[string][]byte{
 		"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"),
@@ -412,6 +486,52 @@ func TestInspectIPARejectsUnsafeAppMetadataBeforeDescriptorUse(t *testing.T) {
 			if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err == nil {
 				t.Fatal("expected unsafe app metadata rejection")
 			}
+		})
+	}
+}
+
+func TestValidateBundleIdentifierSyntax(t *testing.T) {
+	valid := []string{
+		"",
+		"com.example.demo",
+		"Com.Example-2.App",
+		"7legacy.-component",
+		"single",
+		strings.Repeat("a", 255),
+	}
+	for _, value := range valid {
+		if err := validateBundleIdentifier(value); err != nil {
+			t.Fatalf("validateBundleIdentifier(%q) = %v", value, err)
+		}
+	}
+	invalid := []string{
+		"com.example/bad",
+		"com..example",
+		".com.example",
+		"com.example.",
+		"com.example bad",
+		"com.exаmple.demo",
+		"com.example.*",
+		"com.example_bad",
+		strings.Repeat("a", 256),
+	}
+	for _, value := range invalid {
+		if err := validateBundleIdentifier(value); err == nil {
+			t.Fatalf("validateBundleIdentifier(%q) unexpectedly succeeded", value)
+		}
+	}
+}
+
+func TestInspectIPARejectsInvalidConcreteBundleIdentifierBeforeProfileMatching(t *testing.T) {
+	for _, bundleID := range []string{"com.example/bad", "com..example", "com.example.*"} {
+		t.Run(bundleID, func(t *testing.T) {
+			path := writeIPA(t, map[string][]byte{
+				"Payload/Demo.app/Info.plist": infoPlist(t, bundleID),
+				"Payload/Demo.app/embedded.mobileprovision": signedProfile(t, profileFixture{
+					BundleID: "*", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+				}),
+			})
+			assertInspectErrorContains(t, path, "CFBundleIdentifier")
 		})
 	}
 }
@@ -724,6 +844,45 @@ func writeIPA(t *testing.T, entries map[string][]byte) string {
 			t.Fatal(err)
 		}
 		if _, err := entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+type orderedZipEntry struct {
+	Name string
+	Data []byte
+	Mode os.FileMode
+}
+
+func writeOrderedIPA(t *testing.T, entries []orderedZipEntry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "App.ipa")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	for _, fixture := range entries {
+		header := &zip.FileHeader{Name: fixture.Name, Method: zip.Deflate}
+		if fixture.Mode != 0 {
+			header.SetMode(fixture.Mode)
+		}
+		if fixture.Mode.IsDir() {
+			header.Method = zip.Store
+		}
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(fixture.Data); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -247,14 +247,32 @@ func TestInspectIPARejectsFileOverSupportedSizeBeforeZIPWork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := file.Truncate(MaxIPABytes + 1); err != nil {
-		t.Fatal(err)
-	}
 	if _, err := InspectIPA(file, MaxIPABytes+1, InspectOptions{}); err == nil {
 		t.Fatal("expected IPA size limit rejection")
 	}
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestBundleMatchesUniversalProvisioningWildcard(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		app     string
+		want    bool
+	}{
+		{name: "universal wildcard", profile: "*", app: "com.example.demo", want: true},
+		{name: "universal wildcard rejects empty app", profile: "*", app: "", want: false},
+		{name: "prefix wildcard", profile: "com.example.*", app: "com.example.demo", want: true},
+		{name: "prefix wildcard requires suffix", profile: "com.example.*", app: "com.example.", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := bundleMatches(test.profile, test.app); got != test.want {
+				t.Fatalf("bundleMatches(%q, %q) = %t, want %t", test.profile, test.app, got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -3,13 +3,16 @@ package distribution
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -257,6 +260,137 @@ func TestInspectIPAAcceptsExplicitDirectoriesAndSimilarlyPrefixedSiblings(t *tes
 	}
 	if _, err := InspectIPA(file, info.Size(), InspectOptions{}); err != nil {
 		t.Fatalf("InspectIPA() error = %v, want valid explicit directories and sibling", err)
+	}
+}
+
+func TestInspectIPAValidatesDirectoryEntryStreams(t *testing.T) {
+	base := func(directory orderedZipEntry) []orderedZipEntry {
+		return []orderedZipEntry{
+			directory,
+			{Name: "Payload/Demo.app/Info.plist", Data: infoPlist(t, "com.example.demo")},
+			{Name: "Payload/Demo.app/embedded.mobileprovision", Data: signedProfile(t, profileFixture{
+				BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+			})},
+		}
+	}
+	for _, test := range []struct {
+		name      string
+		directory orderedZipEntry
+	}{
+		{name: "stored empty", directory: orderedZipEntry{Name: "Payload/", Mode: os.ModeDir | 0o755}},
+		{name: "deflated empty with data descriptor", directory: orderedZipEntry{Name: "Payload/", Mode: os.ModeDir | 0o755, Deflate: true}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeOrderedIPA(t, base(test.directory))
+			if test.directory.Deflate {
+				file, err := os.Open(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				info, err := file.Stat()
+				if err != nil {
+					t.Fatal(err)
+				}
+				reader, err := zip.NewReader(file, info.Size())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if reader.File[0].Flags&0x8 == 0 {
+					t.Fatal("deflated empty directory did not use a data descriptor")
+				}
+				_ = file.Close()
+			}
+			_ = inspectPath(t, path, false)
+		})
+	}
+
+	t.Run("nonzero payload", func(t *testing.T) {
+		path := writeOrderedIPA(t, base(orderedZipEntry{
+			Name: "Payload/", Data: []byte("directory-data"), Mode: os.ModeDir | 0o755, Deflate: true,
+		}))
+		assertInspectErrorContains(t, path, "contains data")
+	})
+	t.Run("corrupt compressed stream", func(t *testing.T) {
+		path := writeOrderedIPA(t, base(orderedZipEntry{
+			Name: "Payload/", Data: bytes.Repeat([]byte("directory-data"), 32), Mode: os.ModeDir | 0o755, Deflate: true,
+		}))
+		corruptZipMemberData(t, path, "Payload/")
+		assertInspectErrorContains(t, path, "Payload/")
+	})
+	t.Run("CRC mismatch", func(t *testing.T) {
+		path := writeOrderedIPA(t, base(orderedZipEntry{Name: "Payload/", Mode: os.ModeDir | 0o755}))
+		corruptCentralDirectoryCRC(t, path, "Payload/")
+		assertInspectErrorContains(t, path, "Payload/")
+	})
+}
+
+func TestInspectIPAContextCancellationDuringZIPValidationStopsImmediately(t *testing.T) {
+	path := writeOrderedIPA(t, []orderedZipEntry{
+		{Name: "Payload/", Mode: os.ModeDir | 0o755},
+		{Name: "Payload/Demo.app/Info.plist", Data: infoPlist(t, "com.example.demo")},
+		{Name: "Payload/Demo.app/embedded.mobileprovision", Data: signedProfile(t, profileFixture{
+			BundleID: "com.example.demo", Devices: []string{"one"}, Expires: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+		})},
+	})
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	var visited []string
+	duringZIPValidationForTest = func(name string) {
+		visited = append(visited, name)
+	}
+	duringZIPStreamReadForTest = cancel
+	t.Cleanup(func() {
+		duringZIPValidationForTest = nil
+		duringZIPStreamReadForTest = nil
+	})
+	if _, err := InspectIPAContext(ctx, file, info.Size(), InspectOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("InspectIPAContext() error = %v, want context.Canceled", err)
+	}
+	if len(visited) != 1 {
+		t.Fatalf("visited ZIP members = %#v, want exactly one", visited)
+	}
+}
+
+func TestSnapshotIPAContextCancellationCleansPrivateSnapshot(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "app.ipa")
+	if err := os.WriteFile(sourcePath, bytes.Repeat([]byte("snapshot"), 1<<17), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	var snapshotDirectory string
+	snapshotCreatedForTest = func(path string) { snapshotDirectory = path }
+	duringIPASnapshotForTest = cancel
+	t.Cleanup(func() {
+		duringIPASnapshotForTest = nil
+		snapshotCreatedForTest = nil
+	})
+	if _, _, cleanup, err := snapshotIPAContext(ctx, source, info.Size()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("snapshotIPAContext() error = %v, want context.Canceled", err)
+	} else if cleanup != nil {
+		t.Fatal("snapshotIPAContext() returned cleanup after cancellation")
+	}
+	if snapshotDirectory == "" {
+		t.Fatal("snapshot directory creation hook was not called")
+	}
+	if _, err := os.Lstat(snapshotDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot directory stat error = %v, want not found", err)
 	}
 }
 
@@ -862,9 +996,10 @@ func writeIPA(t *testing.T, entries map[string][]byte) string {
 }
 
 type orderedZipEntry struct {
-	Name string
-	Data []byte
-	Mode os.FileMode
+	Name    string
+	Data    []byte
+	Mode    os.FileMode
+	Deflate bool
 }
 
 func writeOrderedIPA(t *testing.T, entries []orderedZipEntry) string {
@@ -875,12 +1010,19 @@ func writeOrderedIPA(t *testing.T, entries []orderedZipEntry) string {
 		t.Fatal(err)
 	}
 	writer := zip.NewWriter(file)
+	directoryAliases := map[string]string{}
 	for _, fixture := range entries {
-		header := &zip.FileHeader{Name: fixture.Name, Method: zip.Deflate}
-		if fixture.Mode != 0 {
+		writeName := fixture.Name
+		streamDirectory := fixture.Mode.IsDir() && (fixture.Deflate || len(fixture.Data) > 0)
+		if streamDirectory {
+			writeName = strings.TrimSuffix(fixture.Name, "/") + "X"
+			directoryAliases[writeName] = fixture.Name
+		}
+		header := &zip.FileHeader{Name: writeName, Method: zip.Deflate}
+		if fixture.Mode != 0 && !streamDirectory {
 			header.SetMode(fixture.Mode)
 		}
-		if fixture.Mode.IsDir() {
+		if fixture.Mode.IsDir() && !fixture.Deflate {
 			header.Method = zip.Store
 		}
 		entry, err := writer.CreateHeader(header)
@@ -897,7 +1039,121 @@ func writeOrderedIPA(t *testing.T, entries []orderedZipEntry) string {
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
+	for from, to := range directoryAliases {
+		convertZipEntryToDirectory(t, path, from, to)
+	}
 	return path
+}
+
+func convertZipEntryToDirectory(t *testing.T, path, from, to string) {
+	t.Helper()
+	if len(from) != len(to) {
+		t.Fatalf("directory alias lengths differ: %q, %q", from, to)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = bytes.ReplaceAll(data, []byte(from), []byte(to))
+	signature := []byte{'P', 'K', 1, 2}
+	for offset := 0; ; {
+		index := bytes.Index(data[offset:], signature)
+		if index < 0 {
+			break
+		}
+		index += offset
+		if index+46 > len(data) {
+			break
+		}
+		nameLength := int(binary.LittleEndian.Uint16(data[index+28 : index+30]))
+		extraLength := int(binary.LittleEndian.Uint16(data[index+30 : index+32]))
+		commentLength := int(binary.LittleEndian.Uint16(data[index+32 : index+34]))
+		end := index + 46 + nameLength
+		if end > len(data) {
+			break
+		}
+		if string(data[index+46:end]) == to {
+			binary.LittleEndian.PutUint16(data[index+4:index+6], 3<<8|20)
+			binary.LittleEndian.PutUint32(data[index+38:index+42], uint32(0o40755)<<16)
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		offset = end + extraLength + commentLength
+	}
+	t.Fatalf("central directory entry %q not found", to)
+}
+
+func corruptZipMemberData(t *testing.T, path, name string) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range reader.File {
+		if member.Name != name {
+			continue
+		}
+		offset, err := member.DataOffset()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var value [1]byte
+		if _, err := file.ReadAt(value[:], offset); err != nil {
+			t.Fatal(err)
+		}
+		value[0] ^= 0xff
+		if _, err := file.WriteAt(value[:], offset); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	t.Fatalf("ZIP member %q not found", name)
+}
+
+func corruptCentralDirectoryCRC(t *testing.T, path, name string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := []byte{'P', 'K', 1, 2}
+	for offset := 0; ; {
+		index := bytes.Index(data[offset:], signature)
+		if index < 0 {
+			break
+		}
+		index += offset
+		if index+46 > len(data) {
+			break
+		}
+		nameLength := int(binary.LittleEndian.Uint16(data[index+28 : index+30]))
+		extraLength := int(binary.LittleEndian.Uint16(data[index+30 : index+32]))
+		commentLength := int(binary.LittleEndian.Uint16(data[index+32 : index+34]))
+		end := index + 46 + nameLength
+		if end > len(data) {
+			break
+		}
+		if string(data[index+46:end]) == name {
+			binary.LittleEndian.PutUint32(data[index+16:index+20], 1)
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		offset = end + extraLength + commentLength
+	}
+	t.Fatalf("central directory entry %q not found", name)
 }
 
 type declaredRawZipEntry struct {

--- a/internal/distribution/inspect_test.go
+++ b/internal/distribution/inspect_test.go
@@ -167,6 +167,8 @@ func TestInspectIPARejectsUnsafeAndAmbiguousArchives(t *testing.T) {
 		{name: "bidirectional control", entries: map[string][]byte{"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"), "Payload/evil\u202Eipa": {1}}},
 		{name: "oversized member name", entries: map[string][]byte{"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo"), "Payload/" + strings.Repeat("a", maxArchiveMemberNameLen): {1}}},
 		{name: "ambiguous main app", entries: map[string][]byte{"Payload/A.app/Info.plist": infoPlist(t, "com.example.a"), "Payload/B.app/Info.plist": infoPlist(t, "com.example.b")}},
+		{name: "regular file shadows top-level directory", entries: map[string][]byte{"Payload": {1}, "Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo")}},
+		{name: "regular file shadows app directory", entries: map[string][]byte{"Payload/Demo.app": {1}, "Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo")}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -386,6 +388,9 @@ func TestInspectIPARejectsUnsafeAppMetadataBeforeDescriptorUse(t *testing.T) {
 	}{
 		{name: "bidirectional title", field: "CFBundleDisplayName", value: "Demo\u202Eipa"},
 		{name: "format control bundle identifier", field: "CFBundleIdentifier", value: "com.example.\u200Bdemo"},
+		{name: "bundle identifier path separator", field: "CFBundleIdentifier", value: "com.example/bad"},
+		{name: "empty bundle identifier component", field: "CFBundleIdentifier", value: "com..example"},
+		{name: "non-ASCII bundle identifier", field: "CFBundleIdentifier", value: "com.example.démo"},
 		{name: "oversized version", field: "CFBundleShortVersionString", value: strings.Repeat("1", 65)},
 	}
 	for _, test := range tests {

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -296,7 +296,7 @@ func validateSourceURL(raw string) error {
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
 		return fmt.Errorf("invalid --source-url: query and fragment are not allowed")
 	}
-	if parsed.Scheme != "https" || parsed.Host == "" {
+	if parsed.Scheme != "https" || parsed.Hostname() == "" {
 		return fmt.Errorf("invalid --source-url: must be an absolute HTTPS URL")
 	}
 	return nil

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -66,6 +66,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (PrepareResul
 	if err != nil {
 		return PrepareResult{}, fmt.Errorf("prepare output root: %w", err)
 	}
+	defer root.Close()
 	// Select and retain the output root before the potentially long snapshot,
 	// archive validation, and code-signing work.
 	if err := root.MkdirAll(".", 0o755); err != nil {

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -260,6 +260,9 @@ func ValidatePrepareOptions(options PrepareOptions) error {
 			return err
 		}
 	}
+	if err := validateDescriptorText("--source-url", options.SourceURL, 2048); err != nil {
+		return err
+	}
 	return validateSourceURL(options.SourceURL)
 }
 

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -1,6 +1,8 @@
 package distribution
 
 import (
+	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -25,6 +27,7 @@ var (
 
 	afterOutputParentsCreatedForTest func()
 	verifyCompleteSigningForTest     func(*Inspection)
+	duringPublicationCopyForTest     func()
 )
 
 type Descriptor struct {
@@ -55,6 +58,13 @@ type PrepareResult struct {
 // PrepareIPA validates an already-open IPA and publishes an immutable local
 // bundle without replacing an existing destination.
 func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result PrepareResult, resultErr error) {
+	return PrepareIPAContext(context.Background(), file, size, options)
+}
+
+func PrepareIPAContext(ctx context.Context, file *os.File, size int64, options PrepareOptions) (result PrepareResult, resultErr error) {
+	if err := contextError(ctx); err != nil {
+		return PrepareResult{}, err
+	}
 	if err := ValidatePrepareOptions(options); err != nil {
 		return PrepareResult{}, err
 	}
@@ -77,7 +87,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	if err := root.MkdirAll(".", 0o755); err != nil {
 		return PrepareResult{}, fmt.Errorf("pin distribution output root: %w", err)
 	}
-	snapshot, digest, cleanup, err := snapshotIPA(file, size)
+	snapshot, digest, cleanup, err := snapshotIPAContext(ctx, file, size)
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -85,12 +95,15 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	if afterIPASnapshotForTest != nil {
 		afterIPASnapshotForTest()
 	}
-	inspection, err := inspectSnapshot(snapshot, size, digest, InspectOptions{})
+	inspection, err := inspectSnapshotContext(ctx, snapshot, size, digest, InspectOptions{})
 	if err != nil {
 		return PrepareResult{}, err
 	}
 	if verifyCompleteSigningForTest != nil {
 		verifyCompleteSigningForTest(&inspection)
+	}
+	if err := contextError(ctx); err != nil {
+		return PrepareResult{}, err
 	}
 	if title := strings.TrimSpace(options.Title); title != "" {
 		inspection.App.Title = title
@@ -139,6 +152,9 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	}
 	defer rooted.Close()
 	parentRelative := filepath.Dir(relativeOutput)
+	if err := contextError(ctx); err != nil {
+		return PrepareResult{}, err
+	}
 	if err := rooted.MkdirAll(parentRelative, 0o755); err != nil {
 		return PrepareResult{}, fmt.Errorf("create distribution output parent: %w", err)
 	}
@@ -153,7 +169,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	bundlePath := filepath.Join(root.Path(), relativeOutput)
 	finalName := filepath.Base(relativeOutput)
 	result = PrepareResult{BundlePath: bundlePath, Descriptor: descriptor}
-	if reused, exists, err := exactBundleExists(parent, finalName, descriptorData, descriptor.Artifact); err != nil {
+	if reused, exists, err := exactBundleExistsContext(ctx, parent, finalName, descriptorData, descriptor.Artifact); err != nil {
 		return PrepareResult{}, err
 	} else if exists {
 		if !reused {
@@ -182,7 +198,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	if err != nil {
 		return PrepareResult{}, fmt.Errorf("open staged payload: %w", err)
 	}
-	if err := copySectionToNewFile(payloadRoot, "app.ipa", snapshot, size, descriptor.Artifact.SHA256, 0o644); err != nil {
+	if err := copySectionToNewFileContext(ctx, payloadRoot, "app.ipa", snapshot, size, descriptor.Artifact.SHA256, 0o644); err != nil {
 		_ = payloadRoot.Close()
 		return PrepareResult{}, fmt.Errorf("copy IPA into staged bundle: %w", err)
 	}
@@ -191,6 +207,9 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	}
 	// Write the descriptor last so even the private staging directory never
 	// advertises a payload that has not finished copying.
+	if err := contextError(ctx); err != nil {
+		return PrepareResult{}, err
+	}
 	if err := writeNewRootedFile(stage, "bundle.json", descriptorData, 0o644); err != nil {
 		return PrepareResult{}, fmt.Errorf("write staged bundle descriptor: %w", err)
 	}
@@ -199,9 +218,12 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	}
 	stageOpen = false
 
+	if err := contextError(ctx); err != nil {
+		return PrepareResult{}, err
+	}
 	if err := secureopen.RenameNoReplaceInRoot(parent, stageName, finalName); err != nil {
 		if errors.Is(err, os.ErrExist) {
-			if reused, exists, reuseErr := exactBundleExists(parent, finalName, descriptorData, descriptor.Artifact); reuseErr == nil && exists && reused {
+			if reused, exists, reuseErr := exactBundleExistsContext(ctx, parent, finalName, descriptorData, descriptor.Artifact); reuseErr == nil && exists && reused {
 				result.Reused = true
 				return result, nil
 			}
@@ -370,13 +392,13 @@ func writeNewRootedFile(root *os.Root, name string, data []byte, mode os.FileMod
 	return file.Close()
 }
 
-func copySectionToNewFile(root *os.Root, name string, source *os.File, size int64, expectedSHA256 string, mode os.FileMode) error {
+func copySectionToNewFileContext(ctx context.Context, root *os.Root, name string, source *os.File, size int64, expectedSHA256 string, mode os.FileMode) error {
 	destination, err := secureopen.OpenNewFileNoFollowInRoot(root, name, mode)
 	if err != nil {
 		return err
 	}
 	hash := sha256.New()
-	written, err := io.Copy(io.MultiWriter(destination, hash), io.NewSectionReader(source, 0, size))
+	written, err := copyWithContext(ctx, io.MultiWriter(destination, hash), io.NewSectionReader(source, 0, size), duringPublicationCopyForTest)
 	if err != nil {
 		_ = destination.Close()
 		return err
@@ -392,7 +414,10 @@ func copySectionToNewFile(root *os.Root, name string, source *os.File, size int6
 	return destination.Close()
 }
 
-func exactBundleExists(parent *os.Root, name string, wantDescriptor []byte, artifact Artifact) (bool, bool, error) {
+func exactBundleExistsContext(ctx context.Context, parent *os.Root, name string, wantDescriptor []byte, artifact Artifact) (bool, bool, error) {
+	if err := contextError(ctx); err != nil {
+		return false, false, err
+	}
 	info, err := parent.Lstat(name)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, false, nil
@@ -425,9 +450,10 @@ func exactBundleExists(parent *os.Root, name string, wantDescriptor []byte, arti
 	if err != nil {
 		return false, true, nil
 	}
-	gotDescriptor, readErr := io.ReadAll(io.LimitReader(descriptor, int64(len(wantDescriptor))+1))
+	var descriptorData bytes.Buffer
+	_, readErr := copyWithContext(ctx, &descriptorData, io.LimitReader(descriptor, int64(len(wantDescriptor))+1), nil)
 	closeErr := descriptor.Close()
-	if readErr != nil || closeErr != nil || string(gotDescriptor) != string(wantDescriptor) {
+	if readErr != nil || closeErr != nil || descriptorData.String() != string(wantDescriptor) {
 		return false, true, nil
 	}
 	ipa, err := secureopen.OpenExistingNoFollowInRoot(payload, "app.ipa")
@@ -440,7 +466,7 @@ func exactBundleExists(parent *os.Root, name string, wantDescriptor []byte, arti
 		return false, true, nil
 	}
 	hash := sha256.New()
-	_, hashErr := io.Copy(hash, ipa)
+	_, hashErr := copyWithContext(ctx, hash, ipa, nil)
 	closeErr = ipa.Close()
 	if hashErr != nil || closeErr != nil || hex.EncodeToString(hash.Sum(nil)) != artifact.SHA256 {
 		return false, true, nil

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -58,6 +58,19 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (PrepareResul
 	if err := ValidatePrepareOptions(options); err != nil {
 		return PrepareResult{}, err
 	}
+	rootPath := strings.TrimSpace(options.Root)
+	if rootPath == "" {
+		rootPath = "."
+	}
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("prepare output root: %w", err)
+	}
+	// Select and retain the output root before the potentially long snapshot,
+	// archive validation, and code-signing work.
+	if err := root.MkdirAll(".", 0o755); err != nil {
+		return PrepareResult{}, fmt.Errorf("pin distribution output root: %w", err)
+	}
 	snapshot, digest, cleanup, err := snapshotIPA(file, size)
 	if err != nil {
 		return PrepareResult{}, err
@@ -110,14 +123,6 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (PrepareResul
 	}
 	descriptorData = append(descriptorData, '\n')
 
-	rootPath := strings.TrimSpace(options.Root)
-	if rootPath == "" {
-		rootPath = "."
-	}
-	root, err := rootfs.New(rootPath)
-	if err != nil {
-		return PrepareResult{}, fmt.Errorf("prepare output root: %w", err)
-	}
 	relativeOutput, err := prepareOutputPath(inspection, options.OutputDir)
 	if err != nil {
 		return PrepareResult{}, err

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -55,7 +56,16 @@ type PrepareResult struct {
 // PrepareIPA validates an already-open IPA and publishes an immutable local
 // bundle without replacing an existing destination.
 func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result PrepareResult, resultErr error) {
+	return PrepareIPAContext(context.Background(), file, size, options)
+}
+
+// PrepareIPAContext validates an already-open IPA and publishes an immutable
+// local bundle, stopping promptly when ctx is canceled.
+func PrepareIPAContext(ctx context.Context, file *os.File, size int64, options PrepareOptions) (result PrepareResult, resultErr error) {
 	if err := ValidatePrepareOptions(options); err != nil {
+		return PrepareResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return PrepareResult{}, err
 	}
 	rootPath := strings.TrimSpace(options.Root)
@@ -77,7 +87,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	if err := root.MkdirAll(".", 0o755); err != nil {
 		return PrepareResult{}, fmt.Errorf("pin distribution output root: %w", err)
 	}
-	snapshot, digest, cleanup, err := snapshotIPA(file, size)
+	snapshot, digest, cleanup, err := snapshotIPA(ctx, file, size)
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -85,7 +95,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	if afterIPASnapshotForTest != nil {
 		afterIPASnapshotForTest()
 	}
-	inspection, err := inspectSnapshot(snapshot, size, digest, InspectOptions{})
+	inspection, err := inspectSnapshot(ctx, snapshot, size, digest, InspectOptions{})
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -153,7 +163,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	bundlePath := filepath.Join(root.Path(), relativeOutput)
 	finalName := filepath.Base(relativeOutput)
 	result = PrepareResult{BundlePath: bundlePath, Descriptor: descriptor}
-	if reused, exists, err := exactBundleExists(parent, finalName, descriptorData, descriptor.Artifact); err != nil {
+	if reused, exists, err := exactBundleExists(ctx, parent, finalName, descriptorData, descriptor.Artifact); err != nil {
 		return PrepareResult{}, err
 	} else if exists {
 		if !reused {
@@ -182,7 +192,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	if err != nil {
 		return PrepareResult{}, fmt.Errorf("open staged payload: %w", err)
 	}
-	if err := copySectionToNewFile(payloadRoot, "app.ipa", snapshot, size, descriptor.Artifact.SHA256, 0o644); err != nil {
+	if err := copySectionToNewFile(ctx, payloadRoot, "app.ipa", snapshot, size, descriptor.Artifact.SHA256, 0o644); err != nil {
 		_ = payloadRoot.Close()
 		return PrepareResult{}, fmt.Errorf("copy IPA into staged bundle: %w", err)
 	}
@@ -199,9 +209,16 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result Prepa
 	}
 	stageOpen = false
 
+	if err := ctx.Err(); err != nil {
+		return PrepareResult{}, err
+	}
 	if err := secureopen.RenameNoReplaceInRoot(parent, stageName, finalName); err != nil {
 		if errors.Is(err, os.ErrExist) {
-			if reused, exists, reuseErr := exactBundleExists(parent, finalName, descriptorData, descriptor.Artifact); reuseErr == nil && exists && reused {
+			reused, exists, reuseErr := exactBundleExists(ctx, parent, finalName, descriptorData, descriptor.Artifact)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return PrepareResult{}, ctxErr
+			}
+			if reuseErr == nil && exists && reused {
 				result.Reused = true
 				return result, nil
 			}
@@ -370,13 +387,13 @@ func writeNewRootedFile(root *os.Root, name string, data []byte, mode os.FileMod
 	return file.Close()
 }
 
-func copySectionToNewFile(root *os.Root, name string, source *os.File, size int64, expectedSHA256 string, mode os.FileMode) error {
+func copySectionToNewFile(ctx context.Context, root *os.Root, name string, source *os.File, size int64, expectedSHA256 string, mode os.FileMode) error {
 	destination, err := secureopen.OpenNewFileNoFollowInRoot(root, name, mode)
 	if err != nil {
 		return err
 	}
 	hash := sha256.New()
-	written, err := io.Copy(io.MultiWriter(destination, hash), io.NewSectionReader(source, 0, size))
+	written, err := copyWithContext(ctx, io.MultiWriter(destination, hash), io.NewSectionReader(source, 0, size))
 	if err != nil {
 		_ = destination.Close()
 		return err
@@ -392,7 +409,10 @@ func copySectionToNewFile(root *os.Root, name string, source *os.File, size int6
 	return destination.Close()
 }
 
-func exactBundleExists(parent *os.Root, name string, wantDescriptor []byte, artifact Artifact) (bool, bool, error) {
+func exactBundleExists(ctx context.Context, parent *os.Root, name string, wantDescriptor []byte, artifact Artifact) (bool, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, false, err
+	}
 	info, err := parent.Lstat(name)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, false, nil
@@ -440,8 +460,11 @@ func exactBundleExists(parent *os.Root, name string, wantDescriptor []byte, arti
 		return false, true, nil
 	}
 	hash := sha256.New()
-	_, hashErr := io.Copy(hash, ipa)
+	_, hashErr := copyWithContext(ctx, hash, ipa)
 	closeErr = ipa.Close()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, true, ctxErr
+	}
 	if hashErr != nil || closeErr != nil || hex.EncodeToString(hash.Sum(nil)) != artifact.SHA256 {
 		return false, true, nil
 	}

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -54,9 +54,30 @@ type PrepareResult struct {
 
 // PrepareIPA validates an already-open IPA and publishes an immutable local
 // bundle without replacing an existing destination.
-func PrepareIPA(file *os.File, size int64, options PrepareOptions) (PrepareResult, error) {
+func PrepareIPA(file *os.File, size int64, options PrepareOptions) (result PrepareResult, resultErr error) {
 	if err := ValidatePrepareOptions(options); err != nil {
 		return PrepareResult{}, err
+	}
+	rootPath := strings.TrimSpace(options.Root)
+	if rootPath == "" {
+		rootPath = "."
+	}
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("prepare output root: %w", err)
+	}
+	defer func() {
+		if err := root.Close(); resultErr == nil && err != nil {
+			result = PrepareResult{}
+			resultErr = fmt.Errorf("close distribution output root: %w", err)
+		}
+	}()
+	probe, err := root.OpenRoot()
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("open distribution output root: %w", err)
+	}
+	if err := probe.Close(); err != nil {
+		return PrepareResult{}, fmt.Errorf("close distribution output root: %w", err)
 	}
 	snapshot, digest, cleanup, err := snapshotIPA(file, size)
 	if err != nil {
@@ -110,14 +131,6 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (PrepareResul
 	}
 	descriptorData = append(descriptorData, '\n')
 
-	rootPath := strings.TrimSpace(options.Root)
-	if rootPath == "" {
-		rootPath = "."
-	}
-	root, err := rootfs.New(rootPath)
-	if err != nil {
-		return PrepareResult{}, fmt.Errorf("prepare output root: %w", err)
-	}
 	relativeOutput, err := prepareOutputPath(inspection, options.OutputDir)
 	if err != nil {
 		return PrepareResult{}, err
@@ -141,7 +154,7 @@ func PrepareIPA(file *os.File, size int64, options PrepareOptions) (PrepareResul
 	defer parent.Close()
 	bundlePath := filepath.Join(root.Path(), relativeOutput)
 	finalName := filepath.Base(relativeOutput)
-	result := PrepareResult{BundlePath: bundlePath, Descriptor: descriptor}
+	result = PrepareResult{BundlePath: bundlePath, Descriptor: descriptor}
 	if reused, exists, err := exactBundleExists(parent, finalName, descriptorData, descriptor.Artifact); err != nil {
 		return PrepareResult{}, err
 	} else if exists {

--- a/internal/distribution/prepare.go
+++ b/internal/distribution/prepare.go
@@ -1,0 +1,464 @@
+package distribution
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
+)
+
+var (
+	ErrNotEligible    = errors.New("IPA metadata is not eligible for release-testing preparation")
+	ErrBundleConflict = errors.New("distribution bundle conflicts with existing output")
+
+	afterOutputParentsCreatedForTest func()
+	verifyCompleteSigningForTest     func(*Inspection)
+)
+
+type Descriptor struct {
+	SchemaVersion      string   `json:"schemaVersion"`
+	Platform           string   `json:"platform"`
+	DistributionMethod string   `json:"distributionMethod"`
+	App                App      `json:"app"`
+	Artifact           Artifact `json:"artifact"`
+	Signing            Signing  `json:"signing"`
+	Source             *Source  `json:"source,omitempty"`
+}
+
+type PrepareOptions struct {
+	Root           string
+	OutputDir      string
+	Title          string
+	Channel        string
+	SourceRevision string
+	SourceURL      string
+}
+
+type PrepareResult struct {
+	BundlePath string     `json:"bundlePath"`
+	Reused     bool       `json:"reused"`
+	Descriptor Descriptor `json:"descriptor"`
+}
+
+// PrepareIPA validates an already-open IPA and publishes an immutable local
+// bundle without replacing an existing destination.
+func PrepareIPA(file *os.File, size int64, options PrepareOptions) (PrepareResult, error) {
+	if err := ValidatePrepareOptions(options); err != nil {
+		return PrepareResult{}, err
+	}
+	snapshot, digest, cleanup, err := snapshotIPA(file, size)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	defer cleanup()
+	if afterIPASnapshotForTest != nil {
+		afterIPASnapshotForTest()
+	}
+	inspection, err := inspectSnapshot(snapshot, size, digest, InspectOptions{})
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	if verifyCompleteSigningForTest != nil {
+		verifyCompleteSigningForTest(&inspection)
+	}
+	if title := strings.TrimSpace(options.Title); title != "" {
+		inspection.App.Title = title
+		inspection.Preparation.Issues = withoutIssue(inspection.Preparation.Issues, "app title is missing")
+		inspection.Preparation.MetadataEligible = len(inspection.Preparation.Issues) == 0
+	}
+	if !inspection.Preparation.MetadataEligible {
+		return PrepareResult{}, fmt.Errorf("%w: %s", ErrNotEligible, strings.Join(inspection.Preparation.Issues, "; "))
+	}
+	if inspection.Signing.ProfileIntegrityVerification.Status != CodeSignatureVerified ||
+		inspection.Signing.ProfileTrustVerification.Status != CodeSignatureVerified ||
+		inspection.Signing.CodeSignatureVerification.Status != CodeSignatureVerified ||
+		inspection.Signing.CodeSignatureVerification.Scope != mainCodeSignatureScope {
+		return PrepareResult{}, fmt.Errorf("%w: provisioning profile trust and complete main-app signature verification are required", ErrNotEligible)
+	}
+
+	descriptor := Descriptor{
+		SchemaVersion:      inspection.SchemaVersion,
+		Platform:           inspection.Platform,
+		DistributionMethod: inspection.DistributionMethod,
+		App:                inspection.App,
+		Artifact: Artifact{
+			RelativePath: "payload/app.ipa",
+			SizeBytes:    inspection.Artifact.SizeBytes,
+			SHA256:       inspection.Artifact.SHA256,
+		},
+		Signing: inspection.Signing,
+	}
+	descriptor.Signing.Devices = nil
+	if source := buildSource(options); source != nil {
+		descriptor.Source = source
+	}
+	descriptorData, err := json.MarshalIndent(descriptor, "", "  ")
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("encode bundle descriptor: %w", err)
+	}
+	descriptorData = append(descriptorData, '\n')
+
+	rootPath := strings.TrimSpace(options.Root)
+	if rootPath == "" {
+		rootPath = "."
+	}
+	root, err := rootfs.New(rootPath)
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("prepare output root: %w", err)
+	}
+	relativeOutput, err := prepareOutputPath(inspection, options.OutputDir)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	rooted, err := root.OpenRoot()
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("open distribution output root: %w", err)
+	}
+	defer rooted.Close()
+	parentRelative := filepath.Dir(relativeOutput)
+	if err := rooted.MkdirAll(parentRelative, 0o755); err != nil {
+		return PrepareResult{}, fmt.Errorf("create distribution output parent: %w", err)
+	}
+	if afterOutputParentsCreatedForTest != nil {
+		afterOutputParentsCreatedForTest()
+	}
+	parent, err := rooted.OpenRoot(parentRelative)
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("open distribution output parent: %w", err)
+	}
+	defer parent.Close()
+	bundlePath := filepath.Join(root.Path(), relativeOutput)
+	finalName := filepath.Base(relativeOutput)
+	result := PrepareResult{BundlePath: bundlePath, Descriptor: descriptor}
+	if reused, exists, err := exactBundleExists(parent, finalName, descriptorData, descriptor.Artifact); err != nil {
+		return PrepareResult{}, err
+	} else if exists {
+		if !reused {
+			return PrepareResult{}, fmt.Errorf("%w: %s", ErrBundleConflict, bundlePath)
+		}
+		result.Reused = true
+		return result, nil
+	}
+
+	stageName, stage, err := createStageDirectory(parent)
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("create distribution staging directory: %w", err)
+	}
+	stageOpen := true
+	defer func() {
+		if stageOpen {
+			_ = stage.Close()
+		}
+		_ = parent.RemoveAll(stageName)
+	}()
+
+	if err := stage.Mkdir("payload", 0o755); err != nil {
+		return PrepareResult{}, fmt.Errorf("create staged payload: %w", err)
+	}
+	payloadRoot, err := stage.OpenRoot("payload")
+	if err != nil {
+		return PrepareResult{}, fmt.Errorf("open staged payload: %w", err)
+	}
+	if err := copySectionToNewFile(payloadRoot, "app.ipa", snapshot, size, descriptor.Artifact.SHA256, 0o644); err != nil {
+		_ = payloadRoot.Close()
+		return PrepareResult{}, fmt.Errorf("copy IPA into staged bundle: %w", err)
+	}
+	if err := payloadRoot.Close(); err != nil {
+		return PrepareResult{}, fmt.Errorf("close staged payload: %w", err)
+	}
+	// Write the descriptor last so even the private staging directory never
+	// advertises a payload that has not finished copying.
+	if err := writeNewRootedFile(stage, "bundle.json", descriptorData, 0o644); err != nil {
+		return PrepareResult{}, fmt.Errorf("write staged bundle descriptor: %w", err)
+	}
+	if err := stage.Close(); err != nil {
+		return PrepareResult{}, fmt.Errorf("close distribution staging directory: %w", err)
+	}
+	stageOpen = false
+
+	if err := secureopen.RenameNoReplaceInRoot(parent, stageName, finalName); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			if reused, exists, reuseErr := exactBundleExists(parent, finalName, descriptorData, descriptor.Artifact); reuseErr == nil && exists && reused {
+				result.Reused = true
+				return result, nil
+			}
+			return PrepareResult{}, fmt.Errorf("%w: %s", ErrBundleConflict, bundlePath)
+		}
+		return PrepareResult{}, fmt.Errorf("publish distribution bundle without replacement: %w", err)
+	}
+	return result, nil
+}
+
+func prepareOutputPath(inspection Inspection, requested string) (string, error) {
+	if requested = strings.TrimSpace(requested); requested != "" {
+		if err := rootfs.ValidateRelative(requested); err != nil {
+			return "", fmt.Errorf("invalid output directory: %w", err)
+		}
+		return filepath.Clean(requested), nil
+	}
+	bundleID, err := safePathComponent(inspection.App.BundleID)
+	if err != nil {
+		return "", fmt.Errorf("invalid bundle identifier path component: %w", err)
+	}
+	version, err := safePathComponent(inspection.App.Version)
+	if err != nil {
+		return "", fmt.Errorf("invalid version path component: %w", err)
+	}
+	build, err := safePathComponent(inspection.App.BuildNumber)
+	if err != nil {
+		return "", fmt.Errorf("invalid build number path component: %w", err)
+	}
+	identity := fmt.Sprintf("%s-%s-%s", version, build, inspection.Artifact.SHA256[:12])
+	return filepath.Join(".asc", "distribution", bundleID, identity), nil
+}
+
+func safePathComponent(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("value is empty")
+	}
+	var builder strings.Builder
+	for _, b := range []byte(value) {
+		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' || b == '_' || b == '.' {
+			builder.WriteByte(b)
+		} else {
+			fmt.Fprintf(&builder, "~%02X", b)
+		}
+	}
+	result := builder.String()
+	if result == "." || result == ".." {
+		result = strings.Repeat("~2E", len(result))
+	}
+	return result, nil
+}
+
+// ValidatePrepareOptions validates optional metadata before preparation opens
+// or writes any filesystem path.
+func ValidatePrepareOptions(options PrepareOptions) error {
+	for _, field := range []struct {
+		name  string
+		value string
+		limit int
+	}{
+		{name: "--title", value: options.Title, limit: 256},
+		{name: "--channel", value: options.Channel, limit: 256},
+		{name: "--source-revision", value: options.SourceRevision, limit: 1024},
+	} {
+		if err := validateDescriptorText(field.name, field.value, field.limit); err != nil {
+			return err
+		}
+	}
+	return validateSourceURL(options.SourceURL)
+}
+
+func validateDescriptorText(name, value string, limit int) error {
+	if len(value) > limit {
+		return fmt.Errorf("invalid %s: must be at most %d bytes", name, limit)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) || unicode.In(r, unicode.Bidi_Control) || unicode.Is(unicode.Cf, r) {
+			return fmt.Errorf("invalid %s: control characters are not allowed", name)
+		}
+	}
+	return nil
+}
+
+func validateSourceURL(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if len(raw) > 2048 {
+		return fmt.Errorf("invalid --source-url: must be at most 2048 bytes")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid --source-url: %w", err)
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("invalid --source-url: user information is not allowed")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("invalid --source-url: query and fragment are not allowed")
+	}
+	if parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("invalid --source-url: must be an absolute HTTPS URL")
+	}
+	return nil
+}
+
+func buildSource(options PrepareOptions) *Source {
+	result := &Source{Channel: strings.TrimSpace(options.Channel), Revision: strings.TrimSpace(options.SourceRevision), URL: strings.TrimSpace(options.SourceURL)}
+	if result.Channel == "" && result.Revision == "" && result.URL == "" {
+		return nil
+	}
+	return result
+}
+
+func withoutIssue(issues []string, remove string) []string {
+	result := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if issue != remove {
+			result = append(result, issue)
+		}
+	}
+	return result
+}
+
+func createStageDirectory(parent *os.Root) (string, *os.Root, error) {
+	for range 100 {
+		var random [16]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return "", nil, err
+		}
+		name := ".asc-distribute-stage-" + hex.EncodeToString(random[:])
+		if err := parent.Mkdir(name, 0o700); err != nil {
+			if errors.Is(err, fs.ErrExist) {
+				continue
+			}
+			return "", nil, err
+		}
+		child, err := parent.OpenRoot(name)
+		if err != nil {
+			_ = parent.RemoveAll(name)
+			return "", nil, err
+		}
+		return name, child, nil
+	}
+	return "", nil, fmt.Errorf("could not allocate a unique staging directory")
+}
+
+func writeNewRootedFile(root *os.Root, name string, data []byte, mode os.FileMode) error {
+	file, err := secureopen.OpenNewFileNoFollowInRoot(root, name, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func copySectionToNewFile(root *os.Root, name string, source *os.File, size int64, expectedSHA256 string, mode os.FileMode) error {
+	destination, err := secureopen.OpenNewFileNoFollowInRoot(root, name, mode)
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	written, err := io.Copy(io.MultiWriter(destination, hash), io.NewSectionReader(source, 0, size))
+	if err != nil {
+		_ = destination.Close()
+		return err
+	}
+	if written != size || hex.EncodeToString(hash.Sum(nil)) != expectedSHA256 {
+		_ = destination.Close()
+		return fmt.Errorf("IPA changed while it was being prepared")
+	}
+	if err := destination.Sync(); err != nil {
+		_ = destination.Close()
+		return err
+	}
+	return destination.Close()
+}
+
+func exactBundleExists(parent *os.Root, name string, wantDescriptor []byte, artifact Artifact) (bool, bool, error) {
+	info, err := parent.Lstat(name)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return false, true, nil
+	}
+	bundle, err := parent.OpenRoot(name)
+	if err != nil {
+		return false, true, nil
+	}
+	defer bundle.Close()
+	entries, err := readDirectory(bundle, ".")
+	if err != nil || !exactEntries(entries, map[string]bool{"bundle.json": false, "payload": true}) {
+		return false, true, nil
+	}
+	payload, err := bundle.OpenRoot("payload")
+	if err != nil {
+		return false, true, nil
+	}
+	defer payload.Close()
+	payloadEntries, err := readDirectory(payload, ".")
+	if err != nil || !exactEntries(payloadEntries, map[string]bool{"app.ipa": false}) {
+		return false, true, nil
+	}
+	descriptor, err := secureopen.OpenExistingNoFollowInRoot(bundle, "bundle.json")
+	if err != nil {
+		return false, true, nil
+	}
+	gotDescriptor, readErr := io.ReadAll(io.LimitReader(descriptor, int64(len(wantDescriptor))+1))
+	closeErr := descriptor.Close()
+	if readErr != nil || closeErr != nil || string(gotDescriptor) != string(wantDescriptor) {
+		return false, true, nil
+	}
+	ipa, err := secureopen.OpenExistingNoFollowInRoot(payload, "app.ipa")
+	if err != nil {
+		return false, true, nil
+	}
+	stat, statErr := ipa.Stat()
+	if statErr != nil || stat.Size() != artifact.SizeBytes {
+		_ = ipa.Close()
+		return false, true, nil
+	}
+	hash := sha256.New()
+	_, hashErr := io.Copy(hash, ipa)
+	closeErr = ipa.Close()
+	if hashErr != nil || closeErr != nil || hex.EncodeToString(hash.Sum(nil)) != artifact.SHA256 {
+		return false, true, nil
+	}
+	return true, true, nil
+}
+
+func readDirectory(root *os.Root, name string) ([]os.DirEntry, error) {
+	dir, err := root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	entries, readErr := dir.ReadDir(-1)
+	closeErr := dir.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	return entries, closeErr
+}
+
+func exactEntries(entries []os.DirEntry, expected map[string]bool) bool {
+	if len(entries) != len(expected) {
+		return false
+	}
+	for _, entry := range entries {
+		wantDir, ok := expected[entry.Name()]
+		if !ok || entry.Type()&os.ModeSymlink != 0 || entry.IsDir() != wantDir {
+			return false
+		}
+		if !wantDir && !entry.Type().IsRegular() {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/distribution/prepare_test.go
+++ b/internal/distribution/prepare_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 func TestPrepareIPAWritesDeterministicPrivateBundle(t *testing.T) {
@@ -127,6 +129,48 @@ func TestPrepareIPAPublishesFromStableSnapshot(t *testing.T) {
 	}
 	if !bytes.Equal(copied, original) {
 		t.Fatal("prepared payload did not use the stable pre-mutation snapshot")
+	}
+}
+
+func TestPrepareIPAPinsOutputRootBeforeInspection(t *testing.T) {
+	installVerifiedPreparationForTest(t)
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false)
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(parent, "output-root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	afterIPASnapshotForTest = func() {
+		if err := os.Rename(root, root+"-original"); err != nil {
+			t.Fatalf("rename selected output root: %v", err)
+		}
+		if err := os.Mkdir(root, 0o755); err != nil {
+			t.Fatalf("replace selected output root: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterIPASnapshotForTest = nil })
+
+	file, err := os.Open(ipaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PrepareIPA(file, info.Size(), PrepareOptions{Root: root}); !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("PrepareIPA() error = %v, want ErrSymlink", err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("PrepareIPA() wrote to replacement root: %#v", entries)
 	}
 }
 

--- a/internal/distribution/prepare_test.go
+++ b/internal/distribution/prepare_test.go
@@ -249,6 +249,9 @@ func TestValidatePrepareOptionsRejectsControlMetadata(t *testing.T) {
 	if err := ValidatePrepareOptions(PrepareOptions{Channel: "safe\u202Esecret"}); err == nil {
 		t.Fatal("expected bidi format control rejection")
 	}
+	if err := ValidatePrepareOptions(PrepareOptions{SourceURL: "https://example.com/safe\u202Esecret"}); err == nil {
+		t.Fatal("expected source URL bidi format control rejection")
+	}
 }
 
 func TestSafePathComponentIsCollisionSafeAndContained(t *testing.T) {

--- a/internal/distribution/prepare_test.go
+++ b/internal/distribution/prepare_test.go
@@ -1,0 +1,300 @@
+package distribution
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrepareIPAWritesDeterministicPrivateBundle(t *testing.T) {
+	ipaPath := validIPA(t, []string{"secret-device-b", "secret-device-a"}, time.Now().Add(24*time.Hour), false)
+	root := t.TempDir()
+	result := preparePath(t, ipaPath, PrepareOptions{
+		Root: root, Title: "Preview", Channel: "pull-request-42", SourceRevision: "abcdef", SourceURL: "https://example.com/revision/abcdef",
+	})
+	if result.Reused {
+		t.Fatal("new bundle reported as reused")
+	}
+	wantSuffix := filepath.Join(".asc", "distribution", "com.example.demo", "1.0-1-"+result.Descriptor.Artifact.SHA256[:12])
+	if !strings.HasSuffix(result.BundlePath, wantSuffix) {
+		t.Fatalf("bundle path = %q, want suffix %q", result.BundlePath, wantSuffix)
+	}
+	data, err := os.ReadFile(filepath.Join(result.BundlePath, "bundle.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte("secret-device")) || bytes.Contains(data, []byte(ipaPath)) {
+		t.Fatalf("descriptor leaked private or absolute input data: %s", data)
+	}
+	var descriptor Descriptor
+	if err := json.Unmarshal(data, &descriptor); err != nil {
+		t.Fatal(err)
+	}
+	if descriptor.App.Title != "Preview" || descriptor.Source == nil || descriptor.Source.Channel != "pull-request-42" {
+		t.Fatalf("unexpected descriptor: %#v", descriptor)
+	}
+	if descriptor.Artifact.RelativePath != "payload/app.ipa" {
+		t.Fatalf("artifact path = %q", descriptor.Artifact.RelativePath)
+	}
+	if bytes.Contains(data, []byte("preparation")) {
+		t.Fatalf("descriptor persisted transient eligibility: %s", data)
+	}
+	copied, err := os.ReadFile(filepath.Join(result.BundlePath, "payload", "app.ipa"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, _ := os.ReadFile(ipaPath)
+	if !bytes.Equal(copied, original) {
+		t.Fatal("copied IPA differs")
+	}
+}
+
+func TestPrepareIPAReusesExactBundleWithoutChangingFiles(t *testing.T) {
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(24*time.Hour), false)
+	root := t.TempDir()
+	first := preparePath(t, ipaPath, PrepareOptions{Root: root})
+	descriptorPath := filepath.Join(first.BundlePath, "bundle.json")
+	before, err := os.Stat(descriptorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	second := preparePath(t, ipaPath, PrepareOptions{Root: root})
+	if !second.Reused || second.BundlePath != first.BundlePath {
+		t.Fatalf("unexpected reuse: %#v", second)
+	}
+	after, err := os.Stat(descriptorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Fatal("reuse rewrote descriptor")
+	}
+}
+
+func TestPrepareIPARefusesConflictingExistingBundle(t *testing.T) {
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(24*time.Hour), false)
+	root := t.TempDir()
+	first := preparePath(t, ipaPath, PrepareOptions{Root: root})
+	descriptorPath := filepath.Join(first.BundlePath, "bundle.json")
+	if err := os.WriteFile(descriptorPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, _ := os.Open(ipaPath)
+	defer file.Close()
+	info, _ := file.Stat()
+	_, err := PrepareIPA(file, info.Size(), PrepareOptions{Root: root})
+	if !errors.Is(err, ErrBundleConflict) {
+		t.Fatalf("error = %v, want ErrBundleConflict", err)
+	}
+	got, _ := os.ReadFile(descriptorPath)
+	if string(got) != "sentinel" {
+		t.Fatalf("conflict overwritten: %q", got)
+	}
+}
+
+func TestPrepareIPAPublishesFromStableSnapshot(t *testing.T) {
+	installVerifiedPreparationForTest(t)
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(24*time.Hour), false)
+	original, err := os.ReadFile(ipaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(ipaPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	afterIPASnapshotForTest = func() {
+		if _, writeErr := file.WriteAt(bytes.Repeat([]byte{0}, len(original)), 0); writeErr != nil {
+			t.Errorf("mutate source after snapshot: %v", writeErr)
+		}
+	}
+	t.Cleanup(func() { afterIPASnapshotForTest = nil })
+
+	result, err := PrepareIPA(file, int64(len(original)), PrepareOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("PrepareIPA() error = %v", err)
+	}
+	copied, err := os.ReadFile(filepath.Join(result.BundlePath, "payload", "app.ipa"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(copied, original) {
+		t.Fatal("prepared payload did not use the stable pre-mutation snapshot")
+	}
+}
+
+func TestPrepareIPARejectsOutputParentSwappedToSymlink(t *testing.T) {
+	installVerifiedPreparationForTest(t)
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false)
+	root := t.TempDir()
+	outside := t.TempDir()
+	parent := filepath.Join(root, "output")
+	afterOutputParentsCreatedForTest = func() {
+		if err := os.Rename(parent, parent+"-original"); err != nil {
+			t.Errorf("rename output parent: %v", err)
+			return
+		}
+		if err := os.Symlink(outside, parent); err != nil {
+			t.Errorf("replace output parent with symlink: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterOutputParentsCreatedForTest = nil })
+
+	file, err := os.Open(ipaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PrepareIPA(file, info.Size(), PrepareOptions{Root: root, OutputDir: "output/bundle"}); err == nil {
+		t.Fatal("expected swapped output parent rejection")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("wrote through swapped output symlink: %#v", entries)
+	}
+}
+
+func TestPrepareIPARejectsIneligibleAndCredentialURLBeforeWriting(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		opts PrepareOptions
+	}{
+		{name: "development", path: validIPA(t, []string{"one"}, time.Now().Add(time.Hour), true), opts: PrepareOptions{}},
+		{name: "expired", path: validIPA(t, []string{"one"}, time.Now().Add(-time.Hour), false), opts: PrepareOptions{}},
+		{name: "credential URL", path: validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false), opts: PrepareOptions{SourceURL: "https://token@example.com/revision"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			test.opts.Root = root
+			file, _ := os.Open(test.path)
+			defer file.Close()
+			info, _ := file.Stat()
+			if _, err := PrepareIPA(file, info.Size(), test.opts); err == nil {
+				t.Fatal("expected error")
+			}
+			entries, _ := os.ReadDir(root)
+			if len(entries) != 0 {
+				t.Fatalf("wrote before validation: %#v", entries)
+			}
+		})
+	}
+}
+
+func TestPrepareIPARejectsUnverifiedProfileTrustAndCodeBeforeWriting(t *testing.T) {
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false)
+	root := t.TempDir()
+	file, err := os.Open(ipaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PrepareIPA(file, info.Size(), PrepareOptions{Root: root}); !errors.Is(err, ErrNotEligible) {
+		t.Fatalf("PrepareIPA() error = %v, want ErrNotEligible", err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("unverified IPA wrote output: %#v", entries)
+	}
+}
+
+func TestPrepareIPARejectsSymlinkedDefaultOutputParent(t *testing.T) {
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false)
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, ".asc")); err != nil {
+		t.Fatal(err)
+	}
+	file, _ := os.Open(ipaPath)
+	defer file.Close()
+	info, _ := file.Stat()
+	if _, err := PrepareIPA(file, info.Size(), PrepareOptions{Root: root}); err == nil {
+		t.Fatal("expected symlinked .asc rejection")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("wrote through symlink: %#v", entries)
+	}
+}
+
+func TestValidatePrepareOptionsRejectsControlMetadata(t *testing.T) {
+	if err := ValidatePrepareOptions(PrepareOptions{Channel: "safe\nsecret"}); err == nil {
+		t.Fatal("expected control character rejection")
+	}
+	if err := ValidatePrepareOptions(PrepareOptions{Channel: "safe\u202Esecret"}); err == nil {
+		t.Fatal("expected bidi format control rejection")
+	}
+}
+
+func TestSafePathComponentIsCollisionSafeAndContained(t *testing.T) {
+	values := []string{"..", "a/b", "a-b", "a\\b", "x\x00y", "é"}
+	seen := map[string]bool{}
+	for _, value := range values {
+		got, err := safePathComponent(value)
+		if err != nil {
+			t.Fatalf("safePathComponent(%q): %v", value, err)
+		}
+		if got == "." || got == ".." || strings.ContainsAny(got, `/\\`) {
+			t.Fatalf("unsafe result %q", got)
+		}
+		if seen[got] {
+			t.Fatalf("collision for %q: %q", value, got)
+		}
+		seen[got] = true
+	}
+}
+
+func preparePath(t *testing.T, path string, options PrepareOptions) PrepareResult {
+	t.Helper()
+	installVerifiedPreparationForTest(t)
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := PrepareIPA(file, info.Size(), options)
+	if err != nil {
+		t.Fatalf("PrepareIPA() error = %v", err)
+	}
+	return result
+}
+
+func installVerifiedPreparationForTest(t *testing.T) {
+	t.Helper()
+	verifyCompleteSigningForTest = func(inspection *Inspection) {
+		inspection.Signing.ProfileIntegrityVerification.Status = CodeSignatureVerified
+		inspection.Signing.ProfileTrustVerification.Status = CodeSignatureVerified
+		inspection.Signing.CodeSignatureVerification.Status = CodeSignatureVerified
+		inspection.Signing.CodeSignatureVerification.Scope = mainCodeSignatureScope
+	}
+	t.Cleanup(func() { verifyCompleteSigningForTest = nil })
+}

--- a/internal/distribution/prepare_test.go
+++ b/internal/distribution/prepare_test.go
@@ -169,6 +169,16 @@ func TestPrepareIPARejectsOutputParentSwappedToSymlink(t *testing.T) {
 }
 
 func TestPrepareIPARejectsIneligibleAndCredentialURLBeforeWriting(t *testing.T) {
+	unsupportedPlatformIPA := writeIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistBytes(t, map[string]any{
+			"CFBundleIdentifier":         "com.example.demo",
+			"CFBundleName":               "Demo",
+			"CFBundleShortVersionString": "1.0",
+			"CFBundleVersion":            "1",
+			"DTPlatformName":             "xros",
+			"CFBundleSupportedPlatforms": []string{"XROS"},
+		}),
+	})
 	tests := []struct {
 		name string
 		path string
@@ -177,6 +187,7 @@ func TestPrepareIPARejectsIneligibleAndCredentialURLBeforeWriting(t *testing.T) 
 		{name: "development", path: validIPA(t, []string{"one"}, time.Now().Add(time.Hour), true), opts: PrepareOptions{}},
 		{name: "expired", path: validIPA(t, []string{"one"}, time.Now().Add(-time.Hour), false), opts: PrepareOptions{}},
 		{name: "credential URL", path: validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false), opts: PrepareOptions{SourceURL: "https://token@example.com/revision"}},
+		{name: "unsupported archive platform", path: unsupportedPlatformIPA, opts: PrepareOptions{}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/distribution/prepare_test.go
+++ b/internal/distribution/prepare_test.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -367,6 +368,51 @@ func TestSafePathComponentIsCollisionSafeAndContained(t *testing.T) {
 			t.Fatalf("collision for %q: %q", value, got)
 		}
 		seen[got] = true
+	}
+}
+
+func TestPrepareIPAContextAlreadyCanceledHasNoFilesystemSideEffects(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "not-created")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := PrepareIPAContext(ctx, nil, 0, PrepareOptions{Root: root}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("PrepareIPAContext() error = %v, want context.Canceled", err)
+	}
+	if _, err := os.Lstat(root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("output root stat error = %v, want not found", err)
+	}
+}
+
+func TestPrepareIPAContextCancellationDuringPublicationDoesNotPublish(t *testing.T) {
+	installVerifiedPreparationForTest(t)
+	path := validIPA(t, []string{"one"}, time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC), false)
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	duringPublicationCopyForTest = cancel
+	t.Cleanup(func() { duringPublicationCopyForTest = nil })
+	if _, err := PrepareIPAContext(ctx, file, info.Size(), PrepareOptions{Root: root}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("PrepareIPAContext() error = %v, want context.Canceled", err)
+	}
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() && (entry.Name() == "bundle.json" || entry.Name() == "app.ipa") {
+			t.Errorf("canceled preparation left publication file %q", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/distribution/prepare_test.go
+++ b/internal/distribution/prepare_test.go
@@ -252,6 +252,9 @@ func TestValidatePrepareOptionsRejectsControlMetadata(t *testing.T) {
 	if err := ValidatePrepareOptions(PrepareOptions{SourceURL: "https://example.com/safe\u202Esecret"}); err == nil {
 		t.Fatal("expected source URL bidi format control rejection")
 	}
+	if err := ValidatePrepareOptions(PrepareOptions{SourceURL: "https://:443/path"}); err == nil {
+		t.Fatal("expected empty source URL hostname rejection")
+	}
 }
 
 func TestSafePathComponentIsCollisionSafeAndContained(t *testing.T) {

--- a/internal/distribution/prepare_test.go
+++ b/internal/distribution/prepare_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 func TestPrepareIPAWritesDeterministicPrivateBundle(t *testing.T) {
@@ -165,6 +167,78 @@ func TestPrepareIPARejectsOutputParentSwappedToSymlink(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("wrote through swapped output symlink: %#v", entries)
+	}
+}
+
+func TestPrepareIPAPinsOutputRootBeforeInspection(t *testing.T) {
+	installVerifiedPreparationForTest(t)
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false)
+	parent := t.TempDir()
+	rootPath := filepath.Join(parent, "root")
+	replacement := filepath.Join(parent, "replacement")
+	if err := os.Mkdir(rootPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(replacement, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	afterIPASnapshotForTest = func() {
+		if err := os.Rename(rootPath, rootPath+"-original"); err != nil {
+			t.Fatalf("rename selected output root: %v", err)
+		}
+		if err := os.Rename(replacement, rootPath); err != nil {
+			t.Fatalf("replace selected output root: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterIPASnapshotForTest = nil })
+
+	file, err := os.Open(ipaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PrepareIPA(file, info.Size(), PrepareOptions{Root: rootPath}); !errors.Is(err, rootfs.ErrSymlink) {
+		t.Fatalf("PrepareIPA() error = %v, want pinned-root replacement rejection", err)
+	}
+	for _, directory := range []string{rootPath, rootPath + "-original"} {
+		entries, err := os.ReadDir(directory)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("PrepareIPA() wrote into %q: %#v", directory, entries)
+		}
+	}
+}
+
+func TestPrepareIPARequiresExistingOutputRootBeforeInspection(t *testing.T) {
+	ipaPath := validIPA(t, []string{"one"}, time.Now().Add(time.Hour), false)
+	rootPath := filepath.Join(t.TempDir(), "missing")
+	inspected := false
+	afterIPASnapshotForTest = func() { inspected = true }
+	t.Cleanup(func() { afterIPASnapshotForTest = nil })
+
+	file, err := os.Open(ipaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PrepareIPA(file, info.Size(), PrepareOptions{Root: rootPath}); err == nil {
+		t.Fatal("PrepareIPA() accepted a root that did not exist when preparation began")
+	}
+	if inspected {
+		t.Fatal("PrepareIPA() inspected the IPA before rejecting the missing output root")
+	}
+	if _, err := os.Stat(rootPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("PrepareIPA() created the missing output root: %v", err)
 	}
 }
 

--- a/internal/distribution/snapshot.go
+++ b/internal/distribution/snapshot.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -16,7 +17,10 @@ var afterIPASnapshotForTest func()
 // immutable-for-this-process file. Metadata parsing, hashing, and publishing
 // all consume this snapshot so concurrent writes to the source cannot produce
 // a descriptor assembled from different byte generations.
-func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) {
+func snapshotIPA(ctx context.Context, source *os.File, size int64) (*os.File, string, func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", nil, err
+	}
 	if source == nil {
 		return nil, "", nil, fmt.Errorf("IPA file is nil")
 	}
@@ -54,7 +58,7 @@ func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) 
 		return nil, "", nil, fmt.Errorf("create private IPA snapshot: %w", err)
 	}
 	hash := sha256.New()
-	written, copyErr := io.Copy(io.MultiWriter(snapshot, hash), io.NewSectionReader(source, 0, size))
+	written, copyErr := copyWithContext(ctx, io.MultiWriter(snapshot, hash), io.NewSectionReader(source, 0, size))
 	if copyErr == nil && written != size {
 		copyErr = fmt.Errorf("copied %d of %d bytes", written, size)
 	}
@@ -85,4 +89,34 @@ func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) 
 		cleanupDirectory()
 	}
 	return snapshot, hex.EncodeToString(hash.Sum(nil)), cleanup, nil
+}
+
+func copyWithContext(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {
+	var written int64
+	buffer := make([]byte, 32<<10)
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		count, readErr := source.Read(buffer)
+		if count > 0 {
+			wrote, writeErr := destination.Write(buffer[:count])
+			written += int64(wrote)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if wrote != count {
+				return written, io.ErrShortWrite
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
 }

--- a/internal/distribution/snapshot.go
+++ b/internal/distribution/snapshot.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -10,13 +11,20 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
-var afterIPASnapshotForTest func()
+var (
+	afterIPASnapshotForTest  func()
+	duringIPASnapshotForTest func()
+	snapshotCreatedForTest   func(string)
+)
 
 // snapshotIPA copies the already-open input exactly once into a private,
 // immutable-for-this-process file. Metadata parsing, hashing, and publishing
 // all consume this snapshot so concurrent writes to the source cannot produce
 // a descriptor assembled from different byte generations.
-func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) {
+func snapshotIPAContext(ctx context.Context, source *os.File, size int64) (*os.File, string, func(), error) {
+	if err := contextError(ctx); err != nil {
+		return nil, "", nil, err
+	}
 	if source == nil {
 		return nil, "", nil, fmt.Errorf("IPA file is nil")
 	}
@@ -41,6 +49,9 @@ func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) 
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("create private IPA snapshot directory: %w", err)
 	}
+	if snapshotCreatedForTest != nil {
+		snapshotCreatedForTest(directory)
+	}
 	cleanupDirectory := func() { _ = os.Remove(directory) }
 	root, err := os.OpenRoot(directory)
 	if err != nil {
@@ -54,7 +65,7 @@ func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) 
 		return nil, "", nil, fmt.Errorf("create private IPA snapshot: %w", err)
 	}
 	hash := sha256.New()
-	written, copyErr := io.Copy(io.MultiWriter(snapshot, hash), io.NewSectionReader(source, 0, size))
+	written, copyErr := copyWithContext(ctx, io.MultiWriter(snapshot, hash), io.NewSectionReader(source, 0, size), duringIPASnapshotForTest)
 	if copyErr == nil && written != size {
 		copyErr = fmt.Errorf("copied %d of %d bytes", written, size)
 	}
@@ -85,4 +96,47 @@ func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) 
 		cleanupDirectory()
 	}
 	return snapshot, hex.EncodeToString(hash.Sum(nil)), cleanup, nil
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}
+
+func copyWithContext(ctx context.Context, destination io.Writer, source io.Reader, hook func()) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	buffer := make([]byte, 64<<10)
+	var written int64
+	for {
+		if hook != nil {
+			hook()
+		}
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			if err := ctx.Err(); err != nil {
+				return written, err
+			}
+			count, writeErr := destination.Write(buffer[:read])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != read {
+				return written, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
 }

--- a/internal/distribution/snapshot.go
+++ b/internal/distribution/snapshot.go
@@ -1,0 +1,88 @@
+package distribution
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
+)
+
+var afterIPASnapshotForTest func()
+
+// snapshotIPA copies the already-open input exactly once into a private,
+// immutable-for-this-process file. Metadata parsing, hashing, and publishing
+// all consume this snapshot so concurrent writes to the source cannot produce
+// a descriptor assembled from different byte generations.
+func snapshotIPA(source *os.File, size int64) (*os.File, string, func(), error) {
+	if source == nil {
+		return nil, "", nil, fmt.Errorf("IPA file is nil")
+	}
+	if size < 0 {
+		return nil, "", nil, fmt.Errorf("IPA size is invalid")
+	}
+	if size > MaxIPABytes {
+		return nil, "", nil, fmt.Errorf("IPA size %d bytes exceeds supported limit of %d bytes", size, MaxIPABytes)
+	}
+	info, err := source.Stat()
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("inspect IPA file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, "", nil, fmt.Errorf("IPA is not a regular file")
+	}
+	if info.Size() != size {
+		return nil, "", nil, fmt.Errorf("IPA size changed before snapshot")
+	}
+
+	directory, err := os.MkdirTemp("", ".asc-distribute-snapshot-")
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("create private IPA snapshot directory: %w", err)
+	}
+	cleanupDirectory := func() { _ = os.Remove(directory) }
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		cleanupDirectory()
+		return nil, "", nil, fmt.Errorf("open private IPA snapshot directory: %w", err)
+	}
+	snapshot, err := secureopen.OpenNewFileNoFollowInRoot(root, "app.ipa", 0o600)
+	if err != nil {
+		_ = root.Close()
+		cleanupDirectory()
+		return nil, "", nil, fmt.Errorf("create private IPA snapshot: %w", err)
+	}
+	hash := sha256.New()
+	written, copyErr := io.Copy(io.MultiWriter(snapshot, hash), io.NewSectionReader(source, 0, size))
+	if copyErr == nil && written != size {
+		copyErr = fmt.Errorf("copied %d of %d bytes", written, size)
+	}
+	if copyErr == nil {
+		copyErr = snapshot.Sync()
+	}
+	if copyErr == nil {
+		copyErr = snapshot.Close()
+	}
+	if copyErr != nil {
+		_ = snapshot.Close()
+		_ = root.Remove("app.ipa")
+		_ = root.Close()
+		cleanupDirectory()
+		return nil, "", nil, fmt.Errorf("snapshot IPA: %w", copyErr)
+	}
+	snapshot, err = secureopen.OpenExistingNoFollowInRoot(root, "app.ipa")
+	if err != nil {
+		_ = root.Remove("app.ipa")
+		_ = root.Close()
+		cleanupDirectory()
+		return nil, "", nil, fmt.Errorf("open private IPA snapshot: %w", err)
+	}
+	cleanup := func() {
+		_ = snapshot.Close()
+		_ = root.Remove("app.ipa")
+		_ = root.Close()
+		cleanupDirectory()
+	}
+	return snapshot, hex.EncodeToString(hash.Sum(nil)), cleanup, nil
+}

--- a/internal/distribution/snapshot_test.go
+++ b/internal/distribution/snapshot_test.go
@@ -1,0 +1,64 @@
+package distribution
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestCopyWithContextStopsAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	source := &cancelingReader{
+		reader: bytes.NewReader(bytes.Repeat([]byte("snapshot"), 16<<10)),
+		cancel: cancel,
+	}
+	var destination bytes.Buffer
+
+	written, err := copyWithContext(ctx, &destination, source)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("copyWithContext() error = %v, want context.Canceled", err)
+	}
+	if written == 0 {
+		t.Fatal("copyWithContext() did not exercise a copy chunk before cancellation")
+	}
+	if source.reads != 1 {
+		t.Fatalf("copyWithContext() reads = %d, want 1", source.reads)
+	}
+}
+
+func TestInspectionAndPreparationPropagateCancellation(t *testing.T) {
+	path := writeIPA(t, map[string][]byte{"Payload/Demo.app/Info.plist": infoPlist(t, "com.example.demo")})
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := InspectIPAContext(ctx, file, info.Size(), InspectOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("InspectIPAContext() error = %v, want context.Canceled", err)
+	}
+	if _, err := PrepareIPAContext(ctx, file, info.Size(), PrepareOptions{Root: t.TempDir()}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("PrepareIPAContext() error = %v, want context.Canceled", err)
+	}
+}
+
+type cancelingReader struct {
+	reader *bytes.Reader
+	cancel context.CancelFunc
+	reads  int
+}
+
+func (r *cancelingReader) Read(buffer []byte) (int, error) {
+	r.reads++
+	count, err := r.reader.Read(buffer)
+	r.cancel()
+	return count, err
+}

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -62,30 +62,59 @@ type Root struct {
 }
 
 type rootIdentity struct {
-	mu   sync.RWMutex
-	info os.FileInfo
+	mu     sync.RWMutex
+	pinned *os.Root
 }
 
-func (identity *rootIdentity) load() os.FileInfo {
+func (identity *rootIdentity) isPinned() bool {
 	if identity == nil {
-		return nil
+		return false
 	}
 	identity.mu.RLock()
 	defer identity.mu.RUnlock()
-	return identity.info
+	return identity.pinned != nil
 }
 
-func (identity *rootIdentity) pin(info os.FileInfo) bool {
-	if identity == nil || info == nil {
+// pin retains one descriptor for the selected directory. Keeping that
+// descriptor open prevents the original inode or file ID from being recycled
+// while Root values still refer to it. The cleanup is attached to the shared
+// identity rather than a Root copy so the descriptor is closed exactly once.
+func (identity *rootIdentity) pin(candidate *os.Root) bool {
+	if candidate == nil {
+		return false
+	}
+	if identity == nil {
+		_ = candidate.Close()
 		return false
 	}
 	identity.mu.Lock()
 	defer identity.mu.Unlock()
-	if identity.info == nil {
-		identity.info = info
+	if identity.pinned == nil {
+		identity.pinned = candidate
+		runtime.AddCleanup(identity, closePinnedRoot, candidate)
 		return true
 	}
-	return os.SameFile(identity.info, info)
+	selectedInfo, selectedErr := identity.pinned.Stat(".")
+	candidateInfo, candidateErr := candidate.Stat(".")
+	_ = candidate.Close()
+	return selectedErr == nil && candidateErr == nil && os.SameFile(selectedInfo, candidateInfo)
+}
+
+func (identity *rootIdentity) matches(candidate os.FileInfo) bool {
+	if identity == nil || candidate == nil {
+		return false
+	}
+	identity.mu.RLock()
+	defer identity.mu.RUnlock()
+	if identity.pinned == nil {
+		return false
+	}
+	selected, err := identity.pinned.Stat(".")
+	return err == nil && os.SameFile(selected, candidate)
+}
+
+func closePinnedRoot(root *os.Root) {
+	_ = root.Close()
 }
 
 // New returns a Root anchored at path. The root itself is operator-selected and
@@ -118,21 +147,22 @@ func New(path string) (Root, error) {
 		return Root{}, fmt.Errorf("open trusted root %q: %w", path, err)
 	}
 	identity, statErr := selected.Stat(".")
-	closeErr := selected.Close()
 	if statErr != nil {
+		_ = selected.Close()
 		return Root{}, fmt.Errorf("stat trusted root %q: %w", path, statErr)
-	}
-	if closeErr != nil {
-		return Root{}, fmt.Errorf("close trusted root %q: %w", path, closeErr)
 	}
 	selectedAtPath, err := os.Stat(absolute)
 	if err != nil {
+		_ = selected.Close()
 		return Root{}, fmt.Errorf("stat selected root %q: %w", path, err)
 	}
 	if !os.SameFile(identity, selectedAtPath) {
+		_ = selected.Close()
 		return Root{}, symlinkError(absolute)
 	}
-	root.selectedIdentity.pin(identity)
+	if !root.selectedIdentity.pin(selected) {
+		return Root{}, symlinkError(absolute)
+	}
 	return root, nil
 }
 
@@ -150,8 +180,7 @@ func (r Root) OpenRoot() (*os.Root, error) {
 	if r.beforeOpenRootForTest != nil {
 		r.beforeOpenRootForTest()
 	}
-	selectedIdentity := r.selectedIdentity.load()
-	if selectedIdentity == nil {
+	if !r.selectedIdentity.isPinned() {
 		return nil, symlinkError(r.path)
 	}
 	opened, err := openAbsoluteRootNoFollow(r.openPath)
@@ -159,7 +188,7 @@ func (r Root) OpenRoot() (*os.Root, error) {
 		return nil, err
 	}
 	identity, err := opened.Stat(".")
-	if err != nil || !os.SameFile(selectedIdentity, identity) {
+	if err != nil || !r.selectedIdentity.matches(identity) {
 		_ = opened.Close()
 		if err != nil {
 			return nil, err
@@ -959,13 +988,13 @@ func (r Root) ensureRootDir(perm os.FileMode) error {
 		if !info.IsDir() {
 			return fmt.Errorf("trusted root %q is not a directory", r.path)
 		}
-		if r.selectedIdentity.load() != nil {
+		if r.selectedIdentity.isPinned() {
 			return nil
 		}
 	case !errors.Is(err, os.ErrNotExist):
 		return err
 	}
-	if r.selectedIdentity.load() != nil {
+	if r.selectedIdentity.isPinned() {
 		return symlinkError(r.path)
 	}
 	if err := os.MkdirAll(r.path, perm); err != nil {
@@ -975,15 +1004,7 @@ func (r Root) ensureRootDir(perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	identity, statErr := opened.Stat(".")
-	closeErr := opened.Close()
-	if statErr != nil {
-		return statErr
-	}
-	if closeErr != nil {
-		return closeErr
-	}
-	if !r.selectedIdentity.pin(identity) {
+	if !r.selectedIdentity.pin(opened) {
 		return symlinkError(r.path)
 	}
 	return nil

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -62,8 +62,11 @@ type Root struct {
 }
 
 type rootIdentity struct {
-	mu     sync.RWMutex
-	pinned *os.Root
+	mu         sync.RWMutex
+	pinned     *os.Root
+	cleanup    runtime.Cleanup
+	hasCleanup bool
+	closed     bool
 }
 
 func (identity *rootIdentity) isPinned() bool {
@@ -89,9 +92,14 @@ func (identity *rootIdentity) pin(candidate *os.Root) bool {
 	}
 	identity.mu.Lock()
 	defer identity.mu.Unlock()
+	if identity.closed {
+		_ = candidate.Close()
+		return false
+	}
 	if identity.pinned == nil {
 		identity.pinned = candidate
-		runtime.AddCleanup(identity, closePinnedRoot, candidate)
+		identity.cleanup = runtime.AddCleanup(identity, closePinnedRoot, candidate)
+		identity.hasCleanup = true
 		return true
 	}
 	selectedInfo, selectedErr := identity.pinned.Stat(".")
@@ -115,6 +123,31 @@ func (identity *rootIdentity) matches(candidate os.FileInfo) bool {
 
 func closePinnedRoot(root *os.Root) {
 	_ = root.Close()
+}
+
+func (identity *rootIdentity) close() error {
+	if identity == nil {
+		return nil
+	}
+	identity.mu.Lock()
+	if identity.closed {
+		identity.mu.Unlock()
+		return nil
+	}
+	identity.closed = true
+	pinned := identity.pinned
+	identity.pinned = nil
+	cleanup := identity.cleanup
+	hasCleanup := identity.hasCleanup
+	identity.hasCleanup = false
+	identity.mu.Unlock()
+	if hasCleanup {
+		cleanup.Stop()
+	}
+	if pinned != nil {
+		return pinned.Close()
+	}
+	return nil
 }
 
 // New returns a Root anchored at path. The root itself is operator-selected and
@@ -169,6 +202,12 @@ func New(path string) (Root, error) {
 // Path returns the absolute trusted root path.
 func (r Root) Path() string {
 	return r.path
+}
+
+// Close releases the descriptor that pins the selected root. Root copies share
+// that descriptor, so closing any copy closes the shared root identity.
+func (r Root) Close() error {
+	return r.selectedIdentity.close()
 }
 
 // OpenRoot opens the trusted root without following symlinks introduced after

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -47,6 +47,7 @@ type Root struct {
 	path             string
 	openPath         string
 	selectedIdentity *rootIdentity
+	pendingCreation  *rootCreation
 	// internalSymlinks tolerates symlinked components below the root when they
 	// resolve back inside the root.
 	internalSymlinks bool
@@ -56,9 +57,20 @@ type Root struct {
 	// beforeOpenRootForTest makes trusted-root path-swap regressions
 	// deterministic. It is intentionally unexported and unset outside tests.
 	beforeOpenRootForTest func()
+	// beforeCreateRootForTest makes missing-root ancestor replacement races
+	// deterministic. It is intentionally unexported and unset outside tests.
+	beforeCreateRootForTest func()
 	// renameNoReplaceForTest makes unsupported-filesystem regressions
 	// deterministic. It is intentionally unexported and unset outside tests.
 	renameNoReplaceForTest func(root *os.Root, oldName, newName string) error
+}
+
+type rootCreation struct {
+	mu           sync.Mutex
+	lexicalBase  string
+	physicalBase string
+	suffix       []string
+	baseIdentity *rootIdentity
 }
 
 type rootIdentity struct {
@@ -156,23 +168,50 @@ func New(path string) (Root, error) {
 	if path == "" {
 		return Root{}, fmt.Errorf("%w: trusted root path is empty", ErrEscapesRoot)
 	}
+	if strings.ContainsRune(path, 0) {
+		return Root{}, fmt.Errorf("%w: trusted root path contains a NUL byte", ErrEscapesRoot)
+	}
 	absolute, err := filepath.Abs(path)
 	if err != nil {
 		return Root{}, fmt.Errorf("resolve trusted root %q: %w", path, err)
 	}
 	absolute = filepath.Clean(absolute)
-	openPath := absolute
-	selectedExists := false
-	if physicalRoot, err := filepath.EvalSymlinks(absolute); err == nil {
-		openPath = physicalRoot
-		selectedExists = true
-	} else if physicalParent, err := filepath.EvalSymlinks(filepath.Dir(absolute)); err == nil {
-		openPath = filepath.Join(physicalParent, filepath.Base(absolute))
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return Root{}, fmt.Errorf("resolve trusted root parent %q: %w", path, err)
+	lexicalBase, physicalBase, suffix, err := resolveRootSelection(absolute)
+	if err != nil {
+		return Root{}, fmt.Errorf("resolve trusted root %q: %w", path, err)
 	}
+	openPath := filepath.Join(append([]string{physicalBase}, suffix...)...)
+	selectedExists := len(suffix) == 0
 	root := Root{path: absolute, openPath: openPath, selectedIdentity: &rootIdentity{}}
 	if !selectedExists {
+		base, err := openAbsoluteRootNoFollow(physicalBase)
+		if err != nil {
+			return Root{}, fmt.Errorf("open trusted root ancestor %q: %w", lexicalBase, err)
+		}
+		baseInfo, statErr := base.Stat(".")
+		if statErr != nil {
+			_ = base.Close()
+			return Root{}, fmt.Errorf("stat trusted root ancestor %q: %w", lexicalBase, statErr)
+		}
+		selectedAtPath, statErr := os.Stat(lexicalBase)
+		if statErr != nil {
+			_ = base.Close()
+			return Root{}, fmt.Errorf("stat selected root ancestor %q: %w", lexicalBase, statErr)
+		}
+		if !os.SameFile(baseInfo, selectedAtPath) {
+			_ = base.Close()
+			return Root{}, symlinkError(lexicalBase)
+		}
+		baseIdentity := &rootIdentity{}
+		if !baseIdentity.pin(base) {
+			return Root{}, symlinkError(lexicalBase)
+		}
+		root.pendingCreation = &rootCreation{
+			lexicalBase:  lexicalBase,
+			physicalBase: physicalBase,
+			suffix:       append([]string(nil), suffix...),
+			baseIdentity: baseIdentity,
+		}
 		return root, nil
 	}
 	selected, err := openAbsoluteRootNoFollow(openPath)
@@ -199,6 +238,54 @@ func New(path string) (Root, error) {
 	return root, nil
 }
 
+func resolveRootSelection(absolute string) (string, string, []string, error) {
+	candidate := absolute
+	reversedSuffix := make([]string, 0)
+	for {
+		_, err := os.Lstat(candidate)
+		if err == nil {
+			physical, err := filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return "", "", nil, fmt.Errorf("resolve existing ancestor %q: %w", candidate, err)
+			}
+			resolvedInfo, err := os.Stat(physical)
+			if err != nil {
+				return "", "", nil, fmt.Errorf("stat existing ancestor %q: %w", candidate, err)
+			}
+			if !resolvedInfo.IsDir() {
+				return "", "", nil, fmt.Errorf("trusted root ancestor %q is not a directory", candidate)
+			}
+			suffix := make([]string, len(reversedSuffix))
+			for index := range reversedSuffix {
+				suffix[len(reversedSuffix)-1-index] = reversedSuffix[index]
+			}
+			return candidate, physical, suffix, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", "", nil, fmt.Errorf("inspect trusted root ancestor %q: %w", candidate, err)
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return "", "", nil, fmt.Errorf("no existing ancestor for trusted root %q", absolute)
+		}
+		component := filepath.Base(candidate)
+		if err := validateMissingRootComponent(component); err != nil {
+			return "", "", nil, err
+		}
+		reversedSuffix = append(reversedSuffix, component)
+		candidate = parent
+	}
+}
+
+func validateMissingRootComponent(component string) error {
+	if component == "" || component == "." || component == ".." ||
+		filepath.Clean(component) != component || filepath.IsAbs(component) ||
+		filepath.VolumeName(component) != "" || strings.ContainsRune(component, 0) {
+		return fmt.Errorf("%w: unsafe missing trusted-root component %q", ErrEscapesRoot, component)
+	}
+	return nil
+}
+
 // Path returns the absolute trusted root path.
 func (r Root) Path() string {
 	return r.path
@@ -207,7 +294,13 @@ func (r Root) Path() string {
 // Close releases the selected directory descriptor shared by this Root and all
 // of its copies. Close is idempotent; no copied Root may be used afterward.
 func (r Root) Close() error {
-	return r.selectedIdentity.close()
+	var pendingErr error
+	if r.pendingCreation != nil {
+		r.pendingCreation.mu.Lock()
+		pendingErr = r.pendingCreation.baseIdentity.close()
+		r.pendingCreation.mu.Unlock()
+	}
+	return errors.Join(r.selectedIdentity.close(), pendingErr)
 }
 
 // OpenRoot opens the trusted root without following symlinks introduced after
@@ -1036,17 +1129,148 @@ func (r Root) ensureRootDir(perm os.FileMode) error {
 	if r.selectedIdentity.isPinned() {
 		return symlinkError(r.path)
 	}
-	if err := os.MkdirAll(r.path, perm); err != nil {
-		return err
+	if r.pendingCreation == nil {
+		return symlinkError(r.path)
 	}
-	opened, err := openAbsoluteRootNoFollow(r.openPath)
+	r.pendingCreation.mu.Lock()
+	defer r.pendingCreation.mu.Unlock()
+	if r.selectedIdentity.isPinned() {
+		return nil
+	}
+	if r.beforeCreateRootForTest != nil {
+		r.beforeCreateRootForTest()
+	}
+	baseAtPath, err := os.Stat(r.pendingCreation.lexicalBase)
 	if err != nil {
 		return err
 	}
+	if !r.pendingCreation.baseIdentity.matches(baseAtPath) {
+		return symlinkError(r.pendingCreation.lexicalBase)
+	}
+	base, err := openAbsoluteRootNoFollow(r.pendingCreation.physicalBase)
+	if err != nil {
+		return err
+	}
+	baseInfo, err := base.Stat(".")
+	if err != nil || !r.pendingCreation.baseIdentity.matches(baseInfo) {
+		_ = base.Close()
+		if err != nil {
+			return err
+		}
+		return symlinkError(r.pendingCreation.physicalBase)
+	}
+	created, err := createMissingRoot(base, r.pendingCreation.suffix, perm, r.pendingCreation.physicalBase)
+	if err != nil {
+		return err
+	}
+	selectedAtPath, err := os.Stat(r.path)
+	if err != nil {
+		created.rollback()
+		return err
+	}
+	openedInfo, err := created.final.Stat(".")
+	if err != nil || !os.SameFile(openedInfo, selectedAtPath) {
+		created.rollback()
+		if err != nil {
+			return err
+		}
+		return symlinkError(r.path)
+	}
+	if err := r.pendingCreation.baseIdentity.close(); err != nil {
+		created.rollback()
+		return err
+	}
+	opened := created.release()
 	if !r.selectedIdentity.pin(opened) {
 		return symlinkError(r.path)
 	}
 	return nil
+}
+
+type missingRootCreation struct {
+	roots      []*os.Root
+	suffix     []string
+	created    []bool
+	final      *os.Root
+	terminated bool
+}
+
+func (creation *missingRootCreation) rollback() {
+	if creation == nil || creation.terminated {
+		return
+	}
+	creation.terminated = true
+	for index := len(creation.suffix) - 1; index >= 0; index-- {
+		if creation.created[index] {
+			_ = creation.roots[index].Remove(creation.suffix[index])
+		}
+	}
+	for _, root := range creation.roots {
+		_ = root.Close()
+	}
+}
+
+func (creation *missingRootCreation) release() *os.Root {
+	if creation == nil || creation.terminated {
+		return nil
+	}
+	creation.terminated = true
+	for index := 0; index < len(creation.roots)-1; index++ {
+		_ = creation.roots[index].Close()
+	}
+	return creation.final
+}
+
+func createMissingRoot(base *os.Root, suffix []string, perm os.FileMode, basePath string) (_ *missingRootCreation, resultErr error) {
+	creation := &missingRootCreation{
+		roots:   []*os.Root{base},
+		suffix:  append([]string(nil), suffix...),
+		created: make([]bool, len(suffix)),
+	}
+	defer func() {
+		if resultErr != nil {
+			creation.rollback()
+		}
+	}()
+	current := base
+	for index, component := range suffix {
+		componentPath := filepath.Join(append([]string{basePath}, suffix[:index+1]...)...)
+		if err := validateMissingRootComponent(component); err != nil {
+			return nil, err
+		}
+		if _, err := current.Lstat(component); err == nil {
+			return nil, symlinkError(componentPath)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if err := current.Mkdir(component, perm); err != nil {
+			return nil, err
+		}
+		creation.created[index] = true
+		before, err := current.Lstat(component)
+		if err != nil {
+			return nil, err
+		}
+		if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
+			return nil, symlinkError(componentPath)
+		}
+		next, err := current.OpenRoot(component)
+		if err != nil {
+			return nil, err
+		}
+		after, err := next.Stat(".")
+		if err != nil || !os.SameFile(before, after) {
+			_ = next.Close()
+			if err != nil {
+				return nil, err
+			}
+			return nil, symlinkError(componentPath)
+		}
+		creation.roots = append(creation.roots, next)
+		current = next
+	}
+	creation.final = current
+	return creation, nil
 }
 
 func (r Root) openRooted(absolute string, resolveFinal bool) (*os.Root, string, error) {

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
@@ -47,6 +48,9 @@ type Root struct {
 	path             string
 	openPath         string
 	selectedIdentity *rootIdentity
+	creationIdentity *rootIdentity
+	creationRelative string
+	creationErr      error
 	// internalSymlinks tolerates symlinked components below the root when they
 	// resolve back inside the root.
 	internalSymlinks bool
@@ -56,6 +60,9 @@ type Root struct {
 	// beforeOpenRootForTest makes trusted-root path-swap regressions
 	// deterministic. It is intentionally unexported and unset outside tests.
 	beforeOpenRootForTest func()
+	// beforeCreateRootForTest makes missing-root ancestor races deterministic.
+	// It is intentionally unexported and unset outside tests.
+	beforeCreateRootForTest func()
 	// renameNoReplaceForTest makes unsupported-filesystem regressions
 	// deterministic. It is intentionally unexported and unset outside tests.
 	renameNoReplaceForTest func(root *os.Root, oldName, newName string) error
@@ -118,6 +125,18 @@ func (identity *rootIdentity) matches(candidate os.FileInfo) bool {
 	return err == nil && os.SameFile(selected, candidate)
 }
 
+func (identity *rootIdentity) createRelative(relative string, perm os.FileMode) (*os.Root, error) {
+	if identity == nil {
+		return nil, ErrSymlink
+	}
+	identity.mu.RLock()
+	defer identity.mu.RUnlock()
+	if identity.pinned == nil {
+		return nil, ErrSymlink
+	}
+	return createRelativeRootNoFollow(identity.pinned, relative, perm)
+}
+
 func closePinnedRoot(root *os.Root) {
 	_ = root.Close()
 }
@@ -141,6 +160,49 @@ func (identity *rootIdentity) close() error {
 	return pinned.Close()
 }
 
+type rootSelection struct {
+	openPath         string
+	existingPath     string
+	existingOpenPath string
+	missingRelative  string
+	selectedExists   bool
+}
+
+func resolveRootSelection(absolute string) (rootSelection, error) {
+	candidate := absolute
+	var missing []string
+	for {
+		physical, err := filepath.EvalSymlinks(candidate)
+		if err == nil {
+			selection := rootSelection{
+				openPath:         physical,
+				existingPath:     candidate,
+				existingOpenPath: physical,
+				selectedExists:   candidate == absolute,
+			}
+			for i := len(missing) - 1; i >= 0; i-- {
+				selection.openPath = filepath.Join(selection.openPath, missing[i])
+				selection.missingRelative = filepath.Join(selection.missingRelative, missing[i])
+			}
+			return selection, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, syscall.ENOTDIR) {
+			return rootSelection{}, err
+		}
+		if _, lstatErr := os.Lstat(candidate); lstatErr == nil {
+			return rootSelection{}, err
+		} else if !errors.Is(lstatErr, os.ErrNotExist) && !errors.Is(lstatErr, syscall.ENOTDIR) {
+			return rootSelection{}, lstatErr
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return rootSelection{}, err
+		}
+		missing = append(missing, filepath.Base(candidate))
+		candidate = parent
+	}
+}
+
 // New returns a Root anchored at path. The root itself is operator-selected and
 // may live outside the current repository; only paths below it are constrained.
 func New(path string) (Root, error) {
@@ -152,21 +214,47 @@ func New(path string) (Root, error) {
 		return Root{}, fmt.Errorf("resolve trusted root %q: %w", path, err)
 	}
 	absolute = filepath.Clean(absolute)
-	openPath := absolute
-	selectedExists := false
-	if physicalRoot, err := filepath.EvalSymlinks(absolute); err == nil {
-		openPath = physicalRoot
-		selectedExists = true
-	} else if physicalParent, err := filepath.EvalSymlinks(filepath.Dir(absolute)); err == nil {
-		openPath = filepath.Join(physicalParent, filepath.Base(absolute))
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return Root{}, fmt.Errorf("resolve trusted root parent %q: %w", path, err)
+	selection, err := resolveRootSelection(absolute)
+	if err != nil {
+		return Root{}, fmt.Errorf("resolve trusted root %q: %w", path, err)
 	}
-	root := Root{path: absolute, openPath: openPath, selectedIdentity: &rootIdentity{}}
-	if !selectedExists {
+	root := Root{
+		path:             absolute,
+		openPath:         selection.openPath,
+		selectedIdentity: &rootIdentity{},
+		creationIdentity: &rootIdentity{},
+		creationRelative: selection.missingRelative,
+	}
+	if !selection.selectedExists {
+		selectedAtPath, err := os.Stat(selection.existingPath)
+		if err != nil {
+			return Root{}, fmt.Errorf("stat selected root ancestor %q: %w", selection.existingPath, err)
+		}
+		if !selectedAtPath.IsDir() {
+			root.creationErr = fmt.Errorf("%q is not a directory", selection.existingPath)
+			return root, nil
+		}
+		creationRoot, err := openAbsoluteRootNoFollow(selection.existingOpenPath)
+		if err != nil {
+			return Root{}, fmt.Errorf("open trusted root ancestor %q: %w", selection.existingPath, err)
+		}
+		identity, statErr := creationRoot.Stat(".")
+		if statErr != nil {
+			_ = creationRoot.Close()
+			return Root{}, fmt.Errorf("stat trusted root ancestor %q: %w", selection.existingPath, statErr)
+		}
+		selectedAtPath, err = os.Stat(selection.existingPath)
+		if err != nil {
+			_ = creationRoot.Close()
+			return Root{}, fmt.Errorf("stat selected root ancestor %q: %w", selection.existingPath, err)
+		}
+		if !os.SameFile(identity, selectedAtPath) || !root.creationIdentity.pin(creationRoot) {
+			_ = creationRoot.Close()
+			return Root{}, symlinkError(selection.existingPath)
+		}
 		return root, nil
 	}
-	selected, err := openAbsoluteRootNoFollow(openPath)
+	selected, err := openAbsoluteRootNoFollow(selection.openPath)
 	if err != nil {
 		return Root{}, fmt.Errorf("open trusted root %q: %w", path, err)
 	}
@@ -198,7 +286,7 @@ func (r Root) Path() string {
 // Close releases the selected directory descriptor shared by this Root and all
 // of its copies. Close is idempotent; no copied Root may be used afterward.
 func (r Root) Close() error {
-	return r.selectedIdentity.close()
+	return errors.Join(r.selectedIdentity.close(), r.creationIdentity.close())
 }
 
 // OpenRoot opens the trusted root without following symlinks introduced after
@@ -270,6 +358,55 @@ func openAbsoluteRootNoFollow(absolute string) (*os.Root, error) {
 				return nil, err
 			}
 			return nil, symlinkError(absolute)
+		}
+		_ = current.Close()
+		current = next
+	}
+	return current, nil
+}
+
+func createRelativeRootNoFollow(anchor *os.Root, relative string, perm os.FileMode) (*os.Root, error) {
+	current, err := anchor.OpenRoot(".")
+	if err != nil {
+		return nil, err
+	}
+	for _, component := range strings.Split(filepath.Clean(relative), string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		before, err := current.Lstat(component)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := current.Mkdir(component, perm); err != nil && !errors.Is(err, os.ErrExist) {
+				_ = current.Close()
+				return nil, err
+			}
+			before, err = current.Lstat(component)
+		}
+		if err != nil {
+			_ = current.Close()
+			return nil, err
+		}
+		if before.Mode()&os.ModeSymlink != 0 {
+			_ = current.Close()
+			return nil, symlinkError(relative)
+		}
+		if !before.IsDir() {
+			_ = current.Close()
+			return nil, fmt.Errorf("%q is not a directory", relative)
+		}
+		next, err := current.OpenRoot(component)
+		if err != nil {
+			_ = current.Close()
+			return nil, err
+		}
+		after, err := next.Stat(".")
+		if err != nil || !os.SameFile(before, after) {
+			_ = next.Close()
+			_ = current.Close()
+			if err != nil {
+				return nil, err
+			}
+			return nil, symlinkError(relative)
 		}
 		_ = current.Close()
 		current = next
@@ -1012,32 +1149,40 @@ func (r Root) prepareWrite(name string) (string, error) {
 }
 
 func (r Root) ensureRootDir(perm os.FileMode) error {
-	info, err := os.Stat(r.path)
-	switch {
-	case err == nil:
-		if !info.IsDir() {
-			return fmt.Errorf("trusted root %q is not a directory", r.path)
-		}
-		if r.selectedIdentity.isPinned() {
-			return nil
-		}
-	case !errors.Is(err, os.ErrNotExist):
-		return err
-	}
 	if r.selectedIdentity.isPinned() {
-		return symlinkError(r.path)
+		return nil
 	}
-	if err := os.MkdirAll(r.path, perm); err != nil {
-		return err
+	if r.creationErr != nil {
+		return r.creationErr
 	}
-	opened, err := openAbsoluteRootNoFollow(r.openPath)
+	if r.beforeCreateRootForTest != nil {
+		r.beforeCreateRootForTest()
+	}
+	opened, err := r.creationIdentity.createRelative(r.creationRelative, perm)
 	if err != nil {
 		return err
+	}
+	identity, statErr := opened.Stat(".")
+	if statErr != nil {
+		_ = opened.Close()
+		return statErr
+	}
+	selectedAtPath, err := os.Stat(r.path)
+	if err != nil {
+		_ = opened.Close()
+		if errors.Is(err, os.ErrNotExist) {
+			return symlinkError(r.path)
+		}
+		return err
+	}
+	if !os.SameFile(identity, selectedAtPath) {
+		_ = opened.Close()
+		return symlinkError(r.path)
 	}
 	if !r.selectedIdentity.pin(opened) {
 		return symlinkError(r.path)
 	}
-	return nil
+	return r.creationIdentity.close()
 }
 
 func (r Root) openRooted(absolute string, resolveFinal bool) (*os.Root, string, error) {

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
@@ -42,8 +43,9 @@ const (
 
 // Root is a trusted directory anchor for rooted filesystem operations.
 type Root struct {
-	path     string
-	openPath string
+	path             string
+	openPath         string
+	selectedIdentity *rootIdentity
 	// internalSymlinks tolerates symlinked components below the root when they
 	// resolve back inside the root.
 	internalSymlinks bool
@@ -53,6 +55,33 @@ type Root struct {
 	// beforeOpenRootForTest makes trusted-root path-swap regressions
 	// deterministic. It is intentionally unexported and unset outside tests.
 	beforeOpenRootForTest func()
+}
+
+type rootIdentity struct {
+	mu   sync.RWMutex
+	info os.FileInfo
+}
+
+func (identity *rootIdentity) load() os.FileInfo {
+	if identity == nil {
+		return nil
+	}
+	identity.mu.RLock()
+	defer identity.mu.RUnlock()
+	return identity.info
+}
+
+func (identity *rootIdentity) pin(info os.FileInfo) bool {
+	if identity == nil || info == nil {
+		return false
+	}
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	if identity.info == nil {
+		identity.info = info
+		return true
+	}
+	return os.SameFile(identity.info, info)
 }
 
 // New returns a Root anchored at path. The root itself is operator-selected and
@@ -67,12 +96,40 @@ func New(path string) (Root, error) {
 	}
 	absolute = filepath.Clean(absolute)
 	openPath := absolute
-	if physicalParent, err := filepath.EvalSymlinks(filepath.Dir(absolute)); err == nil {
+	selectedExists := false
+	if physicalRoot, err := filepath.EvalSymlinks(absolute); err == nil {
+		openPath = physicalRoot
+		selectedExists = true
+	} else if physicalParent, err := filepath.EvalSymlinks(filepath.Dir(absolute)); err == nil {
 		openPath = filepath.Join(physicalParent, filepath.Base(absolute))
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return Root{}, fmt.Errorf("resolve trusted root parent %q: %w", path, err)
 	}
-	return Root{path: absolute, openPath: openPath}, nil
+	root := Root{path: absolute, openPath: openPath, selectedIdentity: &rootIdentity{}}
+	if !selectedExists {
+		return root, nil
+	}
+	selected, err := openAbsoluteRootNoFollow(openPath)
+	if err != nil {
+		return Root{}, fmt.Errorf("open trusted root %q: %w", path, err)
+	}
+	identity, statErr := selected.Stat(".")
+	closeErr := selected.Close()
+	if statErr != nil {
+		return Root{}, fmt.Errorf("stat trusted root %q: %w", path, statErr)
+	}
+	if closeErr != nil {
+		return Root{}, fmt.Errorf("close trusted root %q: %w", path, closeErr)
+	}
+	selectedAtPath, err := os.Stat(absolute)
+	if err != nil {
+		return Root{}, fmt.Errorf("stat selected root %q: %w", path, err)
+	}
+	if !os.SameFile(identity, selectedAtPath) {
+		return Root{}, symlinkError(absolute)
+	}
+	root.selectedIdentity.pin(identity)
+	return root, nil
 }
 
 // Path returns the absolute trusted root path.
@@ -81,15 +138,31 @@ func (r Root) Path() string {
 }
 
 // OpenRoot opens the trusted root without following symlinks introduced after
-// New selected it. New preserves pre-existing symlinked parent layouts by
-// recording their physical parent, while the final root itself must be a
-// directory rather than a symlink. Every physical component and the final root
-// are pinned from parent directory handles.
+// New selected it. New records the physical target of a pre-existing trusted
+// symlink layout, while later path substitutions cannot change the selected
+// directory identity. Every physical component and the final root are reopened
+// from parent directory handles.
 func (r Root) OpenRoot() (*os.Root, error) {
 	if r.beforeOpenRootForTest != nil {
 		r.beforeOpenRootForTest()
 	}
-	return openAbsoluteRootNoFollow(r.openPath)
+	selectedIdentity := r.selectedIdentity.load()
+	if selectedIdentity == nil {
+		return nil, symlinkError(r.path)
+	}
+	opened, err := openAbsoluteRootNoFollow(r.openPath)
+	if err != nil {
+		return nil, err
+	}
+	identity, err := opened.Stat(".")
+	if err != nil || !os.SameFile(selectedIdentity, identity) {
+		_ = opened.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, symlinkError(r.path)
+	}
+	return opened, nil
 }
 
 func openAbsoluteRootNoFollow(absolute string) (*os.Root, error) {
@@ -718,18 +791,38 @@ func (r Root) ensureRootDir(perm os.FileMode) error {
 		if !info.IsDir() {
 			return fmt.Errorf("trusted root %q is not a directory", r.path)
 		}
-		return nil
+		if r.selectedIdentity.load() != nil {
+			return nil
+		}
 	case !errors.Is(err, os.ErrNotExist):
 		return err
 	}
+	if r.selectedIdentity.load() != nil {
+		return symlinkError(r.path)
+	}
 	if err := os.MkdirAll(r.path, perm); err != nil {
 		return err
+	}
+	opened, err := openAbsoluteRootNoFollow(r.openPath)
+	if err != nil {
+		return err
+	}
+	identity, statErr := opened.Stat(".")
+	closeErr := opened.Close()
+	if statErr != nil {
+		return statErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if !r.selectedIdentity.pin(identity) {
+		return symlinkError(r.path)
 	}
 	return nil
 }
 
 func (r Root) openRooted(absolute string, resolveFinal bool) (*os.Root, string, error) {
-	rooted, err := os.OpenRoot(r.path)
+	rooted, err := r.OpenRoot()
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -42,13 +42,17 @@ const (
 
 // Root is a trusted directory anchor for rooted filesystem operations.
 type Root struct {
-	path string
+	path     string
+	openPath string
 	// internalSymlinks tolerates symlinked components below the root when they
 	// resolve back inside the root.
 	internalSymlinks bool
 	// afterValidationForTest makes path-swap regressions deterministic. It is
 	// intentionally unexported and unset outside package tests.
 	afterValidationForTest func()
+	// beforeOpenRootForTest makes trusted-root path-swap regressions
+	// deterministic. It is intentionally unexported and unset outside tests.
+	beforeOpenRootForTest func()
 }
 
 // New returns a Root anchored at path. The root itself is operator-selected and
@@ -61,7 +65,14 @@ func New(path string) (Root, error) {
 	if err != nil {
 		return Root{}, fmt.Errorf("resolve trusted root %q: %w", path, err)
 	}
-	return Root{path: filepath.Clean(absolute)}, nil
+	absolute = filepath.Clean(absolute)
+	openPath := absolute
+	if physicalParent, err := filepath.EvalSymlinks(filepath.Dir(absolute)); err == nil {
+		openPath = filepath.Join(physicalParent, filepath.Base(absolute))
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return Root{}, fmt.Errorf("resolve trusted root parent %q: %w", path, err)
+	}
+	return Root{path: absolute, openPath: openPath}, nil
 }
 
 // Path returns the absolute trusted root path.
@@ -69,15 +80,16 @@ func (r Root) Path() string {
 	return r.path
 }
 
-// OpenRoot opens the trusted root without following a symlink substituted for
-// the root path. Each existing path component is pinned and compared with the
-// directory handle opened from its parent before the next component is used.
+// OpenRoot opens the trusted root without following symlinks introduced after
+// New selected it. New preserves pre-existing symlinked parent layouts by
+// recording their physical parent, while the final root itself must be a
+// directory rather than a symlink. Every physical component and the final root
+// are pinned from parent directory handles.
 func (r Root) OpenRoot() (*os.Root, error) {
-	physical, err := filepath.EvalSymlinks(r.path)
-	if err != nil {
-		return nil, err
+	if r.beforeOpenRootForTest != nil {
+		r.beforeOpenRootForTest()
 	}
-	return openAbsoluteRootNoFollow(physical)
+	return openAbsoluteRootNoFollow(r.openPath)
 }
 
 func openAbsoluteRootNoFollow(absolute string) (*os.Root, error) {

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -69,6 +69,66 @@ func (r Root) Path() string {
 	return r.path
 }
 
+// OpenRoot opens the trusted root without following a symlink substituted for
+// the root path. Each existing path component is pinned and compared with the
+// directory handle opened from its parent before the next component is used.
+func (r Root) OpenRoot() (*os.Root, error) {
+	physical, err := filepath.EvalSymlinks(r.path)
+	if err != nil {
+		return nil, err
+	}
+	return openAbsoluteRootNoFollow(physical)
+}
+
+func openAbsoluteRootNoFollow(absolute string) (*os.Root, error) {
+	absolute = filepath.Clean(absolute)
+	volume := filepath.VolumeName(absolute)
+	anchor := volume + string(filepath.Separator)
+	current, err := os.OpenRoot(anchor)
+	if err != nil {
+		return nil, err
+	}
+	relative := strings.TrimPrefix(absolute, anchor)
+	if relative == "" || relative == "." {
+		return current, nil
+	}
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		before, err := current.Lstat(component)
+		if err != nil {
+			_ = current.Close()
+			return nil, err
+		}
+		if before.Mode()&os.ModeSymlink != 0 {
+			_ = current.Close()
+			return nil, symlinkError(absolute)
+		}
+		if !before.IsDir() {
+			_ = current.Close()
+			return nil, fmt.Errorf("%q is not a directory", absolute)
+		}
+		next, err := current.OpenRoot(component)
+		if err != nil {
+			_ = current.Close()
+			return nil, err
+		}
+		after, err := next.Stat(".")
+		if err != nil || !os.SameFile(before, after) {
+			_ = next.Close()
+			_ = current.Close()
+			if err != nil {
+				return nil, err
+			}
+			return nil, symlinkError(absolute)
+		}
+		_ = current.Close()
+		current = next
+	}
+	return current, nil
+}
+
 // AllowingInternalSymlinks returns a copy of the root that accepts a symlinked
 // directory component below the root when that component resolves back inside
 // the root, and still rejects one that escapes.

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -64,6 +64,7 @@ type Root struct {
 type rootIdentity struct {
 	mu     sync.RWMutex
 	pinned *os.Root
+	closed bool
 }
 
 func (identity *rootIdentity) isPinned() bool {
@@ -89,6 +90,10 @@ func (identity *rootIdentity) pin(candidate *os.Root) bool {
 	}
 	identity.mu.Lock()
 	defer identity.mu.Unlock()
+	if identity.closed {
+		_ = candidate.Close()
+		return false
+	}
 	if identity.pinned == nil {
 		identity.pinned = candidate
 		runtime.AddCleanup(identity, closePinnedRoot, candidate)
@@ -115,6 +120,25 @@ func (identity *rootIdentity) matches(candidate os.FileInfo) bool {
 
 func closePinnedRoot(root *os.Root) {
 	_ = root.Close()
+}
+
+func (identity *rootIdentity) close() error {
+	if identity == nil {
+		return nil
+	}
+	identity.mu.Lock()
+	if identity.closed {
+		identity.mu.Unlock()
+		return nil
+	}
+	identity.closed = true
+	pinned := identity.pinned
+	identity.pinned = nil
+	identity.mu.Unlock()
+	if pinned == nil {
+		return nil
+	}
+	return pinned.Close()
 }
 
 // New returns a Root anchored at path. The root itself is operator-selected and
@@ -169,6 +193,12 @@ func New(path string) (Root, error) {
 // Path returns the absolute trusted root path.
 func (r Root) Path() string {
 	return r.path
+}
+
+// Close releases the selected directory descriptor shared by this Root and all
+// of its copies. Close is idempotent; no copied Root may be used afterward.
+func (r Root) Close() error {
+	return r.selectedIdentity.close()
 }
 
 // OpenRoot opens the trusted root without following symlinks introduced after

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -1185,6 +1185,52 @@ func TestOpenRootPreservesSelectedSymlinkedParentLayout(t *testing.T) {
 	}
 }
 
+func TestCloseReleasesPinnedDescriptorAcrossRootCopies(t *testing.T) {
+	root := mustRoot(t, t.TempDir())
+	copyOfRoot := root
+
+	if err := root.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if opened, err := copyOfRoot.OpenRoot(); err == nil {
+		_ = opened.Close()
+		t.Fatal("copied Root remained usable after shared Close")
+	}
+	if err := copyOfRoot.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestCloseReleasesPinnedDescriptorsDeterministically(t *testing.T) {
+	before := openDescriptorCount(t)
+	const rootCount = 128
+	roots := make([]Root, 0, rootCount)
+	for range rootCount {
+		roots = append(roots, mustRoot(t, t.TempDir()))
+	}
+	for _, root := range roots {
+		if err := root.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}
+	after := openDescriptorCount(t)
+	if after > before+4 {
+		t.Fatalf("open descriptors after Close = %d, baseline %d", after, before)
+	}
+}
+
+func openDescriptorCount(t *testing.T) int {
+	t.Helper()
+	for _, directory := range []string{"/dev/fd", "/proc/self/fd"} {
+		entries, err := os.ReadDir(directory)
+		if err == nil {
+			return len(entries)
+		}
+	}
+	t.Skip("open descriptor enumeration is unavailable")
+	return 0
+}
+
 func mustRoot(t *testing.T, path string) Root {
 	t.Helper()
 	root, err := New(path)

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -928,6 +928,118 @@ func TestOpenRootRejectsSelectedPathSwappedBeforeOpen(t *testing.T) {
 	}
 }
 
+func TestOpenRootRejectsSelectedDirectoryReplacedBeforeOpen(t *testing.T) {
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := filepath.Join(parent, "root")
+	replacement := filepath.Join(parent, "replacement")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(replacement, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root := mustRoot(t, directory)
+	root.beforeOpenRootForTest = func() {
+		if err := os.Rename(directory, directory+"-original"); err != nil {
+			t.Fatalf("rename selected root: %v", err)
+		}
+		if err := os.Rename(replacement, directory); err != nil {
+			t.Fatalf("replace selected root: %v", err)
+		}
+	}
+
+	writeErr := root.WriteFile("escaped", []byte("unsafe"), 0o600)
+	if !errors.Is(writeErr, ErrSymlink) {
+		t.Fatalf("WriteFile() error = %v, want ErrSymlink", writeErr)
+	}
+	if _, err := os.Stat(filepath.Join(directory, "escaped")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("WriteFile() reached replacement directory: %v", err)
+	}
+}
+
+func TestRootedWriteRejectsSelectedDirectoryRecreatedBeforeOpen(t *testing.T) {
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := filepath.Join(parent, "root")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root := mustRoot(t, directory)
+	root.beforeOpenRootForTest = func() {
+		if err := os.Remove(directory); err != nil {
+			t.Fatalf("remove selected root: %v", err)
+		}
+		if err := os.Mkdir(directory, 0o755); err != nil {
+			t.Fatalf("recreate selected root: %v", err)
+		}
+	}
+	if err := root.WriteFile("escaped", []byte("unsafe"), 0o600); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("WriteFile() error = %v, want ErrSymlink", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, "escaped")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("WriteFile() reached recreated directory: %v", err)
+	}
+}
+
+func TestOpenRootDoesNotAdoptDirectoryCreatedAfterNew(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "not-yet-selected")
+	root, err := New(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opened, err := root.OpenRoot()
+	if opened != nil {
+		_ = opened.Close()
+		t.Fatal("OpenRoot() adopted a directory created after New")
+	}
+	if !errors.Is(err, ErrSymlink) {
+		t.Fatalf("OpenRoot() error = %v, want ErrSymlink", err)
+	}
+}
+
+func TestRootedWriteRejectsIntermediateDirectoryReplacedBeforeOpen(t *testing.T) {
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectedParent := filepath.Join(parent, "selected")
+	directory := filepath.Join(selectedParent, "root")
+	replacementParent := filepath.Join(parent, "replacement")
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(replacementParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root := mustRoot(t, directory)
+	root.beforeOpenRootForTest = func() {
+		if err := os.Rename(selectedParent, selectedParent+"-original"); err != nil {
+			t.Fatalf("rename selected parent: %v", err)
+		}
+		if err := os.Rename(replacementParent, selectedParent); err != nil {
+			t.Fatalf("replace selected parent: %v", err)
+		}
+	}
+	if err := root.WriteFile("escaped", []byte("unsafe"), 0o600); err == nil {
+		t.Fatal("WriteFile() succeeded through replacement ancestor")
+	}
+	if _, err := os.Stat(filepath.Join(directory, "escaped")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("WriteFile() reached replacement ancestor: %v", err)
+	}
+	if _, err := os.Stat(directory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("WriteFile() created the selected root in replacement ancestor: %v", err)
+	}
+}
+
 func TestOpenRootPreservesSelectedSymlinkedParentLayout(t *testing.T) {
 	requireSymlinks(t)
 	parent, err := filepath.EvalSymlinks(t.TempDir())

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -3,6 +3,7 @@ package rootfs
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -1201,6 +1202,200 @@ func TestOpenRootPreservesSelectedSymlinkedParentLayout(t *testing.T) {
 	}
 	if got := mustRead(t, filepath.Join(directory, "sentinel")); got != "selected" {
 		t.Fatalf("pinned symlinked parent content = %q", got)
+	}
+}
+
+func TestMissingNestedRootResolvesNearestSymlinkedAncestor(t *testing.T) {
+	requireSymlinks(t)
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	physical := filepath.Join(parent, "physical")
+	if err := os.Mkdir(physical, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(parent, "link")
+	if err := os.Symlink(physical, link); err != nil {
+		t.Fatal(err)
+	}
+	root := mustRoot(t, filepath.Join(link, "one", "two", "root"))
+	defer root.Close()
+	if err := root.MkdirAll(".", 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := root.WriteFile("sentinel", []byte("selected"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(physical, "one", "two", "root", "sentinel"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "selected" {
+		t.Fatalf("sentinel = %q", data)
+	}
+}
+
+func TestMissingRootResolvesNestedSymlinkPrefix(t *testing.T) {
+	requireSymlinks(t)
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(parent, "first")
+	target := filepath.Join(parent, "target")
+	if err := os.Mkdir(first, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(first, filepath.Join(parent, "outer")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(first, "inner")); err != nil {
+		t.Fatal(err)
+	}
+	root := mustRoot(t, filepath.Join(parent, "outer", "inner", "new", "root"))
+	defer root.Close()
+	if err := root.MkdirAll(".", 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(target, "new", "root")); err != nil || !info.IsDir() {
+		t.Fatalf("physical nested root stat = %#v, %v", info, err)
+	}
+}
+
+func TestNewRejectsInvalidExistingAncestorWithoutCreating(t *testing.T) {
+	requireSymlinks(t)
+	parent := t.TempDir()
+	t.Run("dangling symlink", func(t *testing.T) {
+		link := filepath.Join(parent, "dangling")
+		if err := os.Symlink(filepath.Join(parent, "absent"), link); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := New(filepath.Join(link, "new", "root")); err == nil {
+			t.Fatal("New() accepted a dangling symlink ancestor")
+		}
+		if _, err := os.Stat(filepath.Join(parent, "absent")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("New() created through dangling symlink: %v", err)
+		}
+	})
+	t.Run("symlink loop", func(t *testing.T) {
+		loop := filepath.Join(parent, "loop")
+		if err := os.Symlink("loop", loop); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := New(filepath.Join(loop, "new", "root")); err == nil {
+			t.Fatal("New() accepted a symlink loop ancestor")
+		}
+	})
+	t.Run("regular file", func(t *testing.T) {
+		file := filepath.Join(parent, "file")
+		if err := os.WriteFile(file, []byte("file"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := New(filepath.Join(file, "new", "root")); err == nil {
+			t.Fatal("New() accepted a non-directory ancestor")
+		}
+		if data, err := os.ReadFile(file); err != nil || string(data) != "file" {
+			t.Fatalf("ancestor file changed: %q, %v", data, err)
+		}
+	})
+}
+
+func TestMissingRootRejectsAncestorReplacementBeforeCreation(t *testing.T) {
+	requireSymlinks(t)
+	for _, test := range []struct {
+		name    string
+		symlink bool
+	}{
+		{name: "ordinary ancestor"},
+		{name: "symlinked ancestor", symlink: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parent, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			original := filepath.Join(parent, "original")
+			replacement := filepath.Join(parent, "replacement")
+			if err := os.Mkdir(original, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(replacement, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			selectedBase := original
+			if test.symlink {
+				selectedBase = filepath.Join(parent, "selected")
+				if err := os.Symlink(original, selectedBase); err != nil {
+					t.Fatal(err)
+				}
+			}
+			root := mustRoot(t, filepath.Join(selectedBase, "new", "root"))
+			defer root.Close()
+			root.beforeCreateRootForTest = func() {
+				if test.symlink {
+					if err := os.Rename(selectedBase, selectedBase+"-original"); err != nil {
+						t.Fatalf("rename selected symlink: %v", err)
+					}
+					if err := os.Symlink(replacement, selectedBase); err != nil {
+						t.Fatalf("replace selected symlink: %v", err)
+					}
+					return
+				}
+				if err := os.Rename(original, original+"-original"); err != nil {
+					t.Fatalf("rename selected ancestor: %v", err)
+				}
+				if err := os.Rename(replacement, original); err != nil {
+					t.Fatalf("replace selected ancestor: %v", err)
+				}
+			}
+			if err := root.MkdirAll(".", 0o755); !errors.Is(err, ErrSymlink) {
+				t.Fatalf("MkdirAll() error = %v, want ErrSymlink", err)
+			}
+			for _, directory := range []string{original, original + "-original", replacement} {
+				if _, err := os.Stat(filepath.Join(directory, "new")); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("partial root created beneath %q: %v", directory, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateMissingRootComponent(t *testing.T) {
+	for _, component := range []string{"", ".", "..", string([]byte{'b', 'a', 'd', 0})} {
+		if err := validateMissingRootComponent(component); !errors.Is(err, ErrEscapesRoot) {
+			t.Fatalf("validateMissingRootComponent(%q) error = %v, want ErrEscapesRoot", component, err)
+		}
+	}
+	for _, component := range []string{"root", "legacy-name", "a.b"} {
+		if err := validateMissingRootComponent(component); err != nil {
+			t.Fatalf("validateMissingRootComponent(%q) error = %v", component, err)
+		}
+	}
+}
+
+func TestCloseReleasesPendingRootAncestorDescriptors(t *testing.T) {
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := openDescriptorCount(t)
+	const rootCount = 64
+	roots := make([]Root, 0, rootCount)
+	for index := 0; index < rootCount; index++ {
+		roots = append(roots, mustRoot(t, filepath.Join(parent, fmt.Sprintf("missing-%d", index), "root")))
+	}
+	for _, root := range roots {
+		if err := root.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}
+	after := openDescriptorCount(t)
+	if after > before+4 {
+		t.Fatalf("open descriptors after pending-root Close = %d, baseline %d", after, before)
 	}
 }
 

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -985,6 +985,25 @@ func TestOpenRootPinsOriginalDirectoryAcrossPathReplacement(t *testing.T) {
 	}
 }
 
+func TestRootCloseReleasesSharedPinnedIdentity(t *testing.T) {
+	root := mustRoot(t, t.TempDir())
+	copy := root
+	if err := copy.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := root.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+	opened, err := root.OpenRoot()
+	if opened != nil {
+		_ = opened.Close()
+		t.Fatal("OpenRoot() succeeded after a copied Root was closed")
+	}
+	if !errors.Is(err, ErrSymlink) {
+		t.Fatalf("OpenRoot() error = %v, want ErrSymlink", err)
+	}
+}
+
 func TestOpenRootRejectsSelectedPathSwappedBeforeOpen(t *testing.T) {
 	requireSymlinks(t)
 	for _, test := range []struct {

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -840,6 +840,32 @@ func TestErrorMessagesIdentifyRejectedPath(t *testing.T) {
 	}
 }
 
+func TestOpenRootPinsOriginalDirectoryAcrossPathReplacement(t *testing.T) {
+	parent := t.TempDir()
+	directory := filepath.Join(parent, "root")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root := mustRoot(t, directory)
+	opened, err := root.OpenRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer opened.Close()
+	if err := os.Rename(directory, directory+"-original"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), directory); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.WriteFile("sentinel", []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(directory+"-original", "sentinel")); err != nil {
+		t.Fatalf("pinned root did not address original directory: %v", err)
+	}
+}
+
 func mustRoot(t *testing.T, path string) Root {
 	t.Helper()
 	root, err := New(path)

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -727,6 +727,61 @@ func TestMkdirAllCreatesMissingRoot(t *testing.T) {
 	}
 }
 
+func TestMkdirAllCreatesNestedMissingRootBelowSymlinkedAncestor(t *testing.T) {
+	requireSymlinks(t)
+	parent := t.TempDir()
+	physical := filepath.Join(parent, "physical")
+	if err := os.Mkdir(physical, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	selected := filepath.Join(parent, "selected")
+	if err := os.Symlink(physical, selected); err != nil {
+		t.Fatal(err)
+	}
+	directory := filepath.Join(selected, "missing", "root")
+	root := mustRoot(t, directory)
+
+	if err := root.WriteFile("sentinel", []byte("selected"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if got := mustRead(t, filepath.Join(physical, "missing", "root", "sentinel")); got != "selected" {
+		t.Fatalf("nested missing root content = %q", got)
+	}
+}
+
+func TestRootedWriteRejectsMissingRootAncestorReplacedBeforeCreation(t *testing.T) {
+	requireSymlinks(t)
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	physical := filepath.Join(parent, "physical")
+	if err := os.Mkdir(physical, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	selected := filepath.Join(parent, "selected")
+	if err := os.Symlink(physical, selected); err != nil {
+		t.Fatal(err)
+	}
+	directory := filepath.Join(selected, "missing", "root")
+	root := mustRoot(t, directory)
+	root.beforeCreateRootForTest = func() {
+		if err := os.Rename(physical, physical+"-original"); err != nil {
+			t.Fatalf("rename selected ancestor: %v", err)
+		}
+		if err := os.Mkdir(physical, 0o755); err != nil {
+			t.Fatalf("replace selected ancestor: %v", err)
+		}
+	}
+
+	if err := root.WriteFile("escaped", []byte("unsafe"), 0o600); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("WriteFile() error = %v, want ErrSymlink", err)
+	}
+	if _, err := os.Stat(filepath.Join(physical, "missing", "root", "escaped")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("WriteFile() reached replacement ancestor: %v", err)
+	}
+}
+
 func TestAppendFileRefusesSymlinkAndLeavesModeIntact(t *testing.T) {
 	requireSymlinks(t)
 

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -841,7 +841,10 @@ func TestErrorMessagesIdentifyRejectedPath(t *testing.T) {
 }
 
 func TestOpenRootPinsOriginalDirectoryAcrossPathReplacement(t *testing.T) {
-	parent := t.TempDir()
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	directory := filepath.Join(parent, "root")
 	if err := os.Mkdir(directory, 0o755); err != nil {
 		t.Fatal(err)
@@ -863,6 +866,94 @@ func TestOpenRootPinsOriginalDirectoryAcrossPathReplacement(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(directory+"-original", "sentinel")); err != nil {
 		t.Fatalf("pinned root did not address original directory: %v", err)
+	}
+}
+
+func TestOpenRootRejectsSelectedPathSwappedBeforeOpen(t *testing.T) {
+	requireSymlinks(t)
+	for _, test := range []struct {
+		name         string
+		rootRelative string
+		swapRelative string
+		outsideRoot  string
+	}{
+		{name: "final root", rootRelative: "root", swapRelative: "root"},
+		{name: "intermediate directory", rootRelative: filepath.Join("selected", "root"), swapRelative: "selected", outsideRoot: "root"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parent, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			directory := filepath.Join(parent, test.rootRelative)
+			if err := os.MkdirAll(directory, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			swapPath := filepath.Join(parent, test.swapRelative)
+			outside, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.outsideRoot != "" {
+				if err := os.Mkdir(filepath.Join(outside, test.outsideRoot), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			root := mustRoot(t, directory)
+			root.beforeOpenRootForTest = func() {
+				if err := os.Rename(swapPath, swapPath+"-original"); err != nil {
+					t.Fatalf("rename selected path: %v", err)
+				}
+				if err := os.Symlink(outside, swapPath); err != nil {
+					t.Fatalf("replace selected path with symlink: %v", err)
+				}
+			}
+
+			opened, openErr := root.OpenRoot()
+			if opened != nil {
+				if openErr == nil {
+					_ = opened.WriteFile("escaped", []byte("unsafe"), 0o600)
+				}
+				_ = opened.Close()
+			}
+			if !errors.Is(openErr, ErrSymlink) {
+				t.Fatalf("OpenRoot() error = %v, want ErrSymlink", openErr)
+			}
+			if _, err := os.Lstat(filepath.Join(outside, test.outsideRoot, "escaped")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("OpenRoot() wrote through substituted path: %v", err)
+			}
+		})
+	}
+}
+
+func TestOpenRootPreservesSelectedSymlinkedParentLayout(t *testing.T) {
+	requireSymlinks(t)
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	physicalParent := filepath.Join(parent, "physical")
+	directory := filepath.Join(physicalParent, "root")
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkedParent := filepath.Join(parent, "selected")
+	if err := os.Symlink(physicalParent, symlinkedParent); err != nil {
+		t.Fatal(err)
+	}
+
+	root := mustRoot(t, filepath.Join(symlinkedParent, "root"))
+	opened, err := root.OpenRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer opened.Close()
+	if err := opened.WriteFile("sentinel", []byte("selected"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustRead(t, filepath.Join(directory, "sentinel")); got != "selected" {
+		t.Fatalf("pinned symlinked parent content = %q", got)
 	}
 }
 

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -841,6 +841,7 @@ func TestErrorMessagesIdentifyRejectedPath(t *testing.T) {
 }
 
 func TestOpenRootPinsOriginalDirectoryAcrossPathReplacement(t *testing.T) {
+	requireSymlinks(t)
 	parent, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)

--- a/internal/secureopen/rename_noreplace_test.go
+++ b/internal/secureopen/rename_noreplace_test.go
@@ -72,3 +72,42 @@ func TestRenameNoReplaceInRootPreservesExistingDestination(t *testing.T) {
 		t.Fatalf("staged content = %q, want complete", got)
 	}
 }
+
+func TestRenameNoReplaceInRootPublishesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	if err := root.Mkdir("staged", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	staged, err := root.OpenRoot("staged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := OpenNewFileNoFollowInRoot(staged, "bundle.json", 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte("complete")); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := staged.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := RenameNoReplaceInRoot(root, "staged", "published"); err != nil {
+		t.Fatalf("RenameNoReplaceInRoot() directory error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "published", "bundle.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "complete" {
+		t.Fatalf("published data = %q", data)
+	}
+}

--- a/internal/secureopen/rename_noreplace_windows.go
+++ b/internal/secureopen/rename_noreplace_windows.go
@@ -60,6 +60,11 @@ func renameNoReplaceWindows(parent windows.Handle, oldName, newName string) erro
 	}
 	var source windows.Handle
 	var status windows.IO_STATUS_BLOCK
+	createOptions := uint32(windows.FILE_OPEN_REPARSE_POINT | windows.FILE_OPEN_FOR_BACKUP_INTENT | windows.FILE_SYNCHRONOUS_IO_NONALERT)
+	// FILE_NON_DIRECTORY_FILE made this primitive unusable for atomic bundle
+	// directory publication. Omitting both type constraints lets the no-follow
+	// handle open either a regular file or a directory while preserving the
+	// existing rename contract.
 	err = windows.NtCreateFile(
 		&source,
 		windows.DELETE|windows.SYNCHRONIZE,
@@ -69,7 +74,7 @@ func renameNoReplaceWindows(parent windows.Handle, oldName, newName string) erro
 		0,
 		windows.FILE_SHARE_DELETE|windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
 		windows.FILE_OPEN,
-		windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_SYNCHRONOUS_IO_NONALERT|windows.FILE_NON_DIRECTORY_FILE,
+		createOptions,
 		0,
 		0,
 	)

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -69,6 +70,46 @@ type GitStore struct {
 	RepoURL  string
 	LocalDir string
 	Branch   string
+
+	rootMu sync.Mutex
+	root   *rootfs.Root
+}
+
+func (g *GitStore) filesystemRoot() (rootfs.Root, error) {
+	absolute, err := filepath.Abs(g.LocalDir)
+	if err != nil {
+		return rootfs.Root{}, err
+	}
+	absolute = filepath.Clean(absolute)
+
+	g.rootMu.Lock()
+	defer g.rootMu.Unlock()
+	if g.root != nil && g.root.Path() == absolute {
+		return *g.root, nil
+	}
+	if g.root != nil {
+		if err := g.root.Close(); err != nil {
+			return rootfs.Root{}, err
+		}
+		g.root = nil
+	}
+	root, err := rootfs.New(absolute)
+	if err != nil {
+		return rootfs.Root{}, err
+	}
+	g.root = &root
+	return root, nil
+}
+
+func (g *GitStore) closeFilesystemRoot() error {
+	g.rootMu.Lock()
+	defer g.rootMu.Unlock()
+	if g.root == nil {
+		return nil
+	}
+	err := g.root.Close()
+	g.root = nil
+	return err
 }
 
 // Clone clones the git repo. If allowCreate is true (push mode), falls back to
@@ -131,7 +172,7 @@ func (g *GitStore) WriteEncryptedFile(relPath string, plaintext []byte, password
 		return err
 	}
 
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return err
 	}
@@ -149,7 +190,7 @@ func (g *GitStore) WriteEncryptedFileWithMetadata(relPath string, plaintext []by
 	if err != nil {
 		return err
 	}
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return err
 	}
@@ -167,7 +208,7 @@ func (g *GitStore) ReplaceEncryptedFileWithMetadata(relPath string, plaintext []
 	if err != nil {
 		return err
 	}
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return err
 	}
@@ -180,7 +221,7 @@ func (g *GitStore) CheckNewEncryptedFile(relPath string) error {
 	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
 		return err
 	}
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return err
 	}
@@ -193,7 +234,7 @@ func (g *GitStore) CheckWriteEncryptedFile(relPath string) error {
 	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
 		return err
 	}
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return err
 	}
@@ -206,7 +247,7 @@ func (g *GitStore) CheckEncryptedFileParent(relPath string) error {
 	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
 		return err
 	}
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return err
 	}
@@ -218,7 +259,7 @@ func (g *GitStore) EncryptedFileSize(relPath string) (int64, error) {
 	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
 		return 0, err
 	}
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return 0, err
 	}
@@ -247,7 +288,7 @@ func (g *GitStore) ReadEncryptedFileWithMetadata(relPath string, password string
 	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
 		return nil, EncryptedFileMetadata{}, err
 	}
-	root, err := rootfs.New(g.LocalDir)
+	root, err := g.filesystemRoot()
 	if err != nil {
 		return nil, EncryptedFileMetadata{}, err
 	}
@@ -445,10 +486,12 @@ func (g *GitStore) CommitAndPush(ctx context.Context, message string) error {
 
 // Cleanup removes the local clone directory.
 func (g *GitStore) Cleanup() error {
-	if g.LocalDir == "" {
-		return nil
+	closeErr := g.closeFilesystemRoot()
+	var removeErr error
+	if g.LocalDir != "" {
+		removeErr = os.RemoveAll(g.LocalDir)
 	}
-	return os.RemoveAll(g.LocalDir)
+	return errors.Join(closeErr, removeErr)
 }
 
 // EnsureInsideDir checks that target stays inside baseDir and does not traverse

--- a/internal/signing/gitstore_test.go
+++ b/internal/signing/gitstore_test.go
@@ -149,6 +149,38 @@ func TestGitStoreReadEncryptedFileWithMetadataRejectsOversizedArtifact(t *testin
 	}
 }
 
+func TestGitStoreReusesAndClosesRootAcrossEncryptedFileSizing(t *testing.T) {
+	store := &GitStore{LocalDir: t.TempDir()}
+	const relPath = "artifact"
+	if err := os.WriteFile(filepath.Join(store.LocalDir, relPath+".enc"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for range 256 {
+		size, err := store.EncryptedFileSize(relPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if size != 4 {
+			t.Fatalf("EncryptedFileSize() = %d, want 4", size)
+		}
+	}
+	if store.root == nil {
+		t.Fatal("GitStore did not retain a shared root")
+	}
+	pinned := *store.root
+	if err := store.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	if store.root != nil {
+		t.Fatal("Cleanup() retained the shared root")
+	}
+	if opened, err := pinned.OpenRoot(); err == nil {
+		_ = opened.Close()
+		t.Fatal("Cleanup() left a copied shared root usable")
+	}
+}
+
 func TestGitStoreReadEncryptedFileWithMetadataCanonicalizesCrossPlatformPath(t *testing.T) {
 	store := &GitStore{LocalDir: t.TempDir()}
 	localPath := filepath.Join("identities", "distribution", "ABC.p12")

--- a/internal/xcode/version_project.go
+++ b/internal/xcode/version_project.go
@@ -54,6 +54,7 @@ type preparedVersionWrite struct {
 	mode     os.FileMode
 	root     rootfs.Root
 	name     string
+	ownsRoot bool
 }
 
 type xcconfigMutation struct {
@@ -865,6 +866,7 @@ func (project *structuredVersionProject) checkXCConfigWritable(path string, allo
 	if err != nil {
 		return err
 	}
+	defer root.Close()
 	if err := root.AllowingInternalSymlinks().CheckContained(path); err != nil {
 		if errors.Is(err, rootfs.ErrSymlink) {
 			if info, lstatErr := os.Lstat(path); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
@@ -899,12 +901,7 @@ func (project *structuredVersionProject) checkXCConfigWritable(path string, allo
 	return nil
 }
 
-func (project *structuredVersionProject) versionFileTarget(path string, allowExternal bool) (preparedVersionWrite, error) {
-	projectRoot, err := rootfs.New(project.rootDir)
-	if err != nil {
-		return preparedVersionWrite{}, err
-	}
-	projectRoot = projectRoot.AllowingInternalSymlinks()
+func (project *structuredVersionProject) versionFileTarget(projectRoot rootfs.Root, path string, allowExternal bool) (preparedVersionWrite, error) {
 	if err := projectRoot.CheckContained(path); err == nil {
 		return preparedVersionWrite{path: path, root: projectRoot, name: path}, nil
 	} else if !allowExternal {
@@ -920,17 +917,13 @@ func (project *structuredVersionProject) versionFileTarget(path string, allowExt
 	}
 	name := filepath.Base(path)
 	if err := externalRoot.CheckContained(name); err != nil {
+		_ = externalRoot.Close()
 		return preparedVersionWrite{}, err
 	}
-	return preparedVersionWrite{path: path, root: externalRoot, name: name}, nil
+	return preparedVersionWrite{path: path, root: externalRoot, name: name, ownsRoot: true}, nil
 }
 
-func (project *structuredVersionProject) containedVersionFileTarget(path string) (preparedVersionWrite, error) {
-	projectRoot, err := rootfs.New(project.rootDir)
-	if err != nil {
-		return preparedVersionWrite{}, err
-	}
-	projectRoot = projectRoot.AllowingInternalSymlinks()
+func (project *structuredVersionProject) containedVersionFileTarget(projectRoot rootfs.Root, path string) (preparedVersionWrite, error) {
 	if err := projectRoot.CheckContained(path); err != nil {
 		return preparedVersionWrite{}, err
 	}
@@ -1041,9 +1034,16 @@ func (project *structuredVersionProject) setVersion(opts SetVersionOptions) (*Se
 		}
 	}
 
+	projectRoot, err := rootfs.New(project.rootDir)
+	if err != nil {
+		return nil, err
+	}
+	projectRoot = projectRoot.AllowingInternalSymlinks()
+	defer projectRoot.Close()
 	var writes []preparedVersionWrite
+	defer func() { _ = closeVersionWrites(writes) }()
 	if pbxprojChanged {
-		write, err := project.preparePBXProjWrite()
+		write, err := project.preparePBXProjWrite(projectRoot)
 		if err != nil {
 			return nil, err
 		}
@@ -1059,17 +1059,20 @@ func (project *structuredVersionProject) setVersion(opts SetVersionOptions) (*Se
 		if err := project.checkXCConfigWritable(path, opts.AllowExternalXCConfig); err != nil {
 			return nil, err
 		}
-		target, err := project.versionFileTarget(path, opts.AllowExternalXCConfig)
+		target, err := project.versionFileTarget(projectRoot, path, opts.AllowExternalXCConfig)
 		if err != nil {
 			return nil, fmt.Errorf("prepare xcconfig %s: %w", path, err)
 		}
 		write, fileChanges, changed, err := prepareXCConfigWrite(target, xcconfigMutations[path])
 		if err != nil {
+			_ = target.root.Close()
 			return nil, err
 		}
 		if changed {
 			writes = append(writes, write)
 			changes = append(changes, fileChanges...)
+		} else if target.ownsRoot {
+			_ = target.root.Close()
 		}
 	}
 
@@ -1328,11 +1331,16 @@ func consumersSelected(paths []string, consumers map[string]map[string]bool, ide
 	return true
 }
 
-func (project *structuredVersionProject) preparePBXProjWrite() (preparedVersionWrite, error) {
-	target, err := project.containedVersionFileTarget(project.pbxprojPath)
+func (project *structuredVersionProject) preparePBXProjWrite(projectRoot rootfs.Root) (result preparedVersionWrite, resultErr error) {
+	target, err := project.containedVersionFileTarget(projectRoot, project.pbxprojPath)
 	if err != nil {
 		return preparedVersionWrite{}, fmt.Errorf("prepare Xcode project file: %w", err)
 	}
+	defer func() {
+		if resultErr != nil {
+			_ = target.root.Close()
+		}
+	}()
 	original, mode, err := readRegularVersionFile(target)
 	if err != nil {
 		return preparedVersionWrite{}, err
@@ -1438,7 +1446,10 @@ func readRegularVersionFile(target preparedVersionWrite) ([]byte, os.FileMode, e
 
 var atomicWriteVersionFileFn = atomicWritePreparedVersionFile
 
-func commitVersionWrites(writes []preparedVersionWrite) error {
+func commitVersionWrites(writes []preparedVersionWrite) (resultErr error) {
+	defer func() {
+		resultErr = errors.Join(resultErr, closeVersionWrites(writes))
+	}()
 	sort.Slice(writes, func(left, right int) bool { return writes[left].path < writes[right].path })
 	var committed []preparedVersionWrite
 	for _, write := range writes {
@@ -1463,6 +1474,16 @@ func commitVersionWrites(writes []preparedVersionWrite) error {
 	return nil
 }
 
+func closeVersionWrites(writes []preparedVersionWrite) error {
+	var closeErrors []error
+	for _, write := range writes {
+		if err := write.root.Close(); err != nil {
+			closeErrors = append(closeErrors, fmt.Errorf("close root for %s: %w", write.path, err))
+		}
+	}
+	return errors.Join(closeErrors...)
+}
+
 func atomicWritePreparedVersionFile(write preparedVersionWrite, data []byte) error {
 	return write.root.WriteFile(write.name, data, write.mode)
 }
@@ -1476,6 +1497,7 @@ func atomicWriteVersionFile(path string, data []byte, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	defer root.Close()
 	return root.WriteFile(filepath.Base(path), data, mode)
 }
 

--- a/internal/xcode/version_structured_test.go
+++ b/internal/xcode/version_structured_test.go
@@ -1354,6 +1354,67 @@ func TestStructuredVersion_CommitFailureRollsBackEarlierFiles(t *testing.T) {
 	if got := mustReadVersionTestFile(t, secondPath); got != "old-b" {
 		t.Fatalf("second file changed: %q", got)
 	}
+	if opened, err := fileRoot.OpenRoot(); err == nil {
+		_ = opened.Close()
+		t.Fatal("commitVersionWrites() retained its pinned root after rollback")
+	}
+}
+
+func TestStructuredVersion_CommitClosesPreparedRoots(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "version.xcconfig")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fileRoot, err := rootfs.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := commitVersionWrites([]preparedVersionWrite{{
+		path: path, root: fileRoot, name: path, original: []byte("old"), updated: []byte("new"), mode: 0o644,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if opened, err := fileRoot.OpenRoot(); err == nil {
+		_ = opened.Close()
+		t.Fatal("commitVersionWrites() retained its pinned root after commit")
+	}
+}
+
+func TestStructuredVersion_ContainedTargetsReuseProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "a.xcconfig")
+	secondPath := filepath.Join(root, "b.xcconfig")
+	for _, path := range []string{firstPath, secondPath} {
+		if err := os.WriteFile(path, []byte("VERSION = 1\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	projectRoot, err := rootfs.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectRoot = projectRoot.AllowingInternalSymlinks()
+	project := &structuredVersionProject{rootDir: root}
+	first, err := project.versionFileTarget(projectRoot, firstPath, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := project.versionFileTarget(projectRoot, secondPath, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ownsRoot || second.ownsRoot {
+		t.Fatal("contained version targets unexpectedly allocated separate roots")
+	}
+	if err := first.root.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if opened, err := second.root.OpenRoot(); err == nil {
+		_ = opened.Close()
+		t.Fatal("contained version targets did not share the project root")
+	}
 }
 
 func mustGetStructuredVersion(t *testing.T, project, target, configuration string) *VersionInfo {


### PR DESCRIPTION
## Summary

- add experimental `asc distribute inspect` for structured IPA, profile, trust, and signing diagnostics
- add `asc distribute prepare` for deterministic provider-neutral `bundle.json` + byte-identical IPA artifacts
- fail closed before writing unless the ad hoc profile is current and trusted to pinned Apple roots and the complete main app passes signing verification
- keep storage, manifests, URLs, credentials, devices, and account operations out of this slice

## Verification contract

Preparation verifies, on macOS:

- CMS integrity and the expected Apple provisioning signer chain against pinned Apple Root CA generations
- ad hoc class, bundle ID, platform, expiry, registered-device presence, and profile certificates
- the complete main-app resource seal and signed entitlements
- every Mach-O/fat nested code object, every architecture, Apple/team requirement, and leaf certificate equality with the profile and main signer

Embedded extensions, Watch apps, and App Clips remain explicitly blocked until target-by-target verification lands. Inspect remains diagnostic; prepare requires every exact trust/signing status and scope to be verified.

## Real artifact validation

SmolLens `/tmp/SmolLens-pr1994.ipa`:

- SHA-256 `66c849d3832de86a068af464d538bd1ae5fcaceb5720ae9bb777980b9638b425`
- Apple profile trust: verified
- code scope: `complete-main-app-code-resources-entitlements-and-profile-certificate-binding`
- signer/profile leaf matched
- prepared IPA byte-identical to input
- exact second prepare returned `reused=true`
- descriptor omitted raw UDIDs

## Verification

- independent exact-state audit: MERGE, no findings
- focused distribution/rootfs/secureopen/cmd tests
- nested differently-signed-code regression
- pinned-root/trust/entitlement/TOCTOU/path-swap/size/control-character tests
- generated docs, format, build, Windows compilation, diff checks
- pre-commit short repository test suite with Xcode 26.6

## Stack

- base: #1994 (`release-testing` export support)
- next: provider-neutral S3-compatible `asc distribute publish`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental `distribute inspect` for local iOS IPA metadata, signing status, profiles, embedded targets, and optional device identifiers.
  * Added experimental `distribute prepare` to create deterministic, provider-neutral release-testing bundles.
  * Supports table, Markdown, and structured output formats.

* **Security & Reliability**
  * Rejects unsafe archives, symlinks, credential-bearing URLs, unverifiable signatures, and conflicting outputs.
  * Reuses identical bundles while preventing accidental replacement.

* **Documentation**
  * Updated command help, CLI documentation, and distribution design guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->