### PR TITLE
fix(cli): reject repeated comma-separated flags on mutating commands

### DIFF
--- a/internal/cli/androidiosmapping/android_ios_mapping.go
+++ b/internal/cli/androidiosmapping/android_ios_mapping.go
@@ -179,7 +179,7 @@ func AndroidIosMappingCreateCommand() *ffcli.Command {
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
 	packageName := fs.String("android-package-name", "", "Android package name (e.g., com.example.android)")
-	fingerprints := fs.String("fingerprints", "", "Signing key fingerprints (comma-separated)")
+	fingerprints := shared.BindOnceCSVFlag(fs, "fingerprints", "Signing key fingerprints (comma-separated)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -203,7 +203,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --android-package-name is required")
 				return shared.MissingRequiredUsageError("--android-package-name")
 			}
-			fingerprintValues := shared.SplitCSV(*fingerprints)
+			fingerprintValues := shared.SplitCSV(fingerprints.String())
 			if len(fingerprintValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --fingerprints is required")
 				return shared.MissingRequiredUsageError("--fingerprints")
@@ -236,7 +236,7 @@ func AndroidIosMappingUpdateCommand() *ffcli.Command {
 
 	id := fs.String("mapping-id", "", "Mapping ID")
 	packageName := fs.String("android-package-name", "", "Android package name (e.g., com.example.android)")
-	fingerprints := fs.String("fingerprints", "", "Signing key fingerprints (comma-separated)")
+	fingerprints := shared.BindOnceCSVFlag(fs, "fingerprints", "Signing key fingerprints (comma-separated)")
 	clearPackageName := fs.Bool("clear-android-package-name", false, "Clear the Android package name")
 	clearFingerprints := fs.Bool("clear-fingerprints", false, "Clear signing key fingerprints")
 	output := shared.BindOutputFlags(fs)
@@ -287,7 +287,7 @@ Examples:
 				attrs.PackageName = &asc.NullableString{}
 			}
 			if seen["fingerprints"] {
-				fingerprintValues := shared.SplitCSV(*fingerprints)
+				fingerprintValues := shared.SplitCSV(fingerprints.String())
 				if len(fingerprintValues) == 0 {
 					return fmt.Errorf("android-ios-mapping update: --fingerprints must include at least one value")
 				}

--- a/internal/cli/app_events/app_events.go
+++ b/internal/cli/app_events/app_events.go
@@ -178,7 +178,7 @@ func AppEventsCreateCommand() *ffcli.Command {
 	start := fs.String("start", "", "Event start time (RFC3339)")
 	end := fs.String("end", "", "Event end time (RFC3339)")
 	publishStart := fs.String("publish-start", "", "Publish start time (RFC3339)")
-	territories := fs.String("territories", "", "Territory codes (comma-separated)")
+	territories := shared.BindOnceCSVFlag(fs, "territories", "Territory codes (comma-separated)")
 	deepLink := fs.String("deep-link", "", "Deep link URL")
 	purchaseRequirement := fs.String("purchase-requirement", "", "Purchase requirement (currently supported: "+supportedAppEventPurchaseRequirementValues()+")")
 	primaryLocale := fs.String("primary-locale", "", "Primary locale (e.g., en-US)")
@@ -240,7 +240,7 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			schedule, scheduleProvided, err := normalizeAppEventTerritorySchedule(*start, *end, *publishStart, *territories)
+			schedule, scheduleProvided, err := normalizeAppEventTerritorySchedule(*start, *end, *publishStart, territories.String())
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp
@@ -320,7 +320,7 @@ func AppEventsUpdateCommand() *ffcli.Command {
 	start := fs.String("start", "", "Event start time (RFC3339)")
 	end := fs.String("end", "", "Event end time (RFC3339)")
 	publishStart := fs.String("publish-start", "", "Publish start time (RFC3339)")
-	territories := fs.String("territories", "", "Territory codes (comma-separated)")
+	territories := shared.BindOnceCSVFlag(fs, "territories", "Territory codes (comma-separated)")
 	deepLink := fs.String("deep-link", "", "Deep link URL")
 	purchaseRequirement := fs.String("purchase-requirement", "", "Purchase requirement (currently supported: "+supportedAppEventPurchaseRequirementValues()+")")
 	primaryLocale := fs.String("primary-locale", "", "Primary locale (e.g., en-US)")
@@ -421,7 +421,7 @@ Examples:
 				}
 			}
 
-			schedule, scheduleProvided, err := normalizeAppEventTerritorySchedule(*start, *end, *publishStart, *territories)
+			schedule, scheduleProvided, err := normalizeAppEventTerritorySchedule(*start, *end, *publishStart, territories.String())
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp

--- a/internal/cli/apps/apps_beta_testers.go
+++ b/internal/cli/apps/apps_beta_testers.go
@@ -17,7 +17,7 @@ func AppsRemoveBetaTestersCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-beta-testers", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
-	testers := fs.String("tester", "", "Comma-separated beta tester IDs")
+	testers := shared.BindOnceCSVFlag(fs, "tester", "Comma-separated beta tester IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
@@ -39,7 +39,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--app")
 			}
 
-			testerIDs := shared.SplitCSV(*testers)
+			testerIDs := shared.SplitCSV(testers.String())
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
 				return shared.MissingRequiredUsageError("--tester")

--- a/internal/cli/apps/search_keywords.go
+++ b/internal/cli/apps/search_keywords.go
@@ -52,7 +52,7 @@ func AppsSearchKeywordsSetCommand() *ffcli.Command {
 	version := fs.String("version", "", "App Store version string (required)")
 	locale := fs.String("locale", "", "Version localization locale (required; for example en-US)")
 	platform := fs.String("platform", "", "App Store version platform: IOS, MAC_OS, TV_OS, VISION_OS (required only when ambiguous)")
-	keywords := fs.String("keywords", "", "Version-localized keywords (comma-separated)")
+	keywords := shared.BindOnceCSVFlag(fs, "keywords", "Version-localized keywords (comma-separated)")
 	confirm := fs.Bool("confirm", false, "Confirm replacing the localization's keywords")
 	output := shared.BindOutputFlags(fs)
 
@@ -114,7 +114,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--confirm")
 			}
 
-			keywordValue := strings.TrimSpace(*keywords)
+			keywordValue := strings.TrimSpace(keywords.String())
 			if keywordValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --keywords is required")
 				return shared.MissingRequiredUsageError("--keywords")

--- a/internal/cli/builds/builds.go
+++ b/internal/cli/builds/builds.go
@@ -18,7 +18,7 @@ func BuildsAddGroupsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("add-groups", flag.ExitOnError)
 
 	selectors := bindBuildSelectorFlags(fs, buildSelectorFlagOptions{})
-	groups := fs.String("group", "", "Comma-separated beta group IDs or names")
+	groups := shared.BindOnceCSVFlag(fs, "group", "Comma-separated beta group IDs or names")
 	skipInternal := fs.Bool("skip-internal", false, "Skip internal beta groups instead of adding them")
 	submit := fs.Bool("submit", false, "Submit build for beta app review after adding external groups")
 	confirm := fs.Bool("confirm", false, "Confirm beta app review submission (required with --submit)")
@@ -50,7 +50,7 @@ Examples:
 				return err
 			}
 
-			groupInputs := shared.SplitCSV(*groups)
+			groupInputs := shared.SplitCSV(groups.String())
 			if len(groupInputs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
 				return shared.MissingRequiredUsageError("--group")
@@ -244,7 +244,7 @@ func BuildsRemoveGroupsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-groups", flag.ExitOnError)
 
 	selectors := bindBuildSelectorFlags(fs, buildSelectorFlagOptions{})
-	groups := fs.String("group", "", "Comma-separated beta group IDs")
+	groups := shared.BindOnceCSVFlag(fs, "group", "Comma-separated beta group IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
@@ -268,7 +268,7 @@ Examples:
 				return err
 			}
 
-			groupIDs := shared.SplitCSV(*groups)
+			groupIDs := shared.SplitCSV(groups.String())
 			if len(groupIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
 				return shared.MissingRequiredUsageError("--group")

--- a/internal/cli/builds/builds_individual_testers.go
+++ b/internal/cli/builds/builds_individual_testers.go
@@ -138,7 +138,7 @@ func BuildsIndividualTestersAddCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("individual-testers add", flag.ExitOnError)
 
 	selectors := bindBuildSelectorFlags(fs, buildSelectorFlagOptions{})
-	testers := fs.String("tester", "", "Comma-separated tester IDs")
+	testers := shared.BindOnceCSVFlag(fs, "tester", "Comma-separated tester IDs")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -161,7 +161,7 @@ Examples:
 				return err
 			}
 
-			testerIDs := shared.SplitCSV(*testers)
+			testerIDs := shared.SplitCSV(testers.String())
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
 				return shared.MissingRequiredUsageError("--tester")
@@ -200,7 +200,7 @@ func BuildsIndividualTestersRemoveCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("individual-testers remove", flag.ExitOnError)
 
 	selectors := bindBuildSelectorFlags(fs, buildSelectorFlagOptions{})
-	testers := fs.String("tester", "", "Comma-separated tester IDs")
+	testers := shared.BindOnceCSVFlag(fs, "tester", "Comma-separated tester IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
@@ -224,7 +224,7 @@ Examples:
 				return err
 			}
 
-			testerIDs := shared.SplitCSV(*testers)
+			testerIDs := shared.SplitCSV(testers.String())
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
 				return shared.MissingRequiredUsageError("--tester")

--- a/internal/cli/eula/eula.go
+++ b/internal/cli/eula/eula.go
@@ -151,7 +151,7 @@ func EULACreateCommand() *ffcli.Command {
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	agreementText := fs.String("agreement-text", "", "Agreement text")
-	territories := fs.String("territory", "", "Territory inputs, comma-separated (accepts alpha-2, alpha-3, or exact English country names)")
+	territories := shared.BindOnceCSVFlag(fs, "territory", "Territory inputs, comma-separated (accepts alpha-2, alpha-3, or exact English country names)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -176,7 +176,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--agreement-text")
 			}
 
-			territoryIDs, err := shared.NormalizeASCTerritoryCSV(*territories)
+			territoryIDs, err := shared.NormalizeASCTerritoryCSV(territories.String())
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
@@ -209,7 +209,7 @@ func EULAUpdateCommand() *ffcli.Command {
 
 	id := fs.String("id", "", "EULA ID")
 	agreementText := fs.String("agreement-text", "", "Agreement text")
-	territories := fs.String("territory", "", "Territory inputs, comma-separated (accepts alpha-2, alpha-3, or exact English country names)")
+	territories := shared.BindOnceCSVFlag(fs, "territory", "Territory inputs, comma-separated (accepts alpha-2, alpha-3, or exact English country names)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -236,7 +236,7 @@ Examples:
 				agreementValue = &value
 			}
 
-			territoryIDs, err := shared.NormalizeASCTerritoryCSV(*territories)
+			territoryIDs, err := shared.NormalizeASCTerritoryCSV(territories.String())
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}

--- a/internal/cli/gamecenter/game_center_activities.go
+++ b/internal/cli/gamecenter/game_center_activities.go
@@ -497,7 +497,7 @@ func GameCenterActivityAchievementsSetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("set", flag.ExitOnError)
 
 	activityID := fs.String("activity-id", "", "Game Center activity ID")
-	ids := fs.String("ids", "", "Comma-separated achievement IDs")
+	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated achievement IDs")
 	remove := fs.Bool("remove", false, "Remove relationships instead of adding")
 	output := shared.BindOutputFlags(fs)
 
@@ -518,7 +518,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --activity-id is required")
 				return shared.MissingRequiredUsageError("--activity-id")
 			}
-			idsValue := shared.SplitCSV(*ids)
+			idsValue := shared.SplitCSV(ids.String())
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
@@ -579,7 +579,7 @@ func GameCenterActivityLeaderboardsSetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("set", flag.ExitOnError)
 
 	activityID := fs.String("activity-id", "", "Game Center activity ID")
-	ids := fs.String("ids", "", "Comma-separated leaderboard IDs")
+	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated leaderboard IDs")
 	remove := fs.Bool("remove", false, "Remove relationships instead of adding")
 	output := shared.BindOutputFlags(fs)
 
@@ -600,7 +600,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --activity-id is required")
 				return shared.MissingRequiredUsageError("--activity-id")
 			}
-			idsValue := shared.SplitCSV(*ids)
+			idsValue := shared.SplitCSV(ids.String())
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")

--- a/internal/cli/gamecenter/game_center_groups.go
+++ b/internal/cli/gamecenter/game_center_groups.go
@@ -454,7 +454,7 @@ func GameCenterGroupAchievementsSetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("set", flag.ExitOnError)
 
 	groupID := fs.String("group-id", "", "Game Center group ID")
-	ids := fs.String("ids", "", "Comma-separated achievement IDs")
+	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated achievement IDs")
 	v2 := fs.Bool("v2", false, "Use v2 relationships endpoint")
 	output := shared.BindOutputFlags(fs)
 
@@ -475,7 +475,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
 				return shared.MissingRequiredUsageError("--group-id")
 			}
-			idsValue := shared.SplitCSV(*ids)
+			idsValue := shared.SplitCSV(ids.String())
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
@@ -628,7 +628,7 @@ func GameCenterGroupLeaderboardsSetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("set", flag.ExitOnError)
 
 	groupID := fs.String("group-id", "", "Game Center group ID")
-	ids := fs.String("ids", "", "Comma-separated leaderboard IDs")
+	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated leaderboard IDs")
 	v2 := fs.Bool("v2", false, "Use v2 relationships endpoint")
 	output := shared.BindOutputFlags(fs)
 
@@ -649,7 +649,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --group-id is required")
 				return shared.MissingRequiredUsageError("--group-id")
 			}
-			idsValue := shared.SplitCSV(*ids)
+			idsValue := shared.SplitCSV(ids.String())
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members.go
@@ -119,7 +119,7 @@ func GameCenterLeaderboardSetMembersSetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("set", flag.ExitOnError)
 
 	setID := fs.String("set-id", "", "Game Center leaderboard set ID")
-	leaderboardIDs := fs.String("leaderboard-ids", "", "Comma-separated list of leaderboard IDs to set as members")
+	leaderboardIDs := shared.BindOnceCSVFlag(fs, "leaderboard-ids", "Comma-separated list of leaderboard IDs to set as members")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -143,7 +143,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--set-id")
 			}
 
-			ids := shared.SplitUniqueCSV(*leaderboardIDs)
+			ids := shared.SplitUniqueCSV(leaderboardIDs.String())
 
 			client, err := shared.GetASCClient()
 			if err != nil {

--- a/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
@@ -481,7 +481,7 @@ func GameCenterLeaderboardSetMembersV2SetCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("set", flag.ExitOnError)
 
 	setID := fs.String("set-id", "", "Game Center leaderboard set ID")
-	leaderboardIDs := fs.String("leaderboard-ids", "", "Comma-separated leaderboard IDs to set as members")
+	leaderboardIDs := shared.BindOnceCSVFlag(fs, "leaderboard-ids", "Comma-separated leaderboard IDs to set as members")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -502,7 +502,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--set-id")
 			}
 
-			ids := shared.SplitUniqueCSV(*leaderboardIDs)
+			ids := shared.SplitUniqueCSV(leaderboardIDs.String())
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("game-center leaderboard-sets v2 members set: %w", err)

--- a/internal/cli/gamecenter/game_center_matchmaking.go
+++ b/internal/cli/gamecenter/game_center_matchmaking.go
@@ -196,7 +196,7 @@ func GameCenterMatchmakingQueuesCreateCommand() *ffcli.Command {
 	referenceName := fs.String("reference-name", "", "Reference name for the queue")
 	ruleSetID := fs.String("rule-set-id", "", "Matchmaking rule set ID")
 	experimentRuleSetID := fs.String("experiment-rule-set-id", "", "Experiment rule set ID")
-	classicBundleIDs := fs.String("classic-bundle-ids", "", "Comma-separated bundle IDs for classic matchmaking")
+	classicBundleIDs := shared.BindOnceCSVFlag(fs, "classic-bundle-ids", "Comma-separated bundle IDs for classic matchmaking")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -224,7 +224,7 @@ Examples:
 
 			attrs := asc.GameCenterMatchmakingQueueCreateAttributes{
 				ReferenceName:               name,
-				ClassicMatchmakingBundleIDs: shared.SplitCSV(*classicBundleIDs),
+				ClassicMatchmakingBundleIDs: shared.SplitCSV(classicBundleIDs.String()),
 			}
 
 			client, err := shared.GetASCClient()
@@ -252,7 +252,7 @@ func GameCenterMatchmakingQueuesUpdateCommand() *ffcli.Command {
 	queueID := fs.String("id", "", "Matchmaking queue ID")
 	ruleSetID := fs.String("rule-set-id", "", "Matchmaking rule set ID")
 	experimentRuleSetID := fs.String("experiment-rule-set-id", "", "Experiment rule set ID")
-	classicBundleIDs := fs.String("classic-bundle-ids", "", "Comma-separated bundle IDs for classic matchmaking")
+	classicBundleIDs := shared.BindOnceCSVFlag(fs, "classic-bundle-ids", "Comma-separated bundle IDs for classic matchmaking")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -275,8 +275,8 @@ Examples:
 
 			hasUpdate := false
 			attrs := asc.GameCenterMatchmakingQueueUpdateAttributes{}
-			if strings.TrimSpace(*classicBundleIDs) != "" {
-				attrs.ClassicMatchmakingBundleIDs = shared.SplitCSV(*classicBundleIDs)
+			if strings.TrimSpace(classicBundleIDs.String()) != "" {
+				attrs.ClassicMatchmakingBundleIDs = shared.SplitCSV(classicBundleIDs.String())
 				hasUpdate = true
 			}
 

--- a/internal/cli/iap/availability.go
+++ b/internal/cli/iap/availability.go
@@ -90,7 +90,7 @@ func IAPAvailabilitySetCommand() *ffcli.Command {
 
 	appID := addIAPLookupAppFlag(fs)
 	iapID := fs.String("iap-id", "", "In-app purchase ID, product ID, or exact current name")
-	territories := fs.String("territories", "", "Territory inputs (comma-separated; accepts alpha-2, alpha-3, or exact English country names)")
+	territories := shared.BindOnceCSVFlag(fs, "territories", "Territory inputs (comma-separated; accepts alpha-2, alpha-3, or exact English country names)")
 	availableInNew := fs.Bool("available-in-new-territories", false, "Include new territories automatically")
 	output := shared.BindOutputFlags(fs)
 
@@ -115,7 +115,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--iap-id")
 			}
 
-			territoryIDs, err := shared.NormalizeASCTerritoryCSV(*territories)
+			territoryIDs, err := shared.NormalizeASCTerritoryCSV(territories.String())
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}

--- a/internal/cli/promotedpurchases/promoted_purchases.go
+++ b/internal/cli/promotedpurchases/promoted_purchases.go
@@ -389,7 +389,7 @@ func PromotedPurchasesLinkCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("link", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
-	promotedIDs := fs.String("promoted-purchase-id", "", "Comma-separated promoted purchase IDs")
+	promotedIDs := shared.BindOnceCSVFlag(fs, "promoted-purchase-id", "Comma-separated promoted purchase IDs")
 	clear := fs.Bool("clear", false, "Remove all promoted purchases from the app")
 	confirm := fs.Bool("confirm", false, "Confirm removal when using --clear")
 	output := shared.BindOutputFlags(fs)
@@ -415,7 +415,7 @@ Examples:
 
 			var promotedPurchaseIDs []string
 			if *clear {
-				if strings.TrimSpace(*promotedIDs) != "" {
+				if strings.TrimSpace(promotedIDs.String()) != "" {
 					fmt.Fprintln(os.Stderr, "Error: --clear cannot be used with --promoted-purchase-id")
 					return flag.ErrHelp
 				}
@@ -425,7 +425,7 @@ Examples:
 				}
 				promotedPurchaseIDs = nil
 			} else {
-				promotedPurchaseIDs = shared.SplitCSV(*promotedIDs)
+				promotedPurchaseIDs = shared.SplitCSV(promotedIDs.String())
 				if len(promotedPurchaseIDs) == 0 {
 					fmt.Fprintln(os.Stderr, "Error: --promoted-purchase-id is required")
 					return shared.MissingRequiredUsageError("--promoted-purchase-id")

--- a/internal/cli/release/stage.go
+++ b/internal/cli/release/stage.go
@@ -24,8 +24,8 @@ func ReleaseStageCommand() *ffcli.Command {
 	allowDeletes := fs.Bool("allow-deletes", false, "Allow destructive delete operations when applying --metadata-dir (disables default locale fallback for missing locales)")
 	routingCoverageFile := fs.String("routing-coverage-file", "", "[experimental] Routing app coverage GeoJSON file to reconcile before readiness")
 	copyMetadataFrom := fs.String("copy-metadata-from", "", "Copy localization metadata from this source version string")
-	copyFields := fs.String("copy-fields", "", "Comma-separated metadata fields to copy: description, keywords, marketingUrl, promotionalText, supportUrl, whatsNew")
-	excludeFields := fs.String("exclude-fields", "", "Comma-separated metadata fields to exclude from copy")
+	copyFields := shared.BindOnceCSVFlag(fs, "copy-fields", "Comma-separated metadata fields to copy: description, keywords, marketingUrl, promotionalText, supportUrl, whatsNew")
+	excludeFields := shared.BindOnceCSVFlag(fs, "exclude-fields", "Comma-separated metadata fields to exclude from copy")
 	platform := fs.String("platform", "IOS", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	timeout := fs.Duration("timeout", releaseRunTimeout, "Maximum time to run the staging pipeline")
 	dryRun := fs.Bool("dry-run", false, "Preview deterministic plan without mutations")
@@ -86,11 +86,11 @@ Examples:
 				return shared.UsageError("--timeout must be greater than 0")
 			}
 
-			copyFieldsValue, err := shared.NormalizeVersionMetadataCopyFields(*copyFields, "--copy-fields")
+			copyFieldsValue, err := shared.NormalizeVersionMetadataCopyFields(copyFields.String(), "--copy-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
-			excludeFieldsValue, err := shared.NormalizeVersionMetadataCopyFields(*excludeFields, "--exclude-fields")
+			excludeFieldsValue, err := shared.NormalizeVersionMetadataCopyFields(excludeFields.String(), "--exclude-fields")
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -35,7 +35,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 	fs := flag.NewFlagSet(config.FlagSetName, flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
-	territory := fs.String("territory", "", "Territory inputs (comma-separated; accepts alpha-2, alpha-3, or exact English country names, e.g., US,USA,France)")
+	territory := BindOnceCSVFlag(fs, "territory", "Territory inputs (comma-separated; accepts alpha-2, alpha-3, or exact English country names, e.g., US,USA,France)")
 	allTerritories := fs.Bool("all-territories", false, "Apply to all territories (overrides --territory)")
 	var available OptionalBool
 	fs.Var(&available, "available", "Set availability: true or false")
@@ -58,7 +58,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return MissingRequiredUsageError("--app")
 			}
-			if !*allTerritories && strings.TrimSpace(*territory) == "" {
+			if !*allTerritories && strings.TrimSpace(territory.String()) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --territory or --all-territories is required")
 				return MissingRequiredUsageError("")
 			}
@@ -73,7 +73,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 
 			var territories []string
 			if !*allTerritories {
-				normalizedTerritories, normalizeErr := normalizeASCTerritoryCSV(*territory)
+				normalizedTerritories, normalizeErr := normalizeASCTerritoryCSV(territory.String())
 				if normalizeErr != nil {
 					return UsageError(normalizeErr.Error())
 				}

--- a/internal/cli/shared/once_csv_value.go
+++ b/internal/cli/shared/once_csv_value.go
@@ -1,0 +1,36 @@
+package shared
+
+import (
+	"flag"
+	"fmt"
+)
+
+// OnceCSVValue is a flag.Value for comma-separated list flags that rejects
+// repeated flag occurrences instead of silently keeping only the last value.
+type OnceCSVValue struct {
+	flagName string
+	value    string
+	set      bool
+}
+
+// BindOnceCSVFlag registers a comma-separated list flag that errors when the
+// flag is passed more than once.
+func BindOnceCSVFlag(fs *flag.FlagSet, name, usage string) *OnceCSVValue {
+	value := &OnceCSVValue{flagName: name}
+	fs.Var(value, name, usage)
+	return value
+}
+
+func (v *OnceCSVValue) String() string { return v.value }
+
+func (v *OnceCSVValue) Set(raw string) error {
+	if v.set {
+		return fmt.Errorf(
+			"--%s specified multiple times; pass one comma-separated list, for example --%s %q",
+			v.flagName, v.flagName, v.value+","+raw,
+		)
+	}
+	v.value = raw
+	v.set = true
+	return nil
+}

--- a/internal/cli/shared/once_csv_value_test.go
+++ b/internal/cli/shared/once_csv_value_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"errors"
 	"flag"
 	"strings"
 	"testing"
@@ -21,8 +22,9 @@ func TestOnceCSVValue_RejectsRepeatedUse(t *testing.T) {
 	if err == nil {
 		t.Fatal("second Set() should fail")
 	}
-	if !strings.Contains(err.Error(), "--ids") || !strings.Contains(err.Error(), "comma-separated") {
-		t.Fatalf("second Set() error should mention --ids and comma-separated usage, got %q", err.Error())
+	wantMessage := `--ids specified multiple times; pass one comma-separated list, for example --ids "a,b,c"`
+	if err.Error() != wantMessage {
+		t.Fatalf("second Set() error = %q, want %q", err.Error(), wantMessage)
 	}
 	if got := value.String(); got != "a,b" {
 		t.Fatalf("rejected Set() must not overwrite value, got %q", got)
@@ -38,8 +40,12 @@ func TestOnceCSVValue_ParseRejectsRepeatedFlag(t *testing.T) {
 	if err == nil {
 		t.Fatal("parse with repeated --ids should fail")
 	}
-	if !strings.Contains(err.Error(), "specified multiple times") {
-		t.Fatalf("parse error should explain the repetition, got %q", err.Error())
+	if errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("repeated flag should be a parse error, not help: %v", err)
+	}
+	wantFragment := `--ids specified multiple times; pass one comma-separated list, for example --ids "a,b"`
+	if !strings.Contains(err.Error(), wantFragment) {
+		t.Fatalf("parse error = %q, want it to contain %q", err.Error(), wantFragment)
 	}
 }
 

--- a/internal/cli/shared/once_csv_value_test.go
+++ b/internal/cli/shared/once_csv_value_test.go
@@ -1,0 +1,48 @@
+package shared
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestOnceCSVValue_RejectsRepeatedUse(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	value := BindOnceCSVFlag(fs, "ids", "Comma-separated IDs")
+
+	if err := value.Set("a,b"); err != nil {
+		t.Fatalf("first Set() error: %v", err)
+	}
+	if got := value.String(); got != "a,b" {
+		t.Fatalf("String() = %q, want %q", got, "a,b")
+	}
+
+	err := value.Set("c")
+	if err == nil {
+		t.Fatal("second Set() should fail")
+	}
+	if !strings.Contains(err.Error(), "--ids") || !strings.Contains(err.Error(), "comma-separated") {
+		t.Fatalf("second Set() error should mention --ids and comma-separated usage, got %q", err.Error())
+	}
+	if got := value.String(); got != "a,b" {
+		t.Fatalf("rejected Set() must not overwrite value, got %q", got)
+	}
+}
+
+func TestOnceCSVValue_ParseRejectsRepeatedFlag(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(nopWriter{})
+	BindOnceCSVFlag(fs, "ids", "Comma-separated IDs")
+
+	err := fs.Parse([]string{"--ids", "a", "--ids", "b"})
+	if err == nil {
+		t.Fatal("parse with repeated --ids should fail")
+	}
+	if !strings.Contains(err.Error(), "specified multiple times") {
+		t.Fatalf("parse error should explain the repetition, got %q", err.Error())
+	}
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/cli/subscriptions/promotional_offers.go
+++ b/internal/cli/subscriptions/promotional_offers.go
@@ -200,7 +200,7 @@ func SubscriptionsPromotionalOffersCreateCommand() *ffcli.Command {
 	offerDuration := fs.String("offer-duration", "", "Offer duration: "+strings.Join(subscriptionOfferDurationValues, ", "))
 	offerMode := fs.String("offer-mode", "", "Offer mode: "+strings.Join(subscriptionOfferModeValues, ", "))
 	numberOfPeriods := fs.Int("number-of-periods", 0, "Number of periods (required)")
-	prices := fs.String("prices", "", "Promotional offer prices (required): existing PRICE_ID entries, inline TERRITORY entries, or inline TERRITORY:PRICE_POINT_ID entries; territory accepts alpha-2, alpha-3, or exact English country name")
+	prices := shared.BindOnceCSVFlag(fs, "prices", "Promotional offer prices (required): existing PRICE_ID entries, inline TERRITORY entries, or inline TERRITORY:PRICE_POINT_ID entries; territory accepts alpha-2, alpha-3, or exact English country name")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -251,7 +251,7 @@ Examples:
 				return requiredPositiveIntegerUsageError(fs, "number-of-periods")
 			}
 
-			priceEntries, err := parseSubscriptionPromotionalOfferPrices(*prices)
+			priceEntries, err := parseSubscriptionPromotionalOfferPrices(prices.String())
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err.Error())
 				return flag.ErrHelp
@@ -297,7 +297,7 @@ func SubscriptionsPromotionalOffersUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("promotional-offers update", flag.ExitOnError)
 
 	offerID := fs.String("id", "", "Promotional offer ID")
-	prices := fs.String("prices", "", "Promotional offer price ID(s), comma-separated")
+	prices := shared.BindOnceCSVFlag(fs, "prices", "Promotional offer price ID(s), comma-separated")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -317,7 +317,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--id")
 			}
 
-			priceIDs := shared.SplitCSV(*prices)
+			priceIDs := shared.SplitCSV(prices.String())
 			if len(priceIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --prices is required")
 				return shared.MissingRequiredUsageError("--prices")

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -685,8 +685,8 @@ func BetaGroupsAddTestersCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("add-testers", flag.ExitOnError)
 
 	group := fs.String("group", "", "Beta group ID")
-	tester := fs.String("tester", "", "Beta tester ID(s), comma-separated")
-	email := fs.String("email", "", "Beta tester email(s), comma-separated")
+	tester := shared.BindOnceCSVFlag(fs, "tester", "Beta tester ID(s), comma-separated")
+	email := shared.BindOnceCSVFlag(fs, "email", "Beta tester email(s), comma-separated")
 
 	return &ffcli.Command{
 		Name:       "add-testers",
@@ -707,8 +707,8 @@ Examples:
 				return shared.MissingRequiredUsageError("--group")
 			}
 
-			testerIDs := shared.SplitCSV(*tester)
-			testerEmails := shared.SplitCSV(*email)
+			testerIDs := shared.SplitCSV(tester.String())
+			testerEmails := shared.SplitCSV(email.String())
 			if len(testerIDs) == 0 && len(testerEmails) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester or --email is required")
 				return shared.MissingRequiredUsageError("")
@@ -785,7 +785,7 @@ func BetaGroupsRemoveTestersCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-testers", flag.ExitOnError)
 
 	group := fs.String("group", "", "Beta group ID")
-	tester := fs.String("tester", "", "Beta tester ID(s), comma-separated")
+	tester := shared.BindOnceCSVFlag(fs, "tester", "Beta tester ID(s), comma-separated")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 
 	return &ffcli.Command{
@@ -806,7 +806,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--group")
 			}
 
-			testerIDs := shared.SplitCSV(*tester)
+			testerIDs := shared.SplitCSV(tester.String())
 			if len(testerIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --tester is required")
 				return shared.MissingRequiredUsageError("--tester")

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -220,28 +220,6 @@ Examples:
 	}
 }
 
-// onceCSVFlag accepts a single comma-separated flag value and rejects
-// repeated flag occurrences instead of silently keeping only the last one.
-type onceCSVFlag struct {
-	flagName string
-	value    string
-	set      bool
-}
-
-func (v *onceCSVFlag) String() string { return v.value }
-
-func (v *onceCSVFlag) Set(raw string) error {
-	if v.set {
-		return fmt.Errorf(
-			"--%s specified multiple times; pass one comma-separated list, for example --%s %q",
-			v.flagName, v.flagName, v.value+","+raw,
-		)
-	}
-	v.value = raw
-	v.set = true
-	return nil
-}
-
 // BetaTestersAddCommand returns the beta testers add subcommand.
 func BetaTestersAddCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("add", flag.ExitOnError)
@@ -250,8 +228,7 @@ func BetaTestersAddCommand() *ffcli.Command {
 	email := fs.String("email", "", "Tester email address")
 	firstName := fs.String("first-name", "", "Tester first name")
 	lastName := fs.String("last-name", "", "Tester last name")
-	group := &onceCSVFlag{flagName: "group"}
-	fs.Var(group, "group", "Comma-separated beta group names or IDs")
+	group := shared.BindOnceCSVFlag(fs, "group", "Comma-separated beta group names or IDs")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -382,7 +359,7 @@ func BetaTestersAddGroupsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("add-groups", flag.ExitOnError)
 
 	id := fs.String("id", "", "Beta tester ID")
-	groups := fs.String("group", "", "Comma-separated beta group IDs")
+	groups := shared.BindOnceCSVFlag(fs, "group", "Comma-separated beta group IDs")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -403,7 +380,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--id")
 			}
 
-			groupIDs := shared.SplitCSV(*groups)
+			groupIDs := shared.SplitCSV(groups.String())
 			if len(groupIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
 				return shared.MissingRequiredUsageError("--group")
@@ -442,7 +419,7 @@ func BetaTestersRemoveGroupsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-groups", flag.ExitOnError)
 
 	id := fs.String("id", "", "Beta tester ID")
-	groups := fs.String("group", "", "Comma-separated beta group IDs")
+	groups := shared.BindOnceCSVFlag(fs, "group", "Comma-separated beta group IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
@@ -464,7 +441,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--id")
 			}
 
-			groupIDs := shared.SplitCSV(*groups)
+			groupIDs := shared.SplitCSV(groups.String())
 			if len(groupIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --group is required")
 				return shared.MissingRequiredUsageError("--group")
@@ -638,7 +615,7 @@ func BetaTestersRemoveAppsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("remove-apps", flag.ExitOnError)
 
 	id := fs.String("id", "", "Beta tester ID")
-	apps := fs.String("app", "", "Comma-separated app IDs")
+	apps := shared.BindOnceCSVFlag(fs, "app", "Comma-separated app IDs")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
 	output := shared.BindOutputFlags(fs)
 
@@ -660,7 +637,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--id")
 			}
 
-			appIDs := shared.SplitCSV(*apps)
+			appIDs := shared.SplitCSV(apps.String())
 			if len(appIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --app is required")
 				return shared.MissingRequiredUsageError("--app")
@@ -704,7 +681,7 @@ func BetaTestersInviteCommand() *ffcli.Command {
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	email := fs.String("email", "", "Tester email address")
-	group := fs.String("group", "", "Beta group name or ID (optional, creates tester if missing)")
+	group := shared.BindOnceCSVFlag(fs, "group", "Comma-separated beta group names or IDs (optional, creates tester if missing)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -738,7 +715,7 @@ Examples:
 			defer cancel()
 
 			emailValue := strings.TrimSpace(*email)
-			groupValue := strings.TrimSpace(*group)
+			groupValue := strings.TrimSpace(group.String())
 			testerID, err := findBetaTesterIDByEmail(requestCtx, client, resolvedAppID, emailValue)
 			if err != nil {
 				if errors.Is(err, errBetaTesterNotFound) {
@@ -746,12 +723,12 @@ Examples:
 						return fmt.Errorf("beta-testers invite: no tester found for %q (use beta-testers add --group ... or pass --group here)", emailValue)
 					}
 
-					groupID, resolveErr := resolveBetaGroupID(requestCtx, client, resolvedAppID, groupValue)
+					groupIDs, resolveErr := resolveBetaGroupIDs(requestCtx, client, resolvedAppID, groupValue)
 					if resolveErr != nil {
 						return fmt.Errorf("beta-testers invite: %w", resolveErr)
 					}
 
-					created, createErr := client.CreateBetaTester(requestCtx, emailValue, "", "", []string{groupID})
+					created, createErr := client.CreateBetaTester(requestCtx, emailValue, "", "", groupIDs)
 					if createErr != nil {
 						return fmt.Errorf("beta-testers invite: failed to create tester: %w", createErr)
 					}

--- a/internal/cli/testflight/beta_testers_group_flag_test.go
+++ b/internal/cli/testflight/beta_testers_group_flag_test.go
@@ -21,28 +21,6 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
-func TestOnceCSVFlag_RejectsRepeatedUse(t *testing.T) {
-	value := onceCSVFlag{flagName: "group"}
-
-	if err := value.Set("Beta"); err != nil {
-		t.Fatalf("first Set() error: %v", err)
-	}
-	if got := value.String(); got != "Beta" {
-		t.Fatalf("String() = %q, want %q", got, "Beta")
-	}
-
-	err := value.Set("QA")
-	if err == nil {
-		t.Fatal("second Set() should fail")
-	}
-	if !strings.Contains(err.Error(), "--group") || !strings.Contains(err.Error(), "comma-separated") {
-		t.Fatalf("second Set() error should mention --group and comma-separated usage, got %q", err.Error())
-	}
-	if got := value.String(); got != "Beta" {
-		t.Fatalf("rejected Set() must not overwrite value, got %q", got)
-	}
-}
-
 func TestBetaTestersAddCommand_CSVGroupsPassValidation(t *testing.T) {
 	isolateTestFlightAuthEnvForAddTests(t)
 

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -190,8 +190,8 @@ func UsersUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 
 	id := fs.String("id", "", "User ID")
-	roles := fs.String("roles", "", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
-	visibleApps := fs.String("visible-app", "", "Comma-separated app IDs for visible apps")
+	roles := shared.BindOnceCSVFlag(fs, "roles", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
+	visibleApps := shared.BindOnceCSVFlag(fs, "visible-app", "Comma-separated app IDs for visible apps")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -212,7 +212,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--id")
 			}
 
-			roleValues, err := normalizeUserRoles(*roles, "--roles")
+			roleValues, err := normalizeUserRoles(roles.String(), "--roles")
 			if err != nil {
 				return shared.UsageErrorf("users update: %v", err)
 			}
@@ -222,7 +222,7 @@ Examples:
 			}
 			warnDeprecatedUserRoles(roleValues)
 
-			visibleAppIDs := shared.SplitCSV(*visibleApps)
+			visibleAppIDs := shared.SplitCSV(visibleApps.String())
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -309,9 +309,9 @@ func UsersInviteCommand() *ffcli.Command {
 	email := fs.String("email", "", "Email address to invite")
 	firstName := fs.String("first-name", "", "First name of the invitee (required)")
 	lastName := fs.String("last-name", "", "Last name of the invitee (required)")
-	roles := fs.String("roles", "", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
+	roles := shared.BindOnceCSVFlag(fs, "roles", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
 	allApps := fs.Bool("all-apps", false, "Grant access to all apps")
-	visibleApps := fs.String("visible-app", "", "Comma-separated app IDs for visible apps")
+	visibleApps := shared.BindOnceCSVFlag(fs, "visible-app", "Comma-separated app IDs for visible apps")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -344,7 +344,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--last-name")
 			}
 
-			roleValues, err := normalizeUserRoles(*roles, "--roles")
+			roleValues, err := normalizeUserRoles(roles.String(), "--roles")
 			if err != nil {
 				return shared.UsageErrorf("users invite: %v", err)
 			}
@@ -354,12 +354,12 @@ Examples:
 			}
 			warnDeprecatedUserRoles(roleValues)
 
-			if *allApps && strings.TrimSpace(*visibleApps) != "" {
+			if *allApps && strings.TrimSpace(visibleApps.String()) != "" {
 				fmt.Fprintln(os.Stderr, "Error: --all-apps and --visible-app cannot be used together")
 				return flag.ErrHelp
 			}
 
-			visibleAppIDs := shared.SplitCSV(*visibleApps)
+			visibleAppIDs := shared.SplitCSV(visibleApps.String())
 
 			if !*allApps && len(visibleAppIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --all-apps or --visible-app is required")

--- a/internal/cli/web/web_xcode_cloud_shared_envvars.go
+++ b/internal/cli/web/web_xcode_cloud_shared_envvars.go
@@ -149,7 +149,7 @@ func webXcodeCloudEnvVarsSharedSetCommand() *ffcli.Command {
 	value := fs.String("value", "", "Environment variable value (required)")
 	secret := fs.Bool("secret", false, "Encrypt the value as a secret (keep value redacted)")
 	locked := fs.Bool("locked", false, "Restrict editing of this variable")
-	workflowIDs := fs.String("workflow-ids", "", "Comma-separated workflow IDs to link (optional)")
+	workflowIDs := shared.BindOnceCSVFlag(fs, "workflow-ids", "Comma-separated workflow IDs to link (optional)")
 
 	return &ffcli.Command{
 		Name:       "set",
@@ -218,7 +218,7 @@ Examples:
 					envValue = webcore.CIEnvironmentVariableValue{Plaintext: &varValue}
 				}
 
-				wfIDs := parseWorkflowIDs(*workflowIDs)
+				wfIDs := parseWorkflowIDs(workflowIDs.String())
 				if wfIDs == nil {
 					wfIDs = []string{}
 				}

--- a/internal/cli/webhooks/webhooks.go
+++ b/internal/cli/webhooks/webhooks.go
@@ -199,7 +199,7 @@ func WebhooksCreateCommand() *ffcli.Command {
 	name := fs.String("name", "", "Webhook name")
 	url := fs.String("url", "", "Webhook endpoint URL")
 	secret := fs.String("secret", "", "Webhook secret")
-	events := fs.String("events", "", "Webhook event types (comma-separated)")
+	events := shared.BindOnceCSVFlag(fs, "events", "Webhook event types (comma-separated)")
 	var enabled shared.OptionalBool
 	fs.Var(&enabled, "enabled", "Enable or disable the webhook: true or false")
 	output := shared.BindOutputFlags(fs)
@@ -232,7 +232,7 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --secret is required")
 				return shared.MissingRequiredUsageError("--secret")
 			}
-			if strings.TrimSpace(*events) == "" {
+			if strings.TrimSpace(events.String()) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --events is required")
 				return shared.MissingRequiredUsageError("--events")
 			}
@@ -241,7 +241,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--enabled")
 			}
 
-			eventTypes, err := normalizeWebhookEvents(*events)
+			eventTypes, err := normalizeWebhookEvents(events.String())
 			if err != nil {
 				return fmt.Errorf("webhooks create: %w", shared.UsageError(err.Error()))
 			}
@@ -280,7 +280,7 @@ func WebhooksUpdateCommand() *ffcli.Command {
 	name := fs.String("name", "", "Webhook name")
 	url := fs.String("url", "", "Webhook endpoint URL")
 	secret := fs.String("secret", "", "Webhook secret")
-	events := fs.String("events", "", "Webhook event types (comma-separated)")
+	events := shared.BindOnceCSVFlag(fs, "events", "Webhook event types (comma-separated)")
 	var enabled shared.OptionalBool
 	fs.Var(&enabled, "enabled", "Enable or disable the webhook: true or false")
 	output := shared.BindOutputFlags(fs)
@@ -321,8 +321,8 @@ Examples:
 				attrs.Secret = &value
 				hasUpdate = true
 			}
-			if strings.TrimSpace(*events) != "" {
-				eventTypes, err := normalizeWebhookEvents(*events)
+			if strings.TrimSpace(events.String()) != "" {
+				eventTypes, err := normalizeWebhookEvents(events.String())
 				if err != nil {
 					return fmt.Errorf("webhooks update: %w", shared.UsageError(err.Error()))
 				}


### PR DESCRIPTION
## Why

Follow-up to #2051. A systematic audit for the same defect class found that every comma-separated list flag in the CLI is bound with `fs.String`, so repeating the flag silently keeps only the last list. On mutating commands that is silent data loss — `asc builds add-groups --build-id B --group INTERNAL --group EXTERNAL` distributes to only EXTERNAL with exit 0.

Audit scope: ~345 string flags with list semantics, ~84 on mutating commands, tiered by risk. This PR fixes the two highest tiers; the remainder is listed below for follow-up.

## What changed

- `onceCSVFlag` (introduced in #2051, package-private in testflight) is promoted to `shared.BindOnceCSVFlag` / `shared.OnceCSVValue` with unit tests (including a Parse-level repeat-rejection test). Repeating a bound flag exits 2: `--group specified multiple times; pass one comma-separated list, for example --group "A,B"`.
- **Replace/set semantics adopted** (dropped list = silent data deletion): game-center groups achievements/leaderboards set, activities achievements/leaderboards set, leaderboard-sets members set (v1+v2), matchmaking queues create/update, promoted-purchases link, users create/update (--roles, --visible-app), eula create/update, webhooks create/update, apps search-keywords set, pricing/app-setup availability edit (shared binder — one fix, two commands), iap availability set, android-ios-mapping create/update, app-events create/update, subscriptions promotional-offers create/update, app-clips-adjacent env-var linking, release stage --copy-fields/--exclude-fields.
- **Beta-tester family adopted** (siblings of the #2051 bug): beta-testers add-groups/remove-groups/remove-apps, beta-groups add-testers/remove-testers (--tester, --email), apps remove-beta-testers, builds add-groups/remove-groups, builds individual-testers add/remove.
- **beta-testers invite** now accepts a comma-separated --group list via the plural resolver (it was the last remaining `[]string{one}` wrap over the slice-taking `CreateBetaTester`), making add/invite consistent.

## Verification

- Full `go build ./...` + `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/...`: no failures.
- Built-binary spot checks: repeated `--group`/`--roles` on builds add-groups, users update, and testers invite all exit 2 with the CSV hint.
- Pre-commit hook gate (docs check, format, lint, short suite) green.

## Not in this PR (documented follow-ups from the audit)

- Tier C create-time CSV flags (profiles create, nominations create, webhooks/eula create already covered via shared bindings where strings matched; the rest: versions create --copy-fields/--exclude-fields, win-back-offers, offer-codes, subscriptions setup, background-assets submit, signing sync push, app-clips, pre-orders, localizations search-keywords add/delete, encryption assign-builds, testflight build-id CSV binder)
- Tier D CSV scope selectors on write paths (localizations upload --locale, testflight sync pull)
- Single-value last-wins custom flag.Values (trackedStringFlag, DeprecatedStringFlagAlias, optionalInt ×3, etc.) — same defect shape, lower blast radius
- The deprecated no-op `game-center groups challenges set` was intentionally left untouched
- `web subscriptions pricing monthly-commitment bootstrap` single-territory wrap over a slice-taking API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Comma-separated CLI options now consistently support multiple values through a single flag occurrence.
  * Repeated use of these options is rejected with a clear validation error, preventing accidental overwrites.
  * TestFlight invitations now support multiple comma-separated beta groups.
  * Consistent handling is available across territories, testers, groups, IDs, roles, events, prices, and other list-based options.
* **Tests**
  * Added coverage for successful CSV parsing and repeated-flag validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->