### PR TITLE
fix(ads): first-run remediation, stdin payloads, starter examples in help

### DIFF
--- a/internal/appleads/auth_store.go
+++ b/internal/appleads/auth_store.go
@@ -20,6 +20,10 @@ const (
 	adsBypassKeychainEnvVar = "ASC_ADS_BYPASS_KEYCHAIN"
 )
 
+// ErrDefaultCredentialsNotFound reports that no default Apple Ads credential
+// is stored in the keychain or configuration.
+var ErrDefaultCredentialsNotFound = errors.New("default credentials not found")
+
 // StoredCredential is an Apple Ads credential with storage metadata.
 type StoredCredential struct {
 	Credentials
@@ -151,7 +155,7 @@ func GetCredentialsWithSource(profile string) (Credentials, string, error) {
 				return cfgCred.Credentials, "config", nil
 			}
 			if len(credentials) > 0 {
-				return Credentials{}, "", fmt.Errorf("default credentials not found")
+				return Credentials{}, "", ErrDefaultCredentialsNotFound
 			}
 		} else if !isKeyringUnavailable(err) {
 			return Credentials{}, "", err
@@ -560,7 +564,7 @@ func getCredentialFromConfig(profile string) (StoredCredential, error) {
 	if strings.TrimSpace(profile) != "" {
 		return StoredCredential{}, fmt.Errorf("credentials not found for profile %q", profile)
 	}
-	return StoredCredential{}, fmt.Errorf("default credentials not found")
+	return StoredCredential{}, ErrDefaultCredentialsNotFound
 }
 
 func loadConfigWithPath() (*config.Config, string, error) {

--- a/internal/appleads/endpoints.go
+++ b/internal/appleads/endpoints.go
@@ -51,10 +51,13 @@ type EndpointSpec struct {
 	// the SDK/OpenAPI request contract. Apple accepts an empty selector body on
 	// some query endpoints, but the Platform API requires a selector filter for
 	// the keyword queries exposed by asc.
-	CLIRequiresBody  bool
-	BodyType         string
-	BodyHint         string
-	BodyFileExample  string
+	CLIRequiresBody bool
+	BodyType        string
+	BodyHint        string
+	BodyFileExample string
+	// BodyExample is a minimal valid request payload rendered in command help
+	// so callers can start from a working body instead of external schema docs.
+	BodyExample      string
 	ResponseType     string
 	RequiresOrg      bool
 	RequiresConfirm  bool

--- a/internal/appleads/platform_endpoints_reports.go
+++ b/internal/appleads/platform_endpoints_reports.go
@@ -23,11 +23,11 @@ const (
     {"field": "promotedObjectId", "operator": "EQUALS", "value": "123456789"}
   ],
   "options": {"impressionShareReportType": "FIRST_SLOT"},
-  "timeRange": {"start": "2025-01-01", "end": "2025-01-07", "granularity": "DAILY"},
+  "timeRange": {"start": "2025-01-01", "end": "2025-01-07", "timeZone": "UTC", "granularity": "DAILY"},
   "pagination": {"offset": 0, "pageSize": 20}
 }`
 	searchTermPopularityStarterPayload = `{
-  "timeRange": {"start": "2025-01-05", "end": "2025-01-11", "granularity": "WEEKLY_SUN_SAT"},
+  "timeRange": {"start": "2025-01-05", "end": "2025-01-11", "timeZone": "UTC", "granularity": "WEEKLY_SUN_SAT"},
   "filters": [
     {"field": "countryOrRegion", "operator": "EQUALS", "value": "US"}
   ],

--- a/internal/appleads/platform_endpoints_reports.go
+++ b/internal/appleads/platform_endpoints_reports.go
@@ -56,10 +56,24 @@ const (
     "promotedObjectType": "APPSTORE_APP"
   }
 ]`
+	dailyBudgetDismissStarterPayload = `[
+  {
+    "id": "RECOMMENDATION_ID",
+    "promotedObjectId": "123456",
+    "promotedObjectType": "APPSTORE_APP"
+  }
+]`
 	targetCpaApplyStarterPayload = `[
   {
     "id": "RECOMMENDATION_ID",
     "appliedTargetCPA": {"amount": "5.00", "currency": "USD"},
+    "promotedObjectId": "123456",
+    "promotedObjectType": "APPSTORE_APP"
+  }
+]`
+	targetCpaDismissStarterPayload = `[
+  {
+    "id": "RECOMMENDATION_ID",
     "promotedObjectId": "123456",
     "promotedObjectType": "APPSTORE_APP"
   }
@@ -152,10 +166,15 @@ func platformReportsOptimizationEndpointSpecs() []EndpointSpec {
 		case spec.RequiresConfirm || spec.RiskConfirm:
 			spec.BodyFileExample = "recommendations.json"
 			spec.BodyHint = "Pass a non-empty array built from a recommendation query response. Apply and dismiss operations require --confirm."
-			if strings.HasPrefix(spec.Path, "v1/recommendations/daily-budgets/") {
+			switch spec.Path {
+			case "v1/recommendations/daily-budgets/apply":
 				spec.BodyExample = dailyBudgetApplyStarterPayload
-			} else if strings.HasPrefix(spec.Path, "v1/recommendations/target-cpas/") {
+			case "v1/recommendations/daily-budgets/dismiss":
+				spec.BodyExample = dailyBudgetDismissStarterPayload
+			case "v1/recommendations/target-cpas/apply":
 				spec.BodyExample = targetCpaApplyStarterPayload
+			case "v1/recommendations/target-cpas/dismiss":
+				spec.BodyExample = targetCpaDismissStarterPayload
 			}
 		case spec.BodyKind != BodyNone:
 			spec.BodyFileExample = "query.json"

--- a/internal/appleads/platform_endpoints_reports.go
+++ b/internal/appleads/platform_endpoints_reports.go
@@ -2,6 +2,70 @@ package appleads
 
 import "strings"
 
+// Starter payloads mirror the worked request examples in Apple's Platform API
+// documentation so command help offers a valid body without external docs.
+const (
+	appsReportStarterPayload = `{
+  "timeRange": {"start": "2025-01-01", "end": "2025-01-31", "timeZone": "ORTZ", "granularity": "DAILY"},
+  "fields": ["impressions", "taps", "localSpend"],
+  "groupBy": ["countryOrRegion"],
+  "pagination": {"offset": 0, "pageSize": 20}
+}`
+	brandsReportStarterPayload = `{
+  "timeRange": {"start": "2025-01-01", "end": "2025-01-10", "timeZone": "ORTZ", "granularity": "DAILY"},
+  "fields": ["campaignId", "impressions", "taps", "localSpend"],
+  "groupBy": ["deviceClass"],
+  "options": {"includeRows": ["GRAND_TOTAL"]},
+  "pagination": {"offset": 0, "pageSize": 20}
+}`
+	impressionShareStarterPayload = `{
+  "filters": [
+    {"field": "promotedObjectId", "operator": "EQUALS", "value": "123456789"}
+  ],
+  "options": {"impressionShareReportType": "FIRST_SLOT"},
+  "timeRange": {"start": "2025-01-01", "end": "2025-01-07", "granularity": "DAILY"},
+  "pagination": {"offset": 0, "pageSize": 20}
+}`
+	searchTermPopularityStarterPayload = `{
+  "timeRange": {"start": "2025-01-05", "end": "2025-01-11", "granularity": "WEEKLY_SUN_SAT"},
+  "filters": [
+    {"field": "countryOrRegion", "operator": "EQUALS", "value": "US"}
+  ],
+  "sorting": [{"field": "rankInGenre", "order": "ASC"}],
+  "pagination": {"offset": 0, "pageSize": 20}
+}`
+	suggestionQueryStarterPayload = `{
+  "filters": [
+    {"field": "promotedObjectId", "operator": "EQUALS", "value": ["123456"]},
+    {"field": "promotedObjectType", "operator": "EQUALS", "value": ["APPSTORE_APP"]},
+    {"field": "queryType", "operator": "EQUALS", "value": ["SUGGESTION"]}
+  ]
+}`
+	recommendationQueryStarterPayload = `{
+  "filters": [
+    {"field": "promotedObjectId", "operator": "EQUALS", "value": ["123456"]},
+    {"field": "promotedObjectType", "operator": "EQUALS", "value": ["APPSTORE_APP"]}
+  ],
+  "pagination": {"offset": 0, "pageSize": 20}
+}`
+	dailyBudgetApplyStarterPayload = `[
+  {
+    "id": "RECOMMENDATION_ID",
+    "appliedDailyBudget": {"amount": "500.00", "currency": "USD"},
+    "promotedObjectId": "123456",
+    "promotedObjectType": "APPSTORE_APP"
+  }
+]`
+	targetCpaApplyStarterPayload = `[
+  {
+    "id": "RECOMMENDATION_ID",
+    "appliedTargetCPA": {"amount": "5.00", "currency": "USD"},
+    "promotedObjectId": "123456",
+    "promotedObjectType": "APPSTORE_APP"
+  }
+]`
+)
+
 // platformReportsOptimizationEndpointSpecs returns the Platform API v1
 // reporting, insights, recommendations, suggestions, and change-history
 // surface. Reporting request pagination remains in the JSON body, so these
@@ -64,21 +128,35 @@ func platformReportsOptimizationEndpointSpecs() []EndpointSpec {
 		case strings.HasPrefix(spec.Path, "v1/reports/"):
 			spec.BodyFileExample = "report.json"
 			spec.BodyHint = "Use nested timeRange {start,end,timeZone,granularity}; pagination is {offset,pageSize}. Put campaign and ad-group selectors in filters. EMPTY_METRICS cannot be combined with groupBy; brand reports support only GRAND_TOTAL."
+			if strings.HasPrefix(spec.Path, "v1/reports/business-brands/") {
+				spec.BodyExample = brandsReportStarterPayload
+			} else {
+				spec.BodyExample = appsReportStarterPayload
+			}
 		case spec.Name == "platform-query-app-impression-share-data":
 			spec.BodyFileExample = "query.json"
 			spec.BodyHint = "Required: filters must include promotedObjectId, plus a complete timeRange. Use UTC and DAILY (maximum 30 days) or WEEKLY_SUN_SAT (maximum 4 weeks, starting Sunday). impressionShareReportType is FIRST_SLOT or ALL_SLOTS; pageSize max 5000; at most 2 sort fields."
+			spec.BodyExample = impressionShareStarterPayload
 		case spec.Name == "platform-query-app-search-term-popularity-data":
 			spec.BodyFileExample = "query.json"
 			spec.BodyHint = "Required: timeRange. Use UTC and WEEKLY_SUN_SAT or MONTHLY; pageSize max 5000; at most 2 sort fields."
+			spec.BodyExample = searchTermPopularityStarterPayload
 		case strings.HasPrefix(spec.Path, "v1/suggestions/categories/") || strings.HasPrefix(spec.Path, "v1/suggestions/phrases/"):
 			spec.BodyFileExample = "query.json"
 			spec.BodyHint = "For queryType SUGGESTION, filter by promotedObjectId and promotedObjectType. For queryType SEARCH, use the phrase or category filter documented by Apple; Apple's generic request schema does not describe this exception."
+			spec.BodyExample = suggestionQueryStarterPayload
 		case strings.HasPrefix(spec.Path, "v1/suggestions/") || (strings.HasPrefix(spec.Path, "v1/recommendations/") && strings.HasSuffix(spec.Path, "/query")):
 			spec.BodyFileExample = "query.json"
 			spec.BodyHint = "filters must include promotedObjectId and promotedObjectType. Pagination defaults to offset 0 and pageSize 20, with pageSize max 1000."
+			spec.BodyExample = recommendationQueryStarterPayload
 		case spec.RequiresConfirm || spec.RiskConfirm:
 			spec.BodyFileExample = "recommendations.json"
 			spec.BodyHint = "Pass a non-empty array built from a recommendation query response. Apply and dismiss operations require --confirm."
+			if strings.HasPrefix(spec.Path, "v1/recommendations/daily-budgets/") {
+				spec.BodyExample = dailyBudgetApplyStarterPayload
+			} else if strings.HasPrefix(spec.Path, "v1/recommendations/target-cpas/") {
+				spec.BodyExample = targetCpaApplyStarterPayload
+			}
 		case spec.BodyKind != BodyNone:
 			spec.BodyFileExample = "query.json"
 		}

--- a/internal/appleads/platform_endpoints_reports_test.go
+++ b/internal/appleads/platform_endpoints_reports_test.go
@@ -263,6 +263,34 @@ func TestPlatformReportsOptimizationStarterPayloads(t *testing.T) {
 	}
 }
 
+func TestInsightStarterPayloadsUseUTCTimeZone(t *testing.T) {
+	paths := [][]string{
+		{"insights", "impression-share", "find"},
+		{"insights", "search-term-popularity", "find"},
+	}
+
+	for _, path := range paths {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			spec, ok := PlatformEndpointByCommandPath(path...)
+			if !ok {
+				t.Fatalf("missing %q", strings.Join(path, " "))
+			}
+
+			var payload struct {
+				TimeRange struct {
+					TimeZone string `json:"timeZone"`
+				} `json:"timeRange"`
+			}
+			if err := json.Unmarshal([]byte(spec.BodyExample), &payload); err != nil {
+				t.Fatalf("starter payload is not a JSON object: %v", err)
+			}
+			if payload.TimeRange.TimeZone != "UTC" {
+				t.Errorf("timeRange.timeZone = %q, want UTC", payload.TimeRange.TimeZone)
+			}
+		})
+	}
+}
+
 func TestRecommendationDismissStarterPayloadsExcludeApplyOnlyFields(t *testing.T) {
 	tests := []struct {
 		path       []string

--- a/internal/appleads/platform_endpoints_reports_test.go
+++ b/internal/appleads/platform_endpoints_reports_test.go
@@ -262,3 +262,38 @@ func TestPlatformReportsOptimizationStarterPayloads(t *testing.T) {
 		}
 	}
 }
+
+func TestRecommendationDismissStarterPayloadsExcludeApplyOnlyFields(t *testing.T) {
+	tests := []struct {
+		path       []string
+		applyField string
+	}{
+		{path: []string{"recommendations", "daily-budgets", "dismiss"}, applyField: "appliedDailyBudget"},
+		{path: []string{"recommendations", "target-cpas", "dismiss"}, applyField: "appliedTargetCPA"},
+	}
+
+	for _, test := range tests {
+		t.Run(strings.Join(test.path, " "), func(t *testing.T) {
+			spec, ok := PlatformEndpointByCommandPath(test.path...)
+			if !ok {
+				t.Fatalf("missing %q", strings.Join(test.path, " "))
+			}
+
+			var payload []map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(spec.BodyExample), &payload); err != nil {
+				t.Fatalf("starter payload is not a JSON object array: %v", err)
+			}
+			if len(payload) != 1 {
+				t.Fatalf("starter payload has %d items, want 1", len(payload))
+			}
+			if _, ok := payload[0][test.applyField]; ok {
+				t.Fatalf("dismiss starter payload includes apply-only field %q", test.applyField)
+			}
+			for _, field := range []string{"id", "promotedObjectId", "promotedObjectType"} {
+				if _, ok := payload[0][field]; !ok {
+					t.Errorf("dismiss starter payload is missing %q", field)
+				}
+			}
+		})
+	}
+}

--- a/internal/appleads/platform_endpoints_reports_test.go
+++ b/internal/appleads/platform_endpoints_reports_test.go
@@ -2,6 +2,7 @@ package appleads
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -210,6 +211,53 @@ func TestPlatformReportsOptimizationPayloadGuidance(t *testing.T) {
 		for _, want := range test.want {
 			if !strings.Contains(spec.BodyHint, want) {
 				t.Errorf("%s body hint = %q, want %q", strings.Join(test.path, " "), spec.BodyHint, want)
+			}
+		}
+	}
+}
+
+func TestPlatformReportsOptimizationStarterPayloads(t *testing.T) {
+	// Commands whose help must carry a starter payload verified against the
+	// worked examples in Apple's Platform API documentation.
+	required := [][]string{
+		{"reports", "apps", "campaigns"},
+		{"reports", "brands", "campaigns"},
+		{"insights", "impression-share", "find"},
+		{"insights", "search-term-popularity", "find"},
+		{"suggestions", "phrases", "find"},
+		{"suggestions", "keywords", "find"},
+		{"recommendations", "daily-budgets", "find"},
+		{"recommendations", "daily-budgets", "apply"},
+		{"recommendations", "target-cpas", "apply"},
+	}
+	for _, path := range required {
+		spec, ok := PlatformEndpointByCommandPath(path...)
+		if !ok {
+			t.Fatalf("missing %q", strings.Join(path, " "))
+		}
+		if strings.TrimSpace(spec.BodyExample) == "" {
+			t.Errorf("%s has no starter payload", strings.Join(path, " "))
+		}
+	}
+
+	for _, spec := range PlatformEndpointSpecs() {
+		example := strings.TrimSpace(spec.BodyExample)
+		if example == "" {
+			continue
+		}
+		var payload any
+		if err := json.Unmarshal([]byte(example), &payload); err != nil {
+			t.Errorf("%s starter payload is not valid JSON: %v", spec.Name, err)
+			continue
+		}
+		switch spec.BodyKind {
+		case BodyObject:
+			if _, ok := payload.(map[string]any); !ok {
+				t.Errorf("%s starter payload must be a JSON object", spec.Name)
+			}
+		case BodyArray:
+			if _, ok := payload.([]any); !ok {
+				t.Errorf("%s starter payload must be a JSON array", spec.Name)
 			}
 		}
 	}

--- a/internal/cli/ads/api.go
+++ b/internal/cli/ads/api.go
@@ -42,7 +42,7 @@ func APIRequestCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("ads v5 api request", flag.ExitOnError)
 	method := fs.String("method", "GET", "HTTP method: GET, POST, PUT, DELETE")
 	path := fs.String("path", "", "Relative v5 path or Apple Ads API URL")
-	file := fs.String("file", "", "Path to JSON request payload")
+	file := fs.String("file", "", "Path to JSON request payload ('-' reads stdin)")
 	confirm := fs.Bool("confirm", false, "Confirm destructive or operationally risky v5 requests")
 	common := commonFlags{
 		AdsProfile: fs.String("ads-profile", "", "Use named Apple Ads authentication profile"),

--- a/internal/cli/ads/auth.go
+++ b/internal/cli/ads/auth.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -392,10 +393,7 @@ func statusActiveContext() adsAuthContext {
 }
 
 func isNoAdsCredentialError(err error) bool {
-	if err == nil {
-		return false
-	}
-	return err.Error() == "default credentials not found"
+	return errors.Is(err, appleads.ErrDefaultCredentialsNotFound)
 }
 
 func storageDescription(rows []adsAuthStatusRow) string {

--- a/internal/cli/ads/deprecation_test.go
+++ b/internal/cli/ads/deprecation_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestAdsLegacyMigrationLedgerMatchesAllV5EndpointSpecs(t *testing.T) {
@@ -80,6 +82,13 @@ func TestAdsLegacyProductPageRejectionMigrationsUseAppEndpoints(t *testing.T) {
 }
 
 func TestAdsLegacyCommandWarningIsEmittedOnceBeforeExistingExecution(t *testing.T) {
+	// Isolate host credentials so the alias deterministically fails at
+	// credential resolution instead of reaching the live Apple Ads API.
+	asc.ResetConfigCacheForTest()
+	t.Cleanup(asc.ResetConfigCacheForTest)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	setAdsResolverTestEnv(t)
+
 	command := findCommand(AdsCommand(), "v5", "campaigns")
 	if command == nil || command.Exec == nil {
 		t.Fatal("missing campaigns legacy alias")

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -266,6 +266,14 @@ func endpointBodyHelp(spec appleads.EndpointSpec) string {
 		hint = strings.ReplaceAll(hint, "\n", "\n  ")
 		help += "\n  Guidance: " + hint
 	}
+	if strings.TrimSpace(spec.BodyExample) != "" {
+		fileName := strings.TrimSpace(spec.BodyFileExample)
+		if fileName == "" {
+			fileName = "payload.json"
+		}
+		example := strings.ReplaceAll(strings.TrimSpace(spec.BodyExample), "\n", "\n    ")
+		help += fmt.Sprintf("\n  Starter payload (%s):\n    %s", fileName, example)
+	}
 	return help
 }
 

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -392,7 +392,7 @@ func bindEndpointFlags(spec appleads.EndpointSpec, flagSetName string) (*flag.Fl
 		}
 	}
 	if spec.BodyKind != appleads.BodyNone {
-		values.file = fs.String("file", "", "Path to Apple Ads JSON payload")
+		values.file = fs.String("file", "", "Path to Apple Ads JSON payload ('-' reads stdin)")
 	}
 	if spec.RequiresConfirm || spec.RiskConfirm {
 		values.confirm = fs.Bool("confirm", false, confirmFlagUsage(spec))

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -755,8 +755,8 @@ func TestPlatformCampaignAndBudgetRiskConfirmationPrecedesAuth(t *testing.T) {
 	}{
 		{name: "missing status", payload: `{ "name": "agent-test" }`, want: `--confirm is required unless status is explicitly "PAUSED"; otherwise acknowledge potential Apple Ads spend, billing, delivery, targeting, or access impact`},
 		{name: "enabled", payload: `{ "status": "ENABLED" }`, want: `--confirm is required unless status is explicitly "PAUSED"; otherwise acknowledge potential Apple Ads spend, billing, delivery, targeting, or access impact`},
-		{name: "paused", payload: `{ "status": "PAUSED" }`, want: "ads: configuration not found"},
-		{name: "enabled confirmed", payload: `{ "status": "ENABLED" }`, confirm: true, want: "ads: configuration not found"},
+		{name: "paused", payload: `{ "status": "PAUSED" }`, want: "ads: configuration not found; run 'asc ads auth login' to store Apple Ads credentials, set ASC_ADS_* environment credentials, or pass --ads-profile"},
+		{name: "enabled confirmed", payload: `{ "status": "ENABLED" }`, confirm: true, want: "ads: configuration not found; run 'asc ads auth login' to store Apple Ads credentials, set ASC_ADS_* environment credentials, or pass --ads-profile"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			file := filepath.Join(t.TempDir(), "campaign.json")
@@ -837,7 +837,7 @@ func TestPlatformCampaignUpdateAndBudgetUpdateConfirmBeforeAuth(t *testing.T) {
 		confirm bool
 		want    string
 	}{
-		{name: "paused name-only update is safe", payload: `{"name":"paused-name","status":"PAUSED"}`, want: "ads: configuration not found"},
+		{name: "paused name-only update is safe", payload: `{"name":"paused-name","status":"PAUSED"}`, want: "ads: configuration not found; run 'asc ads auth login' to store Apple Ads credentials, set ASC_ADS_* environment credentials, or pass --ads-profile"},
 		{name: "missing status", payload: `{"name":"name-only"}`, want: `--confirm is required unless status is "PAUSED" and only non-spend fields are changed`},
 		{name: "enabled status", payload: `{"status":"ENABLED"}`, want: `--confirm is required unless status is "PAUSED" and only non-spend fields are changed`},
 		{name: "daily budget", payload: `{"status":"PAUSED","dailyBudget":1}`, want: `--confirm is required unless status is "PAUSED" and only non-spend fields are changed`},
@@ -847,7 +847,7 @@ func TestPlatformCampaignUpdateAndBudgetUpdateConfirmBeforeAuth(t *testing.T) {
 		{name: "start", payload: `{"status":"PAUSED","start":"2026-08-15"}`, want: `--confirm is required unless status is "PAUSED" and only non-spend fields are changed`},
 		{name: "resume", payload: `{"status":"PAUSED","resume":true}`, want: `--confirm is required unless status is "PAUSED" and only non-spend fields are changed`},
 		{name: "enabled field", payload: `{"status":"PAUSED","enabled":true}`, want: `--confirm is required unless status is "PAUSED" and only non-spend fields are changed`},
-		{name: "confirmed spend update", payload: `{"status":"ENABLED","dailyBudget":1}`, confirm: true, want: "ads: configuration not found"},
+		{name: "confirmed spend update", payload: `{"status":"ENABLED","dailyBudget":1}`, confirm: true, want: "ads: configuration not found; run 'asc ads auth login' to store Apple Ads credentials, set ASC_ADS_* environment credentials, or pass --ads-profile"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -288,6 +288,20 @@ func TestPlatformEndpointHelpIncludesAgentPayloadGuidance(t *testing.T) {
 			},
 		},
 		{
+			path: []string{"insights", "search-term-popularity", "find"},
+			want: []string{
+				"Starter payload (query.json):",
+				`"granularity": "WEEKLY_SUN_SAT"`,
+			},
+		},
+		{
+			path: []string{"reports", "apps", "campaigns"},
+			want: []string{
+				"Starter payload (report.json):",
+				`"timeZone": "ORTZ"`,
+			},
+		},
+		{
 			path: []string{"budget-orders", "create"},
 			want: []string{
 				"--confirm",

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -1913,3 +1913,36 @@ func assertSpecFlags(t *testing.T, cmd *ffcli.Command, spec appleads.EndpointSpe
 		t.Fatalf("asc ads %s missing --paginate", strings.Join(spec.CommandPath, " "))
 	}
 }
+
+func TestReadBodyReadsStdinPayload(t *testing.T) {
+	spec, ok := appleads.PlatformEndpointByCommandPath("insights", "search-term-popularity", "find")
+	if !ok {
+		t.Fatal("missing insights search-term-popularity find")
+	}
+
+	payload := `{"timeRange":{"start":"2026-07-05","end":"2026-08-08","granularity":"WEEKLY_SUN_SAT"}}`
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	previous := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = previous
+		reader.Close()
+	})
+	go func() {
+		defer writer.Close()
+		_, _ = writer.WriteString(payload)
+	}()
+
+	_, flags := bindEndpointFlags(spec, "insights search-term-popularity find")
+	*flags.file = "-"
+	body, err := readBody(spec, flags)
+	if err != nil {
+		t.Fatalf("readBody(stdin) error: %v", err)
+	}
+	if string(body) != payload {
+		t.Fatalf("readBody(stdin) = %q, want %q", string(body), payload)
+	}
+}

--- a/internal/cli/ads/platform_api.go
+++ b/internal/cli/ads/platform_api.go
@@ -38,7 +38,7 @@ func PlatformAPIRequestCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("ads api request", flag.ExitOnError)
 	method := fs.String("method", "GET", "HTTP method: GET, POST, PUT, DELETE")
 	path := fs.String("path", "", "Relative v1 path or Apple Ads Platform API URL")
-	file := fs.String("file", "", "Path to JSON request payload")
+	file := fs.String("file", "", "Path to JSON request payload ('-' reads stdin)")
 	confirm := fs.Bool("confirm", false, confirmFlagUsage(appleads.EndpointSpec{RiskConfirm: true}))
 	common := commonFlags{
 		AdsProfile: fs.String("ads-profile", "", "Use named Apple Ads authentication profile"),

--- a/internal/cli/ads/resolve.go
+++ b/internal/cli/ads/resolve.go
@@ -111,10 +111,17 @@ func resolveCredentialsWithSource(flags commonFlags) (appleads.Credentials, stri
 
 	credentials, _, err := appleads.GetCredentialsWithSource("")
 	if err != nil {
+		if errors.Is(err, appleads.ErrDefaultCredentialsNotFound) || errors.Is(err, config.ErrNotFound) {
+			return appleads.Credentials{}, "", fmt.Errorf("%w; %s", err, adsCredentialsRemediation)
+		}
 		return appleads.Credentials{}, "", err
 	}
 	return credentials, "default Ads profile", nil
 }
+
+// adsCredentialsRemediation tells a first-run caller how to authenticate when
+// no Apple Ads credential source is configured.
+const adsCredentialsRemediation = "run 'asc ads auth login' to store Apple Ads credentials, set ASC_ADS_* environment credentials, or pass --ads-profile"
 
 func envCredentials() (appleads.Credentials, bool, error) {
 	rawOrgID := os.Getenv("ASC_ADS_ORG_ID")

--- a/internal/cli/ads/resolve_test.go
+++ b/internal/cli/ads/resolve_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
 )
 
@@ -160,6 +161,48 @@ func TestResolveOrgIDRejectsUnsafeValuesFromEverySource(t *testing.T) {
 			_, _, err := resolveOrgIDWithSource(flags, tt.credentials)
 			if err == nil || !strings.Contains(err.Error(), "invalid organization ID") {
 				t.Fatalf("resolveOrgIDWithSource() error = %v, want invalid organization ID", err)
+			}
+		})
+	}
+}
+
+func TestResolveCredentialsMissingDefaultExplainsRemediation(t *testing.T) {
+	tests := []struct {
+		name       string
+		saveConfig bool
+		wantBase   string
+		wantNoCred bool
+	}{
+		{name: "missing config file", saveConfig: false, wantBase: "configuration not found"},
+		{name: "config without ads credentials", saveConfig: true, wantBase: "default credentials not found", wantNoCred: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asc.ResetConfigCacheForTest()
+			t.Cleanup(asc.ResetConfigCacheForTest)
+			configPath := filepath.Join(t.TempDir(), "config.json")
+			t.Setenv("ASC_CONFIG_PATH", configPath)
+			setAdsResolverTestEnv(t)
+			if tt.saveConfig {
+				if err := config.SaveAt(configPath, &config.Config{}); err != nil {
+					t.Fatalf("SaveAt() error: %v", err)
+				}
+			}
+
+			_, err := resolveCredentials(commonFlags{})
+			if err == nil {
+				t.Fatal("resolveCredentials() error = nil, want missing-credentials error")
+			}
+			if !strings.Contains(err.Error(), tt.wantBase) {
+				t.Fatalf("resolveCredentials() error = %v, want %q", err, tt.wantBase)
+			}
+			for _, want := range []string{"asc ads auth login", "ASC_ADS_", "--ads-profile"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("resolveCredentials() error = %q, want remediation mentioning %q", err.Error(), want)
+				}
+			}
+			if got := isNoAdsCredentialError(err); got != tt.wantNoCred {
+				t.Fatalf("isNoAdsCredentialError(%v) = %v, want %v", err, got, tt.wantNoCred)
 			}
 		})
 	}

--- a/internal/cli/shared/json_payload.go
+++ b/internal/cli/shared/json_payload.go
@@ -18,15 +18,18 @@ const (
 	JSONPayloadAny    JSONPayloadKind = "any"
 )
 
-// ReadJSONFilePayload loads a JSON object from a file path for commands that
-// accept raw payload documents.
+// ReadJSONFilePayload loads a JSON object from a file path ("-" for standard
+// input) for commands that accept raw payload documents.
 func ReadJSONFilePayload(path string) (json.RawMessage, error) {
 	return ReadJSONFilePayloadKind(path, JSONPayloadObject)
 }
 
-// ReadJSONFilePayloadKind loads a JSON payload from a file path and validates
-// the requested top-level JSON shape.
+// ReadJSONFilePayloadKind loads a JSON payload from a file path ("-" for
+// standard input) and validates the requested top-level JSON shape.
 func ReadJSONFilePayloadKind(path string, kind JSONPayloadKind) (json.RawMessage, error) {
+	if path == "-" {
+		return readJSONStdinPayloadKind(kind)
+	}
 	file, err := openJSONPayloadFile(path)
 	if err != nil {
 		return nil, err
@@ -45,8 +48,23 @@ func ReadJSONFilePayloadKind(path string, kind JSONPayloadKind) (json.RawMessage
 	if err != nil {
 		return nil, err
 	}
+	return validateJSONPayloadKind(data, "payload file", kind)
+}
+
+func readJSONStdinPayloadKind(kind JSONPayloadKind) (json.RawMessage, error) {
+	if isTerminal(int(os.Stdin.Fd())) {
+		return nil, fmt.Errorf("stdin is a terminal; pipe JSON to --file - or pass a file path")
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+	return validateJSONPayloadKind(data, "stdin payload", kind)
+}
+
+func validateJSONPayloadKind(data []byte, source string, kind JSONPayloadKind) (json.RawMessage, error) {
 	if strings.TrimSpace(string(data)) == "" {
-		return nil, fmt.Errorf("payload file is empty")
+		return nil, fmt.Errorf("%s is empty", source)
 	}
 
 	var payload any

--- a/internal/cli/shared/json_payload_test.go
+++ b/internal/cli/shared/json_payload_test.go
@@ -169,3 +169,99 @@ func TestReadJSONFilePayloadKind(t *testing.T) {
 		}
 	})
 }
+
+func setStdinPayload(t *testing.T, contents string) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	previous := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = previous
+		reader.Close()
+	})
+	go func() {
+		defer writer.Close()
+		_, _ = writer.WriteString(contents)
+	}()
+}
+
+func TestReadJSONFilePayloadKindReadsStdin(t *testing.T) {
+	t.Run("object payload", func(t *testing.T) {
+		setStdinPayload(t, `{"name":"demo"}`)
+
+		payload, err := ReadJSONFilePayloadKind("-", JSONPayloadObject)
+		if err != nil {
+			t.Fatalf("ReadJSONFilePayloadKind unexpected error: %v", err)
+		}
+		if string(payload) != `{"name":"demo"}` {
+			t.Fatalf("unexpected payload: %q", string(payload))
+		}
+	})
+
+	t.Run("array payload", func(t *testing.T) {
+		setStdinPayload(t, `[{"id":"1"}]`)
+
+		payload, err := ReadJSONFilePayloadKind("-", JSONPayloadArray)
+		if err != nil {
+			t.Fatalf("ReadJSONFilePayloadKind unexpected error: %v", err)
+		}
+		if string(payload) != `[{"id":"1"}]` {
+			t.Fatalf("unexpected payload: %q", string(payload))
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		setStdinPayload(t, `{"name"`)
+
+		_, err := ReadJSONFilePayloadKind("-", JSONPayloadObject)
+		if err == nil {
+			t.Fatal("expected error for invalid stdin payload")
+		}
+		if !strings.Contains(err.Error(), "invalid JSON:") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty stdin", func(t *testing.T) {
+		setStdinPayload(t, " \n")
+
+		_, err := ReadJSONFilePayloadKind("-", JSONPayloadObject)
+		if err == nil {
+			t.Fatal("expected error for empty stdin payload")
+		}
+		if !strings.Contains(err.Error(), "stdin payload is empty") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("kind mismatch", func(t *testing.T) {
+		setStdinPayload(t, `[1,2,3]`)
+
+		_, err := ReadJSONFilePayloadKind("-", JSONPayloadObject)
+		if err == nil {
+			t.Fatal("expected object payload error")
+		}
+		if !strings.Contains(err.Error(), "payload must be a JSON object") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("terminal stdin rejected", func(t *testing.T) {
+		previous := isTerminal
+		isTerminal = func(int) bool { return true }
+		t.Cleanup(func() {
+			isTerminal = previous
+		})
+
+		_, err := ReadJSONFilePayloadKind("-", JSONPayloadObject)
+		if err == nil {
+			t.Fatal("expected error for terminal stdin")
+		}
+		if !strings.Contains(err.Error(), "stdin is a terminal") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Three agent-ergonomics fixes for the `asc ads` surface, from a friction review of driving the new Platform v1 commands blind (help-only, no external docs):

1. **Credentials errors now explain the fix.** A first run of any ads endpoint command previously failed with the bare `ads: default credentials not found` (or `ads: configuration not found`). Both first-run flavors now append: `run 'asc ads auth login' to store Apple Ads credentials, set ASC_ADS_* environment credentials, or pass --ads-profile`.
2. **`--file -` reads the JSON payload from stdin.** No more temp-file dance per query for scripted/agent callers. Implemented in the shared JSON payload loader, so non-ads `--file` commands using it inherit the convention; only ads help text advertises it in this PR. If stdin is a terminal, the command errors immediately (`stdin is a terminal; pipe JSON to --file - or pass a file path`) instead of blocking.
3. **Query command help now includes a working starter payload.** Reports (apps/brands), insights (impression-share, search-term-popularity), suggestions, and recommendations query/apply commands render a `Starter payload (query.json):` block mirrored from the worked request examples in Apple's Platform API documentation. `change-history find` stays hint-only because Apple publishes no worked example for `AuditQuery`.

Also includes a standalone test fix discovered while validating: `TestAdsLegacyCommandWarningIsEmittedOnceBeforeExistingExecution` did not isolate `ASC_CONFIG_PATH`/`ASC_ADS_*`, so on a machine with real Apple Ads credentials it reached the live API and failed (`unexpectedly succeeded`). It now runs against an isolated config.

## Expected invocations

```
$ asc ads insights search-term-popularity find --file query.json --ad-account 123
Error: ads: configuration not found; run 'asc ads auth login' to store Apple Ads credentials, set ASC_ADS_* environment credentials, or pass --ads-profile

$ echo '{"timeRange":{...}}' | asc ads insights search-term-popularity find --file - --ad-account 123

$ asc ads insights search-term-popularity find --help
  ...
  Guidance: Required: timeRange. Use UTC and WEEKLY_SUN_SAT or MONTHLY; ...
  Starter payload (query.json):
    {
      "timeRange": {"start": "2025-01-05", "end": "2025-01-11", "granularity": "WEEKLY_SUN_SAT"},
      ...
    }
```

## Design notes and alternatives

- **Remediation at the CLI resolve layer, not in `appleads`**: `appleads.ErrDefaultCredentialsNotFound` is now an exported sentinel and `isNoAdsCredentialError` matches with `errors.Is`, so `ads auth status` still renders an unconfigured state cleanly instead of string-comparing the exact message. Alternative — hint text inside `appleads` — would have leaked CLI flag names into the client library.
- **Stdin in the shared loader vs ads-only**: implemented once in `shared.ReadJSONFilePayloadKind` (single implementation point, standard `-` convention). Alternative — ads-local branch — would fork payload handling. Non-ads commands inherit `-` support silently; their help text can catch up separately.
- **Starter payloads in help vs a new `--example` flag**: help is where agents already look (endpoint, schema, guidance live there), needs no new flag surface, and `BodyExample` slots into the existing `EndpointSpec` table. Examples are asserted valid JSON of the correct body shape by `TestPlatformReportsOptimizationStarterPayloads`.

## Compatibility

- Error message change: the two first-run credential failures gain an appended clause; the original sentence remains a prefix, so prefix/substring matchers keep working. Exact-match tests were updated.
- `--file -` previously failed with `open -: no such file or directory`; it is now meaningful. No other path values change behavior.
- Help output grows a `Starter payload` block on ads query commands; `docs/COMMANDS.md` is unaffected (it does not include the generated ads tree).

## Validation

- TDD: each change landed RED first (`TestResolveCredentialsMissingDefaultExplainsRemediation`, `TestReadJSONFilePayloadKindReadsStdin`, `TestReadBodyReadsStdinPayload`, `TestPlatformReportsOptimizationStarterPayloads`, extended `TestPlatformEndpointHelpIncludesAgentPayloadGuidance`).
- `make format`, `make check-docs`, `make lint` (0 issues), `ASC_BYPASS_KEYCHAIN=1 make test` — full suite green, 0 failures.
- Built binary verification (isolated env, no credentials): remediated error text, stdin happy path (fails later at credentials, proving the payload was read and validated), stdin invalid-JSON error, and rendered starter payload in `--help` all confirmed.
- No live API verification needed: no request/response behavior changes; all changes are pre-auth CLI behavior and help text. Payload examples mirror Apple's published worked examples (`developer.apple.com/documentation/apple-ads-platform-api`).

## Risks / limitations

- Starter payloads are documentation-verified, not live-verified against every endpoint; they use Apple's own example values (placeholder IDs return empty results rather than validation errors).
- The stdin terminal guard is unit-tested via the `isTerminal` seam, not under a real PTY.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added starter JSON payload examples to command help for supported reports, searches, suggestions, and recommendations.
  * Added support for reading JSON request payloads from standard input with `--file -`.
* **Bug Fixes**
  * Improved missing-credential errors with clear guidance for logging in or configuring credentials.
  * Added validation for empty, invalid, and incorrectly shaped JSON payloads from files or standard input.
* **Documentation**
  * Updated command-line help to explain payload input options and provide example request bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->