### PR TITLE
feat(testflight): structure raw validation diagnostics

### DIFF
--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -110,7 +110,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("beta-groups list: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("beta-groups list: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("beta-groups list: %w", err)

--- a/internal/cli/testflight/beta_groups_related.go
+++ b/internal/cli/testflight/beta_groups_related.go
@@ -58,7 +58,11 @@ Examples:
 			if groupValue == "" {
 				groupValue = aliasValue
 			} else if aliasValue != "" && aliasValue != groupValue {
-				return fmt.Errorf("testflight beta-groups app view: --group-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-groups app view: --group-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 			if groupValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
@@ -130,7 +134,11 @@ Examples:
 			if groupValue == "" {
 				groupValue = aliasValue
 			} else if aliasValue != "" && aliasValue != groupValue {
-				return fmt.Errorf("testflight beta-groups beta-recruitment-criteria view: --group-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-groups beta-recruitment-criteria view: --group-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 			if groupValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
@@ -202,7 +210,11 @@ Examples:
 			if groupValue == "" {
 				groupValue = aliasValue
 			} else if aliasValue != "" && aliasValue != groupValue {
-				return fmt.Errorf("testflight beta-groups beta-recruitment-criterion-compatible-build-check view: --group-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-groups beta-recruitment-criterion-compatible-build-check view: --group-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 			if groupValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")

--- a/internal/cli/testflight/beta_groups_relationships.go
+++ b/internal/cli/testflight/beta_groups_relationships.go
@@ -67,7 +67,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight beta-groups relationships view: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-groups relationships view: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight beta-groups relationships view: %w", err)
@@ -90,7 +94,11 @@ Examples:
 			if groupValue == "" {
 				groupValue = aliasValue
 			} else if aliasValue != "" && aliasValue != groupValue {
-				return fmt.Errorf("testflight beta-groups relationships view: --group-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-groups relationships view: --group-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 
 			nextValue := strings.TrimSpace(*next)
@@ -151,6 +159,10 @@ func getBetaGroupRelationshipList(ctx context.Context, client *asc.Client, relat
 	case "builds":
 		return client.GetBetaGroupBuildsRelationships(ctx, groupID, opts...)
 	default:
-		return nil, fmt.Errorf("unsupported relationship type %q", relationshipType)
+		return nil, shared.WithDiagnostic(
+			shared.NewValidationError(fmt.Errorf("unsupported relationship type %q", relationshipType)),
+			shared.DiagnosticInvalidInput,
+			"--type",
+		)
 	}
 }

--- a/internal/cli/testflight/beta_license_agreements.go
+++ b/internal/cli/testflight/beta_license_agreements.go
@@ -69,7 +69,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("beta-license-agreements list: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("beta-license-agreements list: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("beta-license-agreements list: %w", err)

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -97,7 +97,11 @@ Examples:
 				return err
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("beta-testers list: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("beta-testers list: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("beta-testers list: %w", err)

--- a/internal/cli/testflight/beta_testers_metrics.go
+++ b/internal/cli/testflight/beta_testers_metrics.go
@@ -57,7 +57,11 @@ Examples:
 			if testerValue == "" {
 				testerValue = aliasValue
 			} else if aliasValue != "" && aliasValue != testerValue {
-				return fmt.Errorf("testflight beta-testers metrics: --tester-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers metrics: --tester-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 
 			periodValue, err := normalizeBetaTesterUsagePeriod(*period)
@@ -108,7 +112,11 @@ func normalizeBetaTesterUsagePeriod(value string) (string, error) {
 		return "", nil
 	}
 	if _, ok := betaTesterUsagePeriods[value]; !ok {
-		return "", fmt.Errorf("--period must be one of: %s", strings.Join(betaTesterUsagePeriodList(), ", "))
+		return "", shared.WithDiagnostic(
+			shared.NewValidationError(fmt.Errorf("--period must be one of: %s", strings.Join(betaTesterUsagePeriodList(), ", "))),
+			shared.DiagnosticInvalidInput,
+			"--period",
+		)
 	}
 	return value, nil
 }

--- a/internal/cli/testflight/beta_testers_related.go
+++ b/internal/cli/testflight/beta_testers_related.go
@@ -60,7 +60,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight beta-testers apps list: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers apps list: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight beta-testers apps list: %w", err)
@@ -71,7 +75,11 @@ Examples:
 			if testerValue == "" {
 				testerValue = aliasValue
 			} else if aliasValue != "" && aliasValue != testerValue {
-				return fmt.Errorf("testflight beta-testers apps list: --tester-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers apps list: --tester-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 			if testerValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
@@ -169,7 +177,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight beta-testers beta-groups list: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers beta-groups list: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight beta-testers beta-groups list: %w", err)
@@ -180,7 +192,11 @@ Examples:
 			if testerValue == "" {
 				testerValue = aliasValue
 			} else if aliasValue != "" && aliasValue != testerValue {
-				return fmt.Errorf("testflight beta-testers beta-groups list: --tester-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers beta-groups list: --tester-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 			if testerValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")
@@ -278,7 +294,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight beta-testers builds list: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers builds list: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight beta-testers builds list: %w", err)
@@ -289,7 +309,11 @@ Examples:
 			if testerValue == "" {
 				testerValue = aliasValue
 			} else if aliasValue != "" && aliasValue != testerValue {
-				return fmt.Errorf("testflight beta-testers builds list: --tester-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers builds list: --tester-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 			if testerValue == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --tester-id is required")

--- a/internal/cli/testflight/beta_testers_relationships.go
+++ b/internal/cli/testflight/beta_testers_relationships.go
@@ -68,7 +68,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight beta-testers relationships view: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers relationships view: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight beta-testers relationships view: %w", err)
@@ -91,7 +95,11 @@ Examples:
 			if testerValue == "" {
 				testerValue = aliasValue
 			} else if aliasValue != "" && aliasValue != testerValue {
-				return fmt.Errorf("testflight beta-testers relationships view: --tester-id and --id must match")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-testers relationships view: --tester-id and --id must match")),
+					shared.DiagnosticConflictingInput,
+					"",
+				)
 			}
 
 			nextValue := strings.TrimSpace(*next)
@@ -154,6 +162,10 @@ func getBetaTesterRelationshipList(ctx context.Context, client *asc.Client, rela
 	case "builds":
 		return client.GetBetaTesterBuildsRelationships(ctx, testerID, opts...)
 	default:
-		return nil, fmt.Errorf("unsupported relationship type %q", relationshipType)
+		return nil, shared.WithDiagnostic(
+			shared.NewValidationError(fmt.Errorf("unsupported relationship type %q", relationshipType)),
+			shared.DiagnosticInvalidInput,
+			"--type",
+		)
 	}
 }

--- a/internal/cli/testflight/raw_validation_diagnostics_test.go
+++ b/internal/cli/testflight/raw_validation_diagnostics_test.go
@@ -1,0 +1,368 @@
+package testflight
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestTestFlightRawValidationDiagnosticsPreserveContracts(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   func() *ffcli.Command
+		args      []string
+		wantError string
+		wantCode  shared.DiagnosticCode
+		wantParam string
+	}{
+		{
+			name:      "beta groups list limit",
+			command:   BetaGroupsListCommand,
+			args:      []string{"--limit", "201"},
+			wantError: "beta-groups list: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta groups relationships limit",
+			command:   BetaGroupsRelationshipsGetCommand,
+			args:      []string{"--group-id", "group-1", "--type", "betaTesters", "--limit", "201"},
+			wantError: "testflight beta-groups relationships view: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta license agreements list limit",
+			command:   BetaLicenseAgreementsListCommand,
+			args:      []string{"--limit", "201"},
+			wantError: "beta-license-agreements list: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta testers list limit",
+			command:   BetaTestersListCommand,
+			args:      []string{"--limit", "201"},
+			wantError: "beta-testers list: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta tester apps limit",
+			command:   BetaTestersAppsListCommand,
+			args:      []string{"--tester-id", "tester-1", "--limit", "201"},
+			wantError: "testflight beta-testers apps list: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta tester beta groups limit",
+			command:   BetaTestersBetaGroupsListCommand,
+			args:      []string{"--tester-id", "tester-1", "--limit", "201"},
+			wantError: "testflight beta-testers beta-groups list: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta tester builds limit",
+			command:   BetaTestersBuildsListCommand,
+			args:      []string{"--tester-id", "tester-1", "--limit", "201"},
+			wantError: "testflight beta-testers builds list: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta tester relationships limit",
+			command:   BetaTestersRelationshipsGetCommand,
+			args:      []string{"--tester-id", "tester-1", "--type", "apps", "--limit", "201"},
+			wantError: "testflight beta-testers relationships view: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "review view limit",
+			command:   TestFlightReviewGetCommand,
+			args:      []string{"--limit", "201"},
+			wantError: "testflight review view: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "review submissions limit",
+			command:   TestFlightReviewSubmissionsListCommand,
+			args:      []string{"--build-id", "build-1", "--limit", "201"},
+			wantError: "testflight review submissions list: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta details limit",
+			command:   TestFlightBetaDetailsGetCommand,
+			args:      []string{"--limit", "201"},
+			wantError: "testflight beta-details view: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "recruitment options limit",
+			command:   TestFlightRecruitmentOptionsCommand,
+			args:      []string{"--limit", "201"},
+			wantError: "testflight recruitment options: --limit must be between 1 and 200",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--limit",
+		},
+		{
+			name:      "beta groups relationship aliases conflict",
+			command:   BetaGroupsRelationshipsGetCommand,
+			args:      []string{"--group-id", "group-1", "--id", "group-2", "--type", "betaTesters"},
+			wantError: "testflight beta-groups relationships view: --group-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta group app aliases conflict",
+			command:   BetaGroupsAppGetCommand,
+			args:      []string{"--group-id", "group-1", "--id", "group-2"},
+			wantError: "testflight beta-groups app view: --group-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta group recruitment criteria aliases conflict",
+			command:   BetaGroupsRecruitmentCriteriaGetCommand,
+			args:      []string{"--group-id", "group-1", "--id", "group-2"},
+			wantError: "testflight beta-groups beta-recruitment-criteria view: --group-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta group compatible build aliases conflict",
+			command:   BetaGroupsRecruitmentCriterionCompatibleBuildCheckGetCommand,
+			args:      []string{"--group-id", "group-1", "--id", "group-2"},
+			wantError: "testflight beta-groups beta-recruitment-criterion-compatible-build-check view: --group-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta tester apps aliases conflict",
+			command:   BetaTestersAppsListCommand,
+			args:      []string{"--tester-id", "tester-1", "--id", "tester-2"},
+			wantError: "testflight beta-testers apps list: --tester-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta tester beta groups aliases conflict",
+			command:   BetaTestersBetaGroupsListCommand,
+			args:      []string{"--tester-id", "tester-1", "--id", "tester-2"},
+			wantError: "testflight beta-testers beta-groups list: --tester-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta tester builds aliases conflict",
+			command:   BetaTestersBuildsListCommand,
+			args:      []string{"--tester-id", "tester-1", "--id", "tester-2"},
+			wantError: "testflight beta-testers builds list: --tester-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta tester relationships aliases conflict",
+			command:   BetaTestersRelationshipsGetCommand,
+			args:      []string{"--tester-id", "tester-1", "--id", "tester-2", "--type", "apps"},
+			wantError: "testflight beta-testers relationships view: --tester-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "beta tester metrics aliases conflict",
+			command:   BetaTestersMetricsCommand,
+			args:      []string{"--tester-id", "tester-1", "--id", "tester-2"},
+			wantError: "testflight beta-testers metrics: --tester-id and --id must match",
+			wantCode:  shared.DiagnosticConflictingInput,
+		},
+		{
+			name:      "recruitment options fields",
+			command:   TestFlightRecruitmentOptionsCommand,
+			args:      []string{"--fields", "invalid"},
+			wantError: "testflight recruitment options: --fields must be one of: deviceFamilyOsVersions",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--fields",
+		},
+		{
+			name:      "recruitment set filter syntax",
+			command:   TestFlightRecruitmentSetCommand,
+			args:      []string{"--group", "group-1", "--os-version-filter", "IPHONE26"},
+			wantError: "testflight recruitment set: --os-version-filter must use DEVICE_FAMILY=MIN_OS (e.g., IPHONE=26)",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--os-version-filter",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.command()
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+
+			var runErr error
+			stderr := captureTestFlightDiagnosticStderr(t, func() {
+				runErr = cmd.Exec(context.Background(), nil)
+			})
+			if runErr == nil {
+				t.Fatal("expected validation error")
+			}
+			if got := runErr.Error(); got != test.wantError {
+				t.Fatalf("error = %q, want %q", got, test.wantError)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty output for an unreported validation error", stderr)
+			}
+			if errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("errors.Is(flag.ErrHelp) = true, want generic exit semantics: %v", runErr)
+			}
+			if shared.ClassifyUsageError(runErr) != "" {
+				t.Fatalf("usage classification = %q, want generic error classification", shared.ClassifyUsageError(runErr))
+			}
+			if !shared.IsValidationError(runErr) {
+				t.Fatal("expected validation classification")
+			}
+
+			diagnostic, ok := shared.DiagnosticFromError(runErr)
+			if !ok {
+				t.Fatal("expected structured diagnostic")
+			}
+			if diagnostic.Code != test.wantCode || diagnostic.Parameter != test.wantParam {
+				t.Fatalf("diagnostic = %+v, want code %q parameter %q", diagnostic, test.wantCode, test.wantParam)
+			}
+		})
+	}
+}
+
+func TestTestFlightRawValidationHelpersPreserveContracts(t *testing.T) {
+	tests := []struct {
+		name      string
+		run       func() error
+		wantError string
+		wantCode  shared.DiagnosticCode
+		wantParam string
+	}{
+		{
+			name: "unsupported beta group relationship",
+			run: func() error {
+				_, err := getBetaGroupRelationshipList(context.Background(), nil, "unsupported", "group-1")
+				return err
+			},
+			wantError: "unsupported relationship type \"unsupported\"",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--type",
+		},
+		{
+			name: "unsupported beta tester relationship",
+			run: func() error {
+				_, err := getBetaTesterRelationshipList(context.Background(), nil, "unsupported", "tester-1")
+				return err
+			},
+			wantError: "unsupported relationship type \"unsupported\"",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--type",
+		},
+		{
+			name: "invalid beta tester period",
+			run: func() error {
+				_, err := normalizeBetaTesterUsagePeriod("P10D")
+				return err
+			},
+			wantError: "--period must be one of: P7D, P30D, P90D, P365D",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--period",
+		},
+		{
+			name: "invalid recruitment fields",
+			run: func() error {
+				_, err := normalizeBetaRecruitmentCriterionOptionsFields("invalid")
+				return err
+			},
+			wantError: "--fields must be one of: deviceFamilyOsVersions",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--fields",
+		},
+		{
+			name: "missing recruitment filter separator",
+			run: func() error {
+				_, err := parseDeviceFamilyOsVersionFilters("IPHONE26")
+				return err
+			},
+			wantError: "--os-version-filter must use DEVICE_FAMILY=MIN_OS (e.g., IPHONE=26)",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--os-version-filter",
+		},
+		{
+			name: "missing recruitment filter version",
+			run: func() error {
+				_, err := parseDeviceFamilyOsVersionFilters("IPHONE=")
+				return err
+			},
+			wantError: "--os-version-filter must use DEVICE_FAMILY=MIN_OS (e.g., IPHONE=26)",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--os-version-filter",
+		},
+		{
+			name: "invalid recruitment filter range",
+			run: func() error {
+				_, err := parseDeviceFamilyOsVersionFilters("IPHONE=17..")
+				return err
+			},
+			wantError: "--os-version-filter must use DEVICE_FAMILY=MIN_OS[..MAX_OS]",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--os-version-filter",
+		},
+		{
+			name: "invalid recruitment device family",
+			run: func() error {
+				_, err := normalizeBetaRecruitmentDeviceFamily("ANDROID")
+				return err
+			},
+			wantError: "--os-version-filter device family must be one of: IPHONE, IPAD, MAC, VISION, APPLE_TV, APPLE_WATCH",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--os-version-filter",
+		},
+		{
+			name: "empty recruitment criteria state",
+			run: func() error {
+				return validateBetaRecruitmentCriteriaID("")
+			},
+			wantError: "testflight recruitment set: criteria id is empty",
+			wantCode:  shared.DiagnosticStateNotReady,
+			wantParam: "--group",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runErr := test.run()
+			if runErr == nil {
+				t.Fatal("expected validation error")
+			}
+			if got := runErr.Error(); got != test.wantError {
+				t.Fatalf("error = %q, want %q", got, test.wantError)
+			}
+			if errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("errors.Is(flag.ErrHelp) = true, want generic exit semantics: %v", runErr)
+			}
+			if shared.ClassifyUsageError(runErr) != "" {
+				t.Fatalf("usage classification = %q, want generic error classification", shared.ClassifyUsageError(runErr))
+			}
+			if !shared.IsValidationError(runErr) {
+				t.Fatal("expected validation classification")
+			}
+
+			diagnostic, ok := shared.DiagnosticFromError(runErr)
+			if !ok {
+				t.Fatal("expected structured diagnostic")
+			}
+			if diagnostic.Code != test.wantCode || diagnostic.Parameter != test.wantParam {
+				t.Fatalf("diagnostic = %+v, want code %q parameter %q", diagnostic, test.wantCode, test.wantParam)
+			}
+		})
+	}
+}

--- a/internal/cli/testflight/testflight_review.go
+++ b/internal/cli/testflight/testflight_review.go
@@ -68,7 +68,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight review view: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight review view: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight review view: %w", err)
@@ -387,7 +391,11 @@ Examples:
 				return shared.MissingRequiredUsageError("--build-id")
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight review submissions list: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight review submissions list: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight review submissions list: %w", err)
@@ -573,7 +581,11 @@ Examples:
 				return err
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight beta-details view: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight beta-details view: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight beta-details view: %w", err)
@@ -852,7 +864,11 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("testflight recruitment options: --limit must be between 1 and 200")
+				return shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("testflight recruitment options: --limit must be between 1 and 200")),
+					shared.DiagnosticInvalidInput,
+					"--limit",
+				)
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("testflight recruitment options: %w", err)
@@ -932,8 +948,8 @@ Examples:
 			existing, err := client.GetBetaGroupBetaRecruitmentCriteria(requestCtx, trimmedGroupID)
 			if err == nil {
 				criteriaID := strings.TrimSpace(existing.Data.ID)
-				if criteriaID == "" {
-					return fmt.Errorf("testflight recruitment set: criteria id is empty")
+				if validationErr := validateBetaRecruitmentCriteriaID(criteriaID); validationErr != nil {
+					return validationErr
 				}
 				criteria, err := client.UpdateBetaRecruitmentCriteria(requestCtx, criteriaID, filterValues)
 				if err != nil {
@@ -965,10 +981,25 @@ func normalizeBetaRecruitmentCriterionOptionsFields(value string) ([]string, err
 	}
 	for _, field := range fields {
 		if _, ok := allowed[field]; !ok {
-			return nil, fmt.Errorf("--fields must be one of: deviceFamilyOsVersions")
+			return nil, shared.WithDiagnostic(
+				shared.NewValidationError(fmt.Errorf("--fields must be one of: deviceFamilyOsVersions")),
+				shared.DiagnosticInvalidInput,
+				"--fields",
+			)
 		}
 	}
 	return fields, nil
+}
+
+func validateBetaRecruitmentCriteriaID(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return shared.WithDiagnostic(
+			shared.NewValidationError(fmt.Errorf("testflight recruitment set: criteria id is empty")),
+			shared.DiagnosticStateNotReady,
+			"--group",
+		)
+	}
+	return nil
 }
 
 func parseDeviceFamilyOsVersionFilters(value string) ([]asc.DeviceFamilyOsVersionFilter, error) {
@@ -981,12 +1012,20 @@ func parseDeviceFamilyOsVersionFilters(value string) ([]asc.DeviceFamilyOsVersio
 	for _, entry := range entries {
 		parts := strings.SplitN(entry, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("--os-version-filter must use DEVICE_FAMILY=MIN_OS (e.g., IPHONE=26)")
+			return nil, shared.WithDiagnostic(
+				shared.NewValidationError(fmt.Errorf("--os-version-filter must use DEVICE_FAMILY=MIN_OS (e.g., IPHONE=26)")),
+				shared.DiagnosticInvalidInput,
+				"--os-version-filter",
+			)
 		}
 		familyValue := strings.TrimSpace(parts[0])
 		versionValue := strings.TrimSpace(parts[1])
 		if familyValue == "" || versionValue == "" {
-			return nil, fmt.Errorf("--os-version-filter must use DEVICE_FAMILY=MIN_OS (e.g., IPHONE=26)")
+			return nil, shared.WithDiagnostic(
+				shared.NewValidationError(fmt.Errorf("--os-version-filter must use DEVICE_FAMILY=MIN_OS (e.g., IPHONE=26)")),
+				shared.DiagnosticInvalidInput,
+				"--os-version-filter",
+			)
 		}
 
 		family, err := normalizeBetaRecruitmentDeviceFamily(familyValue)
@@ -1001,7 +1040,11 @@ func parseDeviceFamilyOsVersionFilters(value string) ([]asc.DeviceFamilyOsVersio
 			minVersion = strings.TrimSpace(rangeParts[0])
 			maxVersion = strings.TrimSpace(rangeParts[1])
 			if minVersion == "" || maxVersion == "" {
-				return nil, fmt.Errorf("--os-version-filter must use DEVICE_FAMILY=MIN_OS[..MAX_OS]")
+				return nil, shared.WithDiagnostic(
+					shared.NewValidationError(fmt.Errorf("--os-version-filter must use DEVICE_FAMILY=MIN_OS[..MAX_OS]")),
+					shared.DiagnosticInvalidInput,
+					"--os-version-filter",
+				)
 			}
 		}
 
@@ -1020,7 +1063,11 @@ func normalizeBetaRecruitmentDeviceFamily(value string) (asc.DeviceFamily, error
 	if slices.Contains(betaRecruitmentDeviceFamilyList(), normalized) {
 		return asc.DeviceFamily(normalized), nil
 	}
-	return "", fmt.Errorf("--os-version-filter device family must be one of: %s", strings.Join(betaRecruitmentDeviceFamilyList(), ", "))
+	return "", shared.WithDiagnostic(
+		shared.NewValidationError(fmt.Errorf("--os-version-filter device family must be one of: %s", strings.Join(betaRecruitmentDeviceFamilyList(), ", "))),
+		shared.DiagnosticInvalidInput,
+		"--os-version-filter",
+	)
 }
 
 func betaRecruitmentDeviceFamilyList() []string {


### PR DESCRIPTION
## Summary

- attach bounded structured diagnostics to the 30 audited TestFlight raw validation failures
- cover 12 `--limit` range failures, 9 parent/child ID alias conflicts, 8 enum/syntax validators, and the empty recruitment-criteria state
- preserve existing rendered error text, validation ordering, generic exit-code 1 behavior, and no new stderr output

## Scope

This PR is intentionally stacked on #2041 (`codex/testflight-usage-diagnostics`) and does not modify or merge it.

The diagnostics use only existing allowlisted codes and static flag names. No input values, paths, IDs, or error-message text are added to telemetry metadata.

## Verification

- table-driven TestFlight contract tests assert exact error text, structured code/parameter, validation classification, and non-usage (`flag.ErrHelp`-free) semantics
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook: command docs, formatting, lint, and short suite
- built binary smoke check: `asc testflight groups list --limit 201` exits 1 with unchanged diagnostic text and empty stdout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TestFlight CLI validation errors with structured diagnostics for invalid values, conflicting options, unsupported relationships, and unavailable recruitment criteria.
  * Added clearer flag context for pagination, filtering, periods, device families, and recruitment settings.
  * Standardized validation behavior across beta groups, testers, apps, builds, and review commands.

* **Tests**
  * Added comprehensive coverage for validation rules, diagnostic metadata, error behavior, and exit semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->