### PR TITLE
fix(analytics): exclude redownloads and updates from download units

### DIFF
--- a/commands/insights.mdx
+++ b/commands/insights.mdx
@@ -90,7 +90,7 @@ Provides transaction-level insights from sales reports:
 
 **Metrics:**
 
-* `download_units` - App downloads (free or paid)
+* `download_units` - First-time app downloads (free or paid; excludes redownloads and updates)
 * `monetized_units` - Units with revenue (app + IAP/subscriptions linked to app)
 * `units` - Total units across all transaction types
 * `developer_proceeds` - Total developer proceeds

--- a/internal/cli/analytics/analytics_compare.go
+++ b/internal/cli/analytics/analytics_compare.go
@@ -312,6 +312,7 @@ func aggregateSalesMetrics(a, b insights.SalesMetrics) insights.SalesMetrics {
 	return insights.SalesMetrics{
 		RowCount:                       a.RowCount + b.RowCount,
 		UnitsColumnPresent:             a.UnitsColumnPresent && b.UnitsColumnPresent,
+		DownloadUnitsAvailable:         a.DownloadUnitsAvailable && b.DownloadUnitsAvailable,
 		DeveloperProceedsColumnPresent: a.DeveloperProceedsColumnPresent && b.DeveloperProceedsColumnPresent,
 		CustomerPriceColumnPresent:     a.CustomerPriceColumnPresent && b.CustomerPriceColumnPresent,
 		SubscriptionColumnPresent:      a.SubscriptionColumnPresent && b.SubscriptionColumnPresent,
@@ -335,7 +336,7 @@ func buildCompareMetrics(baseline, comparison insights.SalesMetrics) []compareMe
 	metrics := []compareMetric{
 		compareMetricFromValues("download_units", "count", "download units",
 			baseline.DownloadUnitsTotal, comparison.DownloadUnitsTotal,
-			baseline.UnitsColumnPresent, comparison.UnitsColumnPresent),
+			baseline.DownloadUnitsAvailable, comparison.DownloadUnitsAvailable),
 		compareMetricFromValues("monetized_units", "count", "monetized units",
 			baseline.MonetizedUnitsTotal, comparison.MonetizedUnitsTotal,
 			baseline.UnitsColumnPresent, comparison.UnitsColumnPresent),

--- a/internal/cli/analytics/analytics_compare_test.go
+++ b/internal/cli/analytics/analytics_compare_test.go
@@ -246,6 +246,7 @@ func TestAggregateSalesMetrics(t *testing.T) {
 	a := insights.SalesMetrics{
 		RowCount:                       2,
 		UnitsColumnPresent:             true,
+		DownloadUnitsAvailable:         true,
 		DeveloperProceedsColumnPresent: true,
 		CustomerPriceColumnPresent:     true,
 		SubscriptionColumnPresent:      true,
@@ -266,6 +267,7 @@ func TestAggregateSalesMetrics(t *testing.T) {
 	b := insights.SalesMetrics{
 		RowCount:                       3,
 		UnitsColumnPresent:             true,
+		DownloadUnitsAvailable:         true,
 		DeveloperProceedsColumnPresent: true,
 		CustomerPriceColumnPresent:     true,
 		SubscriptionColumnPresent:      true,
@@ -344,6 +346,7 @@ func TestBuildCompareMetrics(t *testing.T) {
 	baseline := insights.SalesMetrics{
 		RowCount:                       5,
 		UnitsColumnPresent:             true,
+		DownloadUnitsAvailable:         true,
 		DeveloperProceedsColumnPresent: true,
 		CustomerPriceColumnPresent:     true,
 		SubscriptionColumnPresent:      true,
@@ -356,6 +359,7 @@ func TestBuildCompareMetrics(t *testing.T) {
 	comparison := insights.SalesMetrics{
 		RowCount:                       8,
 		UnitsColumnPresent:             true,
+		DownloadUnitsAvailable:         true,
 		DeveloperProceedsColumnPresent: true,
 		CustomerPriceColumnPresent:     true,
 		SubscriptionColumnPresent:      true,
@@ -395,7 +399,7 @@ func TestBuildCompareMetrics(t *testing.T) {
 
 func TestBuildCompareMetrics_ExplainsMissingColumns(t *testing.T) {
 	baseline := insights.SalesMetrics{}
-	comparison := insights.SalesMetrics{UnitsColumnPresent: true}
+	comparison := insights.SalesMetrics{UnitsColumnPresent: true, DownloadUnitsAvailable: true}
 
 	metrics := buildCompareMetrics(baseline, comparison)
 	for _, m := range metrics {
@@ -415,12 +419,14 @@ func TestBuildCompareMetrics_ExplainsMissingColumns(t *testing.T) {
 
 func TestBuildCompareMetrics_ExplainsZeroBaselineDeltaPercent(t *testing.T) {
 	baseline := insights.SalesMetrics{
-		UnitsColumnPresent: true,
-		DownloadUnitsTotal: 0,
+		UnitsColumnPresent:     true,
+		DownloadUnitsAvailable: true,
+		DownloadUnitsTotal:     0,
 	}
 	comparison := insights.SalesMetrics{
-		UnitsColumnPresent: true,
-		DownloadUnitsTotal: 12,
+		UnitsColumnPresent:     true,
+		DownloadUnitsAvailable: true,
+		DownloadUnitsTotal:     12,
 	}
 
 	metrics := buildCompareMetrics(baseline, comparison)
@@ -473,6 +479,9 @@ func TestFetchAndAggregate_SingleReportKeepsAvailableColumns(t *testing.T) {
 	}
 	if !metrics.UnitsColumnPresent {
 		t.Fatal("expected units column to be available")
+	}
+	if !metrics.DownloadUnitsAvailable {
+		t.Fatal("expected download units to be available")
 	}
 	if !metrics.DeveloperProceedsColumnPresent {
 		t.Fatal("expected developer proceeds column to be available")

--- a/internal/cli/insights/insights.go
+++ b/internal/cli/insights/insights.go
@@ -269,6 +269,7 @@ type reportWeekWindow struct {
 type SalesMetrics struct {
 	RowCount                       int
 	UnitsColumnPresent             bool
+	DownloadUnitsAvailable         bool
 	DeveloperProceedsColumnPresent bool
 	CustomerPriceColumnPresent     bool
 	SubscriptionColumnPresent      bool
@@ -488,10 +489,10 @@ func collectSalesMetrics(ctx context.Context, client *asc.Client, vendor string,
 	metrics = append(metrics, metricFromOptionalTotals(
 		"download_units",
 		"count",
-		thisData.UnitsColumnPresent && prevData.UnitsColumnPresent && availabilityReason == "",
+		thisData.DownloadUnitsAvailable && prevData.DownloadUnitsAvailable && availabilityReason == "",
 		thisData.DownloadUnitsTotal,
 		prevData.DownloadUnitsTotal,
-		resolveSalesReason("download units", availabilityReason, thisData.UnitsColumnPresent, prevData.UnitsColumnPresent),
+		resolveSalesReason("download units", availabilityReason, thisData.DownloadUnitsAvailable, prevData.DownloadUnitsAvailable),
 	))
 	metrics = append(metrics, metricFromOptionalTotals(
 		"monetized_units",
@@ -607,6 +608,7 @@ func ParseSalesReportMetrics(reader io.Reader, scope salesScope) (salesWeekMetri
 	appleIdentifierIdx := findColumnIndex(headers, "appleidentifier")
 	parentIdentifierIdx := findColumnIndex(headers, "parentidentifier")
 	skuIdx := findColumnIndex(headers, "sku")
+	productTypeIdentifierIdx := findColumnIndex(headers, "producttypeidentifier")
 	subscriptionIdx := findColumnIndex(headers, "subscription")
 	unitsIdx := findColumnIndex(headers, "units")
 	developerProceedsIdx := findColumnIndex(headers, "developerproceeds")
@@ -618,6 +620,7 @@ func ParseSalesReportMetrics(reader io.Reader, scope salesScope) (salesWeekMetri
 	scope = EnrichSalesScopeFromRows(scope, rows[1:], appleIdentifierIdx, skuIdx)
 	metrics := salesWeekMetrics{
 		UnitsColumnPresent:             unitsIdx >= 0,
+		DownloadUnitsAvailable:         unitsIdx >= 0 && productTypeIdentifierIdx >= 0,
 		DeveloperProceedsColumnPresent: developerProceedsIdx >= 0,
 		CustomerPriceColumnPresent:     customerPriceIdx >= 0,
 		SubscriptionColumnPresent:      subscriptionIdx >= 0,
@@ -648,7 +651,7 @@ func ParseSalesReportMetrics(reader io.Reader, scope salesScope) (salesWeekMetri
 		if unitsIdx >= 0 {
 			if value, ok := parseNumericValue(valueAtIndex(row, unitsIdx)); ok {
 				metrics.UnitsTotal += value
-				if isAppRow {
+				if isAppRow && isInitialAppDownloadProductType(valueAtIndex(row, productTypeIdentifierIdx)) {
 					metrics.DownloadUnitsTotal += value
 				}
 				if isMonetizedRow {
@@ -687,6 +690,18 @@ func ParseSalesReportMetrics(reader io.Reader, scope salesScope) (salesWeekMetri
 	}
 
 	return metrics, nil
+}
+
+func isInitialAppDownloadProductType(value string) bool {
+	// Apple defines these as first-time app or app-bundle purchases. Redownload
+	// and update product types are intentionally excluded from download units.
+	// https://developer.apple.com/help/app-store-connect/reference/reporting/product-type-identifiers/
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "1", "1-B", "1E", "1EP", "1EU", "1F", "1T", "F1", "F1-B":
+		return true
+	default:
+		return false
+	}
 }
 
 // EnrichSalesScopeFromRows resolves the app SKU from report data when it is

--- a/internal/cli/insights/insights_test.go
+++ b/internal/cli/insights/insights_test.go
@@ -40,11 +40,14 @@ func TestAnalyticsReportRequestIsActiveUsesCurrentAttribute(t *testing.T) {
 
 func TestParseSalesReportMetrics(t *testing.T) {
 	report := strings.Join([]string{
-		"Provider\tSKU\tApple Identifier\tParent Identifier\tSubscription\tUnits\tDeveloper Proceeds\tCustomer Price",
-		"foo\tChromism12345\t1500196580\t\t \t10\t0.00\t0.00",
-		"foo\tcom.rudrankriyam.chroma_plus\t1619633372\tChromism12345\tRenewal\t3\t0.75\t1.00",
-		"foo\tcom.rudrankriyam.chroma_plus\t1619633372\tChromism12345\tNew\t2\t1.25\t2.00",
-		"foo\tother\t999999\tOtherSKU\tRenewal\t500\t9.99\t9.99",
+		"Provider\tSKU\tApple Identifier\tParent Identifier\tProduct Type Identifier\tSubscription\tUnits\tDeveloper Proceeds\tCustomer Price",
+		"foo\tChromism12345\t1500196580\t\t1F\t \t10\t0.00\t0.00",
+		"foo\tChromism12345\t1500196580\t\t3F\t \t4\t0.00\t0.00",
+		"foo\tChromism12345\t1500196580\t\t7F\t \t6\t0.00\t0.00",
+		"foo\tChromism12345\t1500196580\t\tF1\t \t2\t0.00\t0.00",
+		"foo\tcom.rudrankriyam.chroma_plus\t1619633372\tChromism12345\tIAY\tRenewal\t3\t0.75\t1.00",
+		"foo\tcom.rudrankriyam.chroma_plus\t1619633372\tChromism12345\tIAY\tNew\t2\t1.25\t2.00",
+		"foo\tother\t999999\tOtherSKU\t1F\tRenewal\t500\t9.99\t9.99",
 		"",
 	}, "\n")
 
@@ -57,13 +60,16 @@ func TestParseSalesReportMetrics(t *testing.T) {
 		t.Fatalf("ParseSalesReportMetrics error: %v", err)
 	}
 
-	if metrics.RowCount != 3 {
-		t.Fatalf("expected RowCount=3, got %d", metrics.RowCount)
+	if metrics.RowCount != 6 {
+		t.Fatalf("expected RowCount=6, got %d", metrics.RowCount)
 	}
-	if !metrics.UnitsColumnPresent || metrics.UnitsTotal != 15 {
+	if !metrics.UnitsColumnPresent || metrics.UnitsTotal != 27 {
 		t.Fatalf("unexpected units totals: %+v", metrics)
 	}
-	if metrics.DownloadUnitsTotal != 10 {
+	if !metrics.DownloadUnitsAvailable {
+		t.Fatal("expected download units to be available")
+	}
+	if metrics.DownloadUnitsTotal != 12 {
 		t.Fatalf("unexpected download units totals: %+v", metrics)
 	}
 	if metrics.MonetizedUnitsTotal != 5 {
@@ -80,6 +86,64 @@ func TestParseSalesReportMetrics(t *testing.T) {
 	}
 	if metrics.RenewalRows != 1 || metrics.RenewalUnitsTotal != 3 || metrics.RenewalDeveloperProceeds != 0.75 {
 		t.Fatalf("unexpected renewal totals: %+v", metrics)
+	}
+}
+
+func TestIsInitialAppDownloadProductType(t *testing.T) {
+	tests := []struct {
+		name        string
+		productType string
+		want        bool
+	}{
+		{name: "app", productType: "1", want: true},
+		{name: "app bundle", productType: "1-B", want: true},
+		{name: "custom iOS app", productType: "1E", want: true},
+		{name: "custom iPadOS app", productType: "1EP", want: true},
+		{name: "custom universal app", productType: "1EU", want: true},
+		{name: "universal app", productType: "1F", want: true},
+		{name: "iPad app", productType: "1T", want: true},
+		{name: "Mac app", productType: "F1", want: true},
+		{name: "Mac app bundle", productType: "F1-B", want: true},
+		{name: "redownload", productType: "3", want: false},
+		{name: "universal redownload", productType: "3F", want: false},
+		{name: "update", productType: "7", want: false},
+		{name: "universal update", productType: "7F", want: false},
+		{name: "iPad update", productType: "7T", want: false},
+		{name: "Mac update", productType: "F7", want: false},
+		{name: "in-app purchase", productType: "IA1", want: false},
+		{name: "unknown", productType: "future", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInitialAppDownloadProductType(tt.productType); got != tt.want {
+				t.Fatalf("isInitialAppDownloadProductType(%q) = %v, want %v", tt.productType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSalesReportMetricsMarksDownloadUnitsUnavailableWithoutProductType(t *testing.T) {
+	report := strings.Join([]string{
+		"Provider\tSKU\tApple Identifier\tParent Identifier\tUnits",
+		"foo\tChromism12345\t1500196580\t\t10",
+	}, "\n")
+
+	metrics, err := ParseSalesReportMetrics(bytes.NewReader(gzipText(t, report)), salesScope{
+		AppID:  "1500196580",
+		AppSKU: "Chromism12345",
+	})
+	if err != nil {
+		t.Fatalf("ParseSalesReportMetrics error: %v", err)
+	}
+	if metrics.DownloadUnitsAvailable {
+		t.Fatal("expected download units to be unavailable without Product Type Identifier")
+	}
+	if metrics.DownloadUnitsTotal != 0 {
+		t.Fatalf("expected no inferred download units, got %.2f", metrics.DownloadUnitsTotal)
+	}
+	if metrics.UnitsTotal != 10 {
+		t.Fatalf("expected all units to remain available, got %.2f", metrics.UnitsTotal)
 	}
 }
 


### PR DESCRIPTION
## Summary

- count `download_units` only for Apple's documented first-time app and app-bundle product types
- exclude redownload and update rows while preserving the existing all-transaction `units` metric
- mark download units unavailable when a report lacks `Product Type Identifier` instead of inferring a misleading value
- document the corrected metric and add mixed-transaction regression coverage

## Root cause

`ParseSalesReportMetrics` classified every row whose Apple Identifier matched the app as a download. It did not inspect `Product Type Identifier`, so redownload (`3`, `3F`) and update (`7`, `7F`, `7T`, `F7`) units were included in `download_units`.

Apple defines App and Bundle Units as first-time purchases and explicitly excludes updates and redownloads:

- https://developer.apple.com/help/app-store-connect/reference/reporting/sales-and-trends-metrics-and-dimensions/
- https://developer.apple.com/help/app-store-connect/reference/reporting/product-type-identifiers/

## Compatibility

There are no command, flag, or output-schema changes. The existing `download_units` metric now reports its intended first-time value, so it will be lower for periods containing redownloads or updates. The broader `units` metric is unchanged.

## Verification

- RED regression: a mixed report containing first-time, redownload, update, Mac, and IAP rows returned 22 download units instead of 12
- focused insights and analytics tests pass
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`
- read-only live comparison across two complete adjacent daily reports: the released binary matched first-time + redownload + update rows; this branch matched the raw first-time product-type sum exactly on both days, while the all-units totals remained unchanged

No App Store Connect resources were created, changed, or deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Download metrics now count only first-time app and app-bundle downloads, excluding redownloads and updates.
  * Comparisons correctly indicate when download data is unavailable due to missing report columns.
  * Weekly download metrics now provide more accurate availability reporting.

* **Documentation**
  * Clarified that `download_units` excludes redownloads and app updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->