### PR TITLE
Emit structured diagnostic codes in telemetry

### DIFF
--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -3016,6 +3016,42 @@ func TestWriteJUnitReport(t *testing.T) {
 	}
 }
 
+func TestWriteJUnitReportPreservesMissingRequiredParameter(t *testing.T) {
+	resetReportFlags(t)
+
+	reportPath := filepath.Join(t.TempDir(), "junit.xml")
+	shared.SetReportFile(reportPath)
+	t.Cleanup(func() {
+		shared.SetReportFile("")
+	})
+
+	if err := writeJUnitReport("asc reviews list", shared.MissingRequiredUsageError("--app"), time.Second); err != nil {
+		t.Fatalf("writeJUnitReport() error: %v", err)
+	}
+
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+
+	var suite struct {
+		TestCases []struct {
+			Failure *struct {
+				Message string `xml:"message,attr"`
+			} `xml:"failure"`
+		} `xml:"testcase"`
+	}
+	if err := xml.Unmarshal(data, &suite); err != nil {
+		t.Fatalf("xml.Unmarshal() error: %v", err)
+	}
+	if len(suite.TestCases) != 1 || suite.TestCases[0].Failure == nil {
+		t.Fatalf("unexpected testcase payload: %+v", suite.TestCases)
+	}
+	if got := suite.TestCases[0].Failure.Message; got != "--app" {
+		t.Fatalf("failure message = %q, want %q", got, "--app")
+	}
+}
+
 func resetReportFlags(t *testing.T) {
 	t.Helper()
 	shared.SetReportFormat("")

--- a/cmd/run_telemetry_blackbox_test.go
+++ b/cmd/run_telemetry_blackbox_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
 
@@ -22,8 +23,6 @@ func TestRun_BuiltBinaryEmitsSchemaV4Payload(t *testing.T) {
 		"attach-build",
 		"--version-id",
 		"VERSION_ID",
-		"--app-id",
-		"BUILD_ID",
 	)
 	command.Env = telemetryBlackboxEnv(home, false, "https://127.0.0.1:1/events")
 	output, err := command.CombinedOutput()
@@ -49,8 +48,8 @@ func TestRun_BuiltBinaryEmitsSchemaV4Payload(t *testing.T) {
 	if event.SchemaVersion != 4 || event.OutcomeKind != telemetry.OutcomeUsageError {
 		t.Fatalf("unexpected schema-v4 payload: %+v", event)
 	}
-	if event.FailureParameter == nil || *event.FailureParameter != "--app-id" {
-		t.Fatalf("FailureParameter = %v, want --app-id", event.FailureParameter)
+	if event.FailureParameter != nil {
+		t.Fatalf("FailureParameter = %v, want nil until the call site is migrated", event.FailureParameter)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(record.Event, &payload); err != nil {
@@ -59,8 +58,8 @@ func TestRun_BuiltBinaryEmitsSchemaV4Payload(t *testing.T) {
 	if value, exists := payload["http_status"]; !exists || value != nil {
 		t.Fatalf("http_status = %v (exists=%t), want explicit null", value, exists)
 	}
-	if value, exists := payload["diagnostic_code"]; !exists || value != nil {
-		t.Fatalf("diagnostic_code = %v (exists=%t), want explicit null", value, exists)
+	if value, exists := payload["diagnostic_code"]; !exists || value != string(shared.DiagnosticRequiredInputMissing) {
+		t.Fatalf("diagnostic_code = %v (exists=%t), want %q", value, exists, shared.DiagnosticRequiredInputMissing)
 	}
 }
 

--- a/cmd/run_telemetry_blackbox_test.go
+++ b/cmd/run_telemetry_blackbox_test.go
@@ -59,6 +59,9 @@ func TestRun_BuiltBinaryEmitsSchemaV4Payload(t *testing.T) {
 	if value, exists := payload["http_status"]; !exists || value != nil {
 		t.Fatalf("http_status = %v (exists=%t), want explicit null", value, exists)
 	}
+	if value, exists := payload["diagnostic_code"]; !exists || value != nil {
+		t.Fatalf("diagnostic_code = %v (exists=%t), want explicit null", value, exists)
+	}
 }
 
 func TestRun_BuiltBinaryDoesNotWaitForBlockedTelemetryEndpoint(t *testing.T) {

--- a/commands/telemetry.mdx
+++ b/commands/telemetry.mdx
@@ -109,6 +109,7 @@ The CLI sends a single best-effort JSON event after command completion:
   "error_kind": null,
   "failure_stage": null,
   "failure_parameter": null,
+  "diagnostic_code": null,
   "outcome_kind": "success",
   "http_status": null
 }
@@ -121,11 +122,13 @@ process and changes the next time `asc` starts.
 
 `invocation_shape` is one of `leaf`, `bare_group`, `group_with_flags`, or
 `unknown_child`. Failed schema-v4 events also include an allowlisted
-`error_kind`, `failure_stage`, and nullable `failure_parameter`; successful
-events set these fields to `null`. These fields are derived inside the CLI and
-never contain stderr, error text, flag values, or positional values.
-`failure_parameter` is limited to a sanitized public long flag name such as
-`--app`.
+`error_kind`, `failure_stage`, nullable `failure_parameter`, and nullable
+`diagnostic_code`; successful events set these fields to `null`. These fields
+are derived inside the CLI and never contain stderr, error text, flag values,
+or positional values. `failure_parameter` is limited to a sanitized public
+long flag name such as `--app`. `diagnostic_code` is limited to the CLI's
+low-cardinality allowlist, such as `required_input_missing` or
+`file_invalid_format`.
 
 `outcome_kind` separates success, expected negative validation results, usage errors,
 authentication and API failures, transport failures, cancellations, and
@@ -195,6 +198,7 @@ CREATE TABLE asc_cli_events
   error_kind Nullable(LowCardinality(String)),
   failure_stage Nullable(LowCardinality(String)),
   failure_parameter Nullable(LowCardinality(String)),
+  diagnostic_code Nullable(LowCardinality(String)),
   outcome_kind Nullable(LowCardinality(String)),
   http_status Nullable(Int16),
   source LowCardinality(String),

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -232,7 +232,11 @@ func MissingRequiredUsageError(parameters ...string) error {
 	if len(parameters) > 0 {
 		parameter = strings.TrimSpace(parameters[0])
 	}
-	return classifiedUsageError{kind: UsageErrorMissingRequired, message: parameter}
+	return WithDiagnostic(
+		classifiedUsageError{kind: UsageErrorMissingRequired, message: parameter},
+		DiagnosticRequiredInputMissing,
+		parameter,
+	)
 }
 
 func ClassifyUsageError(err error) UsageErrorKind {

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -233,7 +233,7 @@ func MissingRequiredUsageError(parameters ...string) error {
 		parameter = strings.TrimSpace(parameters[0])
 	}
 	return WithDiagnostic(
-		classifiedUsageError{kind: UsageErrorMissingRequired},
+		classifiedUsageError{kind: UsageErrorMissingRequired, message: parameter},
 		DiagnosticRequiredInputMissing,
 		parameter,
 	)

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -233,7 +233,7 @@ func MissingRequiredUsageError(parameters ...string) error {
 		parameter = strings.TrimSpace(parameters[0])
 	}
 	return WithDiagnostic(
-		classifiedUsageError{kind: UsageErrorMissingRequired, message: parameter},
+		classifiedUsageError{kind: UsageErrorMissingRequired},
 		DiagnosticRequiredInputMissing,
 		parameter,
 	)

--- a/internal/cli/shared/errors_test.go
+++ b/internal/cli/shared/errors_test.go
@@ -93,7 +93,7 @@ func TestMissingRequiredUsageErrorCarriesStructuredDiagnostic(t *testing.T) {
 		wantParameter string
 	}{
 		{name: "without parameter", wantMessage: flag.ErrHelp.Error()},
-		{name: "with parameter", parameter: "--app", wantMessage: flag.ErrHelp.Error(), wantParameter: "--app"},
+		{name: "with parameter", parameter: "--app", wantMessage: "--app", wantParameter: "--app"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := MissingRequiredUsageError(tt.parameter)

--- a/internal/cli/shared/errors_test.go
+++ b/internal/cli/shared/errors_test.go
@@ -93,7 +93,7 @@ func TestMissingRequiredUsageErrorCarriesStructuredDiagnostic(t *testing.T) {
 		wantParameter string
 	}{
 		{name: "without parameter", wantMessage: flag.ErrHelp.Error()},
-		{name: "with parameter", parameter: "--app", wantMessage: "--app", wantParameter: "--app"},
+		{name: "with parameter", parameter: "--app", wantMessage: flag.ErrHelp.Error(), wantParameter: "--app"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := MissingRequiredUsageError(tt.parameter)

--- a/internal/cli/shared/errors_test.go
+++ b/internal/cli/shared/errors_test.go
@@ -85,6 +85,38 @@ func TestWithDiagnosticPreservesExistingErrorContract(t *testing.T) {
 	}
 }
 
+func TestMissingRequiredUsageErrorCarriesStructuredDiagnostic(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		parameter     string
+		wantMessage   string
+		wantParameter string
+	}{
+		{name: "without parameter", wantMessage: flag.ErrHelp.Error()},
+		{name: "with parameter", parameter: "--app", wantMessage: "--app", wantParameter: "--app"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := MissingRequiredUsageError(tt.parameter)
+			if got := err.Error(); got != tt.wantMessage {
+				t.Fatalf("MissingRequiredUsageError().Error() = %q, want %q", got, tt.wantMessage)
+			}
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("MissingRequiredUsageError() should preserve flag.ErrHelp: %v", err)
+			}
+			if got := ClassifyUsageError(err); got != UsageErrorMissingRequired {
+				t.Fatalf("ClassifyUsageError() = %q, want %q", got, UsageErrorMissingRequired)
+			}
+			diagnostic, ok := DiagnosticFromError(err)
+			if !ok {
+				t.Fatal("DiagnosticFromError() did not find required-input metadata")
+			}
+			if diagnostic.Code != DiagnosticRequiredInputMissing || diagnostic.Parameter != tt.wantParameter {
+				t.Fatalf("DiagnosticFromError() = %+v", diagnostic)
+			}
+		})
+	}
+}
+
 func TestDiagnosticFromErrorUsesOutermostAnnotation(t *testing.T) {
 	err := WithDiagnostic(
 		WithDiagnostic(errors.New("unchanged"), DiagnosticInvalidInput, "--issuer-id"),

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 type Event struct {
@@ -30,6 +31,7 @@ type Event struct {
 	ErrorKind        *ErrorKind       `json:"error_kind"`
 	FailureStage     *FailureStage    `json:"failure_stage"`
 	FailureParameter *string          `json:"failure_parameter"`
+	DiagnosticCode   *string          `json:"diagnostic_code,omitempty"`
 	OutcomeKind      OutcomeKind      `json:"outcome_kind,omitempty"`
 	HTTPStatus       *int             `json:"http_status,omitempty"`
 }
@@ -85,8 +87,8 @@ type EventContext struct {
 	ErrorKind        ErrorKind
 	FailureStage     FailureStage
 	FailureParameter string
-	// DiagnosticCode is populated from structured CLI errors. It remains an
-	// in-process field until the ingestion service accepts the new dimension.
+	// DiagnosticCode is populated from structured CLI errors and is sanitized
+	// against the shared low-cardinality taxonomy before it reaches the wire.
 	DiagnosticCode   string
 	OutcomeKind      OutcomeKind
 	HTTPStatus       int
@@ -149,6 +151,7 @@ func BuildEventWithContext(
 		ErrorKind:        optionalErrorKind(eventContext.ErrorKind),
 		FailureStage:     optionalFailureStage(eventContext.FailureStage),
 		FailureParameter: optionalFailureParameter(eventContext.FailureParameter, exitCode),
+		DiagnosticCode:   optionalDiagnosticCode(eventContext.DiagnosticCode, exitCode),
 		OutcomeKind:      eventContext.OutcomeKind,
 		HTTPStatus:       optionalHTTPStatus(eventContext.HTTPStatus),
 	}, true
@@ -167,6 +170,7 @@ func normalizeEventContext(eventContext EventContext, exitCode int) EventContext
 		eventContext.ErrorKind = ""
 		eventContext.FailureStage = ""
 		eventContext.FailureParameter = ""
+		eventContext.DiagnosticCode = ""
 		eventContext.OutcomeKind = OutcomeSuccess
 		eventContext.HTTPStatus = 0
 		return eventContext
@@ -277,6 +281,17 @@ func optionalHTTPStatus(status int) *int {
 	return &status
 }
 
+func optionalDiagnosticCode(code string, exitCode int) *string {
+	if exitCode == 0 {
+		return nil
+	}
+	code = strings.TrimSpace(code)
+	if !shared.IsKnownDiagnosticCode(shared.DiagnosticCode(code)) {
+		return nil
+	}
+	return &code
+}
+
 func sanitizeHTTPStatus(status int) int {
 	if status < 400 || status > 599 {
 		return 0
@@ -293,10 +308,12 @@ func (event Event) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(struct {
 		eventAlias
-		HTTPStatus *int `json:"http_status"`
+		HTTPStatus     *int    `json:"http_status"`
+		DiagnosticCode *string `json:"diagnostic_code"`
 	}{
-		eventAlias: eventAlias(event),
-		HTTPStatus: event.HTTPStatus,
+		eventAlias:     eventAlias(event),
+		HTTPStatus:     event.HTTPStatus,
+		DiagnosticCode: event.DiagnosticCode,
 	})
 }
 

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestBuildEventSanitizesCommand(t *testing.T) {
@@ -51,6 +53,9 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 	if value, exists := payload["http_status"]; !exists || value != nil {
 		t.Fatalf("http_status = %v (exists=%t), want explicit null", value, exists)
 	}
+	if value, exists := payload["diagnostic_code"]; !exists || value != nil {
+		t.Fatalf("diagnostic_code = %v (exists=%t), want explicit null", value, exists)
+	}
 	if _, exists := payload["execution_context"]; exists {
 		t.Fatal("legacy execution_context field should not be emitted")
 	}
@@ -58,6 +63,65 @@ func TestBuildEventSanitizesCommand(t *testing.T) {
 		if _, exists := payload[forbiddenField]; exists {
 			t.Fatalf("event contains forbidden raw-argument field %q", forbiddenField)
 		}
+	}
+}
+
+func TestBuildEventWithContextEmitsAllowlistedDiagnosticCode(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc auth login",
+		"1.2.3",
+		0,
+		2,
+		EventContext{
+			DiagnosticCode: string(shared.DiagnosticFileInvalidFormat),
+		},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.DiagnosticCode == nil || *ev.DiagnosticCode != string(shared.DiagnosticFileInvalidFormat) {
+		t.Fatalf("DiagnosticCode = %v, want %q", ev.DiagnosticCode, shared.DiagnosticFileInvalidFormat)
+	}
+
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+	if payload["diagnostic_code"] != string(shared.DiagnosticFileInvalidFormat) {
+		t.Fatalf("diagnostic_code = %v, want %q", payload["diagnostic_code"], shared.DiagnosticFileInvalidFormat)
+	}
+}
+
+func TestBuildEventWithContextRejectsUnboundedDiagnosticCode(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc auth login",
+		"1.2.3",
+		0,
+		2,
+		EventContext{DiagnosticCode: "private-key-at-/Users/example/AuthKey.p8"},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.DiagnosticCode != nil {
+		t.Fatalf("DiagnosticCode = %q, want nil", *ev.DiagnosticCode)
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	if strings.Contains(string(data), "/Users/example/AuthKey.p8") {
+		t.Fatalf("payload leaked unbounded diagnostic code: %s", data)
 	}
 }
 
@@ -226,7 +290,7 @@ func TestSchemaV3SpoolRecordOmitsSchemaV4Fields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal event: %v", err)
 	}
-	for _, field := range []string{"outcome_kind", "http_status"} {
+	for _, field := range []string{"outcome_kind", "http_status", "diagnostic_code"} {
 		if strings.Contains(string(data), `"`+field+`"`) {
 			t.Fatalf("schema-v3 payload contains schema-v4 field %q: %s", field, data)
 		}


### PR DESCRIPTION
## Summary

- serialize the structured diagnostic code added by #2032 on schema-v4 failure events
- sanitize codes against the shared low-cardinality taxonomy before they reach the wire
- emit explicit null for ordinary v4 events and keep queued schema-v3 records wire-compatible

## Dependency and rollout

This is a stacked draft on #2032.

Do not merge or release this producer change until rorkai/rorkai#5286 has been merged, its database migration has been applied, and the Rork API deployment is accepting diagnostic_code. The required order is:

1. Apply the Rork nullable-column and constraint migration.
2. Deploy rorkai/rorkai#5286.
3. Merge and release this ASC change.

## Verification

- RED: telemetry tests failed because Event had no DiagnosticCode field
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/telemetry
- ASC_BYPASS_KEYCHAIN=1 go test ./cmd ./internal/cli/shared ./internal/telemetry
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- pre-commit docs, format, lint, and short test suite

No existing CLI messages, command behavior, or exit codes change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added diagnostic codes to failed telemetry events, including required-input-missing details.
  * Successful events report no diagnostic code, while unsupported values are excluded.
* **Bug Fixes**
  * Improved missing-required-input errors with consistent classification and parameter details.
  * Ensured schema-v4 telemetry always includes the nullable diagnostic field and schema-v3 behavior remains compatible.
* **Documentation**
  * Documented the new diagnostic field, supported values, and recommended storage format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->