### PR TITLE
fix(ads): correct Search Term Popularity sorting

### DIFF
--- a/docs/design/apple-ads-platform-api-v1.md
+++ b/docs/design/apple-ads-platform-api-v1.md
@@ -126,6 +126,20 @@ reports do not support `EMPTY_METRICS`. The v5 custom impression-share
 `name` and relative `dateRange` members are also rejected with their specific
 v1 migration paths.
 
+Search Term Popularity has one runtime-only exception. Apple's Platform API
+documentation and generated clients model its sort member as `order`, but the
+live endpoint rejects that property and accepts `sortOrder` instead. The CLI
+therefore accepts `sorting[].sortOrder` with the v1 values `ASC` and `DESC`
+only for `SearchTermPopularityQueryRequest`; all other v1 query schemas keep
+the documented `sorting[].order` contract. The starter payload and local
+migration errors expose this endpoint-specific spelling before authentication.
+
+Alternatives considered were silently rewriting `order` on the wire and
+removing sorting from the starter payload. Rewriting would make the sent body
+differ from the operator's file, while omission would leave explicit sorting
+unusable. An endpoint-specific validated spelling is transparent and keeps the
+exception from weakening the other v1 migration guards.
+
 Explicit `null` legacy members are rejected because the Platform API rejects
 the property itself. The CLI does not rewrite payloads automatically: value
 cardinality and accepted fields vary by endpoint, so silent conversion could

--- a/internal/appleads/platform_endpoints_reports.go
+++ b/internal/appleads/platform_endpoints_reports.go
@@ -31,7 +31,7 @@ const (
   "filters": [
     {"field": "countryOrRegion", "operator": "EQUALS", "value": "US"}
   ],
-  "sorting": [{"field": "rankInGenre", "order": "ASC"}],
+  "sorting": [{"field": "rankInGenre", "sortOrder": "ASC"}],
   "pagination": {"offset": 0, "pageSize": 20}
 }`
 	suggestionQueryStarterPayload = `{
@@ -153,7 +153,7 @@ func platformReportsOptimizationEndpointSpecs() []EndpointSpec {
 			spec.BodyExample = impressionShareStarterPayload
 		case spec.Name == "platform-query-app-search-term-popularity-data":
 			spec.BodyFileExample = "query.json"
-			spec.BodyHint = "Required: timeRange. Use UTC and WEEKLY_SUN_SAT or MONTHLY; pageSize max 5000; at most 2 sort fields."
+			spec.BodyHint = "Required: timeRange. Use UTC and WEEKLY_SUN_SAT or MONTHLY; pageSize max 5000; at most 2 sort fields. This endpoint uses sorting[].sortOrder with ASC or DESC."
 			spec.BodyExample = searchTermPopularityStarterPayload
 		case strings.HasPrefix(spec.Path, "v1/suggestions/categories/") || strings.HasPrefix(spec.Path, "v1/suggestions/phrases/"):
 			spec.BodyFileExample = "query.json"

--- a/internal/appleads/platform_endpoints_reports_test.go
+++ b/internal/appleads/platform_endpoints_reports_test.go
@@ -291,6 +291,29 @@ func TestInsightStarterPayloadsUseUTCTimeZone(t *testing.T) {
 	}
 }
 
+func TestSearchTermPopularityStarterPayloadUsesRuntimeSortKey(t *testing.T) {
+	spec, ok := PlatformEndpointByCommandPath("insights", "search-term-popularity", "find")
+	if !ok {
+		t.Fatal("missing search-term-popularity find")
+	}
+
+	var payload struct {
+		Sorting []map[string]json.RawMessage `json:"sorting"`
+	}
+	if err := json.Unmarshal([]byte(spec.BodyExample), &payload); err != nil {
+		t.Fatalf("starter payload is not a JSON object: %v", err)
+	}
+	if len(payload.Sorting) != 1 {
+		t.Fatalf("sorting has %d entries, want 1", len(payload.Sorting))
+	}
+	if _, ok := payload.Sorting[0]["order"]; ok {
+		t.Fatal("search term popularity starter payload uses documentation-only order key")
+	}
+	if got := string(payload.Sorting[0]["sortOrder"]); got != `"ASC"` {
+		t.Fatalf("sorting sortOrder = %s, want ASC", got)
+	}
+}
+
 func TestRecommendationDismissStarterPayloadsExcludeApplyOnlyFields(t *testing.T) {
 	tests := []struct {
 		path       []string

--- a/internal/cli/ads/endpoints.go
+++ b/internal/cli/ads/endpoints.go
@@ -818,6 +818,7 @@ type legacyPlatformQueryMembers struct {
 	conditions                 bool
 	values                     bool
 	orderBy                    bool
+	order                      bool
 	sortOrder                  bool
 	limit                      bool
 	selectorFields             bool
@@ -864,7 +865,11 @@ func validatePlatformQueryMigration(spec appleads.EndpointSpec, body json.RawMes
 	if legacy.orderBy {
 		migrations = append(migrations, `"orderBy" -> "sorting"`)
 	}
-	if legacy.sortOrder {
+	if spec.BodyType == "SearchTermPopularityQueryRequest" {
+		if legacy.order {
+			migrations = append(migrations, `sorting "order" -> "sortOrder" for Search Term Popularity`)
+		}
+	} else if legacy.sortOrder {
 		migrations = append(migrations, `sorting "sortOrder" -> "order"`)
 	}
 	if legacy.limit {
@@ -994,6 +999,9 @@ func inspectLegacyPlatformSorting(raw json.RawMessage, legacy *legacyPlatformQue
 		return
 	}
 	for _, entry := range entries {
+		if _, present := entry["order"]; present {
+			legacy.order = true
+		}
 		if _, present := entry["sortOrder"]; present {
 			legacy.sortOrder = true
 		}

--- a/internal/cli/ads/endpoints_test.go
+++ b/internal/cli/ads/endpoints_test.go
@@ -458,10 +458,15 @@ func TestPlatformQueryMigrationValidation(t *testing.T) {
 	}
 
 	validV1 := json.RawMessage(`{"filters":[{"field":"id","operator":"EQUALS","value":"123"}],"sorting":[{"field":"id","order":"DESC"}],"pagination":{"offset":0,"pageSize":5}}`)
+	validSearchTermPopularity := json.RawMessage(`{"filters":[{"field":"countryOrRegion","operator":"EQUALS","value":"US"}],"sorting":[{"field":"rankInGenre","sortOrder":"DESC"}],"pagination":{"offset":0,"pageSize":5}}`)
 	legacyConditions := json.RawMessage(`{"conditions":null}`)
 	for _, spec := range querySpecs {
 		t.Run(strings.Join(spec.CommandPath, "-"), func(t *testing.T) {
-			if err := validateEndpointBody(spec, validV1, false); err != nil {
+			validBody := validV1
+			if spec.BodyType == "SearchTermPopularityQueryRequest" {
+				validBody = validSearchTermPopularity
+			}
+			if err := validateEndpointBody(spec, validBody, false); err != nil {
 				t.Fatalf("valid Platform v1 query rejected: %v", err)
 			}
 			fieldsErr := validatePlatformQueryMigration(spec, json.RawMessage(`{"fields":null}`))
@@ -485,6 +490,16 @@ func TestPlatformQueryMigrationValidation(t *testing.T) {
 	}
 	if err := validateEndpointBody(campaigns, json.RawMessage(`{"filters":[{"field":"name","operator":"STARTS_WITH","value":"x"}],"sorting":[{"field":"id","order":"DESC"}]}`), false); err != nil {
 		t.Fatalf("renamed v1 operator and sort order rejected: %v", err)
+	}
+	searchTermPopularity, ok := appleads.PlatformEndpointByCommandPath("insights", "search-term-popularity", "find")
+	if !ok {
+		t.Fatal("missing search term popularity find")
+	}
+	if err := validateEndpointBody(searchTermPopularity, json.RawMessage(`{"sorting":[{"field":"rankInGenre","sortOrder":"ASC"}]}`), false); err != nil {
+		t.Fatalf("runtime search term popularity sort key rejected: %v", err)
+	}
+	if err := validateEndpointBody(searchTermPopularity, json.RawMessage(`{"sorting":[{"field":"rankInGenre","order":"ASC"}]}`), false); err == nil || !strings.Contains(err.Error(), `sorting "order" -> "sortOrder"`) {
+		t.Fatalf("documentation-only search term popularity sort key error = %v, want runtime migration hint", err)
 	}
 	for _, test := range []struct {
 		name string

--- a/internal/cli/cmdtest/ads_platform_reports_test.go
+++ b/internal/cli/cmdtest/ads_platform_reports_test.go
@@ -86,6 +86,59 @@ func TestAdsPlatformAppCampaignReportRequest(t *testing.T) {
 	}
 }
 
+func TestAdsPlatformSearchTermPopularityUsesRuntimeSortKey(t *testing.T) {
+	isolateAdsGuideEnv(t)
+	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_ADS_ACCESS_TOKEN", "ACCESS")
+	t.Setenv("ASC_ADS_AD_ACCOUNT_ID", "AD_ACCOUNT")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.json"))
+
+	requestJSON := `{
+  "timeRange": {"start": "2026-08-02", "end": "2026-08-08", "timeZone": "UTC", "granularity": "WEEKLY_SUN_SAT"},
+  "sorting": [{"field": "rankInGenre", "sortOrder": "ASC"}],
+  "pagination": {"offset": 0, "pageSize": 20}
+}`
+	payloadPath := filepath.Join(t.TempDir(), "query.json")
+	if err := os.WriteFile(payloadPath, []byte(requestJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	installDefaultTransport(t, adsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.Host != "api.ads.apple.com" || req.URL.Path != "/v1/insights/apps/search-term-popularity/query" {
+			t.Fatalf("request = %s %s", req.Method, req.URL.String())
+		}
+		var body struct {
+			Sorting []map[string]json.RawMessage `json:"sorting"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(body.Sorting) != 1 || string(body.Sorting[0]["sortOrder"]) != `"ASC"` {
+			t.Fatalf("sorting = %#v, want sortOrder ASC", body.Sorting)
+		}
+		if _, ok := body.Sorting[0]["order"]; ok {
+			t.Fatalf("sorting sent documentation-only order key: %#v", body.Sorting)
+		}
+		return adsJSONResponse(200, `{"result":[],"pagination":{"totalResults":0}}`), nil
+	}))
+
+	root := RootCommand("dev")
+	if err := root.Parse([]string{"ads", "insights", "search-term-popularity", "find", "--file", payloadPath, "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if !json.Valid([]byte(stdout)) {
+		t.Fatalf("stdout is not JSON: %s", stdout)
+	}
+}
+
 func TestAdsPlatformChangeHistoryDetailRequest(t *testing.T) {
 	isolateAdsGuideEnv(t)
 	t.Setenv("ASC_ADS_BYPASS_KEYCHAIN", "1")


### PR DESCRIPTION
Fixes #2038.

## Problem

Apple's published Platform API schema and generated clients describe Search Term Popularity sorting as `sorting[].order`, but the live endpoint rejects `order`. The runtime endpoint expects `sorting[].sortOrder`, while the CLI's generic v5 migration guard rejected that spelling before the request could be sent.

## Changes

- use `sorting[].sortOrder` with `ASC` / `DESC` in the Search Term Popularity starter payload and help
- accept that runtime spelling only for `SearchTermPopularityQueryRequest`
- reject `sorting[].order` for that endpoint with a targeted migration hint
- keep the documented `sorting[].order` contract for every other Platform API v1 query
- document the runtime-only exception and why the CLI does not silently rewrite payloads

## Verification

- RED regression reproduced against the old starter payload
- focused endpoint, validator, and HTTP transport tests pass
- built CLI accepts `sortOrder`, sends it unchanged to `/v1/insights/apps/search-term-popularity/query`, and rejects `order` locally with the targeted hint
- live authenticated control against ad account `21771090`: the pre-fix binary sends `order` and Apple returns HTTP 400 `REQUEST: Unrecognized property 'order'.`
- live authenticated verification against the same account: the fixed binary sends `sortOrder: ASC`, exits successfully, and returns 20 result rows with no API error
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
