### PR TITLE
fix(build): pin golangci-lint cache inside the checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build/
 /dist/
 .gocache/
+.golangci-cache/
 
 # Binaries for programs and plugins
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test-integration:
 lint:
 	@echo "$(BLUE)Linting code...$(NC)"
 	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run --timeout=$(GOLANGCI_LINT_TIMEOUT) ./...; \
+		GOLANGCI_LINT_CACHE=$(CURDIR)/.golangci-cache golangci-lint run --timeout=$(GOLANGCI_LINT_TIMEOUT) ./...; \
 	else \
 		echo "$(YELLOW)golangci-lint not found; falling back to 'go vet ./...'.$(NC)"; \
 		echo "$(YELLOW)Install with: make tools (or: GOTOOLCHAIN=$(GO_TOOLCHAIN_VERSION) $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)$(NC)"; \

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test-integration:
 lint:
 	@echo "$(BLUE)Linting code...$(NC)"
 	@if command -v golangci-lint >/dev/null 2>&1; then \
-		GOLANGCI_LINT_CACHE=$(CURDIR)/.golangci-cache golangci-lint run --timeout=$(GOLANGCI_LINT_TIMEOUT) ./...; \
+		GOLANGCI_LINT_CACHE="$(CURDIR)/.golangci-cache" golangci-lint run --timeout=$(GOLANGCI_LINT_TIMEOUT) ./...; \
 	else \
 		echo "$(YELLOW)golangci-lint not found; falling back to 'go vet ./...'.$(NC)"; \
 		echo "$(YELLOW)Install with: make tools (or: GOTOOLCHAIN=$(GO_TOOLCHAIN_VERSION) $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)$(NC)"; \


### PR DESCRIPTION
## Problem

`make lint` uses golangci-lint's user-global cache. After a lint run inside a temporary worktree (e.g. the `$audit-asc-pr` skill), the shared cache can keep serving findings whose file paths point into the now-deleted worktree. Observed today: **51 phantom issues** (1 errorlint, 50 staticcheck) all pointing into `/private/tmp/asc-pr-2045-audit.*`, reported identically on an untouched `main`, until a manual `golangci-lint cache clean`.

## Fix

Pin `GOLANGCI_LINT_CACHE` to `$(CURDIR)/.golangci-cache` in the `lint` target so every checkout and worktree gets its own cache, and gitignore the directory (same pattern as `.gocache/`).

## Verification

- `make lint` in a fresh worktree: creates `.golangci-cache/` locally, 0 issues.
- Full pre-commit hook suite (docs check, format, lint, short tests) passed on commit.
- Trade-off: cold-cache lint is slower once per fresh checkout; that is the cost of hermeticism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the linting workflow by storing cache files in a repository-local directory.
  * Excluded lint cache artifacts from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->