### PR TITLE
feat(web): manage Developer Portal App Groups

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -17,6 +17,10 @@ asc web api-keys create --name "Release automation" --output-dir ~/.asc/keys
 # Create an app through the web flow
 asc web apps create --name "My App" --bundle-id "com.example.app" --sku "MYAPP123"
 
+# Register and assign an App Group unavailable through the public API
+asc web app-groups create --name "My App Shared" --identifier "group.com.example.app.shared" --confirm
+asc web app-groups list --output table
+
 # Bootstrap app availability where the public API falls short
 asc web apps availability create --app "123456789" --territory "USA,GBR" --available-in-new-territories false
 
@@ -117,6 +121,34 @@ Sandbox tester creation via the App Store Connect web UI contract.
 Available commands:
 
 * `asc web sandbox create` - create a sandbox tester
+
+### `asc web app-groups`
+
+App Group registration and Bundle ID assignment through Apple Developer Portal.
+The public App Store Connect API can enable the `APP_GROUPS` capability but
+does not expose App Group resources or their associations.
+
+Available commands:
+
+* `asc web app-groups list` - list every App Group for the selected Developer team
+* `asc web app-groups create` - register a new `group.` identifier
+* `asc web app-groups assign` - idempotently associate a group with a Bundle ID and enable `APP_GROUPS` when needed
+
+Use the opaque IDs returned by the list commands for assignment:
+
+```bash  theme={null}
+asc web app-groups list --output table
+asc bundle-ids list --output table
+
+asc web app-groups assign \
+  --group "GROUP_RESOURCE_ID" \
+  --bundle-id "BUNDLE_RESOURCE_ID" \
+  --confirm
+```
+
+These commands require an Account Holder or Admin web session. Because Apple
+does not publish these Developer Portal endpoints, scripts should treat this
+command family as a web-session workflow rather than a public API guarantee.
 
 ### `asc web privacy`
 

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -17,7 +17,7 @@ asc web api-keys create --name "Release automation" --output-dir ~/.asc/keys
 # Create an app through the web flow
 asc web apps create --name "My App" --bundle-id "com.example.app" --sku "MYAPP123"
 
-# Register and assign an App Group unavailable through the public API
+# Register and list an App Group unavailable through the public API
 asc web app-groups create --name "My App Shared" --identifier "group.com.example.app.shared" --confirm
 asc web app-groups list --output table
 
@@ -130,7 +130,7 @@ does not expose App Group resources or their associations.
 
 Available commands:
 
-* `asc web app-groups list` - list every App Group for the selected Developer team
+* `asc web app-groups list` - list the first page of App Groups for the selected Developer team; pass `--paginate` to fetch every page
 * `asc web app-groups create` - register a new `group.` identifier
 * `asc web app-groups assign` - idempotently associate a group with a Bundle ID and enable `APP_GROUPS` when needed
 
@@ -146,9 +146,19 @@ asc web app-groups assign \
   --confirm
 ```
 
+Repeating an assignment that already exists succeeds without mutating the
+Bundle ID and returns `{"changed":false,"status":"already-assigned"}`.
+
 These commands require an Account Holder or Admin web session. Because Apple
 does not publish these Developer Portal endpoints, scripts should treat this
 command family as a web-session workflow rather than a public API guarantee.
+If Apple rejects an expired or invalid Developer Portal session, refresh the
+cached session before retrying:
+
+```bash  theme={null}
+asc web auth logout --apple-id "user@example.com"
+asc web auth login --apple-id "user@example.com"
+```
 
 ### `asc web privacy`
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudrankriyam/App-Store-Connect-CLI
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/1Password/srp v0.2.0

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -47,6 +47,7 @@ Examples:
 			WebAppsCommand(),
 			WebRemovedAppsCommand(),
 			WebBundleIDsCommand(),
+			WebAppGroupsCommand(),
 			WebPrivacyCommand(),
 			WebReviewCommand(),
 			WebSubscriptionsCommand(),

--- a/internal/cli/web/web_app_groups.go
+++ b/internal/cli/web/web_app_groups.go
@@ -1,0 +1,279 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+var listDeveloperAppGroupsFn = func(ctx context.Context, client *webcore.Client) (*webcore.DeveloperAppGroupsListResult, error) {
+	return client.ListDeveloperAppGroups(ctx)
+}
+
+var createDeveloperAppGroupFn = func(ctx context.Context, client *webcore.Client, request webcore.DeveloperAppGroupCreateRequest) (*webcore.DeveloperAppGroup, error) {
+	return client.CreateDeveloperAppGroup(ctx, request)
+}
+
+var assignDeveloperAppGroupFn = func(ctx context.Context, client *webcore.Client, request webcore.DeveloperAppGroupAssignRequest) (*webcore.DeveloperAppGroupAssignResult, error) {
+	return client.AssignDeveloperAppGroup(ctx, request)
+}
+
+// WebAppGroupsCommand returns the Developer Portal App Groups command group.
+func WebAppGroupsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web app-groups", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "app-groups",
+		ShortUsage: "asc web app-groups <subcommand> [flags]",
+		ShortHelp:  "Manage App Groups via Developer Portal web sessions.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+List, register, and assign App Groups through Apple Developer Portal.
+These resources are not exposed by the public App Store Connect API and require
+a user-owned Apple web session with Account Holder or Admin access.
+
+Examples:
+  asc web app-groups list --output table
+  asc web app-groups create --name "Example Shared" --identifier "group.com.example.shared" --confirm
+  asc web app-groups assign --group "GROUP_RESOURCE_ID" --bundle-id "BUNDLE_RESOURCE_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebAppGroupsListCommand(),
+			WebAppGroupsCreateCommand(),
+			WebAppGroupsAssignCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebAppGroupsListCommand lists App Groups for the selected Developer Portal team.
+func WebAppGroupsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web app-groups list", flag.ExitOnError)
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc web app-groups list [flags]",
+		ShortHelp:  "List App Groups via a Developer Portal web session.",
+		LongHelp: `List every App Group visible to the selected Apple Developer team.
+
+The ID column is Apple's opaque App Group resource ID. Pass that value to
+"asc web app-groups assign --group".
+
+Example:
+  asc web app-groups list --apple-id "user@example.com" --output table`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web app-groups list does not accept positional arguments")
+			}
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return withWebAuthHint(err, "web app-groups list")
+			}
+			result, err := listDeveloperAppGroupsFn(requestCtx, newWebClientFn(session))
+			if err != nil {
+				return withWebAuthHint(err, "web app-groups list")
+			}
+			_ = persistWebSessionFn(session)
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderDeveloperAppGroupsTable(result) },
+				func() error { return renderDeveloperAppGroupsMarkdown(result) },
+			)
+		},
+	}
+}
+
+// WebAppGroupsCreateCommand registers an App Group identifier.
+func WebAppGroupsCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web app-groups create", flag.ExitOnError)
+	name := fs.String("name", "", "Human-readable App Group name")
+	identifier := fs.String("identifier", "", "App Group identifier beginning with group.")
+	confirm := fs.Bool("confirm", false, "Confirm registering this App Group")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "asc web app-groups create --name NAME --identifier GROUP_ID --confirm [flags]",
+		ShortHelp:  "Register an App Group via a Developer Portal web session.",
+		LongHelp: `Register a new App Group for the selected Apple Developer team.
+
+Example:
+  asc web app-groups create --name "Example Shared" --identifier "group.com.example.shared" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web app-groups create does not accept positional arguments")
+			}
+			resolvedName := strings.TrimSpace(*name)
+			resolvedIdentifier := strings.TrimSpace(*identifier)
+			switch {
+			case resolvedName == "":
+				return shared.UsageError("--name is required")
+			case resolvedIdentifier == "":
+				return shared.UsageError("--identifier is required")
+			case !strings.HasPrefix(resolvedIdentifier, "group."):
+				return shared.UsageError("--identifier must start with group.")
+			case strings.ContainsAny(resolvedIdentifier, " \t\r\n"):
+				return shared.UsageError("--identifier must not contain whitespace")
+			case !*confirm:
+				return shared.UsageError("--confirm is required")
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return withWebAuthHint(err, "web app-groups create")
+			}
+			result, err := createDeveloperAppGroupFn(requestCtx, newWebClientFn(session), webcore.DeveloperAppGroupCreateRequest{Name: resolvedName, Identifier: resolvedIdentifier})
+			if err != nil {
+				return withWebAuthHint(err, "web app-groups create")
+			}
+			if result == nil {
+				return fmt.Errorf("web app-groups create failed: missing create result")
+			}
+			_ = persistWebSessionFn(session)
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderDeveloperAppGroupTable(result) },
+				func() error { return renderDeveloperAppGroupMarkdown(result) },
+			)
+		},
+	}
+}
+
+// WebAppGroupsAssignCommand assigns an App Group to a Bundle ID.
+func WebAppGroupsAssignCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web app-groups assign", flag.ExitOnError)
+	groupID := fs.String("group", "", "Opaque App Group resource ID from app-groups list")
+	bundleID := fs.String("bundle-id", "", "Opaque Developer Portal Bundle ID resource ID")
+	confirm := fs.Bool("confirm", false, "Confirm assigning this App Group")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name:       "assign",
+		ShortUsage: "asc web app-groups assign --group GROUP_RESOURCE_ID --bundle-id BUNDLE_RESOURCE_ID --confirm [flags]",
+		ShortHelp:  "Assign an App Group to a Bundle ID via a web session.",
+		LongHelp: `Assign an existing App Group to a Bundle ID while preserving every current
+Bundle ID capability and relationship. The operation also enables APP_GROUPS
+when needed and is idempotent when the association already exists.
+
+Use opaque resource IDs returned by "asc web app-groups list" and
+"asc bundle-ids list".
+
+Example:
+  asc web app-groups assign --group "GROUP_RESOURCE_ID" --bundle-id "BUNDLE_RESOURCE_ID" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web app-groups assign does not accept positional arguments")
+			}
+			resolvedGroupID := strings.TrimSpace(*groupID)
+			resolvedBundleID := strings.TrimSpace(*bundleID)
+			switch {
+			case resolvedGroupID == "":
+				return shared.UsageError("--group is required")
+			case resolvedBundleID == "":
+				return shared.UsageError("--bundle-id is required")
+			case !*confirm:
+				return shared.UsageError("--confirm is required")
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return withWebAuthHint(err, "web app-groups assign")
+			}
+			result, err := assignDeveloperAppGroupFn(requestCtx, newWebClientFn(session), webcore.DeveloperAppGroupAssignRequest{BundleID: resolvedBundleID, GroupID: resolvedGroupID})
+			if err != nil {
+				return withWebAuthHint(err, "web app-groups assign")
+			}
+			if result == nil {
+				return fmt.Errorf("web app-groups assign failed: missing assign result")
+			}
+			_ = persistWebSessionFn(session)
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderDeveloperAppGroupAssignTable(result) },
+				func() error { return renderDeveloperAppGroupAssignMarkdown(result) },
+			)
+		},
+	}
+}
+
+func developerAppGroupsHeaders() []string {
+	return []string{"ID", "Name", "Identifier", "Status"}
+}
+
+func developerAppGroupsRows(groups []webcore.DeveloperAppGroup) [][]string {
+	rows := make([][]string, 0, len(groups))
+	for _, group := range groups {
+		rows = append(rows, []string{shared.OrNA(group.ID), shared.OrNA(group.Name), shared.OrNA(group.Identifier), shared.OrNA(group.Status)})
+	}
+	return rows
+}
+
+func renderDeveloperAppGroupsTable(result *webcore.DeveloperAppGroupsListResult) error {
+	if result == nil {
+		asc.RenderTable(developerAppGroupsHeaders(), nil)
+		return nil
+	}
+	asc.RenderTable(developerAppGroupsHeaders(), developerAppGroupsRows(result.Data))
+	return nil
+}
+
+func renderDeveloperAppGroupsMarkdown(result *webcore.DeveloperAppGroupsListResult) error {
+	if result == nil {
+		asc.RenderMarkdown(developerAppGroupsHeaders(), nil)
+		return nil
+	}
+	asc.RenderMarkdown(developerAppGroupsHeaders(), developerAppGroupsRows(result.Data))
+	return nil
+}
+
+func renderDeveloperAppGroupTable(result *webcore.DeveloperAppGroup) error {
+	asc.RenderTable(developerAppGroupsHeaders(), developerAppGroupsRows([]webcore.DeveloperAppGroup{*result}))
+	return nil
+}
+
+func renderDeveloperAppGroupMarkdown(result *webcore.DeveloperAppGroup) error {
+	asc.RenderMarkdown(developerAppGroupsHeaders(), developerAppGroupsRows([]webcore.DeveloperAppGroup{*result}))
+	return nil
+}
+
+func developerAppGroupAssignRows(result *webcore.DeveloperAppGroupAssignResult) [][]string {
+	return [][]string{{result.BundleID, result.GroupID, fmt.Sprintf("%t", result.Changed), result.Status}}
+}
+
+func renderDeveloperAppGroupAssignTable(result *webcore.DeveloperAppGroupAssignResult) error {
+	asc.RenderTable([]string{"Bundle ID", "Group ID", "Changed", "Status"}, developerAppGroupAssignRows(result))
+	return nil
+}
+
+func renderDeveloperAppGroupAssignMarkdown(result *webcore.DeveloperAppGroupAssignResult) error {
+	asc.RenderMarkdown([]string{"Bundle ID", "Group ID", "Changed", "Status"}, developerAppGroupAssignRows(result))
+	return nil
+}

--- a/internal/cli/web/web_app_groups.go
+++ b/internal/cli/web/web_app_groups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -13,8 +14,8 @@ import (
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
-var listDeveloperAppGroupsFn = func(ctx context.Context, client *webcore.Client) (*webcore.DeveloperAppGroupsListResult, error) {
-	return client.ListDeveloperAppGroups(ctx)
+var listDeveloperAppGroupsFn = func(ctx context.Context, client *webcore.Client, options webcore.DeveloperAppGroupsListOptions) (*webcore.DeveloperAppGroupsListResult, error) {
+	return client.ListDeveloperAppGroups(ctx, options)
 }
 
 var createDeveloperAppGroupFn = func(ctx context.Context, client *webcore.Client, request webcore.DeveloperAppGroupCreateRequest) (*webcore.DeveloperAppGroup, error) {
@@ -58,13 +59,17 @@ Examples:
 // WebAppGroupsListCommand lists App Groups for the selected Developer Portal team.
 func WebAppGroupsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("web app-groups list", flag.ExitOnError)
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
 	authFlags := bindWebSessionFlags(fs)
 	output := shared.BindOutputFlags(fs)
 	return &ffcli.Command{
 		Name:       "list",
 		ShortUsage: "asc web app-groups list [flags]",
 		ShortHelp:  "List App Groups via a Developer Portal web session.",
-		LongHelp: `List every App Group visible to the selected Apple Developer team.
+		LongHelp: `List App Groups visible to the selected Apple Developer team.
+
+By default, the command fetches the first page. Pass --paginate to fetch every
+page.
 
 The ID column is Apple's opaque App Group resource ID. Pass that value to
 "asc web app-groups assign --group".
@@ -83,11 +88,11 @@ Example:
 			if err != nil {
 				return withWebAuthHint(err, "web app-groups list")
 			}
-			result, err := listDeveloperAppGroupsFn(requestCtx, newWebClientFn(session))
+			result, err := listDeveloperAppGroupsFn(requestCtx, newWebClientFn(session), webcore.DeveloperAppGroupsListOptions{Paginate: *paginate})
 			if err != nil {
 				return withWebAuthHint(err, "web app-groups list")
 			}
-			_ = persistWebSessionFn(session)
+			persistDeveloperAppGroupSession(session)
 			return shared.PrintOutputWithRenderers(
 				result,
 				*output.Output,
@@ -149,7 +154,7 @@ Example:
 			if result == nil {
 				return fmt.Errorf("web app-groups create failed: missing create result")
 			}
-			_ = persistWebSessionFn(session)
+			persistDeveloperAppGroupSession(session)
 			return shared.PrintOutputWithRenderers(
 				result,
 				*output.Output,
@@ -212,7 +217,7 @@ Example:
 			if result == nil {
 				return fmt.Errorf("web app-groups assign failed: missing assign result")
 			}
-			_ = persistWebSessionFn(session)
+			persistDeveloperAppGroupSession(session)
 			return shared.PrintOutputWithRenderers(
 				result,
 				*output.Output,
@@ -221,6 +226,12 @@ Example:
 				func() error { return renderDeveloperAppGroupAssignMarkdown(result) },
 			)
 		},
+	}
+}
+
+func persistDeveloperAppGroupSession(session *webcore.AuthSession) {
+	if err := persistWebSessionFn(session); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to persist refreshed web session: %v\n", err)
 	}
 }
 

--- a/internal/cli/web/web_app_groups_test.go
+++ b/internal/cli/web/web_app_groups_test.go
@@ -1,0 +1,172 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebAppGroupsCommandHierarchy(t *testing.T) {
+	command := WebAppGroupsCommand()
+	if command.Name != "app-groups" || command.UsageFunc == nil {
+		t.Fatalf("unexpected command: %+v", command)
+	}
+	want := []string{"list", "create", "assign"}
+	if len(command.Subcommands) != len(want) {
+		t.Fatalf("subcommands = %+v", command.Subcommands)
+	}
+	for index, name := range want {
+		if command.Subcommands[index].Name != name || command.Subcommands[index].UsageFunc == nil {
+			t.Fatalf("subcommand %d = %+v", index, command.Subcommands[index])
+		}
+	}
+}
+
+func TestWebAppGroupsValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+		wantErr string
+	}{
+		{name: "list positional", command: WebAppGroupsListCommand, args: []string{"extra"}, wantErr: "does not accept positional arguments"},
+		{name: "create missing name", command: WebAppGroupsCreateCommand, args: []string{"--identifier", "group.com.example", "--confirm"}, wantErr: "--name is required"},
+		{name: "create invalid identifier", command: WebAppGroupsCreateCommand, args: []string{"--name", "Example", "--identifier", "com.example", "--confirm"}, wantErr: "must start with group."},
+		{name: "create missing confirm", command: WebAppGroupsCreateCommand, args: []string{"--name", "Example", "--identifier", "group.com.example"}, wantErr: "--confirm is required"},
+		{name: "assign missing group", command: WebAppGroupsAssignCommand, args: []string{"--bundle-id", "bundle-1", "--confirm"}, wantErr: "--group is required"},
+		{name: "assign missing bundle", command: WebAppGroupsAssignCommand, args: []string{"--group", "group-1", "--confirm"}, wantErr: "--bundle-id is required"},
+		{name: "assign missing confirm", command: WebAppGroupsAssignCommand, args: []string{"--group", "group-1", "--bundle-id", "bundle-1"}, wantErr: "--confirm is required"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := test.command()
+			if err := command.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			_, stderr := captureWebCommandOutput(t, func() {
+				err := command.Exec(context.Background(), command.FlagSet.Args())
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("expected usage error, got %v", err)
+				}
+			})
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("stderr %q does not contain %q", stderr, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestWebAppGroupsListOutputsJSON(t *testing.T) {
+	restore, cleanup := stubWebAppGroupsDependencies(t)
+	defer cleanup()
+	listDeveloperAppGroupsFn = func(context.Context, *webcore.Client) (*webcore.DeveloperAppGroupsListResult, error) {
+		return &webcore.DeveloperAppGroupsListResult{Data: []webcore.DeveloperAppGroup{{ID: "GROUP1", Name: "Shared", Identifier: "group.com.example.shared"}}}, nil
+	}
+	defer restore()
+
+	command := WebAppGroupsListCommand()
+	if err := command.FlagSet.Parse([]string{"--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := command.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("Exec() error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+	var result webcore.DeveloperAppGroupsListResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output: %v; stdout=%q", err, stdout)
+	}
+	if len(result.Data) != 1 || result.Data[0].ID != "GROUP1" {
+		t.Fatalf("unexpected output: %+v", result)
+	}
+
+	tableCommand := WebAppGroupsListCommand()
+	if err := tableCommand.FlagSet.Parse([]string{"--output", "table"}); err != nil {
+		t.Fatalf("parse table: %v", err)
+	}
+	stdout, _ = captureWebCommandOutput(t, func() {
+		if err := tableCommand.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("table Exec() error: %v", err)
+		}
+	})
+	for _, expected := range []string{"ID", "Name", "Identifier", "Status", "GROUP1", "Shared", "group.com.example.shared"} {
+		if !strings.Contains(stdout, expected) {
+			t.Fatalf("table output %q does not contain %q", stdout, expected)
+		}
+	}
+}
+
+func TestWebAppGroupsCreateAndAssignCallClient(t *testing.T) {
+	restore, cleanup := stubWebAppGroupsDependencies(t)
+	defer cleanup()
+	defer restore()
+
+	var createRequest webcore.DeveloperAppGroupCreateRequest
+	createDeveloperAppGroupFn = func(_ context.Context, _ *webcore.Client, request webcore.DeveloperAppGroupCreateRequest) (*webcore.DeveloperAppGroup, error) {
+		createRequest = request
+		return &webcore.DeveloperAppGroup{ID: "GROUP1", Name: request.Name, Identifier: request.Identifier}, nil
+	}
+	create := WebAppGroupsCreateCommand()
+	if err := create.FlagSet.Parse([]string{"--name", "Example Preview", "--identifier", "group.com.example.preview", "--confirm", "--output", "json"}); err != nil {
+		t.Fatalf("parse create: %v", err)
+	}
+	stdout, _ := captureWebCommandOutput(t, func() {
+		if err := create.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("create Exec() error: %v", err)
+		}
+	})
+	if createRequest.Name != "Example Preview" || createRequest.Identifier != "group.com.example.preview" || !strings.Contains(stdout, `"id":"GROUP1"`) {
+		t.Fatalf("unexpected create request/output: %+v %q", createRequest, stdout)
+	}
+
+	var assignRequest webcore.DeveloperAppGroupAssignRequest
+	assignDeveloperAppGroupFn = func(_ context.Context, _ *webcore.Client, request webcore.DeveloperAppGroupAssignRequest) (*webcore.DeveloperAppGroupAssignResult, error) {
+		assignRequest = request
+		return &webcore.DeveloperAppGroupAssignResult{BundleID: request.BundleID, GroupID: request.GroupID, Changed: true, Status: "assigned"}, nil
+	}
+	assign := WebAppGroupsAssignCommand()
+	if err := assign.FlagSet.Parse([]string{"--group", "GROUP1", "--bundle-id", "bundle-1", "--confirm", "--output", "json"}); err != nil {
+		t.Fatalf("parse assign: %v", err)
+	}
+	stdout, _ = captureWebCommandOutput(t, func() {
+		if err := assign.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("assign Exec() error: %v", err)
+		}
+	})
+	if assignRequest.GroupID != "GROUP1" || assignRequest.BundleID != "bundle-1" || !strings.Contains(stdout, `"status":"assigned"`) {
+		t.Fatalf("unexpected assign request/output: %+v %q", assignRequest, stdout)
+	}
+}
+
+func stubWebAppGroupsDependencies(t *testing.T) (restoreFunctions func(), cleanupSession func()) {
+	t.Helper()
+	originalNewClient := newWebClientFn
+	originalList := listDeveloperAppGroupsFn
+	originalCreate := createDeveloperAppGroupFn
+	originalAssign := assignDeveloperAppGroupFn
+	originalPersist := persistWebSessionFn
+	cleanupSession = SetResolveWebSession(func(context.Context, string, string, string, string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	newWebClientFn = func(*webcore.AuthSession) *webcore.Client { return &webcore.Client{} }
+	persistWebSessionFn = func(*webcore.AuthSession) error { return nil }
+	return func() {
+		newWebClientFn = originalNewClient
+		listDeveloperAppGroupsFn = originalList
+		createDeveloperAppGroupFn = originalCreate
+		assignDeveloperAppGroupFn = originalAssign
+		persistWebSessionFn = originalPersist
+	}, cleanupSession
+}

--- a/internal/cli/web/web_app_groups_test.go
+++ b/internal/cli/web/web_app_groups_test.go
@@ -67,7 +67,7 @@ func TestWebAppGroupsValidationErrors(t *testing.T) {
 func TestWebAppGroupsListOutputsJSON(t *testing.T) {
 	restore, cleanup := stubWebAppGroupsDependencies(t)
 	defer cleanup()
-	listDeveloperAppGroupsFn = func(context.Context, *webcore.Client) (*webcore.DeveloperAppGroupsListResult, error) {
+	listDeveloperAppGroupsFn = func(context.Context, *webcore.Client, webcore.DeveloperAppGroupsListOptions) (*webcore.DeveloperAppGroupsListResult, error) {
 		return &webcore.DeveloperAppGroupsListResult{Data: []webcore.DeveloperAppGroup{{ID: "GROUP1", Name: "Shared", Identifier: "group.com.example.shared"}}}, nil
 	}
 	defer restore()
@@ -105,6 +105,56 @@ func TestWebAppGroupsListOutputsJSON(t *testing.T) {
 		if !strings.Contains(stdout, expected) {
 			t.Fatalf("table output %q does not contain %q", stdout, expected)
 		}
+	}
+}
+
+func TestWebAppGroupsListPropagatesPagination(t *testing.T) {
+	restore, cleanup := stubWebAppGroupsDependencies(t)
+	defer cleanup()
+	defer restore()
+
+	var received webcore.DeveloperAppGroupsListOptions
+	listDeveloperAppGroupsFn = func(_ context.Context, _ *webcore.Client, options webcore.DeveloperAppGroupsListOptions) (*webcore.DeveloperAppGroupsListResult, error) {
+		received = options
+		return &webcore.DeveloperAppGroupsListResult{Data: []webcore.DeveloperAppGroup{}}, nil
+	}
+	command := WebAppGroupsListCommand()
+	if err := command.FlagSet.Parse([]string{"--paginate", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	_, _ = captureWebCommandOutput(t, func() {
+		if err := command.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("Exec() error: %v", err)
+		}
+	})
+	if !received.Paginate {
+		t.Fatal("Paginate = false, want true")
+	}
+}
+
+func TestWebAppGroupsWarnsWhenRefreshedSessionCannotBePersisted(t *testing.T) {
+	restore, cleanup := stubWebAppGroupsDependencies(t)
+	defer cleanup()
+	defer restore()
+
+	listDeveloperAppGroupsFn = func(context.Context, *webcore.Client, webcore.DeveloperAppGroupsListOptions) (*webcore.DeveloperAppGroupsListResult, error) {
+		return &webcore.DeveloperAppGroupsListResult{Data: []webcore.DeveloperAppGroup{{ID: "GROUP1", Name: "Shared", Identifier: "group.com.example.shared"}}}, nil
+	}
+	persistWebSessionFn = func(*webcore.AuthSession) error { return errors.New("disk full") }
+	command := WebAppGroupsListCommand()
+	if err := command.FlagSet.Parse([]string{"--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := command.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("Exec() error: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `"id":"GROUP1"`) {
+		t.Fatalf("successful output missing from stdout: %q", stdout)
+	}
+	if !strings.Contains(stderr, "failed to persist refreshed web session") || !strings.Contains(stderr, "disk full") {
+		t.Fatalf("persistence warning missing from stderr: %q", stderr)
 	}
 }
 

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -152,8 +152,9 @@ const (
 
 // Client is an internal web API client using a web session cookie jar.
 type Client struct {
-	httpClient *http.Client
-	baseURL    string
+	httpClient         *http.Client
+	baseURL            string
+	developerPortalURL string
 
 	developerSessionMu sync.Mutex
 	developerCSRF      string

--- a/internal/web/developer_app_groups.go
+++ b/internal/web/developer_app_groups.go
@@ -1,0 +1,390 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	developerPortalLegacyBaseURL     = developerPortalBaseURL + "/services-account/QH65B2"
+	developerAppGroupsListPath       = "/account/ios/identifiers/listApplicationGroups.action"
+	developerAppGroupsCreatePath     = "/account/ios/identifiers/addApplicationGroup.action"
+	developerAppGroupsPageSize       = 500
+	developerAppGroupsCapabilityType = "APP_GROUPS"
+)
+
+// DeveloperAppGroup is an App Group identifier returned by Apple Developer Portal.
+type DeveloperAppGroup struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Identifier string `json:"identifier"`
+	Prefix     string `json:"prefix,omitempty"`
+	Status     string `json:"status,omitempty"`
+}
+
+// DeveloperAppGroupsListResult contains every App Group visible to the selected team.
+type DeveloperAppGroupsListResult struct {
+	Data []DeveloperAppGroup `json:"data"`
+}
+
+// DeveloperAppGroupCreateRequest registers an App Group identifier.
+type DeveloperAppGroupCreateRequest struct {
+	Name       string
+	Identifier string
+}
+
+// DeveloperAppGroupAssignRequest associates an App Group with a Bundle ID.
+type DeveloperAppGroupAssignRequest struct {
+	BundleID string
+	GroupID  string
+}
+
+// DeveloperAppGroupAssignResult summarizes an App Group assignment.
+type DeveloperAppGroupAssignResult struct {
+	BundleID string `json:"bundleId"`
+	GroupID  string `json:"groupId"`
+	Changed  bool   `json:"changed"`
+	Status   string `json:"status"`
+}
+
+type developerPortalLegacyResponse struct {
+	ResultCode   *int   `json:"resultCode"`
+	ResultString string `json:"resultString"`
+	UserString   string `json:"userString"`
+	RequestID    string `json:"requestId"`
+}
+
+type developerAppGroupPayload struct {
+	Name             string `json:"name"`
+	Prefix           string `json:"prefix"`
+	Identifier       string `json:"identifier"`
+	Status           string `json:"status"`
+	ApplicationGroup string `json:"applicationGroup"`
+}
+
+type developerAppGroupsListResponse struct {
+	developerPortalLegacyResponse
+	PageNumber           int                        `json:"pageNumber"`
+	PageSize             int                        `json:"pageSize"`
+	TotalRecords         int                        `json:"totalRecords"`
+	ApplicationGroupList []developerAppGroupPayload `json:"applicationGroupList"`
+}
+
+type developerAppGroupCreateResponse struct {
+	developerPortalLegacyResponse
+	ApplicationGroup developerAppGroupPayload `json:"applicationGroup"`
+}
+
+// ListDeveloperAppGroups lists App Groups through the selected Developer Portal team.
+func (c *Client) ListDeveloperAppGroups(ctx context.Context) (*DeveloperAppGroupsListResult, error) {
+	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
+		return nil, err
+	}
+	teamID := c.developerPortalTeamID()
+	if teamID == "" {
+		return nil, fmt.Errorf("developer portal team is not selected; %s", developerPortalAuthHint)
+	}
+
+	result := &DeveloperAppGroupsListResult{Data: []DeveloperAppGroup{}}
+	for pageNumber := 1; ; pageNumber++ {
+		body, err := c.doDeveloperPortalLegacyFormRequest(ctx, developerAppGroupsListPath, url.Values{
+			"teamId":     {teamID},
+			"pageNumber": {strconv.Itoa(pageNumber)},
+			"pageSize":   {strconv.Itoa(developerAppGroupsPageSize)},
+			"sort":       {"name=asc"},
+		}, false)
+		if err != nil {
+			return nil, err
+		}
+
+		var page developerAppGroupsListResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("failed to parse Developer Portal App Groups response: %w", err)
+		}
+		if err := validateDeveloperPortalLegacyResponse(page.developerPortalLegacyResponse); err != nil {
+			return nil, err
+		}
+		for _, group := range page.ApplicationGroupList {
+			decoded, err := decodeDeveloperAppGroup(group)
+			if err != nil {
+				return nil, err
+			}
+			result.Data = append(result.Data, decoded)
+		}
+
+		if len(page.ApplicationGroupList) == 0 || page.TotalRecords <= len(result.Data) {
+			break
+		}
+	}
+	return result, nil
+}
+
+// CreateDeveloperAppGroup registers an App Group through Developer Portal.
+func (c *Client) CreateDeveloperAppGroup(ctx context.Context, request DeveloperAppGroupCreateRequest) (*DeveloperAppGroup, error) {
+	request.Name = strings.TrimSpace(request.Name)
+	request.Identifier = strings.TrimSpace(request.Identifier)
+	if request.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateDeveloperAppGroupIdentifier(request.Identifier); err != nil {
+		return nil, err
+	}
+	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
+		return nil, err
+	}
+	teamID := c.developerPortalTeamID()
+	if teamID == "" {
+		return nil, fmt.Errorf("developer portal team is not selected; %s", developerPortalAuthHint)
+	}
+
+	body, err := c.doDeveloperPortalLegacyFormRequest(ctx, developerAppGroupsCreatePath, url.Values{
+		"teamId":     {teamID},
+		"name":       {request.Name},
+		"identifier": {request.Identifier},
+	}, true)
+	if err != nil {
+		return nil, err
+	}
+	var response developerAppGroupCreateResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse Developer Portal App Group create response: %w", err)
+	}
+	if err := validateDeveloperPortalLegacyResponse(response.developerPortalLegacyResponse); err != nil {
+		return nil, err
+	}
+	group, err := decodeDeveloperAppGroup(response.ApplicationGroup)
+	if err != nil {
+		return nil, err
+	}
+	return &group, nil
+}
+
+// AssignDeveloperAppGroup associates an App Group with a Bundle ID while
+// preserving Apple's complete current capability graph.
+func (c *Client) AssignDeveloperAppGroup(ctx context.Context, request DeveloperAppGroupAssignRequest) (*DeveloperAppGroupAssignResult, error) {
+	request.BundleID = strings.TrimSpace(request.BundleID)
+	request.GroupID = strings.TrimSpace(request.GroupID)
+	if request.BundleID == "" {
+		return nil, fmt.Errorf("bundle id is required")
+	}
+	if request.GroupID == "" {
+		return nil, fmt.Errorf("group id is required")
+	}
+	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
+		return nil, err
+	}
+	current, err := c.loadDeveloperBundleID(ctx, request.BundleID)
+	if err != nil {
+		return nil, err
+	}
+	payload, alreadyAssigned, err := buildDeveloperAppGroupAssignmentPatchRequest(current, request.GroupID)
+	if err != nil {
+		return nil, err
+	}
+	if alreadyAssigned {
+		return &DeveloperAppGroupAssignResult{BundleID: request.BundleID, GroupID: request.GroupID, Changed: false, Status: "already-assigned"}, nil
+	}
+	payload, err = addDeveloperPortalTeamID(payload, c.developerPortalTeamID())
+	if err != nil {
+		return nil, err
+	}
+	if _, err := c.doDeveloperPortalRequest(ctx, http.MethodPatch, "/bundleIds/"+url.PathEscape(request.BundleID), payload, developerPortalHeaders(request.BundleID), true); err != nil {
+		return nil, err
+	}
+	return &DeveloperAppGroupAssignResult{BundleID: request.BundleID, GroupID: request.GroupID, Changed: true, Status: "assigned"}, nil
+}
+
+func decodeDeveloperAppGroup(payload developerAppGroupPayload) (DeveloperAppGroup, error) {
+	group := DeveloperAppGroup{
+		ID:         strings.TrimSpace(payload.ApplicationGroup),
+		Name:       strings.TrimSpace(payload.Name),
+		Identifier: strings.TrimSpace(payload.Identifier),
+		Prefix:     strings.TrimSpace(payload.Prefix),
+		Status:     strings.TrimSpace(payload.Status),
+	}
+	if group.ID == "" || group.Identifier == "" {
+		return DeveloperAppGroup{}, fmt.Errorf("incomplete App Group resource returned by Developer Portal")
+	}
+	return group, nil
+}
+
+func validateDeveloperAppGroupIdentifier(identifier string) error {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return fmt.Errorf("identifier is required")
+	}
+	if !strings.HasPrefix(identifier, "group.") {
+		return fmt.Errorf("App Group identifier must start with group.")
+	}
+	if strings.ContainsAny(identifier, " \t\r\n") {
+		return fmt.Errorf("App Group identifier must not contain whitespace")
+	}
+	return nil
+}
+
+func validateDeveloperPortalLegacyResponse(response developerPortalLegacyResponse) error {
+	if response.ResultCode == nil {
+		return fmt.Errorf("Developer Portal response is missing resultCode")
+	}
+	if *response.ResultCode == 0 {
+		return nil
+	}
+	message := strings.TrimSpace(response.UserString)
+	if message == "" {
+		message = strings.TrimSpace(response.ResultString)
+	}
+	if message == "" {
+		message = "unknown Developer Portal error"
+	}
+	if response.RequestID != "" {
+		return fmt.Errorf("Developer Portal request failed (result code %d, request ID %s): %s", *response.ResultCode, response.RequestID, message)
+	}
+	return fmt.Errorf("Developer Portal request failed (result code %d): %s", *response.ResultCode, message)
+}
+
+func (c *Client) doDeveloperPortalLegacyFormRequest(ctx context.Context, path string, values url.Values, requireCSRF bool) ([]byte, error) {
+	headers := developerPortalHeaders("")
+	headers.Set("Accept", "application/json, text/javascript, */*; q=0.01")
+	headers.Set("Content-Type", "application/x-www-form-urlencoded")
+	csrf, csrfTS := c.developerCSRFTokens()
+	if csrf != "" {
+		headers.Set("csrf", csrf)
+	}
+	if csrfTS != "" {
+		headers.Set("csrf_ts", csrfTS)
+	}
+	if requireCSRF && (csrf == "" || csrfTS == "") {
+		return nil, fmt.Errorf("missing Developer Portal CSRF headers; %s", developerPortalAuthHint)
+	}
+	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodPost, developerPortalLegacyBaseURL+path, values, headers)
+	if err != nil {
+		return nil, err
+	}
+	c.captureDeveloperCSRFTokens(response.Header)
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+		return nil, developerPortalSessionError(response.StatusCode)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, &APIError{Status: response.StatusCode, AppleRequestID: extractAppleRequestID(response.Header), rawBody: body}
+	}
+	return body, nil
+}
+
+func buildDeveloperAppGroupAssignmentPatchRequest(current developerBundleIDResponse, groupID string) (developerBundleIDPatchRequest, bool, error) {
+	capabilities, err := developerBundleIDCapabilities(current)
+	if err != nil {
+		return developerBundleIDPatchRequest{}, false, err
+	}
+	groupID = strings.TrimSpace(groupID)
+	if groupID == "" {
+		return developerBundleIDPatchRequest{}, false, fmt.Errorf("group id is required")
+	}
+
+	updated := make([]developerResource, 0, len(capabilities)+1)
+	foundAppGroups := false
+	for _, capability := range capabilities {
+		capabilityID, err := developerBundleIDCapabilityID(capability)
+		if err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		if capabilityID != developerAppGroupsCapabilityType {
+			updated = append(updated, capability)
+			continue
+		}
+		if foundAppGroups {
+			return developerBundleIDPatchRequest{}, false, fmt.Errorf("cannot safely update duplicate APP_GROUPS capability resources")
+		}
+		foundAppGroups = true
+		enabled, err := developerBundleIDCapabilityEnabled(capability)
+		if err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		groups, err := developerAppGroupRelationships(capability)
+		if err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		for _, group := range groups {
+			if group.ID == groupID && enabled {
+				return developerBundleIDPatchRequest{}, true, nil
+			}
+		}
+		capability.Attributes, err = setDeveloperCapabilityEnabled(capability.Attributes)
+		if err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		if !containsDeveloperResource(groups, "appGroups", groupID) {
+			groups = append(groups, developerResource{Type: "appGroups", ID: groupID})
+		}
+		if err := setDeveloperAppGroupRelationships(&capability, groups); err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		updated = append(updated, capability)
+	}
+	if !foundAppGroups {
+		capability := newDeveloperBundleIDCapability(developerAppGroupsCapabilityType)
+		if err := setDeveloperAppGroupRelationships(&capability, []developerResource{{Type: "appGroups", ID: groupID}}); err != nil {
+			return developerBundleIDPatchRequest{}, false, err
+		}
+		updated = append(updated, capability)
+	}
+
+	relationship, err := json.Marshal(developerResourceRelationship{Data: updated})
+	if err != nil {
+		return developerBundleIDPatchRequest{}, false, fmt.Errorf("failed to build Bundle ID capability relationships: %w", err)
+	}
+	relationships := cloneRawMessageMap(current.Data.Relationships)
+	if relationships == nil {
+		relationships = make(map[string]json.RawMessage)
+	}
+	relationships["bundleIdCapabilities"] = relationship
+
+	var payload developerBundleIDPatchRequest
+	payload.Data.ID = current.Data.ID
+	payload.Data.Type = current.Data.Type
+	payload.Data.Attributes = append(json.RawMessage(nil), current.Data.Attributes...)
+	payload.Data.Relationships = relationships
+	return payload, false, nil
+}
+
+func developerAppGroupRelationships(capability developerResource) ([]developerResource, error) {
+	raw, exists := capability.Relationships["appGroups"]
+	if !exists {
+		return []developerResource{}, nil
+	}
+	var relationship developerResourceRelationship
+	if err := json.Unmarshal(raw, &relationship); err != nil {
+		return nil, fmt.Errorf("failed to parse current App Group relationships: %w", err)
+	}
+	for _, group := range relationship.Data {
+		if group.Type != "appGroups" || strings.TrimSpace(group.ID) == "" {
+			return nil, fmt.Errorf("invalid App Group relationship returned by Developer Portal")
+		}
+	}
+	return relationship.Data, nil
+}
+
+func setDeveloperAppGroupRelationships(capability *developerResource, groups []developerResource) error {
+	encoded, err := json.Marshal(developerResourceRelationship{Data: groups})
+	if err != nil {
+		return fmt.Errorf("failed to encode App Group relationships: %w", err)
+	}
+	if capability.Relationships == nil {
+		capability.Relationships = make(map[string]json.RawMessage)
+	}
+	capability.Relationships["appGroups"] = encoded
+	return nil
+}
+
+func containsDeveloperResource(resources []developerResource, resourceType, id string) bool {
+	for _, resource := range resources {
+		if resource.Type == resourceType && resource.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/developer_app_groups.go
+++ b/internal/web/developer_app_groups.go
@@ -137,6 +137,9 @@ func (c *Client) CreateDeveloperAppGroup(ctx context.Context, request DeveloperA
 	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
 		return nil, err
 	}
+	if err := c.primeDeveloperAppGroupCSRF(ctx); err != nil {
+		return nil, err
+	}
 	teamID := c.developerPortalTeamID()
 	if teamID == "" {
 		return nil, fmt.Errorf("developer portal team is not selected; %s", developerPortalAuthHint)
@@ -178,6 +181,9 @@ func (c *Client) AssignDeveloperAppGroup(ctx context.Context, request DeveloperA
 	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
 		return nil, err
 	}
+	if err := c.primeDeveloperAppGroupCSRF(ctx); err != nil {
+		return nil, err
+	}
 	current, err := c.loadDeveloperBundleID(ctx, request.BundleID)
 	if err != nil {
 		return nil, err
@@ -197,6 +203,38 @@ func (c *Client) AssignDeveloperAppGroup(ctx context.Context, request DeveloperA
 		return nil, err
 	}
 	return &DeveloperAppGroupAssignResult{BundleID: request.BundleID, GroupID: request.GroupID, Changed: true, Status: "assigned"}, nil
+}
+
+func (c *Client) primeDeveloperAppGroupCSRF(ctx context.Context) error {
+	csrf, csrfTS := c.developerCSRFTokens()
+	if csrf != "" && csrfTS != "" {
+		return nil
+	}
+	teamID := c.developerPortalTeamID()
+	if teamID == "" {
+		return fmt.Errorf("developer portal team is not selected; %s", developerPortalAuthHint)
+	}
+	body, err := c.doDeveloperPortalLegacyFormRequest(ctx, developerAppGroupsListPath, url.Values{
+		"teamId":     {teamID},
+		"pageNumber": {"1"},
+		"pageSize":   {strconv.Itoa(developerAppGroupsPageSize)},
+		"sort":       {"name=asc"},
+	}, false)
+	if err != nil {
+		return err
+	}
+	var response developerAppGroupsListResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("failed to parse Developer Portal App Groups response while priming CSRF: %w", err)
+	}
+	if err := validateDeveloperPortalLegacyResponse(response.developerPortalLegacyResponse); err != nil {
+		return err
+	}
+	csrf, csrfTS = c.developerCSRFTokens()
+	if csrf == "" || csrfTS == "" {
+		return fmt.Errorf("missing Developer Portal CSRF headers after App Groups lookup; %s", developerPortalAuthHint)
+	}
+	return nil
 }
 
 func decodeDeveloperAppGroup(payload developerAppGroupPayload) (DeveloperAppGroup, error) {

--- a/internal/web/developer_app_groups.go
+++ b/internal/web/developer_app_groups.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	developerPortalLegacyBaseURL     = developerPortalBaseURL + "/services-account/QH65B2"
+	developerPortalLegacyPath        = "/services-account/QH65B2"
 	developerAppGroupsListPath       = "/account/ios/identifiers/listApplicationGroups.action"
 	developerAppGroupsCreatePath     = "/account/ios/identifiers/addApplicationGroup.action"
 	developerAppGroupsPageSize       = 500
@@ -27,9 +27,14 @@ type DeveloperAppGroup struct {
 	Status     string `json:"status,omitempty"`
 }
 
-// DeveloperAppGroupsListResult contains every App Group visible to the selected team.
+// DeveloperAppGroupsListResult contains App Groups visible to the selected team.
 type DeveloperAppGroupsListResult struct {
 	Data []DeveloperAppGroup `json:"data"`
+}
+
+// DeveloperAppGroupsListOptions controls App Group list pagination.
+type DeveloperAppGroupsListOptions struct {
+	Paginate bool
 }
 
 // DeveloperAppGroupCreateRequest registers an App Group identifier.
@@ -81,7 +86,7 @@ type developerAppGroupCreateResponse struct {
 }
 
 // ListDeveloperAppGroups lists App Groups through the selected Developer Portal team.
-func (c *Client) ListDeveloperAppGroups(ctx context.Context) (*DeveloperAppGroupsListResult, error) {
+func (c *Client) ListDeveloperAppGroups(ctx context.Context, options DeveloperAppGroupsListOptions) (*DeveloperAppGroupsListResult, error) {
 	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
 		return nil, err
 	}
@@ -117,7 +122,7 @@ func (c *Client) ListDeveloperAppGroups(ctx context.Context) (*DeveloperAppGroup
 			result.Data = append(result.Data, decoded)
 		}
 
-		if len(page.ApplicationGroupList) == 0 || page.TotalRecords <= len(result.Data) {
+		if !options.Paginate || len(page.ApplicationGroupList) == 0 || page.TotalRecords <= len(result.Data) {
 			break
 		}
 	}
@@ -257,17 +262,17 @@ func validateDeveloperAppGroupIdentifier(identifier string) error {
 		return fmt.Errorf("identifier is required")
 	}
 	if !strings.HasPrefix(identifier, "group.") {
-		return fmt.Errorf("App Group identifier must start with group.")
+		return fmt.Errorf("app group identifier must use the group. prefix")
 	}
 	if strings.ContainsAny(identifier, " \t\r\n") {
-		return fmt.Errorf("App Group identifier must not contain whitespace")
+		return fmt.Errorf("app group identifier must not contain whitespace")
 	}
 	return nil
 }
 
 func validateDeveloperPortalLegacyResponse(response developerPortalLegacyResponse) error {
 	if response.ResultCode == nil {
-		return fmt.Errorf("Developer Portal response is missing resultCode")
+		return fmt.Errorf("developer portal response is missing resultCode")
 	}
 	if *response.ResultCode == 0 {
 		return nil
@@ -280,9 +285,9 @@ func validateDeveloperPortalLegacyResponse(response developerPortalLegacyRespons
 		message = "unknown Developer Portal error"
 	}
 	if response.RequestID != "" {
-		return fmt.Errorf("Developer Portal request failed (result code %d, request ID %s): %s", *response.ResultCode, response.RequestID, message)
+		return fmt.Errorf("developer portal request failed (result code %d, request ID %s): %s", *response.ResultCode, response.RequestID, message)
 	}
-	return fmt.Errorf("Developer Portal request failed (result code %d): %s", *response.ResultCode, message)
+	return fmt.Errorf("developer portal request failed (result code %d): %s", *response.ResultCode, message)
 }
 
 func (c *Client) doDeveloperPortalLegacyFormRequest(ctx context.Context, path string, values url.Values, requireCSRF bool) ([]byte, error) {
@@ -299,7 +304,7 @@ func (c *Client) doDeveloperPortalLegacyFormRequest(ctx context.Context, path st
 	if requireCSRF && (csrf == "" || csrfTS == "") {
 		return nil, fmt.Errorf("missing Developer Portal CSRF headers; %s", developerPortalAuthHint)
 	}
-	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodPost, developerPortalLegacyBaseURL+path, values, headers)
+	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodPost, c.developerPortalOrigin()+developerPortalLegacyPath+path, values, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/web/developer_app_groups.go
+++ b/internal/web/developer_app_groups.go
@@ -186,9 +186,6 @@ func (c *Client) AssignDeveloperAppGroup(ctx context.Context, request DeveloperA
 	if err := c.ensureDeveloperPortalSession(ctx); err != nil {
 		return nil, err
 	}
-	if err := c.primeDeveloperAppGroupCSRF(ctx); err != nil {
-		return nil, err
-	}
 	current, err := c.loadDeveloperBundleID(ctx, request.BundleID)
 	if err != nil {
 		return nil, err
@@ -199,6 +196,9 @@ func (c *Client) AssignDeveloperAppGroup(ctx context.Context, request DeveloperA
 	}
 	if alreadyAssigned {
 		return &DeveloperAppGroupAssignResult{BundleID: request.BundleID, GroupID: request.GroupID, Changed: false, Status: "already-assigned"}, nil
+	}
+	if err := c.primeDeveloperAppGroupCSRF(ctx); err != nil {
+		return nil, err
 	}
 	payload, err = addDeveloperPortalTeamID(payload, c.developerPortalTeamID())
 	if err != nil {
@@ -211,14 +211,11 @@ func (c *Client) AssignDeveloperAppGroup(ctx context.Context, request DeveloperA
 }
 
 func (c *Client) primeDeveloperAppGroupCSRF(ctx context.Context) error {
-	csrf, csrfTS := c.developerCSRFTokens()
-	if csrf != "" && csrfTS != "" {
-		return nil
-	}
 	teamID := c.developerPortalTeamID()
 	if teamID == "" {
 		return fmt.Errorf("developer portal team is not selected; %s", developerPortalAuthHint)
 	}
+	c.clearDeveloperCSRFTokens()
 	body, err := c.doDeveloperPortalLegacyFormRequest(ctx, developerAppGroupsListPath, url.Values{
 		"teamId":     {teamID},
 		"pageNumber": {"1"},
@@ -235,7 +232,7 @@ func (c *Client) primeDeveloperAppGroupCSRF(ctx context.Context) error {
 	if err := validateDeveloperPortalLegacyResponse(response.developerPortalLegacyResponse); err != nil {
 		return err
 	}
-	csrf, csrfTS = c.developerCSRFTokens()
+	csrf, csrfTS := c.developerCSRFTokens()
 	if csrf == "" || csrfTS == "" {
 		return fmt.Errorf("missing Developer Portal CSRF headers after App Groups lookup; %s", developerPortalAuthHint)
 	}

--- a/internal/web/developer_app_groups_test.go
+++ b/internal/web/developer_app_groups_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/cookiejar"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
@@ -44,7 +44,7 @@ func TestListDeveloperAppGroupsUsesPortalFormEndpoint(t *testing.T) {
 		}
 	})
 
-	result, err := client.ListDeveloperAppGroups(context.Background())
+	result, err := client.ListDeveloperAppGroups(context.Background(), DeveloperAppGroupsListOptions{})
 	if err != nil {
 		t.Fatalf("ListDeveloperAppGroups() error: %v", err)
 	}
@@ -124,12 +124,37 @@ func TestListDeveloperAppGroupsPaginates(t *testing.T) {
 		}
 	})
 
-	result, err := client.ListDeveloperAppGroups(context.Background())
+	result, err := client.ListDeveloperAppGroups(context.Background(), DeveloperAppGroupsListOptions{Paginate: true})
 	if err != nil {
 		t.Fatalf("ListDeveloperAppGroups() error: %v", err)
 	}
 	if len(result.Data) != 2 || result.Data[1].ID != "GROUP2" {
 		t.Fatalf("unexpected paginated result: %+v", result)
+	}
+}
+
+func TestListDeveloperAppGroupsStopsAfterFirstPageByDefault(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		switch requestNumber {
+		case 1:
+			return assertDeveloperPortalBootstrap(t, request), nil
+		case 2:
+			return developerPortalTestResponse(http.StatusOK, `{
+				"resultCode":0,"pageNumber":1,"pageSize":1,"totalRecords":2,
+				"applicationGroupList":[{"name":"Group 1","identifier":"group.com.example.1","applicationGroup":"GROUP1"}]
+			}`, nil), nil
+		default:
+			t.Fatalf("default list fetched unexpected request %d", requestNumber)
+			return nil, nil
+		}
+	})
+
+	result, err := client.ListDeveloperAppGroups(context.Background(), DeveloperAppGroupsListOptions{})
+	if err != nil {
+		t.Fatalf("ListDeveloperAppGroups() error: %v", err)
+	}
+	if len(result.Data) != 1 || result.Data[0].ID != "GROUP1" {
+		t.Fatalf("unexpected first-page result: %+v", result)
 	}
 }
 
@@ -155,7 +180,7 @@ func TestDeveloperAppGroupsRejectsMalformedSuccessEnvelope(t *testing.T) {
 		return developerPortalTestResponse(http.StatusOK, `{"applicationGroupList":[]}`, nil), nil
 	})
 
-	_, err := client.ListDeveloperAppGroups(context.Background())
+	_, err := client.ListDeveloperAppGroups(context.Background(), DeveloperAppGroupsListOptions{})
 	if err == nil || !strings.Contains(err.Error(), "missing resultCode") {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,7 +194,7 @@ func TestDeveloperAppGroupsSurfacesHTTPError(t *testing.T) {
 		return developerPortalTestResponse(http.StatusInternalServerError, `{"error":"portal unavailable"}`, http.Header{"X-Apple-Request-UUID": {"apple-request-1"}}), nil
 	})
 
-	_, err := client.ListDeveloperAppGroups(context.Background())
+	_, err := client.ListDeveloperAppGroups(context.Background(), DeveloperAppGroupsListOptions{})
 	if err == nil || !strings.Contains(err.Error(), "500") {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -275,15 +300,35 @@ func TestAssignDeveloperAppGroupIsIdempotent(t *testing.T) {
 
 func newDeveloperAppGroupsTestClient(t *testing.T, handler func(int, *http.Request) (*http.Response, error)) *Client {
 	t.Helper()
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatalf("cookiejar.New() error: %v", err)
-	}
 	requestNumber := 0
-	return &Client{httpClient: &http.Client{Jar: jar, Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		requestNumber++
-		return handler(requestNumber, request)
-	})}}
+		response, err := handler(requestNumber, request)
+		if err != nil {
+			t.Errorf("test Developer Portal handler: %v", err)
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if response == nil {
+			t.Error("test Developer Portal handler returned a nil response")
+			http.Error(writer, "missing test response", http.StatusInternalServerError)
+			return
+		}
+		for name, values := range response.Header {
+			for _, value := range values {
+				writer.Header().Add(name, value)
+			}
+		}
+		writer.WriteHeader(response.StatusCode)
+		if response.Body != nil {
+			defer func() { _ = response.Body.Close() }()
+			if _, err := io.Copy(writer, response.Body); err != nil {
+				t.Errorf("write test Developer Portal response: %v", err)
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+	return &Client{httpClient: server.Client(), developerPortalURL: server.URL}
 }
 
 func assertDeveloperPortalBootstrap(t *testing.T, request *http.Request) *http.Response {

--- a/internal/web/developer_app_groups_test.go
+++ b/internal/web/developer_app_groups_test.go
@@ -1,0 +1,297 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestListDeveloperAppGroupsUsesPortalFormEndpoint(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		switch requestNumber {
+		case 1:
+			return assertDeveloperPortalBootstrap(t, request), nil
+		case 2:
+			if request.Method != http.MethodPost || request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
+				t.Fatalf("unexpected list request %s %s", request.Method, request.URL.String())
+			}
+			assertDeveloperPortalForm(t, request, url.Values{
+				"teamId":     {"TEAM123456"},
+				"pageNumber": {"1"},
+				"pageSize":   {"500"},
+				"sort":       {"name=asc"},
+			})
+			return developerPortalTestResponse(http.StatusOK, `{
+				"resultCode":0,
+				"pageNumber":1,
+				"pageSize":500,
+				"totalRecords":2,
+				"applicationGroupList":[
+					{"name":"Shared","prefix":"TEAM123456","identifier":"group.com.example.shared","status":"current","applicationGroup":"GROUP12345"},
+					{"name":"Preview","prefix":"TEAM123456","identifier":"group.com.example.preview","status":"current","applicationGroup":"GROUP67890"}
+				]
+			}`, nil), nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requestNumber, request.Method, request.URL.String())
+			return nil, nil
+		}
+	})
+
+	result, err := client.ListDeveloperAppGroups(context.Background())
+	if err != nil {
+		t.Fatalf("ListDeveloperAppGroups() error: %v", err)
+	}
+	if len(result.Data) != 2 || result.Data[0].ID != "GROUP12345" || result.Data[0].Identifier != "group.com.example.shared" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestCreateDeveloperAppGroupUsesPortalFormEndpoint(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		switch requestNumber {
+		case 1:
+			return assertDeveloperPortalBootstrap(t, request), nil
+		case 2:
+			if request.Method != http.MethodPost || request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/addApplicationGroup.action" {
+				t.Fatalf("unexpected create request %s %s", request.Method, request.URL.String())
+			}
+			if request.Header.Get("csrf") != "bootstrap-csrf" || request.Header.Get("csrf_ts") != "bootstrap-ts" {
+				t.Fatalf("create request missing CSRF headers")
+			}
+			assertDeveloperPortalForm(t, request, url.Values{
+				"teamId":     {"TEAM123456"},
+				"name":       {"Example Preview"},
+				"identifier": {"group.com.example.preview"},
+			})
+			return developerPortalTestResponse(http.StatusOK, `{
+				"resultCode":0,
+				"applicationGroup":{"name":"Example Preview","prefix":"TEAM123456","identifier":"group.com.example.preview","status":"current","applicationGroup":"GROUP12345"}
+			}`, nil), nil
+		default:
+			t.Fatalf("unexpected request %d", requestNumber)
+			return nil, nil
+		}
+	})
+
+	result, err := client.CreateDeveloperAppGroup(context.Background(), DeveloperAppGroupCreateRequest{
+		Name:       "Example Preview",
+		Identifier: "group.com.example.preview",
+	})
+	if err != nil {
+		t.Fatalf("CreateDeveloperAppGroup() error: %v", err)
+	}
+	if result.ID != "GROUP12345" || result.Name != "Example Preview" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestListDeveloperAppGroupsPaginates(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		switch requestNumber {
+		case 1:
+			return assertDeveloperPortalBootstrap(t, request), nil
+		case 2, 3:
+			if request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
+				t.Fatalf("unexpected path: %s", request.URL.Path)
+			}
+			if err := request.ParseForm(); err != nil {
+				t.Fatalf("ParseForm() error: %v", err)
+			}
+			wantPage := strconv.Itoa(requestNumber - 1)
+			if request.PostForm.Get("pageNumber") != wantPage {
+				t.Fatalf("pageNumber = %q, want %q", request.PostForm.Get("pageNumber"), wantPage)
+			}
+			id := "GROUP" + wantPage
+			return developerPortalTestResponse(http.StatusOK, fmt.Sprintf(`{
+				"resultCode":0,"pageNumber":%s,"pageSize":1,"totalRecords":2,
+				"applicationGroupList":[{"name":"Group %s","identifier":"group.com.example.%s","applicationGroup":"%s"}]
+			}`, wantPage, wantPage, wantPage, id), nil), nil
+		default:
+			t.Fatalf("unexpected request %d", requestNumber)
+			return nil, nil
+		}
+	})
+
+	result, err := client.ListDeveloperAppGroups(context.Background())
+	if err != nil {
+		t.Fatalf("ListDeveloperAppGroups() error: %v", err)
+	}
+	if len(result.Data) != 2 || result.Data[1].ID != "GROUP2" {
+		t.Fatalf("unexpected paginated result: %+v", result)
+	}
+}
+
+func TestDeveloperAppGroupsRejectsPortalErrorEnvelope(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		if requestNumber == 1 {
+			return assertDeveloperPortalBootstrap(t, request), nil
+		}
+		return developerPortalTestResponse(http.StatusOK, `{"resultCode":35,"userString":"Identifier already exists","requestId":"request-1"}`, nil), nil
+	})
+
+	_, err := client.CreateDeveloperAppGroup(context.Background(), DeveloperAppGroupCreateRequest{Name: "Example", Identifier: "group.com.example.shared"})
+	if err == nil || !strings.Contains(err.Error(), "result code 35") || !strings.Contains(err.Error(), "Identifier already exists") || !strings.Contains(err.Error(), "request-1") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeveloperAppGroupsRejectsMalformedSuccessEnvelope(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		if requestNumber == 1 {
+			return assertDeveloperPortalBootstrap(t, request), nil
+		}
+		return developerPortalTestResponse(http.StatusOK, `{"applicationGroupList":[]}`, nil), nil
+	})
+
+	_, err := client.ListDeveloperAppGroups(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "missing resultCode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeveloperAppGroupsSurfacesHTTPError(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		if requestNumber == 1 {
+			return assertDeveloperPortalBootstrap(t, request), nil
+		}
+		return developerPortalTestResponse(http.StatusInternalServerError, `{"error":"portal unavailable"}`, http.Header{"X-Apple-Request-UUID": {"apple-request-1"}}), nil
+	})
+
+	_, err := client.ListDeveloperAppGroups(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
+	var patchBody []byte
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		switch requestNumber {
+		case 1:
+			return assertDeveloperPortalBootstrap(t, request), nil
+		case 2:
+			if request.Method != http.MethodPost || request.URL.Path != "/services-account/v1/bundleIds/bundle-1" || request.Header.Get("X-HTTP-Method-Override") != http.MethodGet {
+				t.Fatalf("unexpected bundle read %s %s", request.Method, request.URL.String())
+			}
+			return developerPortalTestResponse(http.StatusOK, `{
+				"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app","platform":"IOS"},"relationships":{"bundleIdCapabilities":{"data":[{"type":"bundleIdCapabilities","id":"push-1"}]}}},
+				"included":[{"type":"bundleIdCapabilities","id":"push-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PUSH_NOTIFICATIONS"}}}}]
+			}`, nil), nil
+		case 3:
+			if request.Method != http.MethodPatch || request.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
+				t.Fatalf("unexpected bundle patch %s %s", request.Method, request.URL.String())
+			}
+			var err error
+			patchBody, err = io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			return developerPortalTestResponse(http.StatusOK, `{"data":{"type":"bundleIds","id":"bundle-1"}}`, nil), nil
+		default:
+			t.Fatalf("unexpected request %d", requestNumber)
+			return nil, nil
+		}
+	})
+
+	result, err := client.AssignDeveloperAppGroup(context.Background(), DeveloperAppGroupAssignRequest{BundleID: "bundle-1", GroupID: "GROUP12345"})
+	if err != nil {
+		t.Fatalf("AssignDeveloperAppGroup() error: %v", err)
+	}
+	if !result.Changed || result.Status != "assigned" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	var payload developerBundleIDPatchRequest
+	if err := json.Unmarshal(patchBody, &payload); err != nil {
+		t.Fatalf("decode patch: %v; body=%s", err, patchBody)
+	}
+	if payload.Data.Attributes == nil || !strings.Contains(string(payload.Data.Attributes), `"teamId":"TEAM123456"`) {
+		t.Fatalf("team and existing attributes not preserved: %s", payload.Data.Attributes)
+	}
+	var capabilities developerResourceRelationship
+	if err := json.Unmarshal(payload.Data.Relationships["bundleIdCapabilities"], &capabilities); err != nil {
+		t.Fatalf("decode capabilities: %v", err)
+	}
+	if len(capabilities.Data) != 2 {
+		t.Fatalf("capability count = %d, want existing plus APP_GROUPS", len(capabilities.Data))
+	}
+	appGroupsCapability := capabilities.Data[1]
+	if capability, err := developerBundleIDCapabilityID(appGroupsCapability); err != nil || capability != "APP_GROUPS" {
+		t.Fatalf("unexpected app groups capability: %+v, err=%v", appGroupsCapability, err)
+	}
+	var groups developerResourceRelationship
+	if err := json.Unmarshal(appGroupsCapability.Relationships["appGroups"], &groups); err != nil {
+		t.Fatalf("decode appGroups: %v", err)
+	}
+	if len(groups.Data) != 1 || groups.Data[0].ID != "GROUP12345" || groups.Data[0].Type != "appGroups" {
+		t.Fatalf("unexpected appGroups relationship: %+v", groups.Data)
+	}
+}
+
+func TestAssignDeveloperAppGroupIsIdempotent(t *testing.T) {
+	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
+		switch requestNumber {
+		case 1:
+			return assertDeveloperPortalBootstrap(t, request), nil
+		case 2:
+			return developerPortalTestResponse(http.StatusOK, `{
+				"data":{"id":"bundle-1","type":"bundleIds","attributes":{"identifier":"com.example.app"},"relationships":{"bundleIdCapabilities":{"data":[{"type":"bundleIdCapabilities","id":"groups-1"}]}}},
+				"included":[{"type":"bundleIdCapabilities","id":"groups-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"APP_GROUPS"}},"appGroups":{"data":[{"type":"appGroups","id":"GROUP12345"}]}}}]
+			}`, nil), nil
+		default:
+			t.Fatalf("idempotent assignment sent unexpected request %d", requestNumber)
+			return nil, nil
+		}
+	})
+
+	result, err := client.AssignDeveloperAppGroup(context.Background(), DeveloperAppGroupAssignRequest{BundleID: "bundle-1", GroupID: "GROUP12345"})
+	if err != nil {
+		t.Fatalf("AssignDeveloperAppGroup() error: %v", err)
+	}
+	if result.Changed || result.Status != "already-assigned" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func newDeveloperAppGroupsTestClient(t *testing.T, handler func(int, *http.Request) (*http.Response, error)) *Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New() error: %v", err)
+	}
+	requestNumber := 0
+	return &Client{httpClient: &http.Client{Jar: jar, Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requestNumber++
+		return handler(requestNumber, request)
+	})}}
+}
+
+func assertDeveloperPortalBootstrap(t *testing.T, request *http.Request) *http.Response {
+	t.Helper()
+	if request.Method != http.MethodPost || request.URL.Path != "/services-account/QH65B2/account/listTeams.action" {
+		t.Fatalf("unexpected bootstrap request %s %s", request.Method, request.URL.String())
+	}
+	return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": {"bootstrap-csrf"}, "csrf_ts": {"bootstrap-ts"}})
+}
+
+func assertDeveloperPortalForm(t *testing.T, request *http.Request, expected url.Values) {
+	t.Helper()
+	if got := request.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/x-www-form-urlencoded") {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if err := request.ParseForm(); err != nil {
+		t.Fatalf("ParseForm() error: %v", err)
+	}
+	for key, values := range expected {
+		if got := request.PostForm[key]; strings.Join(got, "\x00") != strings.Join(values, "\x00") {
+			t.Fatalf("form %s = %q, want %q", key, got, values)
+		}
+	}
+}

--- a/internal/web/developer_app_groups_test.go
+++ b/internal/web/developer_app_groups_test.go
@@ -57,12 +57,17 @@ func TestCreateDeveloperAppGroupUsesPortalFormEndpoint(t *testing.T) {
 	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
 		switch requestNumber {
 		case 1:
-			return assertDeveloperPortalBootstrap(t, request), nil
+			return assertDeveloperPortalBootstrapWithoutCSRF(t, request), nil
 		case 2:
+			if request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
+				t.Fatalf("unexpected CSRF priming request %s %s", request.Method, request.URL.String())
+			}
+			return developerPortalTestResponse(http.StatusOK, `{"resultCode":0,"applicationGroupList":[]}`, http.Header{"csrf": {"primed-csrf"}, "csrf_ts": {"primed-ts"}}), nil
+		case 3:
 			if request.Method != http.MethodPost || request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/addApplicationGroup.action" {
 				t.Fatalf("unexpected create request %s %s", request.Method, request.URL.String())
 			}
-			if request.Header.Get("csrf") != "bootstrap-csrf" || request.Header.Get("csrf_ts") != "bootstrap-ts" {
+			if request.Header.Get("csrf") != "primed-csrf" || request.Header.Get("csrf_ts") != "primed-ts" {
 				t.Fatalf("create request missing CSRF headers")
 			}
 			assertDeveloperPortalForm(t, request, url.Values{
@@ -175,8 +180,13 @@ func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
 	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
 		switch requestNumber {
 		case 1:
-			return assertDeveloperPortalBootstrap(t, request), nil
+			return assertDeveloperPortalBootstrapWithoutCSRF(t, request), nil
 		case 2:
+			if request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
+				t.Fatalf("unexpected CSRF priming request %s %s", request.Method, request.URL.String())
+			}
+			return developerPortalTestResponse(http.StatusOK, `{"resultCode":0,"applicationGroupList":[]}`, http.Header{"csrf": {"primed-csrf"}, "csrf_ts": {"primed-ts"}}), nil
+		case 3:
 			if request.Method != http.MethodPost || request.URL.Path != "/services-account/v1/bundleIds/bundle-1" || request.Header.Get("X-HTTP-Method-Override") != http.MethodGet {
 				t.Fatalf("unexpected bundle read %s %s", request.Method, request.URL.String())
 			}
@@ -184,9 +194,12 @@ func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
 				"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app","platform":"IOS"},"relationships":{"bundleIdCapabilities":{"data":[{"type":"bundleIdCapabilities","id":"push-1"}]}}},
 				"included":[{"type":"bundleIdCapabilities","id":"push-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PUSH_NOTIFICATIONS"}}}}]
 			}`, nil), nil
-		case 3:
+		case 4:
 			if request.Method != http.MethodPatch || request.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
 				t.Fatalf("unexpected bundle patch %s %s", request.Method, request.URL.String())
+			}
+			if request.Header.Get("csrf") != "primed-csrf" || request.Header.Get("csrf_ts") != "primed-ts" {
+				t.Fatalf("bundle patch missing primed CSRF headers")
 			}
 			var err error
 			patchBody, err = io.ReadAll(request.Body)
@@ -279,6 +292,14 @@ func assertDeveloperPortalBootstrap(t *testing.T, request *http.Request) *http.R
 		t.Fatalf("unexpected bootstrap request %s %s", request.Method, request.URL.String())
 	}
 	return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": {"bootstrap-csrf"}, "csrf_ts": {"bootstrap-ts"}})
+}
+
+func assertDeveloperPortalBootstrapWithoutCSRF(t *testing.T, request *http.Request) *http.Response {
+	t.Helper()
+	if request.Method != http.MethodPost || request.URL.Path != "/services-account/QH65B2/account/listTeams.action" {
+		t.Fatalf("unexpected bootstrap request %s %s", request.Method, request.URL.String())
+	}
+	return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil)
 }
 
 func assertDeveloperPortalForm(t *testing.T, request *http.Request, expected url.Values) {

--- a/internal/web/developer_app_groups_test.go
+++ b/internal/web/developer_app_groups_test.go
@@ -57,10 +57,13 @@ func TestCreateDeveloperAppGroupUsesPortalFormEndpoint(t *testing.T) {
 	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
 		switch requestNumber {
 		case 1:
-			return assertDeveloperPortalBootstrapWithoutCSRF(t, request), nil
+			return assertDeveloperPortalBootstrap(t, request), nil
 		case 2:
 			if request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
 				t.Fatalf("unexpected CSRF priming request %s %s", request.Method, request.URL.String())
+			}
+			if request.Header.Get("csrf") != "" || request.Header.Get("csrf_ts") != "" {
+				t.Fatalf("CSRF priming request reused tokens from another endpoint scope")
 			}
 			return developerPortalTestResponse(http.StatusOK, `{"resultCode":0,"applicationGroupList":[]}`, http.Header{"csrf": {"primed-csrf"}, "csrf_ts": {"primed-ts"}}), nil
 		case 3:
@@ -205,13 +208,8 @@ func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
 	client := newDeveloperAppGroupsTestClient(t, func(requestNumber int, request *http.Request) (*http.Response, error) {
 		switch requestNumber {
 		case 1:
-			return assertDeveloperPortalBootstrapWithoutCSRF(t, request), nil
+			return assertDeveloperPortalBootstrap(t, request), nil
 		case 2:
-			if request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
-				t.Fatalf("unexpected CSRF priming request %s %s", request.Method, request.URL.String())
-			}
-			return developerPortalTestResponse(http.StatusOK, `{"resultCode":0,"applicationGroupList":[]}`, http.Header{"csrf": {"primed-csrf"}, "csrf_ts": {"primed-ts"}}), nil
-		case 3:
 			if request.Method != http.MethodPost || request.URL.Path != "/services-account/v1/bundleIds/bundle-1" || request.Header.Get("X-HTTP-Method-Override") != http.MethodGet {
 				t.Fatalf("unexpected bundle read %s %s", request.Method, request.URL.String())
 			}
@@ -219,6 +217,14 @@ func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
 				"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app","platform":"IOS"},"relationships":{"bundleIdCapabilities":{"data":[{"type":"bundleIdCapabilities","id":"push-1"}]}}},
 				"included":[{"type":"bundleIdCapabilities","id":"push-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PUSH_NOTIFICATIONS"}}}}]
 			}`, nil), nil
+		case 3:
+			if request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
+				t.Fatalf("unexpected CSRF priming request %s %s", request.Method, request.URL.String())
+			}
+			if request.Header.Get("csrf") != "" || request.Header.Get("csrf_ts") != "" {
+				t.Fatalf("CSRF priming request reused tokens from another endpoint scope")
+			}
+			return developerPortalTestResponse(http.StatusOK, `{"resultCode":0,"applicationGroupList":[]}`, http.Header{"csrf": {"primed-csrf"}, "csrf_ts": {"primed-ts"}}), nil
 		case 4:
 			if request.Method != http.MethodPatch || request.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
 				t.Fatalf("unexpected bundle patch %s %s", request.Method, request.URL.String())
@@ -337,14 +343,6 @@ func assertDeveloperPortalBootstrap(t *testing.T, request *http.Request) *http.R
 		t.Fatalf("unexpected bootstrap request %s %s", request.Method, request.URL.String())
 	}
 	return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": {"bootstrap-csrf"}, "csrf_ts": {"bootstrap-ts"}})
-}
-
-func assertDeveloperPortalBootstrapWithoutCSRF(t *testing.T, request *http.Request) *http.Response {
-	t.Helper()
-	if request.Method != http.MethodPost || request.URL.Path != "/services-account/QH65B2/account/listTeams.action" {
-		t.Fatalf("unexpected bootstrap request %s %s", request.Method, request.URL.String())
-	}
-	return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), nil)
 }
 
 func assertDeveloperPortalForm(t *testing.T, request *http.Request, expected url.Values) {

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	developerPortalBaseURL   = "https://developer.apple.com"
-	developerPortalTeamsURL  = developerPortalBaseURL + "/services-account/QH65B2/account/listTeams.action"
-	developerServicesBaseURL = developerPortalBaseURL + "/services-account/v1"
+	developerPortalTeamsPath = "/services-account/QH65B2/account/listTeams.action"
+	developerServicesPath    = "/services-account/v1"
 	privateCloudCompute      = "PRIVATE_CLOUD_COMPUTE"
 	developerPortalAuthHint  = "run 'asc web auth logout --apple-id EMAIL', then 'asc web auth login --apple-id EMAIL', and try again"
 )
@@ -210,7 +210,7 @@ func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
 	headers := developerPortalHeaders("")
 	headers.Set("Accept", "application/json, text/javascript, */*; q=0.01")
 	headers.Set("Content-Type", "application/x-www-form-urlencoded")
-	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodPost, developerPortalTeamsURL, nil, headers)
+	body, response, err := c.doDeveloperPortalHTTP(ctx, http.MethodPost, c.developerPortalOrigin()+developerPortalTeamsPath, nil, headers)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,11 @@ func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return &APIError{Status: response.StatusCode, AppleRequestID: extractAppleRequestID(response.Header), rawBody: body}
 	}
-	if response.Request != nil && response.Request.URL != nil && !strings.EqualFold(response.Request.URL.Hostname(), "developer.apple.com") {
+	portalURL, parseErr := url.Parse(c.developerPortalOrigin())
+	if parseErr != nil {
+		return fmt.Errorf("invalid Developer Portal base URL: %w", parseErr)
+	}
+	if response.Request != nil && response.Request.URL != nil && !strings.EqualFold(response.Request.URL.Hostname(), portalURL.Hostname()) {
 		return fmt.Errorf("authentication redirected to %s instead of Developer Portal; %s", response.Request.URL.Hostname(), developerPortalAuthHint)
 	}
 
@@ -571,6 +575,13 @@ func developerPortalHeaders(bundleID string) http.Header {
 	return headers
 }
 
+func (c *Client) developerPortalOrigin() string {
+	if c != nil && strings.TrimSpace(c.developerPortalURL) != "" {
+		return strings.TrimRight(strings.TrimSpace(c.developerPortalURL), "/")
+	}
+	return developerPortalBaseURL
+}
+
 func (c *Client) doDeveloperPortalProxyRead(ctx context.Context, path string, query url.Values, headers http.Header) ([]byte, error) {
 	// Developer Portal's cookie-authenticated v1 API proxies logical GETs as
 	// POSTs carrying the team and encoded query in the request body.
@@ -598,7 +609,7 @@ func (c *Client) doDeveloperPortalRequest(ctx context.Context, method, path stri
 			return nil, fmt.Errorf("missing Developer Portal CSRF headers; %s", developerPortalAuthHint)
 		}
 	}
-	responseBody, response, err := c.doDeveloperPortalHTTP(ctx, method, developerServicesBaseURL+path, body, headers)
+	responseBody, response, err := c.doDeveloperPortalHTTP(ctx, method, c.developerPortalOrigin()+developerServicesPath+path, body, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -630,11 +630,16 @@ func (c *Client) doDeveloperPortalHTTP(ctx context.Context, method, requestURL s
 
 	var requestBody io.Reader
 	if body != nil {
-		encoded, err := json.Marshal(body)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to marshal Developer Portal request: %w", err)
+		switch typed := body.(type) {
+		case url.Values:
+			requestBody = strings.NewReader(typed.Encode())
+		default:
+			encoded, err := json.Marshal(body)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal Developer Portal request: %w", err)
+			}
+			requestBody = bytes.NewReader(encoded)
 		}
-		requestBody = bytes.NewReader(encoded)
 	}
 	request, err := http.NewRequestWithContext(ctx, method, requestURL, requestBody)
 	if err != nil {

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -225,8 +225,8 @@ func (c *Client) ensureDeveloperPortalSession(ctx context.Context) error {
 	if parseErr != nil {
 		return fmt.Errorf("invalid Developer Portal base URL: %w", parseErr)
 	}
-	if response.Request != nil && response.Request.URL != nil && !strings.EqualFold(response.Request.URL.Hostname(), portalURL.Hostname()) {
-		return fmt.Errorf("authentication redirected to %s instead of Developer Portal; %s", response.Request.URL.Hostname(), developerPortalAuthHint)
+	if response.Request != nil && response.Request.URL != nil && !sameURLOrigin(portalURL, response.Request.URL) {
+		return fmt.Errorf("authentication redirected to %s instead of Developer Portal; %s", response.Request.URL.Host, developerPortalAuthHint)
 	}
 
 	var payload developerPortalTeamsResponse
@@ -659,7 +659,21 @@ func (c *Client) doDeveloperPortalHTTP(ctx context.Context, method, requestURL s
 	request.Header = cloneHeaders(headers)
 	setModifiedCookieHeader(c.httpClient, request)
 
-	response, err := c.httpClient.Do(request)
+	httpClient := *c.httpClient
+	previousCheckRedirect := httpClient.CheckRedirect
+	httpClient.CheckRedirect = func(redirect *http.Request, via []*http.Request) error {
+		if !sameURLOrigin(request.URL, redirect.URL) {
+			return fmt.Errorf("authentication redirected to %s instead of Developer Portal; %s", redirect.URL.Host, developerPortalAuthHint)
+		}
+		if previousCheckRedirect != nil {
+			return previousCheckRedirect(redirect, via)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+	response, err := httpClient.Do(request)
 	if err != nil {
 		logWebAuthHTTP("developer_portal_request", request, nil, nil, err)
 		return nil, nil, fmt.Errorf("request to Developer Portal failed: %w", err)
@@ -672,6 +686,29 @@ func (c *Client) doDeveloperPortalHTTP(ctx context.Context, method, requestURL s
 	}
 	logWebAuthHTTP("developer_portal_request", request, response, responseBody, nil)
 	return responseBody, response, nil
+}
+
+func sameURLOrigin(expected, actual *url.URL) bool {
+	if expected == nil || actual == nil || expected.Scheme == "" || actual.Scheme == "" || expected.Hostname() == "" || actual.Hostname() == "" {
+		return false
+	}
+	return strings.EqualFold(expected.Scheme, actual.Scheme) &&
+		strings.EqualFold(expected.Hostname(), actual.Hostname()) &&
+		effectiveURLPort(expected) == effectiveURLPort(actual)
+}
+
+func effectiveURLPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
 }
 
 func (c *Client) captureDeveloperCSRFTokens(headers http.Header) {
@@ -688,6 +725,13 @@ func (c *Client) captureDeveloperCSRFTokens(headers http.Header) {
 	if csrfTS != "" {
 		c.developerCSRFTS = csrfTS
 	}
+}
+
+func (c *Client) clearDeveloperCSRFTokens() {
+	c.developerSessionMu.Lock()
+	defer c.developerSessionMu.Unlock()
+	c.developerCSRF = ""
+	c.developerCSRFTS = ""
 }
 
 func headerValueCaseInsensitive(headers http.Header, name string) string {

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -7,10 +7,60 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
+
+func TestEnsureDeveloperPortalSessionRejectsHTTPSDowngradeRedirect(t *testing.T) {
+	var targetCalled atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		targetCalled.Store(true)
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(developerPortalTeamsFixture()))
+	}))
+	t.Cleanup(target.Close)
+
+	portal := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(portal.Close)
+
+	client := &Client{httpClient: portal.Client(), developerPortalURL: portal.URL}
+	err := client.ensureDeveloperPortalSession(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "authentication redirected to") {
+		t.Fatalf("ensureDeveloperPortalSession() error = %v, want redirect rejection", err)
+	}
+	if targetCalled.Load() {
+		t.Fatal("authenticated request followed HTTPS-to-HTTP redirect")
+	}
+}
+
+func TestEnsureDeveloperPortalSessionRejectsDifferentPortRedirect(t *testing.T) {
+	var targetCalled atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		targetCalled.Store(true)
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(developerPortalTeamsFixture()))
+	}))
+	t.Cleanup(target.Close)
+
+	portal := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(portal.Close)
+
+	client := &Client{httpClient: portal.Client(), developerPortalURL: portal.URL}
+	err := client.ensureDeveloperPortalSession(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "authentication redirected to") {
+		t.Fatalf("ensureDeveloperPortalSession() error = %v, want redirect rejection", err)
+	}
+	if targetCalled.Load() {
+		t.Fatal("authenticated request followed redirect to a different port")
+	}
+}
 
 func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 	jar, err := cookiejar.New(nil)


### PR DESCRIPTION
## Summary

- add `asc web app-groups list` for team-scoped Developer Portal App Groups
- add `asc web app-groups create --name ... --identifier group.... --confirm`
- add idempotent `asc web app-groups assign --group ... --bundle-id ... --confirm`
- preserve the complete existing Bundle ID capability graph when enabling/assigning `APP_GROUPS`
- document why these commands live under the web-session boundary rather than the public API surface

## Why `asc web`

Apple's public App Store Connect OpenAPI schema exposes the `APP_GROUPS` capability enum, but it does not expose App Group resources or Bundle ID associations. Apple Developer Portal does expose those operations to an Account Holder/Admin web session.

List/create use the established `QH65B2` form endpoints also exercised by Fastlane. Assignment uses ASC's existing Developer Portal JSON:API Bundle ID read/PATCH path so the full current capability graph and unrelated relationships are preserved.

## Commands

```bash
asc web app-groups list --output table

asc web app-groups create \
  --name "Example Shared" \
  --identifier "group.com.example.shared" \
  --confirm

asc web app-groups assign \
  --group "GROUP_RESOURCE_ID" \
  --bundle-id "BUNDLE_RESOURCE_ID" \
  --confirm
```

Repeated assignment returns `changed: false` and `status: already-assigned` without sending a PATCH.

## Verification

- RED established with missing CLI/client surface before implementation
- focused CLI tests cover hierarchy, validation, JSON/table output, and request forwarding
- focused HTTP tests cover team bootstrap, form encoding, CSRF, pagination, response decoding, Apple error envelopes, malformed responses, HTTP errors, full-graph assignment, and idempotency
- built binary help checked manually
- built binary invalid identifier checked: exit 2, empty stdout, diagnostic/usage on stderr
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`

## Live verification

No live mutation was performed: the available cached Apple web session was expired, and this contribution must not alter a real App ID without an explicitly selected disposable resource. The endpoint shapes are covered with representative Developer Portal fixtures and match Fastlane's maintained PortalClient contract.

## Compatibility and risk

- additive experimental web-session commands only
- no public API-key behavior changes
- mutation requires `--confirm`
- private Developer Portal contracts can drift; failures surface Apple's HTTP/error envelope and never claim success


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `asc web app-groups` commands to list, create, and assign App Groups to Bundle IDs.
  * Added table, Markdown, and JSON output, validation, confirmation prompts, and authentication guidance.
  * Added session refresh support and duplicate-safe assignments that preserve existing Bundle ID capabilities.

* **Documentation**
  * Added quick-start examples and command reference documentation covering roles, resource IDs, pagination, and session requirements.

* **Bug Fixes**
  * Improved form requests, pagination, and redirect security when connecting to the Developer Portal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->