### PR TITLE
apps wall: add Sleep Analysis - Lunomia

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1386,6 +1386,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/98/db/d6/98dbd62d-1923-b384-c9fe-7233fcf3e8e7/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Sleep Analysis - Lunomia",
+    "link": "https://apps.apple.com/us/app/sleep-analysis-lunomia/id6741118991?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/64/36/fa/6436fa8f-de92-01a9-62a3-52a8c8bd8580/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Slop Or Not - AI Fake Detector",
     "link": "https://apps.apple.com/us/app/slop-or-not-ai-fake-detector/id6744578596?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fb/f9/05/fbf9052f-756b-1660-e575-62e7a85d73b7/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Sleep Analysis - Lunomia` to the Wall of Apps

## Entry

- App ID: 6741118991
- App: Sleep Analysis - Lunomia
- Link: https://apps.apple.com/us/app/sleep-analysis-lunomia/id6741118991?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Sleep Analysis - Lunomia” to the app directory.
  * Included links to its App Store listing and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->