### PR TITLE
fix(submit): request the appStoreVersion relationship on review submission items

### DIFF
--- a/internal/cli/submit/submit_create.go
+++ b/internal/cli/submit/submit_create.go
@@ -292,7 +292,15 @@ func summarizeReviewSubmissionItems(
 		return summary, nil
 	}
 
-	resp, err := client.GetReviewSubmissionItems(ctx, submissionID, asc.WithReviewSubmissionItemsLimit(200))
+	// appStoreVersion must be requested explicitly. Without it the API returns items carrying no
+	// relationship linkage, so every item reads as an empty version id, hasTargetVersion never
+	// becomes true, and a correctly prepared submission is rejected as not containing its version.
+	resp, err := client.GetReviewSubmissionItems(
+		ctx,
+		submissionID,
+		asc.WithReviewSubmissionItemsFields([]string{"appStoreVersion"}),
+		asc.WithReviewSubmissionItemsLimit(200),
+	)
 	if err != nil {
 		return summary, err
 	}

--- a/internal/cli/submit/submit_create_items_relationship_test.go
+++ b/internal/cli/submit/submit_create_items_relationship_test.go
@@ -1,0 +1,76 @@
+package submit
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// TestSummarizeReviewSubmissionItemsRequestsVersionRelationship proves the items query asks for the
+// appStoreVersion relationship.
+//
+// App Store Connect returns review submission items with no relationship linkage unless the request
+// asks for it. Without that ask, every item reads as an empty version id, hasTargetVersion can never
+// become true, and a correctly prepared submission is rejected with "does not contain target
+// version". The other tests in this package do not catch it because their stubbed responses always
+// include relationships, which the real API only does on request.
+func TestSummarizeReviewSubmissionItemsRequestsVersionRelationship(t *testing.T) {
+	var itemFields string
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/reviewSubmissions/submission-1/items" {
+			t.Fatalf("unexpected path %s", req.URL.Path)
+		}
+		itemFields = req.URL.Query().Get("fields[reviewSubmissionItems]")
+
+		return submitJSONResponse(http.StatusOK, `{
+			"data": [{
+				"type": "reviewSubmissionItems",
+				"id": "item-1",
+				"relationships": {
+					"appStoreVersion": {
+						"data": {"type": "appStoreVersions", "id": "version-1"}
+					}
+				}
+			}]
+		}`)
+	}))
+
+	summary, err := summarizeReviewSubmissionItems(context.Background(), client, "submission-1", "version-1")
+	if err != nil {
+		t.Fatalf("summarizeReviewSubmissionItems() error: %v", err)
+	}
+
+	if itemFields != "appStoreVersion" {
+		t.Fatalf("expected fields[reviewSubmissionItems]=appStoreVersion, got %q", itemFields)
+	}
+	if !summary.hasTargetVersion {
+		t.Fatal("expected the summary to find the target version")
+	}
+}
+
+// TestSummarizeReviewSubmissionItemsWithoutRelationshipsIsNotTarget pins the behaviour the fix
+// depends on: an item that arrives without relationship linkage counts as unrelated rather than as
+// the target version, so the guard stays honest when the API declines to expand it.
+func TestSummarizeReviewSubmissionItemsWithoutRelationshipsIsNotTarget(t *testing.T) {
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return submitJSONResponse(http.StatusOK, `{
+			"data": [{
+				"type": "reviewSubmissionItems",
+				"id": "item-1",
+				"attributes": {"state": "READY_FOR_REVIEW"}
+			}]
+		}`)
+	}))
+
+	summary, err := summarizeReviewSubmissionItems(context.Background(), client, "submission-1", "version-1")
+	if err != nil {
+		t.Fatalf("summarizeReviewSubmissionItems() error: %v", err)
+	}
+
+	if summary.hasTargetVersion {
+		t.Fatal("expected an item with no relationships not to count as the target version")
+	}
+	if !summary.hasOtherItems {
+		t.Fatal("expected an item with no relationships to count as an unrelated item")
+	}
+}

--- a/internal/cli/submit/submit_test.go
+++ b/internal/cli/submit/submit_test.go
@@ -2212,7 +2212,7 @@ func TestPrepareReviewSubmissionForCreateSkipsMixedTargetVersionSubmission(t *te
 
 	wantRequests := []string{
 		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/mixed-submission/items?limit=200",
+		"GET /v1/reviewSubmissions/mixed-submission/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&limit=200",
 	}
 	if !reflect.DeepEqual(requests, wantRequests) {
 		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
@@ -2269,7 +2269,7 @@ func TestPrepareReviewSubmissionForCreateTreatsEmptyItemsAsMissingVersion(t *tes
 
 	wantRequests := []string{
 		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/empty-items-submission/items?limit=200",
+		"GET /v1/reviewSubmissions/empty-items-submission/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&limit=200",
 	}
 	if !reflect.DeepEqual(requests, wantRequests) {
 		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)


### PR DESCRIPTION
## Problem

`asc review submit` always fails at its final step against the real API, even when the submission it just built is complete and correct:

```
Error: review submit: submit review: final submission validation: review submission 68616bff-... does not contain target version 5434872c-...
```

Everything before that succeeds: the build is attached, the review submission is created, and the version item is added. Only the last call is refused, leaving a fully formed `READY_FOR_REVIEW` draft that has to be finished by hand with `asc review submissions-submit --id <id> --confirm`.

## Cause

`summarizeReviewSubmissionItems` decides membership with `reviewSubmissionItemVersionID`, which reads `item.Relationships.AppStoreVersion.Data.ID`. But the items request asked for neither `include` nor `fields[reviewSubmissionItems]`, and App Store Connect returns items with no relationship linkage at all in that case:

```json
{"type":"reviewSubmissionItems","id":"Njg2...","attributes":{"state":"READY_FOR_REVIEW"},"links":{}}
```

So the version id reads as `""` for every item, each one falls to the `default:` branch as unrelated, `hasTargetVersion` stays false, and a submission containing exactly the target version is rejected as not containing it. No flag works around it, and `--version-id` does not help: target resolution is fine, the items response is what comes back thin.

`fields[reviewSubmissionItems]=appStoreVersion` is valid per the bundled spec (`docs/openapi/latest.json`, `/v1/reviewSubmissions/{id}/items`), and `internal/cli/submit/submit_status.go` already requests it exactly this way, so this change brings the two call sites in line.

## Why the suite did not catch it

Existing stubs always return `relationships` on items, which the real API only does on request, so the fake is more generous than production. The two new tests pin both halves: that the query asks for the relationship, and that an item arriving without linkage still counts as unrelated rather than silently as the target.

## Verification

- New test fails on `main` (`expected fields[reviewSubmissionItems]=appStoreVersion, got ""`) and passes with the fix.
- Two existing tests pinned the exact request URI and are updated for the added parameter.
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/...` passes: 100 packages, 0 failures. `gofmt` clean.
- Behaviour confirmed live on 2026-08-15 shipping app `6787275694` version 1.3.1 build 148: submit aborted with the error above, the draft was complete, and `asc review submissions-submit` moved it straight to `WAITING_FOR_REVIEW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review submission item reuse validation by accurately identifying items associated with the target app version.
  * Prevented items with missing version relationship data from being incorrectly treated as matches.
* **Tests**
  * Added coverage for version relationship requests and validation of unrelated items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->