### PR TITLE
apps wall: add hora Calendar

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -637,6 +637,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/38/05/66/38056606-4649-101f-cdc3-a4ed626181dc/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "hora Calendar",
+    "link": "https://apps.apple.com/us/app/hora-calendar/id6761409895?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e5/c2/e3/e5c2e3ee-f9f0-c491-4f22-5f6282853823/Hora-0-0-85-220-0-6-0-2x-sRGB.png/512x512bb.png"
+  },
+  {
     "app": "HoverCalc",
     "link": "https://apps.apple.com/us/app/hovercalc/id6759318126?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4d/d5/0f/4dd50f26-4b76-e382-9774-5894156f11df/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `hora Calendar` to the Wall of Apps

## Entry

- App ID: 6761409895
- App: hora Calendar
- Link: https://apps.apple.com/us/app/hora-calendar/id6761409895?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the hora Calendar app to the wall of apps, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->