### PR TITLE
apps wall: add oh? daily home screen widget

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1017,6 +1017,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/29/00/51/2900519e-a076-de61-c91c-7e0313faf41e/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "oh? daily home screen widget",
+    "link": "https://apps.apple.com/us/app/oh-daily-home-screen-widget/id6789181341?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/01/c5/6b/01c56bf4-5653-758b-8eb0-e4253687f800/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "P2P View",
     "link": "https://apps.apple.com/us/app/p2p-view/id1643919225?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f3/cc/c0/f3ccc01d-a2ab-5a17-13d7-5095b55763cc/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `oh? daily home screen widget` to the Wall of Apps

## Entry

- App ID: 6789181341
- App: oh? daily home screen widget
- Link: https://apps.apple.com/us/app/oh-daily-home-screen-widget/id6789181341?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “oh? daily home screen widget” app to the app listing.
  * Included its App Store link and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->