### PR TITLE
fix(testflight): preserve period validation diagnostics

### DIFF
--- a/internal/cli/cmdtest/builds_parity_test.go
+++ b/internal/cli/cmdtest/builds_parity_test.go
@@ -252,11 +252,6 @@ func TestTestFlightRelationshipsValidationErrors(t *testing.T) {
 			wantErr: "--app is required",
 		},
 		{
-			name:    "testers metrics invalid period",
-			args:    []string{"testflight", "testers", "metrics", "--tester-id", "TESTER_ID", "--app", "APP_ID", "--period", "P1D"},
-			wantErr: "--period must be one of",
-		},
-		{
 			name:    "testers metrics invalid limit",
 			args:    []string{"testflight", "testers", "metrics", "--tester-id", "TESTER_ID", "--app", "APP_ID", "--limit", "500"},
 			wantErr: "--limit must be between 1 and 200",
@@ -264,6 +259,37 @@ func TestTestFlightRelationshipsValidationErrors(t *testing.T) {
 	}
 
 	runValidationTests(t, tests)
+}
+
+func TestTestFlightMetricsInvalidPeriodReturnsValidationError(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	args := []string{"testflight", "testers", "metrics", "--tester-id", "TESTER_ID", "--app", "APP_ID", "--period", "P1D"}
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr from direct command execution, got %q", stderr)
+	}
+	if runErr == nil {
+		t.Fatal("expected validation error")
+	}
+	if errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("errors.Is(flag.ErrHelp) = true, error = %v", runErr)
+	}
+	if got, want := runErr.Error(), "--period must be one of: P7D, P30D, P90D, P365D"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
 }
 
 func TestPreReleaseRelationshipsValidationErrors(t *testing.T) {

--- a/internal/cli/testflight/beta_testers_metrics.go
+++ b/internal/cli/testflight/beta_testers_metrics.go
@@ -66,8 +66,7 @@ Examples:
 
 			periodValue, err := normalizeBetaTesterUsagePeriod(*period)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-				return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticInvalidInput, "--period")
+				return err
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)

--- a/internal/cli/testflight/diagnostics_test.go
+++ b/internal/cli/testflight/diagnostics_test.go
@@ -22,6 +22,7 @@ func TestTestFlightValidationDiagnosticsPreserveContracts(t *testing.T) {
 		command    func() *ffcli.Command
 		args       []string
 		wantStderr string
+		wantError  string
 		wantCode   shared.DiagnosticCode
 		wantParam  string
 		noOutput   bool
@@ -115,12 +116,13 @@ func TestTestFlightValidationDiagnosticsPreserveContracts(t *testing.T) {
 			wantParam:  "--limit",
 		},
 		{
-			name:       "beta tester metrics period enum",
-			command:    BetaTestersMetricsCommand,
-			args:       []string{"--period", "P10D"},
-			wantStderr: "Error: --period must be one of: P7D, P30D, P90D, P365D\n",
-			wantCode:   shared.DiagnosticInvalidInput,
-			wantParam:  "--period",
+			name:      "beta tester metrics period enum",
+			command:   BetaTestersMetricsCommand,
+			args:      []string{"--period", "P10D"},
+			wantError: "--period must be one of: P7D, P30D, P90D, P365D",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--period",
+			noOutput:  true,
 		},
 		{
 			name:       "beta tester relationship enum",
@@ -195,11 +197,20 @@ func TestTestFlightValidationDiagnosticsPreserveContracts(t *testing.T) {
 			if runErr == nil {
 				t.Fatal("expected validation error")
 			}
-			if !errors.Is(runErr, flag.ErrHelp) {
-				t.Fatalf("errors.Is(flag.ErrHelp) = false, error = %v", runErr)
-			}
-			if runErr.Error() != flag.ErrHelp.Error() {
-				t.Fatalf("error = %q, want %q", runErr, flag.ErrHelp.Error())
+			if test.wantError != "" {
+				if errors.Is(runErr, flag.ErrHelp) {
+					t.Fatalf("errors.Is(flag.ErrHelp) = true, error = %v", runErr)
+				}
+				if runErr.Error() != test.wantError {
+					t.Fatalf("error = %q, want %q", runErr, test.wantError)
+				}
+			} else {
+				if !errors.Is(runErr, flag.ErrHelp) {
+					t.Fatalf("errors.Is(flag.ErrHelp) = false, error = %v", runErr)
+				}
+				if runErr.Error() != flag.ErrHelp.Error() {
+					t.Fatalf("error = %q, want %q", runErr, flag.ErrHelp.Error())
+				}
 			}
 			if stderr != test.wantStderr {
 				t.Fatalf("stderr = %q, want %q", stderr, test.wantStderr)

--- a/internal/cli/testflight/raw_validation_diagnostics_test.go
+++ b/internal/cli/testflight/raw_validation_diagnostics_test.go
@@ -180,6 +180,14 @@ func TestTestFlightRawValidationDiagnosticsPreserveContracts(t *testing.T) {
 			wantCode:  shared.DiagnosticConflictingInput,
 		},
 		{
+			name:      "beta tester metrics period",
+			command:   BetaTestersMetricsCommand,
+			args:      []string{"--period", "P10D"},
+			wantError: "--period must be one of: P7D, P30D, P90D, P365D",
+			wantCode:  shared.DiagnosticInvalidInput,
+			wantParam: "--period",
+		},
+		{
 			name:      "recruitment options fields",
 			command:   TestFlightRecruitmentOptionsCommand,
 			args:      []string{"--fields", "invalid"},


### PR DESCRIPTION
## Summary

- preserve the structured validation error returned for invalid `--period` values in beta tester metrics
- keep the command on generic validation exit semantics instead of replacing it with `flag.ErrHelp`
- update focused contract and command-path tests

## Why

PR #2043 structured `normalizeBetaTesterUsagePeriod`, but `BetaTestersMetricsCommand` still printed the error and returned `flag.ErrHelp`, dropping the diagnostic and producing exit code 2.

## Verification

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/testflight -count=1`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run 'TestTestFlightMetricsInvalidPeriodReturnsValidationError|TestTestFlightRelationshipsValidationErrors' -count=1`\n- `make lint`\n- built command exits 1 with unchanged error text, empty stdout\n\nFixes the post-merge defect found in #2043.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid beta tester metrics period values now return a clear validation error directly.
  * Invalid period input no longer produces unexpected help text or output.

* **Tests**
  * Added coverage for direct command execution, error messages, diagnostic codes, and parameter details for invalid period values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->