### PR TITLE
fix(rootfs): support restricted working directories

### DIFF
--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -502,14 +502,65 @@ func resolveProspectivePhysicalPath(absolute string) (string, error) {
 }
 
 func openAbsoluteRootNoFollow(absolute string) (*os.Root, error) {
+	workingDir := workingDirectory()
+	if workingDir != "" {
+		physicalWorkingDir, err := filepath.EvalSymlinks(workingDir)
+		if err == nil {
+			workingDir = filepath.Clean(physicalWorkingDir)
+		} else {
+			workingDir = ""
+		}
+	}
+	return openAbsoluteRootNoFollowFrom(
+		absolute,
+		workingDir,
+		func() (*os.Root, error) { return os.OpenRoot(".") },
+		os.OpenRoot,
+	)
+}
+
+func openAbsoluteRootNoFollowFrom(
+	absolute string,
+	workingDir string,
+	openWorkingDir func() (*os.Root, error),
+	openVolumeRoot func(string) (*os.Root, error),
+) (*os.Root, error) {
 	absolute = filepath.Clean(absolute)
 	volume := filepath.VolumeName(absolute)
 	anchor := volume + string(filepath.Separator)
-	current, err := os.OpenRoot(anchor)
-	if err != nil {
-		return nil, err
-	}
 	relative := strings.TrimPrefix(absolute, anchor)
+
+	var current *os.Root
+	if workingDir != "" {
+		workingDir = filepath.Clean(workingDir)
+		if workingRelative, err := relativeWithinRoot(workingDir, absolute); err == nil {
+			current, err = openWorkingDir()
+			if err != nil {
+				return nil, err
+			}
+			openedInfo, openedErr := current.Stat(".")
+			selectedInfo, selectedErr := os.Stat(workingDir)
+			if openedErr != nil || selectedErr != nil || !os.SameFile(openedInfo, selectedInfo) {
+				_ = current.Close()
+				if openedErr != nil {
+					return nil, openedErr
+				}
+				if selectedErr != nil {
+					return nil, selectedErr
+				}
+				return nil, symlinkError(workingDir)
+			}
+			anchor = workingDir
+			relative = workingRelative
+		}
+	}
+	if current == nil {
+		var err error
+		current, err = openVolumeRoot(anchor)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if relative == "" || relative == "." {
 		return current, nil
 	}

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -1060,6 +1060,105 @@ func TestErrorMessagesIdentifyRejectedPath(t *testing.T) {
 	}
 }
 
+func TestOpenAbsoluteRootNoFollowUsesCurrentDirectoryAnchor(t *testing.T) {
+	workingDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := filepath.Join(workingDir, "selected")
+	if err := os.Mkdir(selected, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	openWorkingDir := func() (*os.Root, error) {
+		return os.OpenRoot(workingDir)
+	}
+	denyVolumeRoot := func(string) (*os.Root, error) {
+		return nil, os.ErrPermission
+	}
+
+	opened, err := openAbsoluteRootNoFollowFrom(
+		selected,
+		workingDir,
+		openWorkingDir,
+		denyVolumeRoot,
+	)
+	if err != nil {
+		t.Fatalf("openAbsoluteRootNoFollowFrom() error = %v", err)
+	}
+	defer opened.Close()
+	if _, err := opened.Stat("."); err != nil {
+		t.Fatalf("opened selected root is unusable: %v", err)
+	}
+}
+
+func TestOpenAbsoluteRootNoFollowFailsClosedOutsideCurrentDirectory(t *testing.T) {
+	workingDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	openWorkingDir := func() (*os.Root, error) {
+		return os.OpenRoot(workingDir)
+	}
+	denyVolumeRoot := func(string) (*os.Root, error) {
+		return nil, os.ErrPermission
+	}
+
+	opened, err := openAbsoluteRootNoFollowFrom(
+		outside,
+		workingDir,
+		openWorkingDir,
+		denyVolumeRoot,
+	)
+	if opened != nil {
+		_ = opened.Close()
+		t.Fatal("openAbsoluteRootNoFollowFrom() opened a root outside the current directory")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("openAbsoluteRootNoFollowFrom() error = %v, want permission denied", err)
+	}
+}
+
+func TestOpenAbsoluteRootNoFollowRejectsReplacedCurrentDirectoryPath(t *testing.T) {
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	workingDir := filepath.Join(parent, "working")
+	if err := os.Mkdir(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	openedWorkingDir, err := os.OpenRoot(workingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(workingDir, workingDir+"-original"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	opened, err := openAbsoluteRootNoFollowFrom(
+		workingDir,
+		workingDir,
+		func() (*os.Root, error) { return openedWorkingDir, nil },
+		os.OpenRoot,
+	)
+	if opened != nil {
+		_ = opened.Close()
+		t.Fatal("openAbsoluteRootNoFollowFrom() accepted a replaced working directory path")
+	}
+	if !errors.Is(err, ErrSymlink) {
+		t.Fatalf("openAbsoluteRootNoFollowFrom() error = %v, want ErrSymlink", err)
+	}
+}
+
 func TestOpenRootPinsOriginalDirectoryAcrossPathReplacement(t *testing.T) {
 	requireSymlinks(t)
 	parent, err := filepath.EvalSymlinks(t.TempDir())


### PR DESCRIPTION
## What changed

- anchor no-follow root traversal at the already-open current working directory when the selected root is contained there
- preserve volume-root traversal and fail-closed behavior for roots outside the working directory
- verify the working-directory descriptor still matches its physical path before using it
- add regressions for denied volume-root access, outside-cwd fail-closed behavior, and cwd path replacement

## Why

Homebrew Core’s `asc` bump tests run `asc init` inside a Landlock-restricted test directory. Since the rootfs hardening introduced in 4.3.0, `asc init` attempted to open `/` before walking to that directory, and Homebrew denied it with `open /: permission denied`. This has kept Core on 4.2.0.

## Impact

Commands writing beneath the current working directory now work in restrictive sandboxes without weakening traversal checks below the selected anchor. Paths outside cwd keep the existing filesystem-root validation behavior.

## Validation

- RED regression reproduced the denied volume-root path
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/rootfs -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/rootfs -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/docs -count=1`
- `make format`
- `make check-docs`
- `make check-wall-of-apps`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `make build`
- built-binary `asc init` smoke test
- temporary Homebrew formula built patched source and passed the exact Core sandbox test: `asc init --path <testpath>/ASC.md --link=false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure path resolution when accessing files beneath the current working directory.
  * Prevented access to paths outside the working directory through unsafe traversal.
  * Added safeguards for cases where the current-directory path is replaced before access.
* **Tests**
  * Added coverage for valid resolution, out-of-scope paths, and replaced directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->