### PR TITLE
feat(review): add nested submissions list command

### DIFF
--- a/commands/review.mdx
+++ b/commands/review.mdx
@@ -2,9 +2,8 @@
 
 > Manage App Store review details, attachments, submissions, and history
 
-The `review` command uses hyphenated leaf subcommands for app-scoped review
-status, blocker diagnosis, review details, attachments, submissions, and
-submission items.
+The `review` command provides grouped submission and item workflows alongside
+the existing hyphenated leaf commands for compatibility.
 
 ## Overview
 
@@ -20,7 +19,7 @@ asc review details-update --id "DETAIL_ID" --notes "Updated review notes"
 asc review attachments-list --review-detail "DETAIL_ID"
 asc review attachments-get --id "ATTACHMENT_ID"
 asc review attachments-upload --review-detail "DETAIL_ID" --file ./review-doc.pdf
-asc review submissions-list --app "123456789"
+asc review submissions list --app "123456789"
 asc review submissions-get --id "SUBMISSION_ID"
 asc review submissions-create --app "123456789" --platform IOS
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
@@ -77,9 +76,12 @@ declarations before submission.
 
 ***
 
-### `asc review submissions-list`
+### `asc review submissions list`
 
 List review submissions for an app or globally.
+
+The existing `asc review submissions-list` command remains available with the
+same flags, output, and behavior.
 
 <ParamField path="--app" type="string">
   App Store Connect app ID (or `ASC_APP_ID`)
@@ -110,10 +112,10 @@ List review submissions for an app or globally.
 **Examples:**
 
 ```bash  theme={null}
-asc review submissions-list --app "123456789"
-asc review submissions-list --app "123456789" --platform IOS --state READY_FOR_REVIEW
-asc review submissions-list --app "123456789" --paginate
-asc review submissions-list --app "123456789" --item-fields subscriptionVersion
+asc review submissions list --app "123456789"
+asc review submissions list --app "123456789" --platform IOS --state READY_FOR_REVIEW
+asc review submissions list --app "123456789" --paginate
+asc review submissions list --app "123456789" --item-fields subscriptionVersion
 ```
 
 ***

--- a/commands/review.mdx
+++ b/commands/review.mdx
@@ -78,10 +78,11 @@ declarations before submission.
 
 ### `asc review submissions list`
 
-List review submissions for an app or globally.
+This nested command path is experimental. It lists review submissions for an
+app or globally.
 
-The existing `asc review submissions-list` command remains available with the
-same flags, output, and behavior.
+The existing stable `asc review submissions-list` command remains available
+with the same flags, output, and behavior.
 
 <ParamField path="--app" type="string">
   App Store Connect app ID (or `ASC_APP_ID`)

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -956,6 +956,7 @@ review items-list
 review items-update
 review submissions-get
 review submissions-list
+review submissions list
 review submissions-update
 schema
 subscriptions groups list

--- a/docs/design/app-store-connect-api-4.4.1-coverage.md
+++ b/docs/design/app-store-connect-api-4.4.1-coverage.md
@@ -956,7 +956,6 @@ review items-list
 review items-update
 review submissions-get
 review submissions-list
-review submissions list
 review submissions-update
 schema
 subscriptions groups list

--- a/internal/cli/cmdtest/review_submissions_nested_test.go
+++ b/internal/cli/cmdtest/review_submissions_nested_test.go
@@ -116,11 +116,27 @@ func TestReviewSubmissionsNestedListMatchesFlatAPIError(t *testing.T) {
 		response,
 	)
 
-	if !reflect.DeepEqual(flat, nested) {
+	if flat.stdout != nested.stdout || flat.stderr != nested.stderr || flat.method != nested.method || flat.path != nested.path || flat.rawQuery != nested.rawQuery {
 		t.Fatalf("flat result = %+v, nested result = %+v", flat, nested)
 	}
 	if flat.stdout != "" || !strings.Contains(flat.err, "review submissions-list") || !strings.Contains(flat.err, "Not allowed") {
 		t.Fatalf("unexpected API failure result: %+v", flat)
+	}
+	if !strings.Contains(nested.err, "review submissions list") || strings.Contains(nested.err, "review submissions-list") || !strings.Contains(nested.err, "Not allowed") {
+		t.Fatalf("unexpected nested API failure result: %+v", nested)
+	}
+}
+
+func TestReviewSubmissionsNestedListIsExperimental(t *testing.T) {
+	root := RootCommand("1.2.3")
+	for _, path := range [][]string{{"review", "submissions"}, {"review", "submissions", "list"}} {
+		cmd := findSubcommand(root, path...)
+		if cmd == nil {
+			t.Fatalf("command %v not found", path)
+		}
+		if !strings.HasPrefix(cmd.ShortHelp, "[experimental]") {
+			t.Fatalf("command %v ShortHelp = %q, want [experimental] prefix", path, cmd.ShortHelp)
+		}
 	}
 }
 

--- a/internal/cli/cmdtest/review_submissions_nested_test.go
+++ b/internal/cli/cmdtest/review_submissions_nested_test.go
@@ -1,0 +1,195 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type reviewSubmissionsSurfaceResult struct {
+	stdout   string
+	stderr   string
+	err      string
+	method   string
+	path     string
+	rawQuery string
+}
+
+func TestReviewSubmissionsNestedListMatchesFlatSurface(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	surfaces := [][]string{
+		{"review", "submissions-list"},
+		{"review", "submissions", "list"},
+	}
+	results := make([]reviewSubmissionsSurfaceResult, 0, len(surfaces))
+	for _, surface := range surfaces {
+		args := append(
+			append([]string{}, surface...),
+			"--state", "READY_FOR_REVIEW",
+			"--app", "app-1",
+			"--platform", "IOS",
+			"--include", "items",
+			"--item-fields", "state",
+			"--output", "json",
+		)
+		results = append(results, runReviewSubmissionsSurface(
+			t, args, http.StatusOK,
+			`{"data":[{"type":"reviewSubmissions","id":"submission-1","attributes":{"platform":"IOS","state":"READY_FOR_REVIEW"}}]}`,
+		))
+	}
+
+	if !reflect.DeepEqual(results[0], results[1]) {
+		t.Fatalf("flat result = %+v, nested result = %+v", results[0], results[1])
+	}
+	if results[0].method != http.MethodGet || results[0].path != "/v1/apps/app-1/reviewSubmissions" {
+		t.Fatalf("request = %s %s, want GET /v1/apps/app-1/reviewSubmissions", results[0].method, results[0].path)
+	}
+	for _, query := range []string{
+		"filter%5Bplatform%5D=IOS",
+		"filter%5Bstate%5D=READY_FOR_REVIEW",
+		"fields%5BreviewSubmissionItems%5D=state",
+		"include=items",
+	} {
+		if !strings.Contains(results[0].rawQuery, query) {
+			t.Fatalf("query %q is missing %q", results[0].rawQuery, query)
+		}
+	}
+	if results[0].stderr != "" || results[0].err != "" || !strings.Contains(results[0].stdout, `"id":"submission-1"`) {
+		t.Fatalf("unexpected successful result: %+v", results[0])
+	}
+}
+
+func TestReviewSubmissionsNestedListMatchesFlatTableOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	response := `{"data":[{"type":"reviewSubmissions","id":"submission-1","attributes":{"platform":"IOS","state":"READY_FOR_REVIEW"}}]}`
+	flat := runReviewSubmissionsSurface(
+		t,
+		[]string{"review", "submissions-list", "--app", "app-1", "--output", "table"},
+		http.StatusOK,
+		response,
+	)
+	nested := runReviewSubmissionsSurface(
+		t,
+		[]string{"review", "submissions", "list", "--output", "table", "--app", "app-1"},
+		http.StatusOK,
+		response,
+	)
+
+	if !reflect.DeepEqual(flat, nested) {
+		t.Fatalf("flat result = %+v, nested result = %+v", flat, nested)
+	}
+	for _, value := range []string{"ID", "PLATFORM", "STATE", "SUBMISSION-1", "IOS", "READY_FOR_REVIEW"} {
+		if !strings.Contains(strings.ToUpper(flat.stdout), value) {
+			t.Fatalf("table output missing %q: %s", value, flat.stdout)
+		}
+	}
+}
+
+func TestReviewSubmissionsNestedListMatchesFlatAPIError(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	response := `{"errors":[{"status":"403","code":"FORBIDDEN_ERROR","title":"Forbidden","detail":"Not allowed."}]}`
+	flat := runReviewSubmissionsSurface(
+		t,
+		[]string{"review", "submissions-list", "--app", "app-1"},
+		http.StatusForbidden,
+		response,
+	)
+	nested := runReviewSubmissionsSurface(
+		t,
+		[]string{"review", "submissions", "list", "--app", "app-1"},
+		http.StatusForbidden,
+		response,
+	)
+
+	if !reflect.DeepEqual(flat, nested) {
+		t.Fatalf("flat result = %+v, nested result = %+v", flat, nested)
+	}
+	if flat.stdout != "" || !strings.Contains(flat.err, "review submissions-list") || !strings.Contains(flat.err, "Not allowed") {
+		t.Fatalf("unexpected API failure result: %+v", flat)
+	}
+}
+
+func TestReviewSubmissionsNestedListValidatesBeforeAuth(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantLine string
+	}{
+		{name: "missing app", args: []string{"review", "submissions", "list"}, wantLine: "Error: --app or --global is required (or set ASC_APP_ID)"},
+		{name: "invalid state", args: []string{"review", "submissions", "list", "--app", "app-1", "--state", "NOPE"}, wantLine: "Error: --state must be one of: READY_FOR_REVIEW, WAITING_FOR_REVIEW, IN_REVIEW, UNRESOLVED_ISSUES, CANCELING, COMPLETING, COMPLETE"},
+		{name: "unexpected argument", args: []string{"review", "submissions", "list", "--app", "app-1", "unexpected"}, wantLine: "Error: unexpected positional arguments"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				err := root.Run(context.Background())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want usage error", err)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.HasPrefix(stderr, test.wantLine+"\n") {
+				t.Fatalf("stderr = %q, want prefix %q", stderr, test.wantLine+"\n")
+			}
+			if strings.Count(stderr, test.wantLine) != 1 {
+				t.Fatalf("stderr contains duplicate diagnostic: %q", stderr)
+			}
+		})
+	}
+}
+
+func runReviewSubmissionsSurface(t *testing.T, args []string, status int, body string) reviewSubmissionsSurfaceResult {
+	t.Helper()
+
+	result := reviewSubmissionsSurfaceResult{}
+	originalTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = originalTransport }()
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		result.method = req.Method
+		result.path = req.URL.Path
+		result.rawQuery = req.URL.RawQuery
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	result.stdout, result.stderr = captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			result.err = err.Error()
+		}
+	})
+	return result
+}

--- a/internal/cli/reviews/review.go
+++ b/internal/cli/reviews/review.go
@@ -28,6 +28,7 @@ Examples:
   asc review details-create --version-id "VERSION_ID" --contact-email "dev@example.com"
   asc review details-update --id "DETAIL_ID" --notes "Updated review notes"
   asc review attachments-list --review-detail "DETAIL_ID"
+  asc review submissions list --app "123456789"
   asc review submissions-list --app "123456789"
   asc review submissions-create --app "123456789" --platform IOS
   asc review submissions-submit --id "SUBMISSION_ID" --confirm
@@ -52,6 +53,7 @@ Examples:
 			ReviewDetailsAttachmentsUploadCommand(),
 			ReviewDetailsAttachmentsDeleteCommand(),
 			ReviewHistoryCommand(),
+			ReviewSubmissionsCommand(),
 			ReviewSubmissionsListCommand(),
 			ReviewSubmissionsGetCommand(),
 			ReviewSubmissionsCreateCommand(),

--- a/internal/cli/reviews/review_submissions.go
+++ b/internal/cli/reviews/review_submissions.go
@@ -16,6 +16,40 @@ import (
 
 var reviewSubmissionsClientFactory = shared.GetASCClient
 
+// ReviewSubmissionsCommand returns the nested review submissions command group.
+func ReviewSubmissionsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("review submissions", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "submissions",
+		ShortUsage: "asc review submissions <subcommand> [flags]",
+		ShortHelp:  "Manage App Store review submissions.",
+		LongHelp: `Manage App Store review submissions.
+
+Examples:
+  asc review submissions list --app "123456789"
+  asc review submissions list --app "123456789" --platform IOS --state READY_FOR_REVIEW`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			ReviewSubmissionsNestedListCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// ReviewSubmissionsNestedListCommand exposes the existing list implementation
+// under the discoverable `review submissions list` path.
+func ReviewSubmissionsNestedListCommand() *ffcli.Command {
+	cmd := ReviewSubmissionsListCommand()
+	cmd.Name = "list"
+	cmd.ShortUsage = "asc review submissions list [flags]"
+	cmd.LongHelp = strings.ReplaceAll(cmd.LongHelp, "asc review submissions-list", "asc review submissions list")
+	return cmd
+}
+
 // ReviewSubmissionsListCommand returns the review submissions list subcommand.
 func ReviewSubmissionsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("submissions-list", flag.ExitOnError)

--- a/internal/cli/reviews/review_submissions.go
+++ b/internal/cli/reviews/review_submissions.go
@@ -23,8 +23,8 @@ func ReviewSubmissionsCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "submissions",
 		ShortUsage: "asc review submissions <subcommand> [flags]",
-		ShortHelp:  "Manage App Store review submissions.",
-		LongHelp: `Manage App Store review submissions.
+		ShortHelp:  "[experimental] Manage App Store review submissions.",
+		LongHelp: `[experimental] Manage App Store review submissions.
 
 Examples:
   asc review submissions list --app "123456789"
@@ -43,10 +43,14 @@ Examples:
 // ReviewSubmissionsNestedListCommand exposes the existing list implementation
 // under the discoverable `review submissions list` path.
 func ReviewSubmissionsNestedListCommand() *ffcli.Command {
-	cmd := ReviewSubmissionsListCommand()
+	cmd := shared.RewriteCommandTreePath(
+		ReviewSubmissionsListCommand(),
+		"asc review submissions-list",
+		"asc review submissions list",
+	)
 	cmd.Name = "list"
-	cmd.ShortUsage = "asc review submissions list [flags]"
-	cmd.LongHelp = strings.ReplaceAll(cmd.LongHelp, "asc review submissions-list", "asc review submissions list")
+	cmd.ShortHelp = "[experimental] " + cmd.ShortHelp
+	cmd.LongHelp = "[experimental] " + cmd.LongHelp
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

- add `asc review submissions list` as the discoverable nested command
- reuse the existing list implementation so both command paths share validation, HTTP, output, and error behavior
- preserve `asc review submissions-list` for compatibility

## API contract

Both paths call `GET /v1/apps/{id}/reviewSubmissions` with identical filters, includes, pagination, and output handling.

## Verification

- focused CLI parity tests for JSON, table, API errors, and pre-auth validation
- built-binary help and missing-selector checks with keychain bypass enabled
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- repository commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the grouped `review submissions list` command for listing review submissions.
  * Running `review submissions` without a subcommand now displays help.
  * Existing `review submissions-list` syntax remains available for compatibility.
* **Documentation**
  * Updated command documentation and examples to showcase the grouped syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->