### PR TITLE
Add HowHigh and ReShoot to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -100,6 +100,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/03/45/5a/03455ad1-896f-c341-6d38-13bab0c40e8b/AppIcon-0-1x_U007epad-0-1-P3-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Barometer & Altimeter: HowHigh",
+    "link": "https://apps.apple.com/us/app/barometer-altimeter-howhigh/id921339656?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/79/66/ab/7966ab76-f237-ff79-e866-a51e96a530f3/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Beauty Fonts - Font Keyboard",
     "link": "https://apps.apple.com/us/app/beauty-fonts-font-keyboard/id1438854446?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ce/85/c5/ce85c50d-e009-34b8-96f1-924e6881a364/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"
@@ -1304,6 +1309,11 @@
     "app": "Reps: AI Fitness & Recovery",
     "link": "https://apps.apple.com/app/id6746460451",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/d4/6b/88/d46b88b6-e459-a316-6e0d-321ccb5c501a/Reps_AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
+    "app": "ReShoot · Video Reframe & Crop",
+    "link": "https://apps.apple.com/us/app/reshoot-video-reframe-crop/id6753581365?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/52/db/cc/52dbcc8f-c4aa-2cf0-36f9-bdeacf943fd7/AppIcon-0-1x_U007epad-0-11-0-85-220-0.png/512x512bb.jpg"
   },
   {
     "app": "Ripple News - AI Personal News",

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -657,7 +657,7 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4d/d5/0f/4dd50f26-4b76-e382-9774-5894156f11df/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
   },
   {
-    "app": "HowHigh • Barometer & Altimeter",
+    "app": "HowHigh · Barometer & Altimeter",
     "link": "https://apps.apple.com/us/app/barometer-altimeter-howhigh/id921339656?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/79/66/ab/7966ab76-f237-ff79-e866-a51e96a530f3/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
   },

--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -100,11 +100,6 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/03/45/5a/03455ad1-896f-c341-6d38-13bab0c40e8b/AppIcon-0-1x_U007epad-0-1-P3-85-220-0.png/512x512bb.jpg"
   },
   {
-    "app": "Barometer & Altimeter: HowHigh",
-    "link": "https://apps.apple.com/us/app/barometer-altimeter-howhigh/id921339656?uo=4",
-    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/79/66/ab/7966ab76-f237-ff79-e866-a51e96a530f3/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
-  },
-  {
     "app": "Beauty Fonts - Font Keyboard",
     "link": "https://apps.apple.com/us/app/beauty-fonts-font-keyboard/id1438854446?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ce/85/c5/ce85c50d-e009-34b8-96f1-924e6881a364/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"
@@ -660,6 +655,11 @@
     "app": "HoverCalc",
     "link": "https://apps.apple.com/us/app/hovercalc/id6759318126?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4d/d5/0f/4dd50f26-4b76-e382-9774-5894156f11df/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
+  },
+  {
+    "app": "HowHigh • Barometer & Altimeter",
+    "link": "https://apps.apple.com/us/app/barometer-altimeter-howhigh/id921339656?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/79/66/ab/7966ab76-f237-ff79-e866-a51e96a530f3/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
   },
   {
     "app": "HRM Battery",


### PR DESCRIPTION
## Summary

Adds the following published apps to the Wall of Apps:

- **Barometer & Altimeter: HowHigh** — version 1.4.1 is currently available on the App Store.
- **ReShoot · Video Reframe & Crop** — current public App Store listing (version 1.0.2).

Both entries use the App Store's public URLs and 512px artwork.

## Validation

- `jq empty docs/wall-of-apps.json`
- `make check-wall-of-apps`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HowHigh · Barometer & Altimeter to the app showcase.
  * Added ReShoot · Video Reframe & Crop to the app showcase.
  * Included App Store links and app icons for both entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->