### PR TITLE
Add structured diagnostics to TestFlight validation

### DIFF
--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -121,7 +121,7 @@ Examples:
 
 			if *internal && *external {
 				fmt.Fprintln(os.Stderr, "Error: --internal and --external are mutually exclusive")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "")
 			}
 			appIDSet := false
 			buildIDSet := false
@@ -138,15 +138,15 @@ Examples:
 			})
 			if buildIDSet && resolvedBuildID == "" {
 				fmt.Fprintln(os.Stderr, "Error: --build-id cannot be empty")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--build-id")
 			}
 			if resolvedBuildID != "" && appIDSet && strings.TrimSpace(*appID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app cannot be empty when used with --build-id")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--app")
 			}
 			if resolvedBuildID != "" && membershipPageControlSet {
 				fmt.Fprintln(os.Stderr, "Error: --global, --limit, --next, and --paginate cannot be used with --build-id; membership lookup always fetches all required pages")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "")
 			}
 
 			if resolvedBuildID != "" {
@@ -177,7 +177,7 @@ Examples:
 			// Reject --global + --app combination (check explicit flag, not resolved value)
 			if *global && strings.TrimSpace(*appID) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --global and --app are mutually exclusive")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "")
 			}
 
 			// Require one of --app or --global (unless --next is provided)
@@ -567,7 +567,7 @@ Examples:
 
 			if visited["public-link-limit"] && (*publicLinkLimit < 1 || *publicLinkLimit > 10000) {
 				fmt.Fprintln(os.Stderr, "Error: --public-link-limit must be between 1 and 10000")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--public-link-limit")
 			}
 
 			hasUpdates := strings.TrimSpace(*name) != "" ||

--- a/internal/cli/testflight/beta_groups_relationships.go
+++ b/internal/cli/testflight/beta_groups_relationships.go
@@ -82,7 +82,7 @@ Examples:
 			kind, ok := betaGroupRelationshipKinds[relationshipType]
 			if !ok {
 				fmt.Fprintf(os.Stderr, "Error: --type must be one of: %s\n", strings.Join(relationshipTypeList(betaGroupRelationshipKinds), ", "))
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--type")
 			}
 
 			groupValue := strings.TrimSpace(*groupID)
@@ -101,7 +101,7 @@ Examples:
 
 			if kind == relationshipSingle && (nextValue != "" || *paginate || *limit != 0) {
 				fmt.Fprintln(os.Stderr, "Error: --limit, --next, and --paginate are only valid for to-many relationships")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "")
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_license_agreements.go
+++ b/internal/cli/testflight/beta_license_agreements.go
@@ -151,11 +151,11 @@ Examples:
 			}
 			if idValue != "" && strings.TrimSpace(*appID) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --id and --app are mutually exclusive")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "")
 			}
 			if appValue != "" && (strings.TrimSpace(*appFields) != "" || strings.TrimSpace(*include) != "") {
 				fmt.Fprintln(os.Stderr, "Error: --app-fields and --include are only valid with --id")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "")
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_testers_metrics.go
+++ b/internal/cli/testflight/beta_testers_metrics.go
@@ -46,7 +46,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				fmt.Fprintln(os.Stderr, "Error: --limit must be between 1 and 200")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--limit")
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight beta-testers metrics: %w", err)
@@ -63,7 +63,7 @@ Examples:
 			periodValue, err := normalizeBetaTesterUsagePeriod(*period)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--period")
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)

--- a/internal/cli/testflight/beta_testers_relationships.go
+++ b/internal/cli/testflight/beta_testers_relationships.go
@@ -83,7 +83,7 @@ Examples:
 			kind, ok := betaTesterRelationshipKinds[relationshipType]
 			if !ok {
 				fmt.Fprintf(os.Stderr, "Error: --type must be one of: %s\n", strings.Join(relationshipTypeList(betaTesterRelationshipKinds), ", "))
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--type")
 			}
 
 			testerValue := strings.TrimSpace(*testerID)
@@ -102,7 +102,7 @@ Examples:
 
 			if kind == relationshipSingle && (nextValue != "" || *paginate || *limit != 0) {
 				fmt.Fprintln(os.Stderr, "Error: --limit, --next, and --paginate are only valid for to-many relationships")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "")
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/diagnostics_test.go
+++ b/internal/cli/testflight/diagnostics_test.go
@@ -1,0 +1,254 @@
+package testflight
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestTestFlightValidationDiagnosticsPreserveContracts(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "testflight.yaml")
+
+	tests := []struct {
+		name       string
+		command    func() *ffcli.Command
+		args       []string
+		wantStderr string
+		wantCode   shared.DiagnosticCode
+		wantParam  string
+		noOutput   bool
+		setup      func(*testing.T)
+	}{
+		{
+			name:       "beta groups internal and external conflict",
+			command:    BetaGroupsListCommand,
+			args:       []string{"--internal", "--external"},
+			wantStderr: "Error: --internal and --external are mutually exclusive\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+		},
+		{
+			name:       "beta groups empty build id",
+			command:    BetaGroupsListCommand,
+			args:       []string{"--build-id", "   "},
+			wantStderr: "Error: --build-id cannot be empty\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--build-id",
+		},
+		{
+			name:       "beta groups empty app with build id",
+			command:    BetaGroupsListCommand,
+			args:       []string{"--build-id", "build-1", "--app", "   "},
+			wantStderr: "Error: --app cannot be empty when used with --build-id\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--app",
+		},
+		{
+			name:       "beta groups membership controls with build id",
+			command:    BetaGroupsListCommand,
+			args:       []string{"--build-id", "build-1", "--limit", "10"},
+			wantStderr: "Error: --global, --limit, --next, and --paginate cannot be used with --build-id; membership lookup always fetches all required pages\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+		},
+		{
+			name:       "beta groups global and app conflict",
+			command:    BetaGroupsListCommand,
+			args:       []string{"--global", "--app", "app-1"},
+			wantStderr: "Error: --global and --app are mutually exclusive\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+		},
+		{
+			name:       "beta group public link limit range",
+			command:    BetaGroupsUpdateCommand,
+			args:       []string{"--id", "group-1", "--public-link-limit", "10001"},
+			wantStderr: "Error: --public-link-limit must be between 1 and 10000\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--public-link-limit",
+		},
+		{
+			name:       "beta group relationship enum",
+			command:    BetaGroupsRelationshipsGetCommand,
+			args:       []string{"--group-id", "group-1", "--type", "unknown"},
+			wantStderr: "Error: --type must be one of: betaTesters, builds\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--type",
+		},
+		{
+			name:       "beta group relationship single conflict",
+			command:    BetaGroupsRelationshipsGetCommand,
+			args:       []string{"--group-id", "group-1", "--type", "betaTesters", "--paginate"},
+			wantStderr: "Error: --limit, --next, and --paginate are only valid for to-many relationships\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+			setup: func(t *testing.T) {
+				previous := betaGroupRelationshipKinds["betaTesters"]
+				betaGroupRelationshipKinds["betaTesters"] = relationshipSingle
+				t.Cleanup(func() { betaGroupRelationshipKinds["betaTesters"] = previous })
+			},
+		},
+		{
+			name:       "beta license agreement id and app conflict",
+			command:    BetaLicenseAgreementsGetCommand,
+			args:       []string{"--id", "agreement-1", "--app", "app-1"},
+			wantStderr: "Error: --id and --app are mutually exclusive\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+		},
+		{
+			name:       "beta license agreement app-only fields conflict",
+			command:    BetaLicenseAgreementsGetCommand,
+			args:       []string{"--app", "app-1", "--include", "app"},
+			wantStderr: "Error: --app-fields and --include are only valid with --id\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+		},
+		{
+			name:       "beta tester metrics limit range",
+			command:    BetaTestersMetricsCommand,
+			args:       []string{"--limit", "201"},
+			wantStderr: "Error: --limit must be between 1 and 200\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--limit",
+		},
+		{
+			name:       "beta tester metrics period enum",
+			command:    BetaTestersMetricsCommand,
+			args:       []string{"--period", "P10D"},
+			wantStderr: "Error: --period must be one of: P7D, P30D, P90D, P365D\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--period",
+		},
+		{
+			name:       "beta tester relationship enum",
+			command:    BetaTestersRelationshipsGetCommand,
+			args:       []string{"--tester-id", "tester-1", "--type", "unknown"},
+			wantStderr: "Error: --type must be one of: apps, betaGroups, builds\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--type",
+		},
+		{
+			name:       "beta tester relationship single conflict",
+			command:    BetaTestersRelationshipsGetCommand,
+			args:       []string{"--tester-id", "tester-1", "--type", "apps", "--paginate"},
+			wantStderr: "Error: --limit, --next, and --paginate are only valid for to-many relationships\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+			setup: func(t *testing.T) {
+				previous := betaTesterRelationshipKinds["apps"]
+				betaTesterRelationshipKinds["apps"] = relationshipSingle
+				t.Cleanup(func() { betaTesterRelationshipKinds["apps"] = previous })
+			},
+		},
+		{
+			name:       "app tester usage limit range",
+			command:    TestFlightMetricsBetaTesterUsagesCommand,
+			args:       []string{"--limit", "201"},
+			wantStderr: "Error: --limit must be between 1 and 200\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--limit",
+		},
+		{
+			name:       "app tester usage period enum",
+			command:    TestFlightMetricsBetaTesterUsagesCommand,
+			args:       []string{"--period", "P10D"},
+			wantStderr: "Error: --period must be one of: P7D, P30D, P90D, P365D\n",
+			wantCode:   shared.DiagnosticInvalidInput,
+			wantParam:  "--period",
+		},
+		{
+			name:       "sync build filter requires include builds",
+			command:    TestFlightSyncPullCommand,
+			args:       []string{"--app", "app-1", "--output", outputPath, "--build-id", "build-1"},
+			wantStderr: "Error: --build-id requires --include-builds\n\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+			wantParam:  "--build-id",
+			noOutput:   true,
+		},
+		{
+			name:       "sync tester filter requires include testers",
+			command:    TestFlightSyncPullCommand,
+			args:       []string{"--app", "app-1", "--output", outputPath, "--tester", "tester-1"},
+			wantStderr: "Error: --tester requires --include-testers\n\n",
+			wantCode:   shared.DiagnosticConflictingInput,
+			wantParam:  "--tester",
+			noOutput:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup(t)
+			}
+			cmd := test.command()
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+
+			var runErr error
+			stderr := captureTestFlightDiagnosticStderr(t, func() {
+				runErr = cmd.Exec(context.Background(), nil)
+			})
+			if runErr == nil {
+				t.Fatal("expected validation error")
+			}
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("errors.Is(flag.ErrHelp) = false, error = %v", runErr)
+			}
+			if runErr.Error() != flag.ErrHelp.Error() {
+				t.Fatalf("error = %q, want %q", runErr, flag.ErrHelp.Error())
+			}
+			if stderr != test.wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, test.wantStderr)
+			}
+
+			diagnostic, ok := shared.DiagnosticFromError(runErr)
+			if !ok {
+				t.Fatal("expected structured diagnostic")
+			}
+			if diagnostic.Code != test.wantCode || diagnostic.Parameter != test.wantParam {
+				t.Fatalf("diagnostic = %+v, want code %q parameter %q", diagnostic, test.wantCode, test.wantParam)
+			}
+			if test.noOutput {
+				if _, err := os.Stat(outputPath); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("output path exists after validation: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func captureTestFlightDiagnosticStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	readResult := make(chan []byte, 1)
+	readError := make(chan error, 1)
+	go func() {
+		data, readErr := io.ReadAll(reader)
+		readResult <- data
+		readError <- readErr
+	}()
+
+	os.Stderr = writer
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	os.Stderr = original
+	data := <-readResult
+	if err := <-readError; err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stderr reader: %v", err)
+	}
+	return string(data)
+}

--- a/internal/cli/testflight/metrics_beta_tester_usages.go
+++ b/internal/cli/testflight/metrics_beta_tester_usages.go
@@ -98,7 +98,7 @@ Examples:
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				fmt.Fprintln(os.Stderr, "Error: --limit must be between 1 and 200")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--limit")
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight metrics beta-tester-usages: %w", err)
@@ -107,7 +107,7 @@ Examples:
 			periodValue, err := normalizeBetaTesterUsagePeriod(*period)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--period")
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)

--- a/internal/cli/testflight/testflight_sync.go
+++ b/internal/cli/testflight/testflight_sync.go
@@ -160,11 +160,11 @@ Examples:
 			testerFilters := shared.SplitCSV(*testerFilter)
 			if len(buildFilters) > 0 && !*includeBuilds {
 				fmt.Fprintf(os.Stderr, "Error: --build-id requires --include-builds\n\n")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "--build-id")
 			}
 			if len(testerFilters) > 0 && !*includeTesters {
 				fmt.Fprintf(os.Stderr, "Error: --tester requires --include-testers\n\n")
-				return flag.ErrHelp
+				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "--tester")
 			}
 
 			resolvedOutputPath, err := resolveTestFlightOutputPath(outputValue)


### PR DESCRIPTION
## Summary

- attach allowlisted structured diagnostics to the 18 leaf TestFlight validation failures that still return bare `flag.ErrHelp`
- classify ranges and enum/period checks as `invalid_input` with a bounded flag parameter
- classify incompatible and mutually exclusive inputs as `conflicting_input`, using an empty parameter when the message names multiple flags
- classify sync filter dependency failures with the offending `--build-id` or `--tester` parameter
- preserve existing stderr text, `flag.ErrHelp` matching, exit-code behavior, validation order, and side-effect boundaries

## Coverage

The contract test covers beta-groups, beta-group relationships, beta-license-agreements, beta-testers metrics, beta-tester relationships, app tester usage metrics, and TestFlight sync. It asserts exact stderr, the legacy `flag.ErrHelp` error contract, structured code/parameter, and that sync validation does not create its output file.

## Verification

- `go test ./internal/cli/testflight -run TestTestFlightValidationDiagnosticsPreserveContracts -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/testflight -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `go build -o /tmp/asc-testflight-validation-bin .`
- built binary: canonical `asc testflight groups edit --id group-1 --public-link-limit 10001` exited 2, preserved the validation message, and wrote no stdout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TestFlight CLI validation errors with clearer diagnostics for invalid, conflicting, and unsupported inputs.
  - Enhanced feedback for pagination, relationship types, metrics limits and periods, sync filters, and mutually exclusive options.
  - Preserved help output and exit behavior when validation fails.

- **Tests**
  - Added comprehensive coverage for validation messages, diagnostic metadata, help behavior, stderr output, and prevention of unintended output-file creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->