### PR TITLE
fix(submit): include the appStoreVersion relationship instead of only naming it in fields[]

### DIFF
--- a/internal/cli/reviews/review_overview.go
+++ b/internal/cli/reviews/review_overview.go
@@ -405,6 +405,7 @@ func summarizeReviewSubmissionItems(ctx context.Context, client *asc.Client, sub
 		ctx,
 		submissionID,
 		asc.WithReviewSubmissionItemsLimit(200),
+		asc.WithReviewSubmissionItemsInclude([]string{"appStoreVersion"}),
 		asc.WithReviewSubmissionItemsFields([]string{"state", "appStoreVersion"}),
 	)
 	if err != nil {

--- a/internal/cli/submit/submit_create.go
+++ b/internal/cli/submit/submit_create.go
@@ -292,12 +292,16 @@ func summarizeReviewSubmissionItems(
 		return summary, nil
 	}
 
-	// appStoreVersion must be requested explicitly. Without it the API returns items carrying no
-	// relationship linkage, so every item reads as an empty version id, hasTargetVersion never
-	// becomes true, and a correctly prepared submission is rejected as not containing its version.
+	// appStoreVersion must be INCLUDED, not merely named in fields[]. fields[] is a sparse-fieldset
+	// selector: it narrows what comes back, and the API answers it with items that carry "links" only
+	// and no "relationships" key at all. Every item then reads as an empty version id,
+	// hasTargetVersion never becomes true, and a correctly prepared submission is rejected as not
+	// containing its version. include= is what makes App Store Connect materialise the linkage;
+	// fields[] rides along to keep the item payload narrow.
 	resp, err := client.GetReviewSubmissionItems(
 		ctx,
 		submissionID,
+		asc.WithReviewSubmissionItemsInclude([]string{"appStoreVersion"}),
 		asc.WithReviewSubmissionItemsFields([]string{"appStoreVersion"}),
 		asc.WithReviewSubmissionItemsLimit(200),
 	)

--- a/internal/cli/submit/submit_create_items_include_test.go
+++ b/internal/cli/submit/submit_create_items_include_test.go
@@ -1,0 +1,114 @@
+package submit
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// respondLikeAppStoreConnectItems replays what the live API actually does for
+// GET /v1/reviewSubmissions/{id}/items, captured on 2026-08-16 against submission
+// 3f07316f-1770-4675-96db-07b0eb857f55:
+//
+//   - ?fields[reviewSubmissionItems]=appStoreVersion  -> the item carries "links" ONLY. There is no
+//     "relationships" key at all, because fields[] is a sparse-FIELDSET selector and does not ask
+//     the API to materialise relationship linkage.
+//   - ?include=appStoreVersion                        -> the item carries
+//     relationships.appStoreVersion.data.id.
+//
+// Stubbing that difference is the whole point. A stub that returns relationships unconditionally
+// cannot distinguish a request that asks for linkage from one that does not, so it reports a fix as
+// working when the real API would still withhold the linkage.
+func respondLikeAppStoreConnectItems(req *http.Request) (*http.Response, error) {
+	for _, value := range req.URL.Query()["include"] {
+		if value == "appStoreVersion" {
+			return submitJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "reviewSubmissionItems",
+					"id": "item-1",
+					"attributes": {"state": "READY_FOR_REVIEW"},
+					"relationships": {
+						"appStoreVersion": {
+							"data": {"type": "appStoreVersions", "id": "version-1"}
+						}
+					}
+				}],
+				"meta": {"paging": {"total": 1, "limit": 200}}
+			}`)
+		}
+	}
+
+	return submitJSONResponse(http.StatusOK, `{
+		"data": [{
+			"type": "reviewSubmissionItems",
+			"id": "item-1",
+			"links": {"self": "https://api.appstoreconnect.apple.com/v1/reviewSubmissionItems/item-1"}
+		}],
+		"meta": {"paging": {"total": 1, "limit": 200}}
+	}`)
+}
+
+// TestSummarizeReviewSubmissionItemsIncludesVersionRelationship is the regression test for the
+// second half of the "does not contain target version" bug.
+//
+// Requesting fields[reviewSubmissionItems]=appStoreVersion was not enough: the API answered with an
+// item that had no relationships at all, so reviewSubmissionItemVersionID read an empty id,
+// hasTargetVersion stayed false, and a correctly prepared submission was rejected. Only
+// include=appStoreVersion makes App Store Connect materialise the linkage.
+//
+// This test drives the stub above, which withholds linkage exactly as the live API does, so it fails
+// against a query that only sets fields[] and passes once include is sent.
+func TestSummarizeReviewSubmissionItemsIncludesVersionRelationship(t *testing.T) {
+	var sawInclude bool
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/reviewSubmissions/submission-1/items" {
+			t.Fatalf("unexpected path %s", req.URL.Path)
+		}
+		for _, value := range req.URL.Query()["include"] {
+			if value == "appStoreVersion" {
+				sawInclude = true
+			}
+		}
+
+		return respondLikeAppStoreConnectItems(req)
+	}))
+
+	summary, err := summarizeReviewSubmissionItems(context.Background(), client, "submission-1", "version-1")
+	if err != nil {
+		t.Fatalf("summarizeReviewSubmissionItems() error: %v", err)
+	}
+
+	if !sawInclude {
+		t.Fatal("expected the items query to send include=appStoreVersion")
+	}
+	if !summary.hasTargetVersion {
+		t.Fatal("expected the summary to find the target version once linkage is requested")
+	}
+	if summary.hasOtherItems {
+		t.Fatal("the only item is the target version, so it must not count as unrelated")
+	}
+}
+
+// TestSummarizeReviewSubmissionItemsFieldsAloneCannotResolveVersion pins WHY the previous fix was
+// insufficient, so nobody re-introduces it by swapping include back for fields. It asserts the
+// captured link-only payload (what fields[] alone returns) is unusable, which is the exact condition
+// that produced "review submission %s does not contain target version %s" in production.
+func TestSummarizeReviewSubmissionItemsFieldsAloneCannotResolveVersion(t *testing.T) {
+	client := newSubmitTestClient(t, submitRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		// Strip include to simulate a query that only sets fields[reviewSubmissionItems].
+		query := req.URL.Query()
+		query.Del("include")
+		req.URL.RawQuery = query.Encode()
+
+		return respondLikeAppStoreConnectItems(req)
+	}))
+
+	summary, err := summarizeReviewSubmissionItems(context.Background(), client, "submission-1", "version-1")
+	if err != nil {
+		t.Fatalf("summarizeReviewSubmissionItems() error: %v", err)
+	}
+
+	if summary.hasTargetVersion {
+		t.Fatal("an item with no relationship linkage cannot prove it is the target version")
+	}
+}

--- a/internal/cli/submit/submit_status.go
+++ b/internal/cli/submit/submit_status.go
@@ -202,7 +202,11 @@ func resolveReviewSubmissionVersionIDFromItems(ctx context.Context, client *asc.
 		return "", nil
 	}
 
+	// include=, not just fields[]: the API only materialises relationship linkage for an included
+	// relationship, so without it every item arrives with no relationships and this resolver reports
+	// "no version" for a submission that plainly has one.
 	opts := []asc.ReviewSubmissionItemsOption{
+		asc.WithReviewSubmissionItemsInclude([]string{"appStoreVersion"}),
 		asc.WithReviewSubmissionItemsFields([]string{"appStoreVersion"}),
 		asc.WithReviewSubmissionItemsLimit(200),
 	}

--- a/internal/cli/submit/submit_test.go
+++ b/internal/cli/submit/submit_test.go
@@ -254,7 +254,7 @@ func TestSubmitStatusCommand_ByIDIgnoresInaccessibleItemLookup(t *testing.T) {
 
 			wantRequests := []string{
 				"GET /v1/reviewSubmissions/review-submission-123",
-				"GET /v1/reviewSubmissions/review-submission-123/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&limit=200",
+				"GET /v1/reviewSubmissions/review-submission-123/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&include=appStoreVersion&limit=200",
 			}
 			if !reflect.DeepEqual(requests, wantRequests) {
 				t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
@@ -1783,7 +1783,7 @@ func TestFindReviewSubmissionForVersion_FallsBackToSubmissionItems(t *testing.T)
 
 	wantRequests := []string{
 		"GET /v1/apps/app-123/reviewSubmissions?include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/review-submission-123/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&limit=200",
+		"GET /v1/reviewSubmissions/review-submission-123/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&include=appStoreVersion&limit=200",
 	}
 	if !reflect.DeepEqual(requests, wantRequests) {
 		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
@@ -2212,7 +2212,7 @@ func TestPrepareReviewSubmissionForCreateSkipsMixedTargetVersionSubmission(t *te
 
 	wantRequests := []string{
 		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/mixed-submission/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&limit=200",
+		"GET /v1/reviewSubmissions/mixed-submission/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&include=appStoreVersion&limit=200",
 	}
 	if !reflect.DeepEqual(requests, wantRequests) {
 		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)
@@ -2269,7 +2269,7 @@ func TestPrepareReviewSubmissionForCreateTreatsEmptyItemsAsMissingVersion(t *tes
 
 	wantRequests := []string{
 		"GET /v1/apps/app-1/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW&include=appStoreVersionForReview&limit=200",
-		"GET /v1/reviewSubmissions/empty-items-submission/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&limit=200",
+		"GET /v1/reviewSubmissions/empty-items-submission/items?fields%5BreviewSubmissionItems%5D=appStoreVersion&include=appStoreVersion&limit=200",
 	}
 	if !reflect.DeepEqual(requests, wantRequests) {
 		t.Fatalf("unexpected requests: got %v want %v", requests, wantRequests)


### PR DESCRIPTION
## Problem

#2027 did not fix `asc review submit`. Running **4.4.2** (which contains that fix) still aborts on its final call:

```
Error: review submit: submit review: final submission validation:
review submission 3f07316f-1770-4675-96db-07b0eb857f55 does not contain target version 5434872c-4d84-4d72-af52-9da1a46d62ee
```

## Why the previous fix was wrong

#2027 correctly identified the function and the missing linkage, but reached for the wrong query parameter:

```go
asc.WithReviewSubmissionItemsFields([]string{"appStoreVersion"})
```

`fields[...]` is a **sparse-fieldset selector**. It narrows which fields come back; it does not ask the API to materialise relationship *linkage*. Measured against the live API on the submission above:

`?fields[reviewSubmissionItems]=appStoreVersion&limit=200`

```json
{ "data": [ { "type": "reviewSubmissionItems",
              "id": "M2YwNzMxNmYt…",
              "links": { "self": "…" } } ],
  "meta": { "paging": { "total": 1, "limit": 200 } } }
```

No `relationships` key at all. Note `total: 1` — the item was always present; only its linkage was missing. So `reviewSubmissionItemVersionID` still read `""`, `hasTargetVersion` stayed false, and the guard rejected a correctly prepared submission exactly as before.

`?include=appStoreVersion&limit=200` on the same submission:

```json
"relationships": {
  "appStoreVersion": { "data": { "type": "appStoreVersions",
                                 "id": "5434872c-4d84-4d72-af52-9da1a46d62ee" } } }
```

That is the target version id. `include=` is what makes App Store Connect emit the linkage.

## Why #2027's test stayed green

Its stub returns `relationships` unconditionally:

```go
return submitJSONResponse(http.StatusOK, `{
    "data": [{ "type": "reviewSubmissionItems", "id": "item-1",
               "relationships": { "appStoreVersion": { "data": {…} } } }]
}`)
```

A stub that always supplies linkage cannot tell a request that asks for it from one that does not, so it pins the *request shape* and never the API's actual reply. The PR reasoned that the real API returns relationships "on request" — true, but only for `include=`, and the test could not check that.

## The fix

Send `include=appStoreVersion` at the three call sites that read `appStoreVersion.data.id`; `fields[]` rides along to keep the payload narrow.

- `internal/cli/submit/submit_create.go` — `summarizeReviewSubmissionItems`, the one that breaks `review submit`
- `internal/cli/submit/submit_status.go` — `resolveReviewSubmissionVersionIDFromItems`, same bug, fails soft by reporting "no version"
- `internal/cli/reviews/review_overview.go` — same bug, feeds `reviewItemMatchesVersion`

`internal/cli/backgroundassets/background_assets_submit.go` and `internal/cli/reviews/{submissions_history,review_items}.go` already pair `Fields` with `Include`, which is the pattern this brings the rest in line with.

## Verification

**1. Against the live API.** A temporary GET-only probe (transport rejected any non-GET) called the real `summarizeReviewSubmissionItems` against submission `3f07316f…`:

| build | request | result |
|---|---|---|
| 4.4.2 as shipped | `fields[]` only | `hasTargetVersion=false hasOtherItems=true` — the production bug |
| this PR | `fields[]` + `include=` | `hasTargetVersion=true hasOtherItems=false` |

Same code, same submission; the `include` is the only difference. The probe is not part of this PR.

**2. Regression test that actually fails first.** `submit_create_items_include_test.go` stubs the API's *observed* behaviour — linkage only when `include=appStoreVersion` is present, otherwise the captured link-only payload. Against `main` it fails; with the fix it passes. A second test pins the link-only payload as unusable so nobody swaps `include` back for `fields`.

Checked before/after: `#2027`'s own test passes against unfixed code, which is precisely the blind spot this replaces.

**3.** `go build ./...`, `go vet`, and `go test ./internal/cli/submit/ ./internal/cli/reviews/` all pass. Four pinned request URLs in `submit_test.go` were updated for the new query string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-submission processing to reliably identify the associated App Store version.
  * Fixed version-specific filtering and status detection when retrieving submission items.

* **Tests**
  * Added regression coverage to verify App Store version relationships are correctly retrieved and resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->