### PR TITLE
feat(apps): add platform-aware public app ranking

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -6,6 +6,12 @@ Quirks and tips for specific App Store Connect API endpoints.
 
 - Apple Ads named profiles use only the context stored on that profile: they do not inherit `ads.org_id` or `ads.ad_account_id` from root config or another profile. This prevents a selected profile from silently sending a request to the wrong organization or ad account. Profile-less access-token and environment authentication can still use matching root context.
 
+## Public App Store Ranking
+
+- `asc apps public rank` is an unauthenticated experimental storefront command, not an App Store Connect OpenAPI operation or an Apple Ads metric.
+- iOS ranking inspects up to 200 results from the public iTunes `/search` endpoint. Apple TV ranking uses the undocumented MZStore search endpoint with `X-Apple-Store-Front: <numeric-storefront-id>,33`, so it is available only for countries with a known numeric storefront ID.
+- `found: false` means only that the app was absent from Apple's returned result window. Storefront order, window size, and the Apple TV response schema can change independently of the CLI.
+
 ## Analytics & Sales Reports
 
 - Although Apple's current Sales Reports documentation describes `YYYY-MM-DD` for non-daily dates, the live endpoint requires `YYYY-MM` for monthly reports and `YYYY` for yearly reports. The CLI accepts either form and reduces full monthly or yearly dates to those live period identifiers before the request.

--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -48,6 +48,7 @@ Examples:
   asc apps wall submit --app "1234567890" --confirm
   asc apps public view --app "1234567890"
   asc apps public search --term "focus" --country us
+  asc apps public rank --app "1234567890" --term "focus timer" --country us --platform TV_OS
   asc apps public storefronts list
   asc apps registry pull --path ".asc/app-registry.json"
   asc apps view --id "APP_ID"

--- a/internal/cli/apps/public.go
+++ b/internal/cli/apps/public.go
@@ -59,6 +59,7 @@ No authentication is required.
 Examples:
   asc apps public view --app "1479784361"
   asc apps public search --term "focus" --country us
+  asc apps public rank --app "1234567890" --term "focus timer" --country us --platform TV_OS
   asc apps public prices --app "1479784361"
   asc apps public descriptions --app "1479784361"
   asc apps public storefronts list`,
@@ -67,6 +68,7 @@ Examples:
 		Subcommands: []*ffcli.Command{
 			AppsPublicViewCommand(),
 			AppsPublicSearchCommand(),
+			AppsPublicRankCommand(),
 			AppsPublicPricesCommand(),
 			AppsPublicDescriptionsCommand(),
 			AppsPublicStorefrontsCommand(),

--- a/internal/cli/apps/public_rank.go
+++ b/internal/cli/apps/public_rank.go
@@ -1,0 +1,161 @@
+package apps
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/itunes"
+)
+
+type publicRankOutput struct {
+	AppID       int64  `json:"appId"`
+	Term        string `json:"term"`
+	Country     string `json:"country"`
+	Platform    string `json:"platform"`
+	Found       bool   `json:"found"`
+	Rank        *int   `json:"rank,omitempty"`
+	ResultCount int    `json:"resultCount"`
+}
+
+// AppsPublicRankCommand returns the experimental public app ranking command.
+func AppsPublicRankCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps public rank", flag.ExitOnError)
+
+	appID := fs.String("app", "", "Public App Store app ID")
+	term := fs.String("term", "", "Search term")
+	platform := fs.String("platform", "", "[experimental] Search platform: IOS or TV_OS")
+	country := fs.String("country", "us", "Storefront country code (ISO alpha-2, e.g. us, gb, de)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "rank",
+		ShortUsage: "asc apps public rank --app APP_ID --term QUERY --platform PLATFORM [--country CODE]",
+		ShortHelp:  "[experimental] Report an app's rank in a public App Store search window.",
+		LongHelp: `[experimental] Report an app's rank in a public App Store search result window.
+
+This command is experimental. No authentication is required.
+
+Supported platforms are IOS and TV_OS. A not-found result means the app is
+absent from the result window returned by Apple; it does not prove the app is
+absent from every possible storefront result.
+
+Examples:
+  asc apps public rank --app "1234567890" --term "focus timer" --country us --platform TV_OS
+  asc apps public rank --app "1234567890" --term "meditation" --country gb --platform tv_os --output table`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				fmt.Fprintln(os.Stderr, "Error: public rank does not accept positional arguments")
+				return flag.ErrHelp
+			}
+
+			resolvedAppID, err := resolvePublicAppID(*appID, "")
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+				return flag.ErrHelp
+			}
+			termValue := strings.TrimSpace(*term)
+			if termValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --term is required")
+				return shared.MissingRequiredUsageError("--term")
+			}
+			platformValue, err := normalizePublicRankPlatform(*platform)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+				return flag.ErrHelp
+			}
+			normalizedCountry, err := normalizePublicCountry(*country)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+				return flag.ErrHelp
+			}
+			if platformValue == itunes.PublicSearchPlatformTVOS && strings.TrimSpace(itunes.Storefronts[normalizedCountry]) == "" {
+				fmt.Fprintf(os.Stderr, "Error: TV_OS ranking is unavailable for storefront %s\n", strings.ToUpper(normalizedCountry))
+				return flag.ErrHelp
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			client := newPublicItunesClient()
+			rankResult, err := client.RankApp(requestCtx, resolvedAppID, termValue, normalizedCountry, platformValue)
+			if err != nil {
+				return fmt.Errorf("apps public rank: %w", err)
+			}
+			numericAppID, err := strconv.ParseInt(resolvedAppID, 10, 64)
+			if err != nil {
+				return fmt.Errorf("apps public rank: parse app ID: %w", err)
+			}
+
+			payload := publicRankOutput{
+				AppID:       numericAppID,
+				Term:        termValue,
+				Country:     strings.ToUpper(normalizedCountry),
+				Platform:    string(platformValue),
+				Found:       rankResult.Found,
+				Rank:        rankResult.Rank,
+				ResultCount: rankResult.ResultCount,
+			}
+
+			return shared.PrintOutputWithRenderers(payload, *output.Output, *output.Pretty, func() error {
+				return renderPublicRankTable(payload)
+			}, func() error {
+				return renderPublicRankMarkdown(payload)
+			})
+		},
+	}
+}
+
+func normalizePublicRankPlatform(value string) (itunes.PublicSearchPlatform, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	if normalized == "" {
+		return "", fmt.Errorf("--platform is required")
+	}
+	switch itunes.PublicSearchPlatform(normalized) {
+	case itunes.PublicSearchPlatformIOS:
+		return itunes.PublicSearchPlatformIOS, nil
+	case itunes.PublicSearchPlatformTVOS:
+		return itunes.PublicSearchPlatformTVOS, nil
+	default:
+		return "", fmt.Errorf("--platform must be one of: IOS, TV_OS")
+	}
+}
+
+func renderPublicRankTable(payload publicRankOutput) error {
+	asc.RenderTable(publicRankHeaders(), [][]string{publicRankRow(payload)})
+	return nil
+}
+
+func renderPublicRankMarkdown(payload publicRankOutput) error {
+	asc.RenderMarkdown(publicRankHeaders(), [][]string{publicRankRow(payload)})
+	return nil
+}
+
+func publicRankHeaders() []string {
+	return []string{"App ID", "Term", "Country", "Platform", "Found", "Rank", "Result Count"}
+}
+
+func publicRankRow(payload publicRankOutput) []string {
+	rank := "-"
+	if payload.Rank != nil {
+		rank = strconv.Itoa(*payload.Rank)
+	}
+	return []string{
+		strconv.FormatInt(payload.AppID, 10),
+		payload.Term,
+		payload.Country,
+		payload.Platform,
+		strconv.FormatBool(payload.Found),
+		rank,
+		strconv.Itoa(payload.ResultCount),
+	}
+}

--- a/internal/cli/cmdtest/apps_public_surface_test.go
+++ b/internal/cli/cmdtest/apps_public_surface_test.go
@@ -42,6 +42,16 @@ type publicSearchPayload struct {
 	Results []itunes.SearchResult `json:"results"`
 }
 
+type publicRankPayload struct {
+	AppID       int64  `json:"appId"`
+	Term        string `json:"term"`
+	Country     string `json:"country"`
+	Platform    string `json:"platform"`
+	Found       bool   `json:"found"`
+	Rank        *int   `json:"rank,omitempty"`
+	ResultCount int    `json:"resultCount"`
+}
+
 func runCommand(t *testing.T, args []string) (string, string, error) {
 	t.Helper()
 
@@ -86,10 +96,26 @@ func TestAppsPublicHelpShowsSubcommands(t *testing.T) {
 	}
 
 	usage := publicCmd.UsageFunc(publicCmd)
-	for _, want := range []string{"view", "search", "prices", "descriptions", "storefronts", "No authentication is required."} {
+	for _, want := range []string{"view", "search", "rank", "prices", "descriptions", "storefronts", "No authentication is required."} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("expected apps public help to contain %q, got %q", want, usage)
 		}
+	}
+}
+
+func TestAppsPublicRankHelpIsExperimental(t *testing.T) {
+	root := RootCommand("1.2.3")
+	rankCmd := findSubcommand(root, "apps", "public", "rank")
+	if rankCmd == nil {
+		t.Fatal("expected apps public rank command")
+		return
+	}
+
+	if !strings.HasPrefix(rankCmd.ShortHelp, "[experimental]") {
+		t.Fatalf("ShortHelp = %q, want experimental prefix", rankCmd.ShortHelp)
+	}
+	if !strings.HasPrefix(rankCmd.LongHelp, "[experimental]") {
+		t.Fatalf("LongHelp = %q, want experimental prefix", rankCmd.LongHelp)
 	}
 }
 
@@ -135,6 +161,51 @@ func TestAppsPublicValidationErrors(t *testing.T) {
 			wantErr: "unsupported country code",
 		},
 		{
+			name:    "rank missing app",
+			args:    []string{"apps", "public", "rank", "--term", "focus", "--platform", "IOS"},
+			wantErr: "--app is required",
+		},
+		{
+			name:    "rank invalid app",
+			args:    []string{"apps", "public", "rank", "--app", "abc", "--term", "focus", "--platform", "IOS"},
+			wantErr: "--app must be a numeric App Store app ID",
+		},
+		{
+			name:    "rank missing term",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--platform", "IOS"},
+			wantErr: "--term is required",
+		},
+		{
+			name:    "rank missing platform",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--term", "focus"},
+			wantErr: "--platform is required",
+		},
+		{
+			name:    "rank rejects macOS",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--term", "focus", "--platform", "MAC_OS"},
+			wantErr: "--platform must be one of: IOS, TV_OS",
+		},
+		{
+			name:    "rank rejects visionOS",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--term", "focus", "--platform", "VISION_OS"},
+			wantErr: "--platform must be one of: IOS, TV_OS",
+		},
+		{
+			name:    "rank rejects unknown platform",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--term", "focus", "--platform", "ANDROID"},
+			wantErr: "--platform must be one of: IOS, TV_OS",
+		},
+		{
+			name:    "rank invalid country",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--term", "focus", "--platform", "IOS", "--country", "usa"},
+			wantErr: "unsupported country code",
+		},
+		{
+			name:    "rank rejects positional argument",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--term", "focus", "--platform", "IOS", "extra"},
+			wantErr: "public rank does not accept positional arguments",
+		},
+		{
 			name:    "prices invalid country",
 			args:    []string{"apps", "public", "prices", "--app", "123", "--country", "usa"},
 			wantErr: "unsupported country code",
@@ -157,6 +228,211 @@ func TestAppsPublicValidationErrors(t *testing.T) {
 			}
 			if !strings.Contains(stderr, test.wantErr) {
 				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestAppsPublicRankRejectsTVStorefrontWithoutNumericIDBeforeRequest(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request for unsupported TV storefront: %s", req.URL.String())
+		return nil, errors.New("unexpected request")
+	})
+
+	stdout, stderr, runErr := runCommand(t, []string{
+		"apps", "public", "rank",
+		"--app", "1234567890",
+		"--term", "focus timer",
+		"--country", "kz",
+		"--platform", "TV_OS",
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "TV_OS ranking is unavailable for storefront KZ") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestAppsPublicRankTVOSJSON(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", req.Method)
+		}
+		if req.URL.Host != "search.itunes.apple.com" {
+			t.Fatalf("host = %q, want search.itunes.apple.com", req.URL.Host)
+		}
+		if req.URL.Path != "/WebObjects/MZStore.woa/wa/search" {
+			t.Fatalf("path = %q, want MZStore search", req.URL.Path)
+		}
+		if got := req.URL.Query().Get("term"); got != "search" {
+			t.Fatalf("term = %q, want search", got)
+		}
+		if got := req.Header.Get("X-Apple-Store-Front"); got != itunes.Storefronts["us"]+",33" {
+			t.Fatalf("storefront header = %q, want %q", got, itunes.Storefronts["us"]+",33")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"pageData":{"bubbles":[{"results":[
+					{"id":"111","entity":"tvSoftware"},
+					{"id":"1234567890","entity":"tvSoftware"}
+				]}]}
+			}`)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	stdout, stderr, runErr := runCommand(t, []string{
+		"apps", "public", "rank",
+		"--term", "search",
+		"--country", "us",
+		"--app", "1234567890",
+		"--output", "json",
+		"--platform", "tv_os",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload publicRankPayload
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal rank: %v", err)
+	}
+	if payload.AppID != 1234567890 || payload.Term != "search" || payload.Country != "US" || payload.Platform != "TV_OS" {
+		t.Fatalf("unexpected rank identity: %+v", payload)
+	}
+	if !payload.Found || payload.Rank == nil || *payload.Rank != 2 || payload.ResultCount != 2 {
+		t.Fatalf("unexpected rank result: %+v", payload)
+	}
+}
+
+func TestAppsPublicRankIOSNormalizesPlatform(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != "itunes.apple.com" || req.URL.Path != "/search" {
+			t.Fatalf("request URL = %s, want iTunes /search", req.URL.String())
+		}
+		if got := req.URL.Query().Get("limit"); got != "200" {
+			t.Fatalf("limit = %q, want 200", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"resultCount":1,
+				"results":[{"trackId":123,"trackName":"Alpha"}]
+			}`)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	stdout, stderr, runErr := runCommand(t, []string{
+		"apps", "public", "rank",
+		"--app", "123",
+		"--term", "alpha",
+		"--platform", "ios",
+		"--output", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload publicRankPayload
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal rank: %v", err)
+	}
+	if payload.Platform != "IOS" || !payload.Found || payload.Rank == nil || *payload.Rank != 1 {
+		t.Fatalf("unexpected iOS rank payload: %+v", payload)
+	}
+}
+
+func TestAppsPublicRankNotFoundOutputs(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+				"pageData":{"bubbles":[{"results":[
+					{"id":"111","entity":"tvSoftware"}
+				]}]}
+			}`)),
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	baseArgs := []string{
+		"apps", "public", "rank",
+		"--app", "1234567890",
+		"--term", "missing",
+		"--platform", "TV_OS",
+	}
+
+	stdout, stderr, runErr := runCommand(t, append(append([]string{}, baseArgs...), "--output", "json"))
+	if runErr != nil {
+		t.Fatalf("JSON run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty JSON stderr, got %q", stderr)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &raw); err != nil {
+		t.Fatalf("unmarshal raw rank: %v", err)
+	}
+	if _, ok := raw["rank"]; ok {
+		t.Fatalf("not-found JSON unexpectedly contains rank: %s", stdout)
+	}
+	var payload publicRankPayload
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal rank: %v", err)
+	}
+	if payload.Found || payload.Rank != nil || payload.ResultCount != 1 {
+		t.Fatalf("unexpected not-found payload: %+v", payload)
+	}
+
+	for _, output := range []string{"table", "markdown"} {
+		t.Run(output, func(t *testing.T) {
+			stdout, stderr, runErr := runCommand(t, append(append([]string{}, baseArgs...), "--output", output))
+			if runErr != nil {
+				t.Fatalf("run error: %v", runErr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			for _, want := range []string{"App ID", "Term", "Country", "Platform", "Found", "Rank", "Result Count", "1234567890", "TV_OS", "false", "-"} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("expected %s output to contain %q, got %q", output, want, stdout)
+				}
 			}
 		})
 	}

--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -422,6 +422,11 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 			wantErr: "--limit must be between 1 and 200",
 		},
 		{
+			name:    "apps public rank invalid platform",
+			args:    []string{"apps", "public", "rank", "--app", "123", "--term", "focus", "--platform", "MAC_OS"},
+			wantErr: "--platform must be one of: IOS, TV_OS",
+		},
+		{
 			name:    "reviews ratings rejects positional args",
 			args:    []string{"reviews", "ratings", "--app", "123", "extra"},
 			wantErr: "reviews ratings does not accept positional arguments",

--- a/internal/itunes/client.go
+++ b/internal/itunes/client.go
@@ -8,19 +8,24 @@ import (
 	"strings"
 )
 
-const defaultBaseURL = "https://itunes.apple.com"
+const (
+	defaultBaseURL                 = "https://itunes.apple.com"
+	defaultStorefrontSearchBaseURL = "https://search.itunes.apple.com"
+)
 
 // Client is an iTunes public API client.
 type Client struct {
-	HTTPClient *http.Client
-	BaseURL    string
+	HTTPClient              *http.Client
+	BaseURL                 string
+	StorefrontSearchBaseURL string
 }
 
 // NewClient creates a new iTunes API client.
 func NewClient() *Client {
 	return &Client{
-		HTTPClient: http.DefaultClient,
-		BaseURL:    defaultBaseURL,
+		HTTPClient:              http.DefaultClient,
+		BaseURL:                 defaultBaseURL,
+		StorefrontSearchBaseURL: defaultStorefrontSearchBaseURL,
 	}
 }
 
@@ -38,6 +43,17 @@ func (c *Client) baseURL() string {
 	base := strings.TrimSpace(c.BaseURL)
 	if base == "" {
 		return defaultBaseURL
+	}
+	return strings.TrimRight(base, "/")
+}
+
+func (c *Client) storefrontSearchBaseURL() string {
+	if c == nil {
+		return defaultStorefrontSearchBaseURL
+	}
+	base := strings.TrimSpace(c.StorefrontSearchBaseURL)
+	if base == "" {
+		return defaultStorefrontSearchBaseURL
 	}
 	return strings.TrimRight(base, "/")
 }

--- a/internal/itunes/rank.go
+++ b/internal/itunes/rank.go
@@ -1,0 +1,159 @@
+package itunes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// PublicSearchPlatform identifies a public App Store software surface.
+type PublicSearchPlatform string
+
+const (
+	// PublicSearchPlatformIOS selects the iOS App Store software surface.
+	PublicSearchPlatformIOS PublicSearchPlatform = "IOS"
+	// PublicSearchPlatformTVOS selects the Apple TV App Store software surface.
+	PublicSearchPlatformTVOS PublicSearchPlatform = "TV_OS"
+
+	appleTVStorefrontSoftwareKind = "33"
+	appleTVSoftwareEntity         = "tvSoftware"
+	storefrontSearchPath          = "/WebObjects/MZStore.woa/wa/search"
+)
+
+// PublicRankResult reports whether an app appears in an ordered result window.
+type PublicRankResult struct {
+	Found       bool
+	Rank        *int
+	ResultCount int
+}
+
+// RankApp reports an app's position in a public App Store search result window.
+func (c *Client) RankApp(
+	ctx context.Context,
+	appID string,
+	term string,
+	country string,
+	platform PublicSearchPlatform,
+) (PublicRankResult, error) {
+	switch platform {
+	case PublicSearchPlatformIOS:
+		results, err := c.SearchApps(ctx, term, country, 200)
+		if err != nil {
+			return PublicRankResult{}, fmt.Errorf("rank iOS apps: %w", err)
+		}
+
+		orderedIDs := make([]string, 0, len(results))
+		for _, result := range results {
+			orderedIDs = append(orderedIDs, strconv.FormatInt(result.AppID, 10))
+		}
+		return rankOrderedAppIDs(appID, orderedIDs), nil
+	case PublicSearchPlatformTVOS:
+		return c.rankTVApp(ctx, appID, term, country)
+	default:
+		return PublicRankResult{}, fmt.Errorf("unsupported public search platform %q", platform)
+	}
+}
+
+type storefrontSearchResponse struct {
+	PageData struct {
+		Bubbles []struct {
+			Results []struct {
+				ID     string `json:"id"`
+				Entity string `json:"entity"`
+			} `json:"results"`
+		} `json:"bubbles"`
+	} `json:"pageData"`
+}
+
+func (c *Client) rankTVApp(ctx context.Context, appID, term, country string) (PublicRankResult, error) {
+	normalizedCountry, err := NormalizeCountryCode(country)
+	if err != nil {
+		return PublicRankResult{}, err
+	}
+	storefrontID := strings.TrimSpace(Storefronts[normalizedCountry])
+	if storefrontID == "" {
+		return PublicRankResult{}, fmt.Errorf("TV_OS ranking is unavailable for storefront %q", strings.ToUpper(normalizedCountry))
+	}
+
+	base, err := url.Parse(c.storefrontSearchBaseURL())
+	if err != nil {
+		return PublicRankResult{}, fmt.Errorf("invalid storefront search base URL: %w", err)
+	}
+	query := url.Values{}
+	query.Set("clientApplication", "Software")
+	query.Set("src", "hint")
+	query.Set("submit", "edit")
+	query.Set("term", strings.TrimSpace(term))
+
+	reqURL := *base
+	reqURL.Path = strings.TrimRight(reqURL.Path, "/") + storefrontSearchPath
+	reqURL.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return PublicRankResult{}, fmt.Errorf("failed to create storefront search request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Apple-Store-Front", storefrontID+","+appleTVStorefrontSoftwareKind)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return PublicRankResult{}, fmt.Errorf("storefront search request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return PublicRankResult{}, &httpStatusError{operation: "storefront search", statusCode: resp.StatusCode}
+	}
+
+	var payload storefrontSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return PublicRankResult{}, fmt.Errorf("failed to parse storefront search response: %w", err)
+	}
+
+	orderedIDs := make([]string, 0)
+	seenIDs := make(map[string]struct{})
+	totalResults := 0
+	tvResults := 0
+	for _, bubble := range payload.PageData.Bubbles {
+		for _, result := range bubble.Results {
+			totalResults++
+			if result.Entity != appleTVSoftwareEntity {
+				continue
+			}
+			tvResults++
+			resultID := strings.TrimSpace(result.ID)
+			if resultID == "" {
+				return PublicRankResult{}, fmt.Errorf("invalid storefront search response: tvSoftware result is missing an ID")
+			}
+			canonicalID := canonicalizeLookupID(resultID)
+			if _, ok := seenIDs[canonicalID]; ok {
+				continue
+			}
+			seenIDs[canonicalID] = struct{}{}
+			orderedIDs = append(orderedIDs, canonicalID)
+		}
+	}
+	if totalResults > 0 && tvResults == 0 {
+		return PublicRankResult{}, fmt.Errorf("invalid storefront search response: expected tvSoftware results")
+	}
+
+	return rankOrderedAppIDs(appID, orderedIDs), nil
+}
+
+func rankOrderedAppIDs(appID string, orderedIDs []string) PublicRankResult {
+	result := PublicRankResult{ResultCount: len(orderedIDs)}
+	targetID := canonicalizeLookupID(appID)
+	for index, candidateID := range orderedIDs {
+		if canonicalizeLookupID(candidateID) != targetID {
+			continue
+		}
+		rank := index + 1
+		result.Found = true
+		result.Rank = &rank
+		return result
+	}
+	return result
+}

--- a/internal/itunes/rank.go
+++ b/internal/itunes/rank.go
@@ -112,12 +112,18 @@ func (c *Client) rankTVApp(ctx context.Context, appID, term, country string) (Pu
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return PublicRankResult{}, fmt.Errorf("failed to parse storefront search response: %w", err)
 	}
+	if payload.PageData.Bubbles == nil {
+		return PublicRankResult{}, fmt.Errorf("invalid storefront search response: missing pageData.bubbles")
+	}
 
 	orderedIDs := make([]string, 0)
 	seenIDs := make(map[string]struct{})
 	totalResults := 0
 	tvResults := 0
-	for _, bubble := range payload.PageData.Bubbles {
+	for bubbleIndex, bubble := range payload.PageData.Bubbles {
+		if bubble.Results == nil {
+			return PublicRankResult{}, fmt.Errorf("invalid storefront search response: missing pageData.bubbles[%d].results", bubbleIndex)
+		}
 		for _, result := range bubble.Results {
 			totalResults++
 			if result.Entity != appleTVSoftwareEntity {

--- a/internal/itunes/rank_test.go
+++ b/internal/itunes/rank_test.go
@@ -164,7 +164,7 @@ func TestRankAppTVOSUsesStorefrontSearchOrder(t *testing.T) {
 					"results": [
 						{"id":"111","entity":"tvSoftware","score":2.0},
 						{"id":"222","entity":"tvSoftware","score":1.9},
-						{"id":"1234567890","entity":"tvSoftware","score":1.8}
+						{"id":"1234567890","entity":"tvSoftware","score":9.9}
 					]
 				}]
 			},

--- a/internal/itunes/rank_test.go
+++ b/internal/itunes/rank_test.go
@@ -216,7 +216,6 @@ func TestRankAppTVOSHandlesEmptyResultWindows(t *testing.T) {
 		name string
 		body string
 	}{
-		{name: "missing bubbles", body: `{"pageData":{}}`},
 		{name: "empty bubbles", body: `{"pageData":{"bubbles":[]}}`},
 		{name: "empty results", body: `{"pageData":{"bubbles":[{"results":[]}]}}`},
 	}
@@ -235,6 +234,34 @@ func TestRankAppTVOSHandlesEmptyResultWindows(t *testing.T) {
 			}
 			if result.Found || result.Rank != nil || result.ResultCount != 0 {
 				t.Fatalf("RankApp() = %+v, want empty not-found result", result)
+			}
+		})
+	}
+}
+
+func TestRankAppTVOSErrorsOnMissingResultWindow(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing page data", body: `{}`},
+		{name: "missing bubbles", body: `{"pageData":{}}`},
+		{name: "null bubbles", body: `{"pageData":{"bubbles":null}}`},
+		{name: "missing bubble results", body: `{"pageData":{"bubbles":[{}]}}`},
+		{name: "null bubble results", body: `{"pageData":{"bubbles":[{"results":null}]}}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeBody(t, w, test.body)
+			}))
+			defer server.Close()
+
+			client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+			_, err := client.RankApp(context.Background(), "1234567890", "missing", "us", PublicSearchPlatformTVOS)
+			if err == nil {
+				t.Fatal("RankApp() error = nil, want missing result window error")
 			}
 		})
 	}

--- a/internal/itunes/rank_test.go
+++ b/internal/itunes/rank_test.go
@@ -1,0 +1,359 @@
+package itunes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRankAppIOSUsesOrderedSearchResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/search" {
+			t.Fatalf("request = %s %s, want GET /search", r.Method, r.URL.Path)
+		}
+
+		query := r.URL.Query()
+		if got := query.Get("term"); got != "focus timer" {
+			t.Fatalf("term = %q, want focus timer", got)
+		}
+		if got := query.Get("country"); got != "us" {
+			t.Fatalf("country = %q, want us", got)
+		}
+		if got := query.Get("entity"); got != "software" {
+			t.Fatalf("entity = %q, want software", got)
+		}
+		if got := query.Get("limit"); got != "200" {
+			t.Fatalf("limit = %q, want 200", got)
+		}
+
+		writeBody(t, w, `{
+			"resultCount": 3,
+			"results": [
+				{"trackId": 111, "trackName": "One"},
+				{"trackId": 1234567890, "trackName": "Focus Timer"},
+				{"trackId": 333, "trackName": "Three"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+	result, err := client.RankApp(
+		context.Background(),
+		"1234567890",
+		"focus timer",
+		"us",
+		PublicSearchPlatformIOS,
+	)
+	if err != nil {
+		t.Fatalf("RankApp() error: %v", err)
+	}
+	if !result.Found {
+		t.Fatal("RankApp() Found = false, want true")
+	}
+	if result.Rank == nil || *result.Rank != 2 {
+		t.Fatalf("RankApp() Rank = %v, want 2", result.Rank)
+	}
+	if result.ResultCount != 3 {
+		t.Fatalf("RankApp() ResultCount = %d, want 3", result.ResultCount)
+	}
+}
+
+func TestRankAppIOSReportsAbsentApp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{
+			"resultCount": 2,
+			"results": [
+				{"trackId": 111, "trackName": "One"},
+				{"trackId": 222, "trackName": "Two"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+	result, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformIOS)
+	if err != nil {
+		t.Fatalf("RankApp() error: %v", err)
+	}
+	if result.Found {
+		t.Fatal("RankApp() Found = true, want false")
+	}
+	if result.Rank != nil {
+		t.Fatalf("RankApp() Rank = %v, want nil", result.Rank)
+	}
+	if result.ResultCount != 2 {
+		t.Fatalf("RankApp() ResultCount = %d, want 2", result.ResultCount)
+	}
+}
+
+func TestRankAppIOSMatchesZeroPaddedAppID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{
+			"resultCount": 1,
+			"results": [{"trackId": 123, "trackName": "Alpha"}]
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+	result, err := client.RankApp(context.Background(), "00123", "alpha", "us", PublicSearchPlatformIOS)
+	if err != nil {
+		t.Fatalf("RankApp() error: %v", err)
+	}
+	if !result.Found || result.Rank == nil || *result.Rank != 1 {
+		t.Fatalf("RankApp() = %+v, want found rank 1", result)
+	}
+}
+
+func TestRankAppIOSHandlesEmptyResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{"resultCount":0,"results":[]}`)
+	}))
+	defer server.Close()
+
+	client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+	result, err := client.RankApp(context.Background(), "1234567890", "missing", "us", PublicSearchPlatformIOS)
+	if err != nil {
+		t.Fatalf("RankApp() error: %v", err)
+	}
+	if result.Found || result.Rank != nil || result.ResultCount != 0 {
+		t.Fatalf("RankApp() = %+v, want empty not-found result", result)
+	}
+}
+
+func TestRankAppRejectsUnsupportedPlatform(t *testing.T) {
+	client := &Client{}
+	_, err := client.RankApp(context.Background(), "123", "alpha", "us", PublicSearchPlatform("MAC_OS"))
+	if err == nil {
+		t.Fatal("RankApp() error = nil, want unsupported platform error")
+	}
+}
+
+func TestRankAppTVOSUsesStorefrontSearchOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/WebObjects/MZStore.woa/wa/search" {
+			t.Fatalf("request = %s %s, want GET /WebObjects/MZStore.woa/wa/search", r.Method, r.URL.Path)
+		}
+
+		query := r.URL.Query()
+		if got := query.Get("clientApplication"); got != "Software" {
+			t.Fatalf("clientApplication = %q, want Software", got)
+		}
+		if got := query.Get("src"); got != "hint" {
+			t.Fatalf("src = %q, want hint", got)
+		}
+		if got := query.Get("submit"); got != "edit" {
+			t.Fatalf("submit = %q, want edit", got)
+		}
+		if got := query.Get("term"); got != "focus timer" {
+			t.Fatalf("term = %q, want focus timer", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Fatalf("Accept = %q, want application/json", got)
+		}
+		if got := r.Header.Get("X-Apple-Store-Front"); got != Storefronts["us"]+",33" {
+			t.Fatalf("X-Apple-Store-Front = %q, want %q", got, Storefronts["us"]+",33")
+		}
+
+		writeBody(t, w, `{
+			"pageData": {
+				"bubbles": [{
+					"results": [
+						{"id":"111","entity":"tvSoftware","score":2.0},
+						{"id":"222","entity":"tvSoftware","score":1.9},
+						{"id":"1234567890","entity":"tvSoftware","score":1.8}
+					]
+				}]
+			},
+			"storePlatformData": {
+				"lockup": {"results": {"111":{},"222":{}}}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		HTTPClient:              server.Client(),
+		StorefrontSearchBaseURL: server.URL,
+	}
+	result, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if err != nil {
+		t.Fatalf("RankApp() error: %v", err)
+	}
+	if !result.Found || result.Rank == nil || *result.Rank != 3 || result.ResultCount != 3 {
+		t.Fatalf("RankApp() = %+v, want found rank 3 of 3", result)
+	}
+}
+
+func TestRankAppTVOSDeduplicatesFirstOccurrence(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{
+			"pageData": {"bubbles": [{"results": [
+				{"id":"111","entity":"tvSoftware"},
+				{"id":"1234567890","entity":"tvSoftware"},
+				{"id":"1234567890","entity":"tvSoftware"},
+				{"id":"333","entity":"tvSoftware"}
+			]}]}
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+	result, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if err != nil {
+		t.Fatalf("RankApp() error: %v", err)
+	}
+	if !result.Found || result.Rank == nil || *result.Rank != 2 || result.ResultCount != 3 {
+		t.Fatalf("RankApp() = %+v, want first occurrence at rank 2 of 3 unique results", result)
+	}
+}
+
+func TestRankAppTVOSHandlesEmptyResultWindows(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing bubbles", body: `{"pageData":{}}`},
+		{name: "empty bubbles", body: `{"pageData":{"bubbles":[]}}`},
+		{name: "empty results", body: `{"pageData":{"bubbles":[{"results":[]}]}}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeBody(t, w, test.body)
+			}))
+			defer server.Close()
+
+			client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+			result, err := client.RankApp(context.Background(), "1234567890", "missing", "us", PublicSearchPlatformTVOS)
+			if err != nil {
+				t.Fatalf("RankApp() error: %v", err)
+			}
+			if result.Found || result.Rank != nil || result.ResultCount != 0 {
+				t.Fatalf("RankApp() = %+v, want empty not-found result", result)
+			}
+		})
+	}
+}
+
+func TestRankAppTVOSReportsAbsentApp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{
+			"pageData": {"bubbles": [{"results": [
+				{"id":"111","entity":"tvSoftware"},
+				{"id":"222","entity":"tvSoftware"}
+			]}]}
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+	result, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if err != nil {
+		t.Fatalf("RankApp() error: %v", err)
+	}
+	if result.Found || result.Rank != nil || result.ResultCount != 2 {
+		t.Fatalf("RankApp() = %+v, want not found in 2 results", result)
+	}
+}
+
+func TestRankAppTVOSErrorsOnMalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{"pageData":`)
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+	_, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if err == nil {
+		t.Fatal("RankApp() error = nil, want malformed JSON error")
+	}
+}
+
+func TestRankAppTVOSErrorsOnMissingTVAppID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{
+			"pageData": {"bubbles": [{"results": [
+				{"entity":"tvSoftware","score":2.0}
+			]}]}
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+	_, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if err == nil {
+		t.Fatal("RankApp() error = nil, want missing TV app ID error")
+	}
+}
+
+func TestRankAppTVOSErrorsOnNonTVResultSet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBody(t, w, `{
+			"pageData": {"bubbles": [{"results": [
+				{"id":"111","entity":"software","score":2.0}
+			]}]}
+		}`)
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+	_, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if err == nil {
+		t.Fatal("RankApp() error = nil, want unexpected entity error")
+	}
+}
+
+func TestRankAppTVOSRejectsMissingStorefrontBeforeRequest(t *testing.T) {
+	client := &Client{HTTPClient: &http.Client{Transport: rankRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request for unsupported storefront: %s", r.URL.String())
+		return nil, errors.New("unexpected request")
+	})}}
+
+	_, err := client.RankApp(context.Background(), "1234567890", "focus timer", "kz", PublicSearchPlatformTVOS)
+	if err == nil {
+		t.Fatal("RankApp() error = nil, want missing storefront error")
+	}
+}
+
+func TestRankAppTVOSRetainsHTTPStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), StorefrontSearchBaseURL: server.URL}
+	_, err := client.RankApp(context.Background(), "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if err == nil {
+		t.Fatal("RankApp() error = nil, want HTTP status error")
+	}
+
+	var statusError interface{ HTTPStatusCode() int }
+	if !errors.As(err, &statusError) {
+		t.Fatalf("error %T does not expose HTTP status", err)
+	}
+	if got := statusError.HTTPStatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("HTTPStatusCode() = %d, want %d", got, http.StatusTooManyRequests)
+	}
+}
+
+func TestRankAppTVOSRespectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := &Client{HTTPClient: http.DefaultClient}
+	_, err := client.RankApp(ctx, "1234567890", "focus timer", "us", PublicSearchPlatformTVOS)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RankApp() error = %v, want context.Canceled", err)
+	}
+}
+
+type rankRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f rankRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/internal/itunes/storefronts.go
+++ b/internal/itunes/storefronts.go
@@ -10,7 +10,8 @@ import (
 )
 
 // Storefronts maps a subset of public App Store country codes to Apple storefront IDs.
-// These IDs are required for the X-Apple-Store-Front header when fetching ratings histograms.
+// These IDs are required for X-Apple-Store-Front requests such as ratings
+// histograms and platform-specific storefront search.
 var Storefronts = map[string]string{
 	"ae": "143481", // United Arab Emirates
 	"ai": "143538", // Anguilla


### PR DESCRIPTION
## Summary

- add experimental `asc apps public rank` support for `IOS` and `TV_OS`
- rank an app within Apple's ordered public storefront result window without authentication
- preserve the stable `apps public search` command and its existing output contract

## Command contract

```bash
asc apps public rank \
  --app "1234567890" \
  --term "focus timer" \
  --country us \
  --platform TV_OS
```

JSON reports `found`, optional one-based `rank`, and `resultCount`. A successful
`found: false` result means only that the app is absent from Apple's returned
window; it does not prove the app has no organic rank outside that window.

## Validation

- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint` (repository `go vet ./...` fallback; `golangci-lint` is not installed locally)
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/itunes ./internal/cli/apps ./internal/cli/cmdtest`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary help, stdout/stderr, invalid-platform exit `2`, and JSON output checks

## Risk

The Apple TV endpoint is a public but undocumented MZStore transport. The
command is explicitly experimental because its response schema, result window,
and ordering can change independently of the CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental `apps public rank` command to check App Store search rankings on iOS and tvOS.
  * Results show storefront, platform, rank, availability, and total result count.
  * Supports JSON, table, and Markdown output formats.
  * Validates app IDs, search terms, platforms, countries, and supported tvOS storefronts.
  * Uses unauthenticated public storefront searches.

* **Documentation**
  * Added command examples, usage guidance, supported storefront details, ranking limitations, and API stability caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->