### PR TITLE
Add structured diagnostic metadata

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -647,6 +647,7 @@ func validationFailureContext(analysis invocationAnalysis, err error) telemetry.
 		ErrorKind:        kind,
 		FailureStage:     telemetry.FailureStageValidation,
 		FailureParameter: failureParameterFromError(err),
+		DiagnosticCode:   diagnosticCodeFromError(err),
 		OutcomeKind:      telemetry.OutcomeUsageError,
 	}
 }
@@ -660,8 +661,12 @@ func runtimeFailureContext(analysis invocationAnalysis, err error, exitCode int)
 		InvocationShape:  analysis.shape,
 		ErrorKind:        telemetry.ErrorKindOther,
 		FailureStage:     telemetry.FailureStageExecution,
+		DiagnosticCode:   diagnosticCodeFromError(err),
 		HTTPStatus:       httpStatusFromError(err),
 		PublicStorefront: isPublicStorefrontError(err),
+	}
+	if diagnostic, ok := shared.DiagnosticFromError(err); ok {
+		eventContext.FailureParameter = diagnostic.Parameter
 	}
 	switch {
 	case errors.Is(err, shared.ErrMissingAuth):
@@ -743,6 +748,9 @@ func failureParameterFromError(err error) string {
 	if err == nil {
 		return ""
 	}
+	if diagnostic, ok := shared.DiagnosticFromError(err); ok && diagnostic.Parameter != "" {
+		return diagnostic.Parameter
+	}
 	for _, field := range strings.Fields(err.Error()) {
 		candidate := strings.Trim(field, "`'\"(),:;.")
 		if strings.HasPrefix(candidate, "--") {
@@ -750,6 +758,14 @@ func failureParameterFromError(err error) string {
 		}
 	}
 	return ""
+}
+
+func diagnosticCodeFromError(err error) string {
+	diagnostic, ok := shared.DiagnosticFromError(err)
+	if !ok {
+		return ""
+	}
+	return string(diagnostic.Code)
 }
 
 func shouldRenderGroupHelp(analysis invocationAnalysis, err error) bool {

--- a/cmd/invocation_context_test.go
+++ b/cmd/invocation_context_test.go
@@ -205,6 +205,60 @@ func TestRuntimeFailureContextClassifiesLowCardinalityFailures(t *testing.T) {
 	}
 }
 
+func TestValidationFailureContextPrefersStructuredDiagnostic(t *testing.T) {
+	err := shared.WithDiagnostic(
+		shared.NewReportedUsageError(shared.UsageErrorMissingRequired, "--issuer-id is required"),
+		shared.DiagnosticRequiredInputMissing,
+		"--key-id",
+	)
+
+	got := validationFailureContext(
+		invocationAnalysis{shape: telemetry.InvocationShapeLeaf},
+		err,
+	)
+
+	if got.ErrorKind != telemetry.ErrorKindMissingRequired ||
+		got.FailureStage != telemetry.FailureStageValidation ||
+		got.FailureParameter != "--key-id" ||
+		got.DiagnosticCode != string(shared.DiagnosticRequiredInputMissing) {
+		t.Fatalf("validationFailureContext() = %+v", got)
+	}
+}
+
+func TestValidationFailureContextRetainsLegacyMessageFallback(t *testing.T) {
+	err := shared.NewReportedUsageError(shared.UsageErrorInvalidValue, "invalid value for --territory")
+
+	got := validationFailureContext(
+		invocationAnalysis{shape: telemetry.InvocationShapeLeaf},
+		err,
+	)
+
+	if got.FailureParameter != "--territory" || got.DiagnosticCode != "" {
+		t.Fatalf("validationFailureContext() = %+v", got)
+	}
+}
+
+func TestRuntimeFailureContextCarriesStructuredDiagnostic(t *testing.T) {
+	err := shared.WithDiagnostic(
+		shared.NewValidationError(errors.New("private key could not be loaded")),
+		shared.DiagnosticFileNotFound,
+		"--private-key",
+	)
+
+	got := runtimeFailureContext(
+		invocationAnalysis{shape: telemetry.InvocationShapeLeaf},
+		err,
+		ExitError,
+	)
+
+	if got.FailureStage != telemetry.FailureStageValidation ||
+		got.OutcomeKind != telemetry.OutcomeExpectedNegative ||
+		got.FailureParameter != "--private-key" ||
+		got.DiagnosticCode != string(shared.DiagnosticFileNotFound) {
+		t.Fatalf("runtimeFailureContext() = %+v", got)
+	}
+}
+
 func TestAnalyzeInvocationPreservesRawTokens(t *testing.T) {
 	root := RootCommand("1.0.0")
 

--- a/internal/cli/shared/diagnostics.go
+++ b/internal/cli/shared/diagnostics.go
@@ -1,0 +1,106 @@
+package shared
+
+import (
+	"errors"
+	"strings"
+)
+
+// DiagnosticCode is a privacy-safe, low-cardinality reason for a command
+// failure. Codes describe the failure independently from the rendered error
+// message; pair them with Parameter when the failure concerns a public flag.
+type DiagnosticCode string
+
+const (
+	DiagnosticRequiredInputMissing    DiagnosticCode = "required_input_missing"
+	DiagnosticInvalidInput            DiagnosticCode = "invalid_input"
+	DiagnosticConflictingInput        DiagnosticCode = "conflicting_input"
+	DiagnosticFileNotFound            DiagnosticCode = "file_not_found"
+	DiagnosticFilePermissionDenied    DiagnosticCode = "file_permission_denied"
+	DiagnosticFileInvalidFormat       DiagnosticCode = "file_invalid_format"
+	DiagnosticKeyAlgorithmUnsupported DiagnosticCode = "key_algorithm_unsupported"
+	DiagnosticAuthenticationRejected  DiagnosticCode = "authentication_rejected"
+	DiagnosticResourceNotFound        DiagnosticCode = "resource_not_found"
+	DiagnosticResourceConflict        DiagnosticCode = "resource_conflict"
+	DiagnosticStateNotReady           DiagnosticCode = "state_not_ready"
+	DiagnosticDependencyFailed        DiagnosticCode = "dependency_failed"
+	DiagnosticRequestFailed           DiagnosticCode = "request_failed"
+	DiagnosticInternalError           DiagnosticCode = "internal_error"
+)
+
+// Diagnostic carries structured failure metadata without changing the error's
+// user-facing message, classification, cause chain, or exit-code behavior.
+type Diagnostic struct {
+	Code      DiagnosticCode
+	Parameter string
+}
+
+type diagnosticCarrier interface {
+	Diagnostic() Diagnostic
+}
+
+type diagnosticError struct {
+	err        error
+	diagnostic Diagnostic
+}
+
+func (e diagnosticError) Error() string          { return e.err.Error() }
+func (e diagnosticError) Unwrap() error          { return e.err }
+func (e diagnosticError) Diagnostic() Diagnostic { return e.diagnostic }
+
+// WithDiagnostic attaches allowlisted structured metadata to err. Unknown
+// codes are deliberately ignored so arbitrary strings cannot become a
+// telemetry dimension.
+func WithDiagnostic(err error, code DiagnosticCode, parameter string) error {
+	if err == nil {
+		return nil
+	}
+	if !IsKnownDiagnosticCode(code) {
+		return err
+	}
+	return diagnosticError{
+		err: err,
+		diagnostic: Diagnostic{
+			Code:      code,
+			Parameter: strings.TrimSpace(parameter),
+		},
+	}
+}
+
+// DiagnosticFromError returns the outermost allowlisted diagnostic annotation
+// in err's chain.
+func DiagnosticFromError(err error) (Diagnostic, bool) {
+	var carrier diagnosticCarrier
+	if !errors.As(err, &carrier) {
+		return Diagnostic{}, false
+	}
+	diagnostic := carrier.Diagnostic()
+	if !IsKnownDiagnosticCode(diagnostic.Code) {
+		return Diagnostic{}, false
+	}
+	diagnostic.Parameter = strings.TrimSpace(diagnostic.Parameter)
+	return diagnostic, true
+}
+
+// IsKnownDiagnosticCode reports whether code belongs to the bounded public
+// diagnostic taxonomy.
+func IsKnownDiagnosticCode(code DiagnosticCode) bool {
+	switch code {
+	case DiagnosticRequiredInputMissing,
+		DiagnosticInvalidInput,
+		DiagnosticConflictingInput,
+		DiagnosticFileNotFound,
+		DiagnosticFilePermissionDenied,
+		DiagnosticFileInvalidFormat,
+		DiagnosticKeyAlgorithmUnsupported,
+		DiagnosticAuthenticationRejected,
+		DiagnosticResourceNotFound,
+		DiagnosticResourceConflict,
+		DiagnosticStateNotReady,
+		DiagnosticDependencyFailed,
+		DiagnosticRequestFailed,
+		DiagnosticInternalError:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/shared/errors_test.go
+++ b/internal/cli/shared/errors_test.go
@@ -54,3 +54,61 @@ func TestNewReportedUsageErrorNormalizesUnknownKind(t *testing.T) {
 		t.Fatalf("ClassifyUsageError() = %q, want %q", got, UsageErrorMissingRequired)
 	}
 }
+
+func TestWithDiagnosticPreservesExistingErrorContract(t *testing.T) {
+	cause := errors.New("credential source")
+	base := NewErrorWithCause(
+		NewReportedUsageError(UsageErrorMissingRequired, "--name is required"),
+		cause,
+	)
+	err := WithDiagnostic(base, DiagnosticRequiredInputMissing, "--name")
+
+	if got, want := err.Error(), "--name is required"; got != want {
+		t.Fatalf("WithDiagnostic().Error() = %q, want %q", got, want)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("WithDiagnostic() should preserve the cause chain: %v", err)
+	}
+	if !IsReportedUsageError(err) {
+		t.Fatalf("WithDiagnostic() should preserve reported usage classification: %T", err)
+	}
+	if got := ClassifyUsageError(err); got != UsageErrorMissingRequired {
+		t.Fatalf("ClassifyUsageError() = %q, want %q", got, UsageErrorMissingRequired)
+	}
+
+	diagnostic, ok := DiagnosticFromError(err)
+	if !ok {
+		t.Fatal("DiagnosticFromError() did not find structured metadata")
+	}
+	if diagnostic.Code != DiagnosticRequiredInputMissing || diagnostic.Parameter != "--name" {
+		t.Fatalf("DiagnosticFromError() = %+v", diagnostic)
+	}
+}
+
+func TestDiagnosticFromErrorUsesOutermostAnnotation(t *testing.T) {
+	err := WithDiagnostic(
+		WithDiagnostic(errors.New("unchanged"), DiagnosticInvalidInput, "--issuer-id"),
+		DiagnosticConflictingInput,
+		"--key-type",
+	)
+
+	diagnostic, ok := DiagnosticFromError(err)
+	if !ok {
+		t.Fatal("DiagnosticFromError() did not find structured metadata")
+	}
+	if diagnostic.Code != DiagnosticConflictingInput || diagnostic.Parameter != "--key-type" {
+		t.Fatalf("DiagnosticFromError() = %+v", diagnostic)
+	}
+}
+
+func TestWithDiagnosticRejectsUnboundedCode(t *testing.T) {
+	base := errors.New("unchanged")
+	err := WithDiagnostic(base, DiagnosticCode("user-controlled-value"), "--name")
+
+	if !errors.Is(err, base) {
+		t.Fatalf("WithDiagnostic() should preserve an error with an unknown code: %T", err)
+	}
+	if _, ok := DiagnosticFromError(err); ok {
+		t.Fatal("DiagnosticFromError() accepted an unknown code")
+	}
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -85,6 +85,9 @@ type EventContext struct {
 	ErrorKind        ErrorKind
 	FailureStage     FailureStage
 	FailureParameter string
+	// DiagnosticCode is populated from structured CLI errors. It remains an
+	// in-process field until the ingestion service accepts the new dimension.
+	DiagnosticCode   string
 	OutcomeKind      OutcomeKind
 	HTTPStatus       int
 	PublicStorefront bool


### PR DESCRIPTION
## Summary

- add an allowlisted, low-cardinality diagnostic taxonomy and an error wrapper that preserves existing messages, causes, usage classification, and exit-code behavior
- make validation telemetry prefer structured failure parameters while retaining the existing rendered-message heuristic for legacy errors
- carry `diagnostic_code` in the in-process event context for both validation and runtime failures

## Compatibility

This PR deliberately does not serialize `diagnostic_code` yet. It can improve existing `failure_parameter` telemetry as commands are annotated, while keeping the schema-v4 wire payload compatible with the current Rork ingestion contract. Wire activation will follow the Rork ingestion change.

There are no command-message, help, or exit-code changes in this PR.

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/shared ./cmd`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- pre-commit docs, formatting, lint, and short-suite hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command failure diagnostics with consistent error codes and relevant parameters.
  * Preserved legacy validation-message handling when structured diagnostics are unavailable.
  * Improved classification of validation and runtime failures.

* **Privacy**
  * Added privacy-safe diagnostic metadata for internal failure analysis without adding diagnostic details to telemetry payloads.

* **Tests**
  * Added coverage for structured diagnostics, fallback behavior, error preservation, and invalid diagnostic codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->