### PR TITLE
fix(builds): reject unexpected add-groups arguments

### DIFF
--- a/internal/cli/builds/builds.go
+++ b/internal/cli/builds/builds.go
@@ -40,6 +40,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
 			if err := selectors.applyLegacyAliases(); err != nil {
 				return err
 			}

--- a/internal/cli/cmdtest/builds_add_groups_args_test.go
+++ b/internal/cli/cmdtest/builds_add_groups_args_test.go
@@ -1,0 +1,47 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildsAddGroupsRejectsUnexpectedArgsBeforeNetwork(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("dev")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"builds", "add-groups",
+		"--build-id", "build-1",
+		"--group", "group-1",
+		"unexpected",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) ||
+		runErr.Error() != "unexpected argument(s): unexpected" ||
+		!strings.Contains(stderr, "unexpected argument(s): unexpected") {
+		t.Fatalf("run error = %v stderr = %q, want unexpected argument usage error", runErr, stderr)
+	}
+}


### PR DESCRIPTION
## Summary

- reject trailing positional arguments for `asc builds add-groups`
- return a usage error before authentication or API requests

Previously, `asc builds add-groups --build-id build-1 --group group-1 unexpected` ignored `unexpected` and continued to the build lookup.

## Tests

- `make check-docs`
- `make lint`
- `make build`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `builds add-groups` now rejects unexpected positional arguments with a clear usage error.
  * Invalid arguments are detected before any network requests are made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->