### PR TITLE
Add Stitch It, Fax It, and ColorCub to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -239,6 +239,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e0/22/11/e02211b9-8e91-5250-17ed-a6105cd42922/Chroma-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "ColorCub: AI Coloring Pages",
+    "link": "https://apps.apple.com/us/app/colorcub-ai-coloring-pages/id6745206164?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4a/7f/ae/4a7faef1-a45e-75d7-d90a-066eda390ea4/AppIcon-0-0-1x_U007emarketing-0-8-0-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Concert Memories 2: Countdown",
     "link": "https://apps.apple.com/us/app/concert-memories-2-countdown/id6744301154?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6c/ce/a1/6ccea161-6da4-52c7-1260-f44955b0bc70/ConcertMemories2-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
@@ -451,6 +456,11 @@
     "app": "Fasting Works: IF & Meal Log",
     "link": "https://apps.apple.com/us/app/fasting-works-if-meal-log/id6757606218?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/56/72/22/567222b9-40dd-cca2-1a58-01a46cfaa2d9/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
+    "app": "Fax It: Send & Receive Fax",
+    "link": "https://apps.apple.com/us/app/fax-it-send-receive-fax/id1458261691?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0a/06/0b/0a060b1f-ecdb-8d01-84f0-5928690fd028/Icon_4-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
     "app": "FeedFlow - RSS Feed Reader",
@@ -1504,6 +1514,11 @@
     "app": "Sticky Widgets",
     "link": "https://apps.apple.com/us/app/sticky-widgets/id1533254320",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/1e/b8/78/1eb878a7-0955-eb1a-f55a-09b630362b71/sw-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220-0.png/512x512bb.jpg"
+  },
+  {
+    "app": "Stitch It · Long Screenshots",
+    "link": "https://www.stitchitapp.com/",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/73/7a/3e/737a3e1e-ccbe-8c01-1249-ac12fcec4a17/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
     "app": "Storyie - AI Journal & Diary",

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1517,7 +1517,7 @@
   },
   {
     "app": "Stitch It · Long Screenshots",
-    "link": "https://www.stitchitapp.com/",
+    "link": "https://apps.apple.com/us/app/stitch-it-long-screenshots/id554594252?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/73/7a/3e/737a3e1e-ccbe-8c01-1249-ac12fcec4a17/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {


### PR DESCRIPTION
## Summary

Adds the following published apps to the Wall of Apps:

- **Stitch It · Long Screenshots**
- **Fax It: Send & Receive Fax** (iOS and macOS)
- **ColorCub: AI Coloring Pages**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ColorCub, Fax It, and Stitch It to the app showcase.
  * Included App Store links and icons for each newly listed app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->