### PR TITLE
fix(ads): reject legacy fields across v1 queries

### DIFF
--- a/docs/design/apple-ads-platform-api-v1.md
+++ b/docs/design/apple-ads-platform-api-v1.md
@@ -106,6 +106,17 @@ workflows, and v5 raw request command remain runnable compatibility paths with
 warnings; the raw v5 command continues to send v5 paths and is never silently
 rewritten.
 
+All named v1 query commands reject legacy v5 selector members before resolving
+credentials or sending a request. The shared migration guard covers the
+standard `QueryRequest` plus reporting, insights, recommendations, policy,
+and audit query bodies. It reports the direct member replacements:
+`conditions` to `filters`, `values` to `value`, `orderBy` to `sorting`,
+`sortOrder` to `order`, and `pagination.limit` to `pagination.pageSize`.
+Explicit `null` legacy members are rejected because the Platform API rejects
+the property itself. The CLI does not rewrite payloads automatically: value
+cardinality and accepted fields vary by endpoint, so silent conversion could
+change query semantics.
+
 Platform v1 unifies campaign and ad-group negative keywords under
 `negative-keywords`, but it has no bulk-delete endpoint. These seven v5 leaves
 have no one-command v1 replacement in 4.4.0: `product-pages countries list`,
@@ -126,6 +137,8 @@ RED-GREEN coverage includes:
 - raw v1 URL guardrails and context-free endpoint exceptions;
 - multipart upload fields, content type, rootfs reads, file failures, and API failures;
 - exact legacy warning text and direct-help migration paths;
+- pre-auth rejection of legacy v5 selector members across every v1 query body
+  type, while preserving valid v1 payloads and raw API pass-through behavior;
 - generated command docs and built-binary smoke tests.
 
 The local repository gate is `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`.
@@ -144,3 +157,10 @@ Never place those credentials in the repository or test fixtures.
 ## Alternatives considered
 
 An `--api-version` flag would mix incompatible leaves and payload schemas in one help surface. Keeping v1 permanently under `platform` would make the future default API more verbose forever. The selected breaking tree gives v1 the idiomatic direct paths and moves the retiring surface under the exact `v5` version label.
+
+For query migration, automatic v5-to-v1 payload conversion was rejected
+because `value` may be scalar or array depending on the schema and operator,
+and report bodies require a larger structural rewrite. Leaving validation to
+Apple was also rejected: it spends a live request on a deterministic local
+error and produces one-field-at-a-time 400 responses instead of a complete
+migration hint.

--- a/docs/design/apple-ads-platform-api-v1.md
+++ b/docs/design/apple-ads-platform-api-v1.md
@@ -112,6 +112,20 @@ standard `QueryRequest` plus reporting, insights, recommendations, policy,
 and audit query bodies. It reports the direct member replacements:
 `conditions` to `filters`, `values` to `value`, `orderBy` to `sorting`,
 `sortOrder` to `order`, and `pagination.limit` to `pagination.pageSize`.
+It also catches the renamed operator and sort values (`STARTSWITH` and
+`ENDSWITH` to `STARTS_WITH` and `ENDS_WITH`; `ASCENDING` and `DESCENDING`
+to `ASC` and `DESC`).
+
+The schema-aware part of the guard handles members that do not have one
+universal replacement. Only `AppsReportingRequest` and
+`BrandsReportingRequest` accept top-level `fields`; other query bodies reject
+the legacy projection member. Reporting dates, time zone, and granularity move
+under `timeRange`, while grand totals and empty app-metric rows move to
+`options.includeRows`. `returnRowTotals` has no v1 request field, and brand
+reports do not support `EMPTY_METRICS`. The v5 custom impression-share
+`name` and relative `dateRange` members are also rejected with their specific
+v1 migration paths.
+
 Explicit `null` legacy members are rejected because the Platform API rejects
 the property itself. The CLI does not rewrite payloads automatically: value
 cardinality and accepted fields vary by endpoint, so silent conversion could

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"slices"
@@ -746,6 +747,11 @@ func validateEndpointBody(spec appleads.EndpointSpec, body json.RawMessage, conf
 		}
 		return fmt.Errorf("--confirm is required to acknowledge %s", riskConfirmationImpact)
 	}
+	if spec.Method == http.MethodPost && strings.HasPrefix(spec.Path, "v1/") && strings.HasSuffix(spec.Path, "/query") {
+		if err := validatePlatformQueryMigration(body); err != nil {
+			return err
+		}
+	}
 	switch spec.Name {
 	case "platform-query-keywords", "platform-query-negative-keywords":
 		if err := validateKeywordQuerySelector(spec.Name, body); err != nil {
@@ -797,32 +803,103 @@ func validateEndpointBody(spec appleads.EndpointSpec, body json.RawMessage, conf
 type querySelectorFilter struct {
 	Field    string `json:"field"`
 	Operator string `json:"operator"`
-	// Legacy v5 selector conditions used "values"; Platform API filters use
-	// the singular "value". Tracked here so a renamed-but-not-migrated
-	// selector still fails pre-auth with a hint instead of a live 400.
-	Values json.RawMessage `json:"values"`
+}
+
+type legacyPlatformQueryMembers struct {
+	selector   bool
+	conditions bool
+	values     bool
+	orderBy    bool
+	sortOrder  bool
+	limit      bool
+}
+
+func validatePlatformQueryMigration(body json.RawMessage) error {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return fmt.Errorf("invalid Platform API query body: %w", err)
+	}
+
+	legacy := legacyPlatformQueryMembers{}
+	inspectLegacyPlatformQueryObject(payload, &legacy)
+	if rawSelector, present := payload["selector"]; present {
+		legacy.selector = true
+		var selector map[string]json.RawMessage
+		if json.Unmarshal(rawSelector, &selector) == nil {
+			inspectLegacyPlatformQueryObject(selector, &legacy)
+		}
+	}
+
+	var migrations []string
+	if legacy.selector {
+		migrations = append(migrations, `remove the v5 "selector" wrapper and move its members to the top-level query object`)
+	}
+	if legacy.conditions {
+		migrations = append(migrations, `"conditions" -> "filters"`)
+	}
+	if legacy.values {
+		migrations = append(migrations, `filter "values" -> "value"`)
+	}
+	if legacy.orderBy {
+		migrations = append(migrations, `"orderBy" -> "sorting"`)
+	}
+	if legacy.sortOrder {
+		migrations = append(migrations, `sorting "sortOrder" -> "order"`)
+	}
+	if legacy.limit {
+		migrations = append(migrations, `"pagination.limit" -> "pagination.pageSize"`)
+	}
+	if len(migrations) > 0 {
+		return fmt.Errorf("platform API v1 query payload uses legacy v5 selector members: %s", strings.Join(migrations, "; "))
+	}
+	return nil
+}
+
+func inspectLegacyPlatformQueryObject(payload map[string]json.RawMessage, legacy *legacyPlatformQueryMembers) {
+	if _, present := payload["conditions"]; present {
+		legacy.conditions = true
+	}
+	if _, present := payload["orderBy"]; present {
+		legacy.orderBy = true
+	}
+	for _, key := range []string{"filters", "conditions"} {
+		if jsonArrayEntriesContainKey(payload[key], "values") {
+			legacy.values = true
+		}
+	}
+	for _, key := range []string{"sorting", "orderBy"} {
+		if jsonArrayEntriesContainKey(payload[key], "sortOrder") {
+			legacy.sortOrder = true
+		}
+	}
+	var pagination map[string]json.RawMessage
+	if json.Unmarshal(payload["pagination"], &pagination) == nil {
+		if _, present := pagination["limit"]; present {
+			legacy.limit = true
+		}
+	}
+}
+
+func jsonArrayEntriesContainKey(raw json.RawMessage, key string) bool {
+	var entries []map[string]json.RawMessage
+	if json.Unmarshal(raw, &entries) != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if _, present := entry[key]; present {
+			return true
+		}
+	}
+	return false
 }
 
 func validateKeywordQuerySelector(specName string, body json.RawMessage) error {
 	var payload struct {
 		Filters []querySelectorFilter `json:"filters"`
-		// Legacy Campaign Management API v5 selectors used "conditions"; the
-		// Platform API rejects that field, so catch it before auth with a
-		// migration hint instead of letting the request 400.
-		Conditions json.RawMessage `json:"conditions"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return fmt.Errorf("invalid QueryRequest selector filters: %w", err)
 	}
-	if len(payload.Conditions) > 0 {
-		return fmt.Errorf("QueryRequest uses \"filters\", not \"conditions\"; rename the selector array and each entry's \"values\" to the singular \"value\" (Campaign Management API v5 selector fields are rejected by the Platform API)")
-	}
-	for _, filter := range payload.Filters {
-		if len(filter.Values) > 0 {
-			return fmt.Errorf("QueryRequest filters use the singular \"value\", not \"values\"; rename it in each filter (Campaign Management API v5 selector fields are rejected by the Platform API)")
-		}
-	}
-
 	switch specName {
 	case "platform-query-keywords":
 		for _, filter := range payload.Filters {

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -748,7 +748,7 @@ func validateEndpointBody(spec appleads.EndpointSpec, body json.RawMessage, conf
 		return fmt.Errorf("--confirm is required to acknowledge %s", riskConfirmationImpact)
 	}
 	if spec.Method == http.MethodPost && strings.HasPrefix(spec.Path, "v1/") && strings.HasSuffix(spec.Path, "/query") {
-		if err := validatePlatformQueryMigration(body); err != nil {
+		if err := validatePlatformQueryMigration(spec, body); err != nil {
 			return err
 		}
 	}
@@ -806,33 +806,46 @@ type querySelectorFilter struct {
 }
 
 type legacyPlatformQueryMembers struct {
-	selector   bool
-	conditions bool
-	values     bool
-	orderBy    bool
-	sortOrder  bool
-	limit      bool
+	selector                   bool
+	conditions                 bool
+	values                     bool
+	orderBy                    bool
+	sortOrder                  bool
+	limit                      bool
+	selectorFields             bool
+	topLevelFields             bool
+	legacyOperator             bool
+	legacyOrder                bool
+	startTime                  bool
+	endTime                    bool
+	timeZone                   bool
+	granularity                bool
+	returnRecordsWithNoMetrics bool
+	returnRowTotals            bool
+	returnGrandTotals          bool
+	name                       bool
+	dateRange                  bool
 }
 
-func validatePlatformQueryMigration(body json.RawMessage) error {
+func validatePlatformQueryMigration(spec appleads.EndpointSpec, body json.RawMessage) error {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return fmt.Errorf("invalid Platform API query body: %w", err)
 	}
 
 	legacy := legacyPlatformQueryMembers{}
-	inspectLegacyPlatformQueryObject(payload, &legacy)
+	inspectLegacyPlatformQueryObject(payload, &legacy, false)
 	if rawSelector, present := payload["selector"]; present {
 		legacy.selector = true
 		var selector map[string]json.RawMessage
 		if json.Unmarshal(rawSelector, &selector) == nil {
-			inspectLegacyPlatformQueryObject(selector, &legacy)
+			inspectLegacyPlatformQueryObject(selector, &legacy, true)
 		}
 	}
 
 	var migrations []string
 	if legacy.selector {
-		migrations = append(migrations, `remove the v5 "selector" wrapper and move its members to the top-level query object`)
+		migrations = append(migrations, `remove the v5 "selector" wrapper; v1 query members are top level`)
 	}
 	if legacy.conditions {
 		migrations = append(migrations, `"conditions" -> "filters"`)
@@ -849,28 +862,84 @@ func validatePlatformQueryMigration(body json.RawMessage) error {
 	if legacy.limit {
 		migrations = append(migrations, `"pagination.limit" -> "pagination.pageSize"`)
 	}
+	if legacy.legacyOperator {
+		migrations = append(migrations, `filter operator "STARTSWITH"/"ENDSWITH" -> "STARTS_WITH"/"ENDS_WITH"`)
+	}
+	if legacy.legacyOrder {
+		migrations = append(migrations, `sort order "ASCENDING"/"DESCENDING" -> "ASC"/"DESC"`)
+	}
+	if legacy.selectorFields {
+		if platformQuerySupportsFields(spec.BodyType) {
+			migrations = append(migrations, `"selector.fields" -> top-level "fields"`)
+		} else {
+			migrations = append(migrations, fmt.Sprintf(`remove "selector.fields"; %s has no field-projection member`, spec.BodyType))
+		}
+	}
+	if legacy.topLevelFields && !platformQuerySupportsFields(spec.BodyType) {
+		migrations = append(migrations, fmt.Sprintf(`remove top-level "fields"; %s has no field-projection member`, spec.BodyType))
+	}
+	if platformQuerySupportsTimeRange(spec.BodyType) {
+		if legacy.startTime {
+			migrations = append(migrations, `"startTime" -> "timeRange.start"`)
+		}
+		if legacy.endTime {
+			migrations = append(migrations, `"endTime" -> "timeRange.end"`)
+		}
+		if legacy.timeZone {
+			migrations = append(migrations, `"timeZone" -> "timeRange.timeZone"`)
+		}
+		if legacy.granularity {
+			migrations = append(migrations, `"granularity" -> "timeRange.granularity"`)
+		}
+	}
+	if platformQueryIsReport(spec.BodyType) {
+		if legacy.returnRecordsWithNoMetrics {
+			if spec.BodyType == "AppsReportingRequest" {
+				migrations = append(migrations, `"returnRecordsWithNoMetrics": true -> add "EMPTY_METRICS" to "options.includeRows"; false -> omit`)
+			} else {
+				migrations = append(migrations, `remove "returnRecordsWithNoMetrics"; BrandsOptions doesn't support EMPTY_METRICS`)
+			}
+		}
+		if legacy.returnRowTotals {
+			migrations = append(migrations, `remove "returnRowTotals"; no v1 report request field exists`)
+		}
+		if legacy.returnGrandTotals {
+			migrations = append(migrations, `"returnGrandTotals": true -> add "GRAND_TOTAL" to "options.includeRows"; false -> omit`)
+		}
+	}
+	if spec.BodyType == "ImpressionShareQueryRequest" {
+		if legacy.dateRange {
+			migrations = append(migrations, `"dateRange" -> explicit "timeRange.start" and "timeRange.end"`)
+		}
+		if legacy.name {
+			migrations = append(migrations, `remove "name"; ImpressionShareQueryRequest has no saved-report name`)
+		}
+	}
 	if len(migrations) > 0 {
-		return fmt.Errorf("platform API v1 query payload uses legacy v5 selector members: %s", strings.Join(migrations, "; "))
+		return fmt.Errorf("platform API v1 query payload uses legacy v5 fields: %s", strings.Join(migrations, "; "))
 	}
 	return nil
 }
 
-func inspectLegacyPlatformQueryObject(payload map[string]json.RawMessage, legacy *legacyPlatformQueryMembers) {
+func inspectLegacyPlatformQueryObject(payload map[string]json.RawMessage, legacy *legacyPlatformQueryMembers, selector bool) {
 	if _, present := payload["conditions"]; present {
 		legacy.conditions = true
 	}
 	if _, present := payload["orderBy"]; present {
 		legacy.orderBy = true
 	}
-	for _, key := range []string{"filters", "conditions"} {
-		if jsonArrayEntriesContainKey(payload[key], "values") {
-			legacy.values = true
+	if _, present := payload["fields"]; present {
+		if selector {
+			legacy.selectorFields = true
+		} else {
+			legacy.topLevelFields = true
 		}
 	}
+	for _, key := range []string{"filters", "conditions"} {
+		inspectLegacyPlatformFilters(payload[key], legacy)
+	}
 	for _, key := range []string{"sorting", "orderBy"} {
-		if jsonArrayEntriesContainKey(payload[key], "sortOrder") {
-			legacy.sortOrder = true
-		}
+		inspectLegacyPlatformSorting(payload[key], legacy)
 	}
 	var pagination map[string]json.RawMessage
 	if json.Unmarshal(payload["pagination"], &pagination) == nil {
@@ -878,19 +947,72 @@ func inspectLegacyPlatformQueryObject(payload map[string]json.RawMessage, legacy
 			legacy.limit = true
 		}
 	}
-}
-
-func jsonArrayEntriesContainKey(raw json.RawMessage, key string) bool {
-	var entries []map[string]json.RawMessage
-	if json.Unmarshal(raw, &entries) != nil {
-		return false
-	}
-	for _, entry := range entries {
-		if _, present := entry[key]; present {
-			return true
+	for key, target := range map[string]*bool{
+		"startTime":                  &legacy.startTime,
+		"endTime":                    &legacy.endTime,
+		"timeZone":                   &legacy.timeZone,
+		"granularity":                &legacy.granularity,
+		"returnRecordsWithNoMetrics": &legacy.returnRecordsWithNoMetrics,
+		"returnRowTotals":            &legacy.returnRowTotals,
+		"returnGrandTotals":          &legacy.returnGrandTotals,
+		"name":                       &legacy.name,
+		"dateRange":                  &legacy.dateRange,
+	} {
+		if _, present := payload[key]; present {
+			*target = true
 		}
 	}
-	return false
+}
+
+func inspectLegacyPlatformFilters(raw json.RawMessage, legacy *legacyPlatformQueryMembers) {
+	var entries []map[string]json.RawMessage
+	if json.Unmarshal(raw, &entries) != nil {
+		return
+	}
+	for _, entry := range entries {
+		if _, present := entry["values"]; present {
+			legacy.values = true
+		}
+		var operator string
+		if json.Unmarshal(entry["operator"], &operator) == nil && (operator == "STARTSWITH" || operator == "ENDSWITH") {
+			legacy.legacyOperator = true
+		}
+	}
+}
+
+func inspectLegacyPlatformSorting(raw json.RawMessage, legacy *legacyPlatformQueryMembers) {
+	var entries []map[string]json.RawMessage
+	if json.Unmarshal(raw, &entries) != nil {
+		return
+	}
+	for _, entry := range entries {
+		if _, present := entry["sortOrder"]; present {
+			legacy.sortOrder = true
+		}
+		for _, key := range []string{"order", "sortOrder"} {
+			var order string
+			if json.Unmarshal(entry[key], &order) == nil && (order == "ASCENDING" || order == "DESCENDING") {
+				legacy.legacyOrder = true
+			}
+		}
+	}
+}
+
+func platformQuerySupportsFields(bodySchema string) bool {
+	return bodySchema == "AppsReportingRequest" || bodySchema == "BrandsReportingRequest"
+}
+
+func platformQuerySupportsTimeRange(bodySchema string) bool {
+	switch bodySchema {
+	case "AppsReportingRequest", "BrandsReportingRequest", "ImpressionShareQueryRequest", "SearchTermPopularityQueryRequest":
+		return true
+	default:
+		return false
+	}
+}
+
+func platformQueryIsReport(bodySchema string) bool {
+	return bodySchema == "AppsReportingRequest" || bodySchema == "BrandsReportingRequest"
 }
 
 func validateKeywordQuerySelector(specName string, body json.RawMessage) error {

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -400,6 +400,106 @@ func TestPlatformKeywordQueriesRequireSelectorBodyBeforeAuth(t *testing.T) {
 	}
 }
 
+func TestPlatformQueryMigrationValidation(t *testing.T) {
+	var querySpecs []appleads.EndpointSpec
+	for _, spec := range appleads.PlatformEndpointSpecs() {
+		if spec.Method == "POST" && strings.HasSuffix(spec.Path, "/query") {
+			querySpecs = append(querySpecs, spec)
+		}
+	}
+	if got, want := len(querySpecs), 38; got != want {
+		t.Fatalf("Platform query endpoint count = %d, want %d", got, want)
+	}
+
+	validV1 := json.RawMessage(`{"filters":[{"field":"id","operator":"EQUALS","value":"123"}],"sorting":[{"field":"id","order":"DESC"}],"pagination":{"offset":0,"pageSize":5}}`)
+	legacyConditions := json.RawMessage(`{"conditions":null}`)
+	for _, spec := range querySpecs {
+		t.Run(strings.Join(spec.CommandPath, "-"), func(t *testing.T) {
+			if err := validateEndpointBody(spec, validV1, false); err != nil {
+				t.Fatalf("valid Platform v1 query rejected: %v", err)
+			}
+			err := validateEndpointBody(spec, legacyConditions, false)
+			if err == nil || !strings.Contains(err.Error(), `"conditions" -> "filters"`) {
+				t.Fatalf("legacy conditions error = %v, want migration hint", err)
+			}
+		})
+	}
+
+	campaigns, ok := appleads.PlatformEndpointByCommandPath("campaigns", "find")
+	if !ok {
+		t.Fatal("missing campaigns find")
+	}
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "filter values", body: `{"filters":[{"field":"id","operator":"IN","values":null}]}`, want: `"values" -> "value"`},
+		{name: "order by", body: `{"orderBy":null}`, want: `"orderBy" -> "sorting"`},
+		{name: "sort order", body: `{"sorting":[{"field":"id","sortOrder":null}]}`, want: `"sortOrder" -> "order"`},
+		{name: "pagination limit", body: `{"pagination":{"limit":null}}`, want: `"pagination.limit" -> "pagination.pageSize"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateEndpointBody(campaigns, json.RawMessage(test.body), false)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateEndpointBody() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	report, ok := appleads.PlatformEndpointByCommandPath("reports", "apps", "campaigns")
+	if !ok {
+		t.Fatal("missing app campaign report")
+	}
+	reportErr := validateEndpointBody(report, json.RawMessage(`{"selector":{"conditions":[{"field":"id","operator":"EQUALS","values":null}],"orderBy":[{"field":"id","sortOrder":null}],"pagination":{"limit":null}}}`), false)
+	for _, want := range []string{
+		`"selector"`,
+		`"conditions" -> "filters"`,
+		`"values" -> "value"`,
+		`"orderBy" -> "sorting"`,
+		`"sortOrder" -> "order"`,
+		`"pagination.limit" -> "pagination.pageSize"`,
+	} {
+		if reportErr == nil || !strings.Contains(reportErr.Error(), want) {
+			t.Fatalf("legacy report selector error = %v, want complete migration hint containing %q", reportErr, want)
+		}
+	}
+
+	createAd, ok := appleads.PlatformEndpointByCommandPath("ads", "create")
+	if !ok {
+		t.Fatal("missing ads create")
+	}
+	if err := validateEndpointBody(createAd, json.RawMessage(`{"conditions":null,"values":null,"orderBy":null}`), true); err != nil {
+		t.Fatalf("non-query body must not use the query migration guard: %v", err)
+	}
+
+	legacyQuery := appleads.EndpointSpec{Version: appleads.APIVersionCampaignV5, Method: "POST", Path: "v5/campaigns/query"}
+	if err := validateEndpointBody(legacyQuery, json.RawMessage(`{"conditions":null,"orderBy":null}`), false); err != nil {
+		t.Fatalf("legacy v5 query body must not use the Platform API migration guard: %v", err)
+	}
+}
+
+func TestPlatformQueryMigrationValidationPrecedesAuth(t *testing.T) {
+	setAdsResolverTestEnv(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing-config.json"))
+	spec, ok := appleads.PlatformEndpointByCommandPath("campaigns", "find")
+	if !ok {
+		t.Fatal("missing campaigns find")
+	}
+	file := filepath.Join(t.TempDir(), "query.json")
+	if err := os.WriteFile(file, []byte(`{"conditions":[{"field":"id","operator":"EQUALS","values":["123"]}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs, flags := bindEndpointFlags(spec, "campaigns find")
+	if err := fs.Set("file", file); err != nil {
+		t.Fatal(err)
+	}
+	err := executeEndpoint(context.Background(), spec, flags)
+	if err == nil || !strings.Contains(err.Error(), `"conditions" -> "filters"`) || strings.Contains(err.Error(), "configuration not found") {
+		t.Fatalf("executeEndpoint() error = %v, want migration validation before auth", err)
+	}
+}
+
 func TestPlatformKeywordQuerySelectorValidation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -417,37 +517,37 @@ func TestPlatformKeywordQuerySelectorValidation(t *testing.T) {
 			name:    "targeting legacy v5 conditions selector",
 			path:    []string{"targeting-keywords", "find"},
 			body:    `{"conditions":[{"field":"campaignId","operator":"EQUALS","values":["campaign-1"]}]}`,
-			wantErr: `rename the selector array and each entry's "values" to the singular "value"`,
+			wantErr: `"conditions" -> "filters"`,
 		},
 		{
 			name:    "negative legacy v5 conditions selector",
 			path:    []string{"negative-keywords", "find"},
 			body:    `{"conditions":[{"field":"adGroupId","operator":"EQUALS","values":["ad-group-1"]}]}`,
-			wantErr: `rename the selector array and each entry's "values" to the singular "value"`,
+			wantErr: `"conditions" -> "filters"`,
 		},
 		{
 			name:    "targeting null legacy conditions key",
 			path:    []string{"targeting-keywords", "find"},
 			body:    `{"filters":[{"field":"campaignId","operator":"EQUALS","value":"campaign-1"}],"conditions":null}`,
-			wantErr: `uses "filters", not "conditions"`,
+			wantErr: `"conditions" -> "filters"`,
 		},
 		{
 			name:    "targeting null legacy values key in filter",
 			path:    []string{"targeting-keywords", "find"},
 			body:    `{"filters":[{"field":"campaignId","operator":"EQUALS","value":"campaign-1","values":null}]}`,
-			wantErr: `singular "value", not "values"`,
+			wantErr: `"values" -> "value"`,
 		},
 		{
 			name:    "targeting legacy v5 values in filter",
 			path:    []string{"targeting-keywords", "find"},
 			body:    `{"filters":[{"field":"campaignId","operator":"IN","values":["campaign-1"]}]}`,
-			wantErr: `singular "value", not "values"`,
+			wantErr: `"values" -> "value"`,
 		},
 		{
 			name:    "negative legacy v5 values in filter",
 			path:    []string{"negative-keywords", "find"},
 			body:    `{"filters":[{"field":"adGroupId","operator":"IN","values":["ad-group-1"]}]}`,
-			wantErr: `singular "value", not "values"`,
+			wantErr: `"values" -> "value"`,
 		},
 		{
 			name:    "targeting irrelevant filter",

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -402,13 +403,44 @@ func TestPlatformKeywordQueriesRequireSelectorBodyBeforeAuth(t *testing.T) {
 
 func TestPlatformQueryMigrationValidation(t *testing.T) {
 	var querySpecs []appleads.EndpointSpec
+	schemaCounts := map[string]int{}
 	for _, spec := range appleads.PlatformEndpointSpecs() {
 		if spec.Method == "POST" && strings.HasSuffix(spec.Path, "/query") {
 			querySpecs = append(querySpecs, spec)
+			schemaCounts[spec.BodyType]++
 		}
 	}
 	if got, want := len(querySpecs), 38; got != want {
 		t.Fatalf("Platform query endpoint count = %d, want %d", got, want)
+	}
+	wantSchemaCounts := map[string]int{
+		"QueryRequest":                        16,
+		"AppsReportingRequest":                5,
+		"BrandsReportingRequest":              5,
+		"RecommendationQueryRequest":          6,
+		"AuditQuery":                          1,
+		"CreativeRejectionReasonQueryRequest": 1,
+		"EligibilityQueryRequest":             1,
+		"ImpressionShareQueryRequest":         1,
+		"PolicyAssignmentQueryRequest":        1,
+		"SearchTermPopularityQueryRequest":    1,
+	}
+	if !reflect.DeepEqual(schemaCounts, wantSchemaCounts) {
+		t.Fatalf("Platform query schemas = %#v, want %#v", schemaCounts, wantSchemaCounts)
+	}
+	for schema := range wantSchemaCounts {
+		wantFields := schema == "AppsReportingRequest" || schema == "BrandsReportingRequest"
+		wantTimeRange := wantFields || schema == "ImpressionShareQueryRequest" || schema == "SearchTermPopularityQueryRequest"
+		wantReport := wantFields
+		if got := platformQuerySupportsFields(schema); got != wantFields {
+			t.Errorf("platformQuerySupportsFields(%q) = %v, want %v", schema, got, wantFields)
+		}
+		if got := platformQuerySupportsTimeRange(schema); got != wantTimeRange {
+			t.Errorf("platformQuerySupportsTimeRange(%q) = %v, want %v", schema, got, wantTimeRange)
+		}
+		if got := platformQueryIsReport(schema); got != wantReport {
+			t.Errorf("platformQueryIsReport(%q) = %v, want %v", schema, got, wantReport)
+		}
 	}
 
 	validV1 := json.RawMessage(`{"filters":[{"field":"id","operator":"EQUALS","value":"123"}],"sorting":[{"field":"id","order":"DESC"}],"pagination":{"offset":0,"pageSize":5}}`)
@@ -417,6 +449,14 @@ func TestPlatformQueryMigrationValidation(t *testing.T) {
 		t.Run(strings.Join(spec.CommandPath, "-"), func(t *testing.T) {
 			if err := validateEndpointBody(spec, validV1, false); err != nil {
 				t.Fatalf("valid Platform v1 query rejected: %v", err)
+			}
+			fieldsErr := validatePlatformQueryMigration(spec, json.RawMessage(`{"fields":null}`))
+			if platformQuerySupportsFields(spec.BodyType) {
+				if fieldsErr != nil {
+					t.Fatalf("%s must accept its documented top-level fields member: %v", spec.BodyType, fieldsErr)
+				}
+			} else if fieldsErr == nil || !strings.Contains(fieldsErr.Error(), `has no field-projection member`) {
+				t.Fatalf("%s fields error = %v, want schema-specific rejection", spec.BodyType, fieldsErr)
 			}
 			err := validateEndpointBody(spec, legacyConditions, false)
 			if err == nil || !strings.Contains(err.Error(), `"conditions" -> "filters"`) {
@@ -429,6 +469,9 @@ func TestPlatformQueryMigrationValidation(t *testing.T) {
 	if !ok {
 		t.Fatal("missing campaigns find")
 	}
+	if err := validateEndpointBody(campaigns, json.RawMessage(`{"filters":[{"field":"name","operator":"STARTS_WITH","value":"x"}],"sorting":[{"field":"id","order":"DESC"}]}`), false); err != nil {
+		t.Fatalf("renamed v1 operator and sort order rejected: %v", err)
+	}
 	for _, test := range []struct {
 		name string
 		body string
@@ -438,6 +481,9 @@ func TestPlatformQueryMigrationValidation(t *testing.T) {
 		{name: "order by", body: `{"orderBy":null}`, want: `"orderBy" -> "sorting"`},
 		{name: "sort order", body: `{"sorting":[{"field":"id","sortOrder":null}]}`, want: `"sortOrder" -> "order"`},
 		{name: "pagination limit", body: `{"pagination":{"limit":null}}`, want: `"pagination.limit" -> "pagination.pageSize"`},
+		{name: "legacy starts with", body: `{"filters":[{"field":"name","operator":"STARTSWITH","value":"x"}]}`, want: `"STARTSWITH"/"ENDSWITH" -> "STARTS_WITH"/"ENDS_WITH"`},
+		{name: "legacy sort direction", body: `{"sorting":[{"field":"id","order":"DESCENDING"}]}`, want: `"ASCENDING"/"DESCENDING" -> "ASC"/"DESC"`},
+		{name: "unsupported field projection", body: `{"fields":null}`, want: `QueryRequest has no field-projection member`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := validateEndpointBody(campaigns, json.RawMessage(test.body), false)
@@ -451,7 +497,10 @@ func TestPlatformQueryMigrationValidation(t *testing.T) {
 	if !ok {
 		t.Fatal("missing app campaign report")
 	}
-	reportErr := validateEndpointBody(report, json.RawMessage(`{"selector":{"conditions":[{"field":"id","operator":"EQUALS","values":null}],"orderBy":[{"field":"id","sortOrder":null}],"pagination":{"limit":null}}}`), false)
+	if err := validateEndpointBody(report, json.RawMessage(`{"fields":["campaignId"],"timeRange":{"start":"2026-08-01","end":"2026-08-02"},"options":{"includeRows":["GRAND_TOTAL"]}}`), false); err != nil {
+		t.Fatalf("valid v1 report fields rejected: %v", err)
+	}
+	reportErr := validateEndpointBody(report, json.RawMessage(`{"startTime":null,"endTime":null,"timeZone":null,"granularity":null,"returnRecordsWithNoMetrics":null,"returnRowTotals":null,"returnGrandTotals":null,"selector":{"fields":null,"conditions":[{"field":"id","operator":"STARTSWITH","values":null}],"orderBy":[{"field":"id","sortOrder":"DESCENDING"}],"pagination":{"limit":null}}}`), false)
 	for _, want := range []string{
 		`"selector"`,
 		`"conditions" -> "filters"`,
@@ -459,9 +508,38 @@ func TestPlatformQueryMigrationValidation(t *testing.T) {
 		`"orderBy" -> "sorting"`,
 		`"sortOrder" -> "order"`,
 		`"pagination.limit" -> "pagination.pageSize"`,
+		`"STARTSWITH"/"ENDSWITH" -> "STARTS_WITH"/"ENDS_WITH"`,
+		`"ASCENDING"/"DESCENDING" -> "ASC"/"DESC"`,
+		`"selector.fields" -> top-level "fields"`,
+		`"startTime" -> "timeRange.start"`,
+		`"endTime" -> "timeRange.end"`,
+		`"timeZone" -> "timeRange.timeZone"`,
+		`"granularity" -> "timeRange.granularity"`,
+		`"returnRecordsWithNoMetrics": true -> add "EMPTY_METRICS"`,
+		`remove "returnRowTotals"`,
+		`"returnGrandTotals": true -> add "GRAND_TOTAL"`,
 	} {
 		if reportErr == nil || !strings.Contains(reportErr.Error(), want) {
 			t.Fatalf("legacy report selector error = %v, want complete migration hint containing %q", reportErr, want)
+		}
+	}
+
+	brandReport, ok := appleads.PlatformEndpointByCommandPath("reports", "brands", "campaigns")
+	if !ok {
+		t.Fatal("missing brand campaign report")
+	}
+	if err := validateEndpointBody(brandReport, json.RawMessage(`{"returnRecordsWithNoMetrics":null}`), false); err == nil || !strings.Contains(err.Error(), `BrandsOptions doesn't support EMPTY_METRICS`) {
+		t.Fatalf("brand empty-metrics migration error = %v, want unsupported hint", err)
+	}
+
+	impressionShare, ok := appleads.PlatformEndpointByCommandPath("insights", "impression-share", "find")
+	if !ok {
+		t.Fatal("missing impression-share query")
+	}
+	impressionErr := validateEndpointBody(impressionShare, json.RawMessage(`{"name":null,"dateRange":null,"startTime":null}`), false)
+	for _, want := range []string{`remove "name"`, `"dateRange" -> explicit "timeRange.start" and "timeRange.end"`, `"startTime" -> "timeRange.start"`} {
+		if impressionErr == nil || !strings.Contains(impressionErr.Error(), want) {
+			t.Fatalf("impression-share migration error = %v, want %q", impressionErr, want)
 		}
 	}
 


### PR DESCRIPTION
## Problem

Apple's Platform API v1 replaced several v5 query fields and enum values. Exact `main` still forwarded those legacy shapes to every named v1 query command outside the two keyword-specific checks, so callers received one Apple API error at a time.

Live requests from the exact-main binary reproduced the failures for:

- `selector`, `conditions`, `values`, `orderBy`, `sortOrder`, and `pagination.limit`
- filter operators `STARTSWITH` and `ENDSWITH`
- sort values `ASCENDING` and `DESCENDING`
- reporting fields `startTime`, `endTime`, `timeZone`, `granularity`, `returnRecordsWithNoMetrics`, `returnRowTotals`, and `returnGrandTotals`
- the v5 custom impression-share `name` and `dateRange` fields

The v1 schema also limits `fields` projection to `AppsReportingRequest` and `BrandsReportingRequest`. Apple accepted `fields: null` on a campaign query while silently ignoring it, so the CLI needs to reject that misleading shape too.

Apple's schemas:

- [QueryRequest](https://developer.apple.com/documentation/apple-ads-platform-api/queryrequest), [QueryFilter](https://developer.apple.com/documentation/apple-ads-platform-api/queryfilter), [QuerySort](https://developer.apple.com/documentation/apple-ads-platform-api/querysort), and [QueryPagination](https://developer.apple.com/documentation/apple-ads-platform-api/querypagination)
- [AppsReportingRequest](https://developer.apple.com/documentation/apple-ads-platform-api/appsreportingrequest) and [BrandsReportingRequest](https://developer.apple.com/documentation/apple-ads-platform-api/brandsreportingrequest)
- [TimeRange](https://developer.apple.com/documentation/apple-ads-platform-api/timerange), [AppsOptions](https://developer.apple.com/documentation/apple-ads-platform-api/appsoptions), and [BrandsOptions](https://developer.apple.com/documentation/apple-ads-platform-api/brandsoptions)

## Fix

Add one schema-aware pre-auth migration check for all 38 named v1 `POST .../query` endpoints and all ten request-body schemas. It reports every applicable migration in one usage error, including explicit `null` members.

The guard accounts for endpoint differences:

- `selector.fields` moves to top-level `fields` only for app and brand reports; the other eight request schemas have no projection member
- reporting date, time zone, and granularity fields move under `timeRange`
- grand totals and empty app-metric rows move to `options.includeRows`; brand reports do not support `EMPTY_METRICS`
- `returnRowTotals` and the saved impression-share report `name` have no v1 request field

The CLI doesn't rewrite payloads because accepted fields and value cardinality vary by endpoint. Raw API requests, v5 commands, and non-query bodies keep their existing behavior.

## Verification

- enumerated all 38 query endpoints and asserted the exact distribution across all ten Apple request schemas
- focused unit tests cover shared migrations, schema-specific `fields` behavior, report options, time ranges, impression-share fields, valid v1 enums, and bypass boundaries
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- repository pre-commit suite with Xcode 26.6
- rebuilt-binary live app campaign report using v1 `timeRange`, `pagination`, and options: HTTP success
- rebuilt-binary legacy payloads: exit 2 before credential resolution with complete migration guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added early validation for legacy v5 fields in Platform API v1 query requests.
  * Provides migration guidance for replaced selectors, operators, sorting, pagination, reporting, and time-range fields.
  * Rejects unsupported legacy fields, including explicit `null` values, before authentication.
  * Applies consistently across reporting, insights, recommendations, policy, audit, and keyword queries.
* **Bug Fixes**
  * Standardized migration errors while preserving valid v1 and raw request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
