### PR TITLE
feat(testflight): multi-group beta-testers add, required --confirm on remove

### DIFF
--- a/internal/cli/cmdtest/testflight_beta_testers_commands_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_commands_test.go
@@ -203,7 +203,7 @@ func TestTestFlightBetaTestersRemoveOutput(t *testing.T) {
 	root.FlagSet.SetOutput(io.Discard)
 
 	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{"testflight", "testers", "remove", "--app", "app-1", "--email", "tester@example.com"}); err != nil {
+		if err := root.Parse([]string{"testflight", "testers", "remove", "--app", "app-1", "--email", "tester@example.com", "--confirm"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		if err := root.Run(context.Background()); err != nil {

--- a/internal/cli/testflight/beta_helpers.go
+++ b/internal/cli/testflight/beta_helpers.go
@@ -12,23 +12,19 @@ import (
 var errBetaTesterNotFound = errors.New("beta tester not found")
 
 func resolveBetaGroupID(ctx context.Context, client *asc.Client, appID, group string) (string, error) {
-	ids, err := resolveBetaGroupIDs(ctx, client, appID, []string{group})
+	ids, err := resolveBetaGroupIDs(ctx, client, appID, group)
 	if err != nil {
 		return "", err
 	}
 	return ids[0], nil
 }
 
-func resolveBetaGroupIDs(ctx context.Context, client *asc.Client, appID string, groupTokens []string) ([]string, error) {
-	tokens := make([]string, 0, len(groupTokens))
-	for _, token := range groupTokens {
-		token = strings.TrimSpace(token)
-		if token == "" {
-			continue
-		}
-		tokens = append(tokens, token)
-	}
-	if len(tokens) == 0 {
+// resolveBetaGroupIDs resolves a raw --group value against a single beta-groups
+// fetch. A value that exactly matches one group ID or name is used as-is, even
+// when it contains commas; otherwise the value is treated as a comma-separated
+// list of group names or IDs.
+func resolveBetaGroupIDs(ctx context.Context, client *asc.Client, appID, rawGroups string) ([]string, error) {
+	if strings.TrimSpace(rawGroups) == "" {
 		return nil, fmt.Errorf("beta group name is required")
 	}
 
@@ -37,8 +33,25 @@ func resolveBetaGroupIDs(ctx context.Context, client *asc.Client, appID string, 
 		return nil, err
 	}
 
+	id, err := matchBetaGroupID(groups, strings.TrimSpace(rawGroups))
+	if err == nil {
+		return []string{id}, nil
+	}
+	if !errors.Is(err, errBetaGroupNotFound) {
+		return nil, err
+	}
+
+	tokens := strings.Split(rawGroups, ",")
+	if len(tokens) == 1 {
+		return nil, err
+	}
+
 	ids := make([]string, 0, len(tokens))
 	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return nil, fmt.Errorf("empty group name in --group value %q", rawGroups)
+		}
 		id, err := matchBetaGroupID(groups, token)
 		if err != nil {
 			return nil, err
@@ -47,6 +60,8 @@ func resolveBetaGroupIDs(ctx context.Context, client *asc.Client, appID string, 
 	}
 	return ids, nil
 }
+
+var errBetaGroupNotFound = errors.New("not found")
 
 func matchBetaGroupID(groups *asc.BetaGroupsResponse, group string) (string, error) {
 	for _, item := range groups.Data {
@@ -64,7 +79,7 @@ func matchBetaGroupID(groups *asc.BetaGroupsResponse, group string) (string, err
 
 	switch len(matches) {
 	case 0:
-		return "", fmt.Errorf("beta group %q not found", group)
+		return "", fmt.Errorf("beta group %q %w", group, errBetaGroupNotFound)
 	case 1:
 		return matches[0], nil
 	default:

--- a/internal/cli/testflight/beta_helpers.go
+++ b/internal/cli/testflight/beta_helpers.go
@@ -12,16 +12,43 @@ import (
 var errBetaTesterNotFound = errors.New("beta tester not found")
 
 func resolveBetaGroupID(ctx context.Context, client *asc.Client, appID, group string) (string, error) {
-	group = strings.TrimSpace(group)
-	if group == "" {
-		return "", fmt.Errorf("beta group name is required")
+	ids, err := resolveBetaGroupIDs(ctx, client, appID, []string{group})
+	if err != nil {
+		return "", err
+	}
+	return ids[0], nil
+}
+
+func resolveBetaGroupIDs(ctx context.Context, client *asc.Client, appID string, groupTokens []string) ([]string, error) {
+	tokens := make([]string, 0, len(groupTokens))
+	for _, token := range groupTokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("beta group name is required")
 	}
 
 	groups, err := client.GetBetaGroups(ctx, appID, asc.WithBetaGroupsLimit(200))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
+	ids := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		id, err := matchBetaGroupID(groups, token)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func matchBetaGroupID(groups *asc.BetaGroupsResponse, group string) (string, error) {
 	for _, item := range groups.Data {
 		if item.ID == group {
 			return item.ID, nil

--- a/internal/cli/testflight/beta_helpers.go
+++ b/internal/cli/testflight/beta_helpers.go
@@ -32,6 +32,14 @@ func resolveBetaGroupIDs(ctx context.Context, client *asc.Client, appID, rawGrou
 	if err != nil {
 		return nil, err
 	}
+	for groups.Links.Next != "" {
+		page, err := client.GetBetaGroups(ctx, appID, asc.WithBetaGroupsNextURL(groups.Links.Next))
+		if err != nil {
+			return nil, err
+		}
+		groups.Data = append(groups.Data, page.Data...)
+		groups.Links.Next = page.Links.Next
+	}
 
 	id, err := matchBetaGroupID(groups, strings.TrimSpace(rawGroups))
 	if err == nil {

--- a/internal/cli/testflight/beta_helpers.go
+++ b/internal/cli/testflight/beta_helpers.go
@@ -16,6 +16,9 @@ func resolveBetaGroupID(ctx context.Context, client *asc.Client, appID, group st
 	if err != nil {
 		return "", err
 	}
+	if len(ids) != 1 {
+		return "", fmt.Errorf("expected a single beta group, got %d from %q", len(ids), group)
+	}
 	return ids[0], nil
 }
 

--- a/internal/cli/testflight/beta_tester_remove_confirm_test.go
+++ b/internal/cli/testflight/beta_tester_remove_confirm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"strings"
 	"testing"
 )
 
@@ -21,6 +22,9 @@ func TestBetaTestersRemoveCommand_RequiresConfirm(t *testing.T) {
 	err := cmd.Exec(context.Background(), []string{})
 	if !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("remove without --confirm should fail validation, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "--confirm") {
+		t.Fatalf("usage error should name --confirm, got %q", err.Error())
 	}
 }
 

--- a/internal/cli/testflight/beta_tester_remove_confirm_test.go
+++ b/internal/cli/testflight/beta_tester_remove_confirm_test.go
@@ -1,0 +1,43 @@
+package testflight
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"testing"
+)
+
+func TestBetaTestersRemoveCommand_RequiresConfirm(t *testing.T) {
+	isolateTestFlightAuthEnvForAddTests(t)
+
+	cmd := BetaTestersRemoveCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--email", "tester@example.com",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), []string{})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("remove without --confirm should fail validation, got %v", err)
+	}
+}
+
+func TestBetaTestersRemoveCommand_ConfirmPassesValidation(t *testing.T) {
+	isolateTestFlightAuthEnvForAddTests(t)
+
+	cmd := BetaTestersRemoveCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--email", "tester@example.com",
+		"--confirm",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), []string{})
+	if errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("remove with --confirm should pass validation, got %v", err)
+	}
+}

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -31,7 +31,7 @@ Examples:
   asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta,iOS 27"
   asc testflight beta-testers export --app "APP_ID" --output "./testflight-testers.csv"
   asc testflight beta-testers import --app "APP_ID" --input "./testflight-testers.csv" --dry-run
-  asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com"
+  asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com" --confirm
   asc testflight beta-testers add-groups --id "TESTER_ID" --group "GROUP_ID"
   asc testflight beta-testers remove-groups --id "TESTER_ID" --group "GROUP_ID"
   asc testflight beta-testers add-builds --id "TESTER_ID" --build-id "BUILD_ID"
@@ -312,16 +312,20 @@ func BetaTestersRemoveCommand() *ffcli.Command {
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	email := fs.String("email", "", "Tester email address")
+	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "remove",
-		ShortUsage: "asc testflight beta-testers remove [flags]",
+		ShortUsage: "asc testflight beta-testers remove --app APP_ID --email EMAIL --confirm",
 		ShortHelp:  "Remove a TestFlight beta tester.",
 		LongHelp: `Remove a TestFlight beta tester.
 
+Removal deletes the tester from the app, including every group membership and
+build assignment. This cannot be undone, so --confirm is required.
+
 Examples:
-  asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com"`,
+  asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -333,6 +337,10 @@ Examples:
 			if strings.TrimSpace(*email) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --email is required")
 				return shared.MissingRequiredUsageError("--email")
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return shared.MissingRequiredUsageError("--confirm")
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -262,7 +262,8 @@ func BetaTestersAddCommand() *ffcli.Command {
 
 The tester is added to every group in the comma-separated --group list. A
 value that exactly matches one group name is used as-is, even when the name
-contains commas.
+contains commas. To combine a comma-containing group name with other groups
+in one list, reference that group by its ID instead.
 
 Examples:
   asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta"

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -28,6 +28,7 @@ Examples:
   asc testflight beta-testers list --app "APP_ID"
   asc testflight beta-testers view --id "TESTER_ID"
   asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta"
+  asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta,iOS 27"
   asc testflight beta-testers export --app "APP_ID" --output "./testflight-testers.csv"
   asc testflight beta-testers import --app "APP_ID" --input "./testflight-testers.csv" --dry-run
   asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com"
@@ -219,6 +220,28 @@ Examples:
 	}
 }
 
+// onceCSVFlag accepts a single comma-separated flag value and rejects
+// repeated flag occurrences instead of silently keeping only the last one.
+type onceCSVFlag struct {
+	flagName string
+	value    string
+	set      bool
+}
+
+func (v *onceCSVFlag) String() string { return v.value }
+
+func (v *onceCSVFlag) Set(raw string) error {
+	if v.set {
+		return fmt.Errorf(
+			"--%s specified multiple times; pass one comma-separated list, for example --%s %q",
+			v.flagName, v.flagName, v.value+","+raw,
+		)
+	}
+	v.value = raw
+	v.set = true
+	return nil
+}
+
 // BetaTestersAddCommand returns the beta testers add subcommand.
 func BetaTestersAddCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("add", flag.ExitOnError)
@@ -227,17 +250,21 @@ func BetaTestersAddCommand() *ffcli.Command {
 	email := fs.String("email", "", "Tester email address")
 	firstName := fs.String("first-name", "", "Tester first name")
 	lastName := fs.String("last-name", "", "Tester last name")
-	group := fs.String("group", "", "Beta group name or ID")
+	group := &onceCSVFlag{flagName: "group"}
+	fs.Var(group, "group", "Comma-separated beta group names or IDs")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "add",
-		ShortUsage: "asc testflight beta-testers add [flags]",
+		ShortUsage: "asc testflight beta-testers add --app APP_ID --email EMAIL --group GROUP[,GROUP...]",
 		ShortHelp:  "Add a TestFlight beta tester.",
 		LongHelp: `Add a TestFlight beta tester.
 
+The tester is added to every group in the comma-separated --group list.
+
 Examples:
-  asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta"`,
+  asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta"
+  asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta,iOS 27"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -250,7 +277,8 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --email is required")
 				return shared.MissingRequiredUsageError("--email")
 			}
-			if strings.TrimSpace(*group) == "" {
+			groupTokens := shared.SplitUniqueCSV(group.String())
+			if len(groupTokens) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
 				return shared.MissingRequiredUsageError("--group")
 			}
@@ -263,12 +291,12 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			groupID, err := resolveBetaGroupID(requestCtx, client, resolvedAppID, *group)
+			groupIDs, err := resolveBetaGroupIDs(requestCtx, client, resolvedAppID, groupTokens)
 			if err != nil {
 				return fmt.Errorf("beta-testers add: %w", err)
 			}
 
-			tester, err := client.CreateBetaTester(requestCtx, *email, *firstName, *lastName, []string{groupID})
+			tester, err := client.CreateBetaTester(requestCtx, *email, *firstName, *lastName, groupIDs)
 			if err != nil {
 				return fmt.Errorf("beta-testers add: failed to create: %w", err)
 			}

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -260,7 +260,9 @@ func BetaTestersAddCommand() *ffcli.Command {
 		ShortHelp:  "Add a TestFlight beta tester.",
 		LongHelp: `Add a TestFlight beta tester.
 
-The tester is added to every group in the comma-separated --group list.
+The tester is added to every group in the comma-separated --group list. A
+value that exactly matches one group name is used as-is, even when the name
+contains commas.
 
 Examples:
   asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta"
@@ -277,8 +279,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --email is required")
 				return shared.MissingRequiredUsageError("--email")
 			}
-			groupTokens := shared.SplitUniqueCSV(group.String())
-			if len(groupTokens) == 0 {
+			if strings.TrimSpace(group.String()) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
 				return shared.MissingRequiredUsageError("--group")
 			}
@@ -291,7 +292,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			groupIDs, err := resolveBetaGroupIDs(requestCtx, client, resolvedAppID, groupTokens)
+			groupIDs, err := resolveBetaGroupIDs(requestCtx, client, resolvedAppID, group.String())
 			if err != nil {
 				return fmt.Errorf("beta-testers add: %w", err)
 			}

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -323,8 +323,9 @@ func BetaTestersRemoveCommand() *ffcli.Command {
 		ShortHelp:  "Remove a TestFlight beta tester.",
 		LongHelp: `Remove a TestFlight beta tester.
 
-Removal deletes the tester from the app, including every group membership and
-build assignment. This cannot be undone, so --confirm is required.
+Removal deletes the beta tester record itself: every group membership and
+build assignment is removed across all apps the tester belongs to, not only
+the app used for the lookup. This cannot be undone, so --confirm is required.
 
 Examples:
   asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com" --confirm`,

--- a/internal/cli/testflight/beta_testers_group_flag_test.go
+++ b/internal/cli/testflight/beta_testers_group_flag_test.go
@@ -1,0 +1,172 @@
+package testflight
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestOnceCSVFlag_RejectsRepeatedUse(t *testing.T) {
+	value := onceCSVFlag{flagName: "group"}
+
+	if err := value.Set("Beta"); err != nil {
+		t.Fatalf("first Set() error: %v", err)
+	}
+	if got := value.String(); got != "Beta" {
+		t.Fatalf("String() = %q, want %q", got, "Beta")
+	}
+
+	err := value.Set("QA")
+	if err == nil {
+		t.Fatal("second Set() should fail")
+	}
+	if !strings.Contains(err.Error(), "--group") || !strings.Contains(err.Error(), "comma-separated") {
+		t.Fatalf("second Set() error should mention --group and comma-separated usage, got %q", err.Error())
+	}
+	if got := value.String(); got != "Beta" {
+		t.Fatalf("rejected Set() must not overwrite value, got %q", got)
+	}
+}
+
+func TestBetaTestersAddCommand_CSVGroupsPassValidation(t *testing.T) {
+	isolateTestFlightAuthEnvForAddTests(t)
+
+	cmd := BetaTestersAddCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--email", "tester@example.com",
+		"--group", "Beta,QA Team",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), []string{})
+	if errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("comma-separated groups should pass validation, got %v", err)
+	}
+}
+
+func TestResolveBetaGroupIDs_SingleFetchResolvesAllTokens(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		if req.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", req.Method)
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if req.URL.Path != "/v1/apps/123456789/betaGroups" {
+			t.Errorf("unexpected request path %q", req.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"type": "betaGroups", "id": "group-beta", "attributes": map[string]any{"name": "Beta"}},
+				{"type": "betaGroups", "id": "group-ios27", "attributes": map[string]any{"name": "iOS 27"}},
+				{"type": "betaGroups", "id": "group-qa", "attributes": map[string]any{"name": "QA Team"}},
+			},
+			"links": map[string]string{},
+		}); err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newBetaGroupResolutionClient(t, server)
+
+	got, err := resolveBetaGroupIDs(context.Background(), client, "123456789", []string{
+		"group-beta",
+		"ios 27",
+		"QA Team",
+	})
+	if err != nil {
+		t.Fatalf("resolveBetaGroupIDs() error: %v", err)
+	}
+
+	want := []string{"group-beta", "group-ios27", "group-qa"}
+	if len(got) != len(want) {
+		t.Fatalf("resolveBetaGroupIDs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resolveBetaGroupIDs()[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("beta group fetches = %d, want 1", requests)
+	}
+}
+
+func TestResolveBetaGroupIDs_UnknownTokenFails(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"type": "betaGroups", "id": "group-beta", "attributes": map[string]any{"name": "Beta"}},
+			},
+			"links": map[string]string{},
+		}); err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newBetaGroupResolutionClient(t, server)
+
+	_, err := resolveBetaGroupIDs(context.Background(), client, "123456789", []string{"Beta", "Nope"})
+	if err == nil {
+		t.Fatal("unknown group token should fail")
+	}
+	if !strings.Contains(err.Error(), "Nope") {
+		t.Fatalf("error should name the unresolved group, got %q", err.Error())
+	}
+}
+
+func newBetaGroupResolutionClient(t *testing.T, server *httptest.Server) *asc.Client {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+
+	transport, ok := server.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("test server transport type = %T, want *http.Transport", server.Client().Transport)
+	}
+	transport = transport.Clone()
+	transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	transport.TLSClientConfig.ServerName = "example.com"
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+	}
+
+	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient() error: %v", err)
+	}
+	return client
+}

--- a/internal/cli/testflight/beta_testers_group_flag_test.go
+++ b/internal/cli/testflight/beta_testers_group_flag_test.go
@@ -153,6 +153,42 @@ func TestResolveBetaGroupIDs_EmptyTokenFails(t *testing.T) {
 	}
 }
 
+func TestResolveBetaGroupIDs_FollowsPagination(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		links := map[string]string{}
+		var data []map[string]any
+		if req.URL.Query().Get("cursor") == "" {
+			data = []map[string]any{
+				{"type": "betaGroups", "id": "group-beta", "attributes": map[string]any{"name": "Beta"}},
+			}
+			links["next"] = "https://api.appstoreconnect.apple.com/v1/apps/123456789/betaGroups?cursor=2"
+		} else {
+			data = []map[string]any{
+				{"type": "betaGroups", "id": "group-second", "attributes": map[string]any{"name": "Second"}},
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"data": data, "links": links}); err != nil {
+			t.Errorf("marshal response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newBetaGroupResolutionClient(t, server)
+
+	got, err := resolveBetaGroupIDs(context.Background(), client, "123456789", "Beta,Second")
+	if err != nil {
+		t.Fatalf("resolveBetaGroupIDs() error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "group-beta" || got[1] != "group-second" {
+		t.Fatalf("paginated resolution = %v, want [group-beta group-second]", got)
+	}
+	if requests != 2 {
+		t.Fatalf("beta group fetches = %d, want 2", requests)
+	}
+}
+
 func newStaticBetaGroupsServer(t *testing.T, groups map[string]string) *httptest.Server {
 	t.Helper()
 

--- a/internal/cli/testflight/beta_testers_group_flag_test.go
+++ b/internal/cli/testflight/beta_testers_group_flag_test.go
@@ -90,11 +90,7 @@ func TestResolveBetaGroupIDs_SingleFetchResolvesAllTokens(t *testing.T) {
 	t.Cleanup(server.Close)
 	client := newBetaGroupResolutionClient(t, server)
 
-	got, err := resolveBetaGroupIDs(context.Background(), client, "123456789", []string{
-		"group-beta",
-		"ios 27",
-		"QA Team",
-	})
+	got, err := resolveBetaGroupIDs(context.Background(), client, "123456789", "group-beta, ios 27,QA Team")
 	if err != nil {
 		t.Fatalf("resolveBetaGroupIDs() error: %v", err)
 	}
@@ -114,27 +110,69 @@ func TestResolveBetaGroupIDs_SingleFetchResolvesAllTokens(t *testing.T) {
 }
 
 func TestResolveBetaGroupIDs_UnknownTokenFails(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(map[string]any{
-			"data": []map[string]any{
-				{"type": "betaGroups", "id": "group-beta", "attributes": map[string]any{"name": "Beta"}},
-			},
-			"links": map[string]string{},
-		}); err != nil {
-			t.Fatalf("marshal response: %v", err)
-		}
+	client := newBetaGroupResolutionClient(t, newStaticBetaGroupsServer(t, map[string]string{
+		"group-beta": "Beta",
 	}))
-	t.Cleanup(server.Close)
-	client := newBetaGroupResolutionClient(t, server)
 
-	_, err := resolveBetaGroupIDs(context.Background(), client, "123456789", []string{"Beta", "Nope"})
+	_, err := resolveBetaGroupIDs(context.Background(), client, "123456789", "Beta,Nope")
 	if err == nil {
 		t.Fatal("unknown group token should fail")
 	}
 	if !strings.Contains(err.Error(), "Nope") {
 		t.Fatalf("error should name the unresolved group, got %q", err.Error())
 	}
+}
+
+func TestResolveBetaGroupIDs_CommaNameResolvesAsSingleGroup(t *testing.T) {
+	client := newBetaGroupResolutionClient(t, newStaticBetaGroupsServer(t, map[string]string{
+		"group-qa-external": "QA, External",
+		"group-qa":          "QA",
+		"group-external":    "External",
+	}))
+
+	got, err := resolveBetaGroupIDs(context.Background(), client, "123456789", "QA, External")
+	if err != nil {
+		t.Fatalf("resolveBetaGroupIDs() error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "group-qa-external" {
+		t.Fatalf("comma-containing name should resolve as one group, got %v", got)
+	}
+}
+
+func TestResolveBetaGroupIDs_EmptyTokenFails(t *testing.T) {
+	client := newBetaGroupResolutionClient(t, newStaticBetaGroupsServer(t, map[string]string{
+		"group-beta": "Beta",
+	}))
+
+	_, err := resolveBetaGroupIDs(context.Background(), client, "123456789", "Beta,,")
+	if err == nil {
+		t.Fatal("empty group token should fail")
+	}
+	if !strings.Contains(err.Error(), "empty group name") {
+		t.Fatalf("error should call out the empty token, got %q", err.Error())
+	}
+}
+
+func newStaticBetaGroupsServer(t *testing.T, groups map[string]string) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		data := make([]map[string]any, 0, len(groups))
+		for id, name := range groups {
+			data = append(data, map[string]any{
+				"type": "betaGroups", "id": id, "attributes": map[string]any{"name": name},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"data":  data,
+			"links": map[string]string{},
+		}); err != nil {
+			t.Errorf("marshal response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
 }
 
 func newBetaGroupResolutionClient(t *testing.T, server *httptest.Server) *asc.Client {

--- a/internal/cli/testflight/beta_testers_group_flag_test.go
+++ b/internal/cli/testflight/beta_testers_group_flag_test.go
@@ -139,6 +139,21 @@ func TestResolveBetaGroupIDs_CommaNameResolvesAsSingleGroup(t *testing.T) {
 	}
 }
 
+func TestResolveBetaGroupID_RejectsMultiGroupValue(t *testing.T) {
+	client := newBetaGroupResolutionClient(t, newStaticBetaGroupsServer(t, map[string]string{
+		"group-beta": "Beta",
+		"group-qa":   "QA",
+	}))
+
+	_, err := resolveBetaGroupID(context.Background(), client, "123456789", "Beta,QA")
+	if err == nil {
+		t.Fatal("singular resolver should reject a value resolving to multiple groups")
+	}
+	if !strings.Contains(err.Error(), "single beta group") {
+		t.Fatalf("error should explain the single-group expectation, got %q", err.Error())
+	}
+}
+
 func TestResolveBetaGroupIDs_EmptyTokenFails(t *testing.T) {
 	client := newBetaGroupResolutionClient(t, newStaticBetaGroupsServer(t, map[string]string{
 		"group-beta": "Beta",


### PR DESCRIPTION
## Why

Both changes fall out of one real incident (adding a tester to two groups from an agent workflow):

1. `beta-testers add --group A --group B` **silently dropped group A** — standard Go flag overwrite kept only the last value, violating the contract that no accepted flag value is silently ignored. The tester landed in one group with exit 0.
2. The recovery path hit the second gap: `beta-testers remove` is the **only destructive beta-testers subcommand without `--confirm`** (remove-groups, remove-builds, remove-apps, and builds expire all require it), even though removing a tester deletes every group membership and build assignment.

## What changed

**Commit 1 — `feat(testflight): accept comma-separated groups in beta-testers add`**
- `--group` now takes `GROUP[,GROUP...]`, matching add-groups/remove-groups CSV semantics; `CreateBetaTester` already accepted `[]string` group IDs, so only the flag surface changed.
- All tokens resolve against a **single** beta-groups fetch (`resolveBetaGroupIDs`; the singular resolver now delegates to it, same error strings).
- Repeating `--group` is now a **usage error (exit 2)** naming the CSV form, instead of a silent last-wins overwrite.

**Commit 2 — `feat(testflight)!: require --confirm for beta-testers remove`**
- Without `--confirm`: exit 2 usage error before any side effect, same pattern and message as the other destructive subcommands.

## BREAKING CHANGE (minor-release callout)

Scripts calling `testflight testers remove` / `beta-testers remove` must add `--confirm`. Deliberately a hard requirement rather than a deprecation warning: a loud, actionable exit-2 failure beats a warning ahead of an irreversible deletion.

## Tests

- `onceCSVFlag` unit test: second occurrence rejected, first value preserved.
- `resolveBetaGroupIDs` httptest: one fetch resolves ID + case-insensitive names in order; unknown token errors by name.
- Validation tests: CSV `--group` passes; `remove` without `--confirm` fails (RED first: it previously sailed into auth), with `--confirm` passes.
- Black-box cmdtest for remove updated to the new contract (transition test).
- Built-binary verification: repeated `--group` and missing `--confirm` both exit 2 with the messages above; `testers` alias help renders the new usage.
- Full pre-commit gate (docs check, format, lint, short suite) green on both commits.

## Alternatives considered

- Repeated-flag *accumulation* (`--group A --group B` appends): rejected for consistency — every other multi-value flag here is CSV.
- Deprecation-warning period for `--confirm`: rejected as above; flagged for release notes instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add beta testers to multiple groups with a comma-separated `--group` value.
  * Identify groups by name or ID, including names containing commas.
  * Duplicate group entries are removed automatically.
  * Beta tester removal now requires the `--confirm` flag.
  * Updated command help and examples reflect these requirements.

* **Bug Fixes**
  * Improved validation and error handling for invalid, unknown, or empty group values.
  * Group lookups now include all available groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->