### PR TITLE
chore: update Go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudrankriyam/App-Store-Connect-CLI
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/1Password/srp v0.2.0


### PR DESCRIPTION
## Summary
- update the Go toolchain directive from 1.26.5 to 1.26.6
- clear newly published reachable standard-library vulnerabilities blocking govulncheck on main and open PRs

## Test plan
- [x] `go version`
- [x] `govulncheck -format text ./...`
- [x] `make build`
- [x] pre-commit format, lint, docs, and short test suite with Xcode 26.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go language version to 1.26.6 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->