### PR TITLE
test(xcode): isolate export preflight from host Xcode

### DIFF
--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -391,6 +391,22 @@ func TestXcodeExportRequiresArchivePath(t *testing.T) {
 }
 
 func TestXcodeExportWithoutExportOptionsPreflightsBeforeGeneration(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		binDir := t.TempDir()
+		xcodebuildPath := filepath.Join(binDir, "xcodebuild")
+		script := "#!/bin/sh\n" +
+			"if [ \"$1\" = \"-version\" ]; then\n" +
+			"  printf 'Xcode 16.0\\nBuild version 16A1\\n'\n" +
+			"  exit 0\n" +
+			"fi\n" +
+			"printf 'unexpected xcodebuild invocation: %s\\n' \"$*\" >&2\n" +
+			"exit 1\n"
+		if err := os.WriteFile(xcodebuildPath, []byte(script), 0o755); err != nil {
+			t.Fatalf("write fake xcodebuild: %v", err)
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 


### PR DESCRIPTION
## What changed

- give `TestXcodeExportWithoutExportOptionsPreflightsBeforeGeneration` a test-local fake `xcodebuild` on macOS
- accept only the `xcodebuild -version` preflight invocation before the test reaches export-options generation

## Root cause

The cmdtest intends to verify that Xcode availability is checked before automatic export-options generation. On a macOS host with Command Line Tools selected but no active full Xcode, the test invoked the machine's real `xcodebuild` and failed at host setup instead of reaching the behavior under test.

## Impact

This changes test infrastructure only. CLI behavior, flags, output, and App Store Connect interactions are unchanged. The test now behaves consistently on macOS hosts regardless of their active developer directory.

## Verification

- RED on current `main`: focused cmdtest failed with `xcodebuild not usable` under `/Library/Developer/CommandLineTools`
- GREEN: focused test passed once and for 20 repeated runs
- `ASC_BYPASS_KEYCHAIN=1 go test -count=1 ./internal/cli/cmdtest ./internal/cli/shared`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

The separate spinner failure observed during PR #2027 triage was not included because it did not reproduce under repeated or race-enabled runs.