### PR TITLE
Fix availability bulk edit resilience

### DIFF
--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -138,6 +138,28 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader) ([
 	return request(ctx)
 }
 
+// doIdempotentMutation performs an explicitly idempotent mutating request with
+// the same transient-failure retry policy used by reads. Callers must only use
+// this for operations whose exact payload can be safely replayed.
+func (c *Client) doIdempotentMutation(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+	}
+
+	return WithRetry(ctx, func() ([]byte, error) {
+		var reader io.Reader
+		if bodyBytes != nil {
+			reader = bytes.NewReader(bodyBytes)
+		}
+		return c.do(ctx, method, path, reader)
+	}, ResolveRetryOptions())
+}
+
 func (c *Client) doWithMutatingRequestLimiter(ctx context.Context, request func(context.Context) ([]byte, error)) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("wait for mutating request slot: %w", err)

--- a/internal/asc/client_pricing.go
+++ b/internal/asc/client_pricing.go
@@ -741,7 +741,9 @@ func (c *Client) UpdateTerritoryAvailability(ctx context.Context, territoryAvail
 	}
 
 	path := fmt.Sprintf("/v1/territoryAvailabilities/%s", territoryAvailabilityID)
-	data, err := c.do(ctx, "PATCH", path, body)
+	// This PATCH sets exact values rather than applying a transition, so replaying
+	// the same payload after a transient failure is safe.
+	data, err := c.doIdempotentMutation(ctx, "PATCH", path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/asc/pricing_test.go
+++ b/internal/asc/pricing_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -806,6 +807,49 @@ func TestUpdateTerritoryAvailability(t *testing.T) {
 		PreOrderEnabled: &preOrderEnabled,
 	}); err != nil {
 		t.Fatalf("UpdateTerritoryAvailability() error: %v", err)
+	}
+}
+
+func TestUpdateTerritoryAvailability_RetriesTransientFailure(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ns")
+	t.Setenv("ASC_MAX_DELAY", "1ns")
+
+	resp := TerritoryAvailabilityResponse{
+		Data: Resource[TerritoryAvailabilityAttributes]{
+			Type: ResourceTypeTerritoryAvailabilities,
+			ID:   "ta-1",
+		},
+	}
+	body, _ := json.Marshal(resp)
+
+	var requests atomic.Int32
+	client := newTestClient(
+		t, func(req *http.Request) {
+			requests.Add(1)
+			if req.Method != http.MethodPatch {
+				t.Fatalf("expected PATCH, got %s", req.Method)
+			}
+			var updateReq TerritoryAvailabilityUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&updateReq); err != nil {
+				t.Fatalf("failed to decode retry request: %v", err)
+			}
+			if updateReq.Data.Attributes == nil || updateReq.Data.Attributes.Available == nil || !*updateReq.Data.Attributes.Available {
+				t.Fatalf("expected available=true on every attempt, got %#v", updateReq.Data.Attributes)
+			}
+		},
+		jsonResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"INTERNAL_ERROR","title":"Internal Error"}]}`),
+		jsonResponse(http.StatusOK, string(body)),
+	)
+
+	available := true
+	if _, err := client.UpdateTerritoryAvailability(context.Background(), "ta-1", TerritoryAvailabilityUpdateAttributes{
+		Available: &available,
+	}); err != nil {
+		t.Fatalf("UpdateTerritoryAvailability() error: %v", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("expected transient PATCH to be retried once, got %d requests", got)
 	}
 }
 

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -315,11 +315,12 @@ func AppSetupAvailabilitySetCommand() *ffcli.Command {
 		LongHelp: `Edit app availability for territories.
 
 Examples:
-  asc app-setup availability edit --app "123456789" --territory "USA,GBR" --available true --available-in-new-territories true
-  asc app-setup availability edit --app "123456789" --all-territories --available true --available-in-new-territories true
+  asc app-setup availability edit --app "123456789" --territory "USA,GBR" --available true
+  asc app-setup availability edit --app "123456789" --all-territories --available true
 
 Note:
-  This command only updates an existing app availability. If the app has no availability record yet, initialize availability in App Store Connect first.`,
+  This command only updates an existing app availability. If the app has no availability record yet, initialize availability in App Store Connect first.
+  If --available-in-new-territories is supplied, it verifies the existing policy; Apple does not expose an update operation for that setting.`,
 		ErrorPrefix:                      "app-setup availability edit",
 		IncludeAvailableInNewTerritories: true,
 	})

--- a/internal/cli/apps/app_setup.go
+++ b/internal/cli/apps/app_setup.go
@@ -27,8 +27,8 @@ func AppSetupCommand() *ffcli.Command {
 Examples:
   asc app-setup info set --app "APP_ID" --primary-locale "en-US" --bundle-id "com.example.app"
   asc app-setup categories set --app "APP_ID" --primary GAMES
-  asc app-setup availability edit --app "APP_ID" --territory "USA,GBR" --available true --available-in-new-territories true
-  asc app-setup availability edit --app "APP_ID" --all-territories --available true --available-in-new-territories true
+  asc app-setup availability edit --app "APP_ID" --territory "USA,GBR" --available true
+  asc app-setup availability edit --app "APP_ID" --all-territories --available true
   asc app-setup pricing set --app "APP_ID" --price-point "PRICE_POINT_ID" --base-territory "USA"
   asc app-setup pricing set --app "APP_ID" --free --start-date "2024-03-01"
   asc app-setup localizations upload --version "VERSION_ID" --path "./localizations"`,
@@ -293,8 +293,8 @@ func AppSetupAvailabilityCommand() *ffcli.Command {
 		LongHelp: `Edit app availability for territories.
 
 Examples:
-  asc app-setup availability edit --app "APP_ID" --territory "USA,GBR" --available true --available-in-new-territories true
-  asc app-setup availability edit --app "APP_ID" --all-territories --available true --available-in-new-territories true`,
+  asc app-setup availability edit --app "APP_ID" --territory "USA,GBR" --available true
+  asc app-setup availability edit --app "APP_ID" --all-territories --available true`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			AppSetupAvailabilitySetCommand(),

--- a/internal/cli/apps/app_setup_test.go
+++ b/internal/cli/apps/app_setup_test.go
@@ -99,7 +99,6 @@ func TestAppSetupAvailabilitySetCommand_MissingFlags(t *testing.T) {
 		{name: "missing territory", args: []string{"--app", "APP", "--available", "true", "--available-in-new-territories", "true"}},
 		{name: "invalid territory csv", args: []string{"--app", "APP", "--territory", ",,,", "--available", "true", "--available-in-new-territories", "true"}},
 		{name: "missing available", args: []string{"--app", "APP", "--territory", "USA", "--available-in-new-territories", "true"}},
-		{name: "missing available in new territories", args: []string{"--app", "APP", "--territory", "USA", "--available", "true"}},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -1421,11 +1421,6 @@ func TestPricingValidationErrors(t *testing.T) {
 			wantErr: "Error: --id and --app are mutually exclusive",
 		},
 		{
-			name:    "pricing availability set missing available in new territories",
-			args:    []string{"pricing", "availability", "edit", "--app", "APP_ID", "--territory", "USA", "--available", "true"},
-			wantErr: "Error: --available-in-new-territories is required",
-		},
-		{
 			name:    "pricing availability create missing app",
 			args:    []string{"pricing", "availability", "create"},
 			wantErr: "Error: --app is required",

--- a/internal/cli/cmdtest/pricing_availability_edit_territory_test.go
+++ b/internal/cli/cmdtest/pricing_availability_edit_territory_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -41,8 +42,8 @@ func TestPricingAvailabilityEditNormalizesTerritories(t *testing.T) {
 			patchedMu.Unlock()
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"patched","attributes":{"available":true}}}`), nil
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -83,7 +84,7 @@ func TestPricingAvailabilityEditSkipsNoOpWithoutNewTerritoriesGuard(t *testing.T
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
-	patches := 0
+	var patches atomic.Int32
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
@@ -96,12 +97,12 @@ func TestPricingAvailabilityEditSkipsNoOpWithoutNewTerritoriesGuard(t *testing.T
 				"links":{"next":""}
 			}`), nil
 		case req.Method == http.MethodPatch:
-			patches++
-			t.Fatalf("no-op territory should not be patched: %s", req.URL.Path)
-			return nil, nil
+			patches.Add(1)
+			t.Errorf("no-op territory should not be patched: %s", req.URL.Path)
+			return nil, fmt.Errorf("unexpected PATCH %s", req.URL.Path)
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -122,14 +123,70 @@ func TestPricingAvailabilityEditSkipsNoOpWithoutNewTerritoriesGuard(t *testing.T
 		}
 	})
 
-	if patches != 0 {
-		t.Fatalf("expected no PATCH requests, got %d", patches)
+	if got := patches.Load(); got != 0 {
+		t.Fatalf("expected no PATCH requests, got %d", got)
 	}
 	if stdout == "" {
 		t.Fatal("expected command output")
 	}
 	if !strings.Contains(stderr, "Updated 0 territories; 1 already matched") {
 		t.Fatalf("expected no-op summary, got stderr %q", stderr)
+	}
+}
+
+func TestPricingAvailabilityEditRejectsMismatchedNewTerritoriesGuardBeforeTerritoryRead(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var territoryReads atomic.Int32
+	var patches atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			territoryReads.Add(1)
+			t.Errorf("policy mismatch should fail before territory reads")
+			return nil, fmt.Errorf("unexpected territory availability read")
+		case req.Method == http.MethodPatch:
+			patches.Add(1)
+			t.Errorf("policy mismatch should not patch %s", req.URL.Path)
+			return nil, fmt.Errorf("unexpected PATCH %s", req.URL.Path)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, _ = captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "availability", "edit",
+			"--app", "app-1",
+			"--territory", "US",
+			"--available", "true",
+			"--available-in-new-territories", "false",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected policy mismatch error")
+		}
+		if !strings.Contains(err.Error(), "does not match the existing policy (current value: true)") {
+			t.Fatalf("expected policy mismatch error, got %v", err)
+		}
+	})
+
+	if got := territoryReads.Load(); got != 0 {
+		t.Fatalf("expected no territory reads, got %d", got)
+	}
+	if got := patches.Load(); got != 0 {
+		t.Fatalf("expected no PATCH requests, got %d", got)
 	}
 }
 
@@ -183,8 +240,8 @@ func TestPricingAvailabilityEditContinuesAfterFailureAndVerifiesFinalState(t *te
 			}
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"patched","attributes":{"available":true}}}`), nil
 		default:
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, nil
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 

--- a/internal/cli/cmdtest/pricing_availability_edit_territory_test.go
+++ b/internal/cli/cmdtest/pricing_availability_edit_territory_test.go
@@ -2,9 +2,12 @@ package cmdtest
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -14,21 +17,28 @@ func TestPricingAvailabilityEditNormalizesTerritories(t *testing.T) {
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
+	var patchedMu sync.Mutex
 	patched := map[string]bool{}
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
-			return jsonHTTPResponse(http.StatusOK, `{
+			patchedMu.Lock()
+			usAvailable := patched["ta-us"]
+			frAvailable := patched["ta-fr"]
+			patchedMu.Unlock()
+			return jsonHTTPResponse(http.StatusOK, fmt.Sprintf(`{
 				"data":[
-					{"type":"territoryAvailabilities","id":"ta-us","relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}},
-					{"type":"territoryAvailabilities","id":"ta-fr","relationships":{"territory":{"data":{"type":"territories","id":"FRA"}}}}
+					{"type":"territoryAvailabilities","id":"ta-us","attributes":{"available":%t},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}},
+					{"type":"territoryAvailabilities","id":"ta-fr","attributes":{"available":%t},"relationships":{"territory":{"data":{"type":"territories","id":"FRA"}}}}
 				],
 				"links":{"next":""}
-			}`), nil
+			}`, usAvailable, frAvailable)), nil
 		case req.Method == http.MethodPatch && strings.HasPrefix(req.URL.Path, "/v1/territoryAvailabilities/"):
+			patchedMu.Lock()
 			patched[strings.TrimPrefix(req.URL.Path, "/v1/territoryAvailabilities/")] = true
+			patchedMu.Unlock()
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"patched","attributes":{"available":true}}}`), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
@@ -60,7 +70,150 @@ func TestPricingAvailabilityEditNormalizesTerritories(t *testing.T) {
 	if stdout == "" {
 		t.Fatal("expected command output")
 	}
+	patchedMu.Lock()
+	defer patchedMu.Unlock()
 	if !patched["ta-us"] || !patched["ta-fr"] {
 		t.Fatalf("expected normalized territories to be patched, got %#v", patched)
+	}
+}
+
+func TestPricingAvailabilityEditSkipsNoOpWithoutNewTerritoriesGuard(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	patches := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"territoryAvailabilities","id":"ta-us","attributes":{"available":true},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}}
+				],
+				"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodPatch:
+			patches++
+			t.Fatalf("no-op territory should not be patched: %s", req.URL.Path)
+			return nil, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "availability", "edit",
+			"--app", "app-1",
+			"--territory", "US",
+			"--available", "true",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if patches != 0 {
+		t.Fatalf("expected no PATCH requests, got %d", patches)
+	}
+	if stdout == "" {
+		t.Fatal("expected command output")
+	}
+	if !strings.Contains(stderr, "Updated 0 territories; 1 already matched") {
+		t.Fatalf("expected no-op summary, got stderr %q", stderr)
+	}
+}
+
+func TestPricingAvailabilityEditContinuesAfterFailureAndVerifiesFinalState(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var mu sync.Mutex
+	states := map[string]bool{"USA": false, "FRA": false, "DEU": false}
+	patched := map[string]int{}
+
+	territoryResponse := func() *http.Response {
+		mu.Lock()
+		defer mu.Unlock()
+		data := make([]map[string]any, 0, 3)
+		for _, territoryID := range []string{"USA", "FRA", "DEU"} {
+			data = append(data, map[string]any{
+				"type":       "territoryAvailabilities",
+				"id":         "ta-" + strings.ToLower(territoryID),
+				"attributes": map[string]any{"available": states[territoryID]},
+				"relationships": map[string]any{
+					"territory": map[string]any{"data": map[string]any{"type": "territories", "id": territoryID}},
+				},
+			})
+		}
+		body, err := json.Marshal(map[string]any{"data": data, "links": map[string]string{"next": ""}})
+		if err != nil {
+			t.Fatalf("marshal territory response: %v", err)
+		}
+		return jsonHTTPResponse(http.StatusOK, string(body))
+	}
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			return territoryResponse(), nil
+		case req.Method == http.MethodPatch && strings.HasPrefix(req.URL.Path, "/v1/territoryAvailabilities/ta-"):
+			territoryID := strings.ToUpper(strings.TrimPrefix(req.URL.Path, "/v1/territoryAvailabilities/ta-"))
+			mu.Lock()
+			patched[territoryID]++
+			if territoryID != "FRA" {
+				states[territoryID] = true
+			}
+			mu.Unlock()
+			if territoryID == "FRA" {
+				return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","title":"Invalid"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"patched","attributes":{"available":true}}}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, _ = captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"pricing", "availability", "edit",
+			"--app", "app-1",
+			"--all-territories",
+			"--available", "true",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected partial failure")
+		}
+		if !strings.Contains(err.Error(), "updated 2, skipped 0, failed 1 (FRA)") {
+			t.Fatalf("expected verified partial-failure summary, got %v", err)
+		}
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, territoryID := range []string{"USA", "FRA", "DEU"} {
+		if patched[territoryID] != 1 {
+			t.Fatalf("expected one PATCH for %s, got %#v", territoryID, patched)
+		}
 	}
 }

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -852,12 +852,14 @@ func PricingAvailabilitySetCommand() *ffcli.Command {
 		LongHelp: `Edit app availability for territories.
 
 Examples:
-  asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true --available-in-new-territories true
-  asc pricing availability edit --app "123456789" --all-territories --available true --available-in-new-territories true
+  asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true
+  asc pricing availability edit --app "123456789" --all-territories --available true
 
 Note:
   This command only updates an existing app availability. If the app has no
-  availability record yet, use "asc pricing availability create" first. If
+  availability record yet, use "asc pricing availability create" first.
+  If --available-in-new-territories is supplied, it verifies the existing
+  policy; Apple does not expose an update operation for that setting. If
   Apple rejects public-API bootstrap, authenticate with
   "asc web auth login --apple-id EMAIL" and use
   "asc web apps availability create", or configure Pricing and Availability in

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -43,8 +43,8 @@ Examples:
   asc pricing availability view --app "123456789"
   asc pricing availability view --id "AVAILABILITY_ID"
   asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
-  asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true --available-in-new-territories true
-  asc pricing availability edit --app "123456789" --all-territories --available true --available-in-new-territories true
+  asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true
+  asc pricing availability edit --app "123456789" --all-territories --available true
   asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -600,8 +600,8 @@ Examples:
   asc pricing availability view --app "123456789"
   asc pricing availability view --id "AVAILABILITY_ID"
   asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
-  asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true --available-in-new-territories true
-  asc pricing availability edit --app "123456789" --all-territories --available true --available-in-new-territories true
+  asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true
+  asc pricing availability edit --app "123456789" --all-territories --available true
   asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -264,7 +264,6 @@ func TestPricingAvailabilitySetCommand_MissingFlags(t *testing.T) {
 		{name: "missing territory", args: []string{"--app", "APP", "--available", "true", "--available-in-new-territories", "true"}},
 		{name: "invalid territory csv", args: []string{"--app", "APP", "--territory", ",,,", "--available", "true", "--available-in-new-territories", "true"}},
 		{name: "missing available", args: []string{"--app", "APP", "--territory", "USA", "--available-in-new-territories", "true"}},
-		{name: "missing available in new territories", args: []string{"--app", "APP", "--territory", "USA", "--available", "true"}},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -7,7 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -15,7 +17,10 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
-const bulkAvailabilityTimeout = 5 * time.Minute
+const (
+	bulkAvailabilityTimeout = 5 * time.Minute
+	bulkAvailabilityWorkers = 4
+)
 
 var availabilityClientFactory = getASCClient
 
@@ -41,7 +46,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 	fs.Var(&available, "available", "Set availability: true or false")
 	var availableInNewTerritories OptionalBool
 	if config.IncludeAvailableInNewTerritories {
-		fs.Var(&availableInNewTerritories, "available-in-new-territories", "Set availability for new territories: true or false")
+		fs.Var(&availableInNewTerritories, "available-in-new-territories", "Verify the existing new-territory policy (optional; this API cannot change it): true or false")
 	}
 	output := BindOutputFlags(fs)
 
@@ -66,11 +71,6 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				fmt.Fprintln(os.Stderr, "Error: --available is required (true or false)")
 				return MissingRequiredUsageError("--available")
 			}
-			if config.IncludeAvailableInNewTerritories && !availableInNewTerritories.IsSet() {
-				fmt.Fprintln(os.Stderr, "Error: --available-in-new-territories is required (true or false)")
-				return MissingRequiredUsageError("--available-in-new-territories")
-			}
-
 			var territories []string
 			if !*allTerritories {
 				normalizedTerritories, normalizeErr := normalizeASCTerritoryCSV(territory.String())
@@ -114,68 +114,130 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				return fmt.Errorf("%s: app availability ID missing from response", config.ErrorPrefix)
 			}
 
-			firstPage, err := client.GetTerritoryAvailabilities(requestCtx, availabilityID, asc.WithTerritoryAvailabilitiesLimit(200))
+			territoryResp, err := getAllTerritoryAvailabilities(requestCtx, client, availabilityID)
 			if err != nil {
 				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
-			}
-			paginated, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-				return client.GetTerritoryAvailabilities(ctx, availabilityID, asc.WithTerritoryAvailabilitiesNextURL(nextURL))
-			})
-			if err != nil {
-				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
-			}
-			territoryResp, ok := paginated.(*asc.TerritoryAvailabilitiesResponse)
-			if !ok {
-				return fmt.Errorf("%s: unexpected territory availabilities response", config.ErrorPrefix)
 			}
 
-			if config.IncludeAvailableInNewTerritories {
+			if config.IncludeAvailableInNewTerritories && availableInNewTerritories.IsSet() {
 				availableInNewTerritoriesValue := availableInNewTerritories.Value()
 				if resp.Data.Attributes.AvailableInNewTerritories != availableInNewTerritoriesValue {
 					return fmt.Errorf(
-						"%s: cannot change --available-in-new-territories for an existing app availability (current value: %t)",
+						"%s: --available-in-new-territories does not match the existing policy (current value: %t); the public API cannot change this setting",
 						config.ErrorPrefix,
 						resp.Data.Attributes.AvailableInNewTerritories,
 					)
 				}
 			}
 
-			territoryMap, err := MapTerritoryAvailabilityIDs(territoryResp)
+			territoryMap, err := mapTerritoryAvailabilities(territoryResp)
 			if err != nil {
 				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
 			}
 
-			var territoryAvailabilityIDs []string
+			var targets []availabilityEditTarget
 			if *allTerritories {
-				territoryAvailabilityIDs = make([]string, 0, len(territoryMap))
-				for _, availabilityID := range territoryMap {
-					territoryAvailabilityIDs = append(territoryAvailabilityIDs, availabilityID)
+				territoryIDs := make([]string, 0, len(territoryMap))
+				for territoryID := range territoryMap {
+					territoryIDs = append(territoryIDs, territoryID)
 				}
-				fmt.Fprintf(os.Stderr, "Updating availability for %d territories...\n", len(territoryAvailabilityIDs))
+				sort.Strings(territoryIDs)
+				targets = make([]availabilityEditTarget, 0, len(territoryIDs))
+				for _, territoryID := range territoryIDs {
+					availability := territoryMap[territoryID]
+					targets = append(targets, availabilityEditTarget{
+						TerritoryID:    territoryID,
+						AvailabilityID: availability.ID,
+						Available:      availability.Attributes.Available,
+					})
+				}
 			} else {
 				missingTerritories := make([]string, 0)
-				territoryAvailabilityIDs = make([]string, 0, len(territories))
+				targets = make([]availabilityEditTarget, 0, len(territories))
 				for _, territoryID := range territories {
-					territoryAvailabilityID := territoryMap[territoryID]
-					if territoryAvailabilityID == "" {
+					availability, ok := territoryMap[territoryID]
+					if !ok {
 						missingTerritories = append(missingTerritories, territoryID)
 						continue
 					}
-					territoryAvailabilityIDs = append(territoryAvailabilityIDs, territoryAvailabilityID)
+					targets = append(targets, availabilityEditTarget{
+						TerritoryID:    territoryID,
+						AvailabilityID: availability.ID,
+						Available:      availability.Attributes.Available,
+					})
 				}
 				if len(missingTerritories) > 0 {
 					return fmt.Errorf("%s: territory availability not found for territories: %s", config.ErrorPrefix, strings.Join(missingTerritories, ", "))
 				}
 			}
 
-			for _, territoryAvailabilityID := range territoryAvailabilityIDs {
-				if _, err := client.UpdateTerritoryAvailability(requestCtx, territoryAvailabilityID, asc.TerritoryAvailabilityUpdateAttributes{
-					Available: &availableValue,
-				}); err != nil {
-					return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
+			pending := make([]availabilityEditTarget, 0, len(targets))
+			skipped := 0
+			for _, target := range targets {
+				if target.Available == availableValue {
+					skipped++
+					continue
+				}
+				pending = append(pending, target)
+			}
+
+			if len(pending) == 0 {
+				fmt.Fprintf(os.Stderr, "Updated 0 territories; %d already matched.\n", skipped)
+				return printOutput(resp, *output.Output, *output.Pretty)
+			}
+
+			fmt.Fprintf(os.Stderr, "Updating availability for %d territories (%d already matched)...\n", len(pending), skipped)
+			patchErrors := updateTerritoryAvailabilityTargets(requestCtx, client, pending, availableValue)
+
+			verifiedResp, err := getAllTerritoryAvailabilities(requestCtx, client, availabilityID)
+			if err != nil {
+				return fmt.Errorf(
+					"%s: attempted %d territory updates (%d request failures, %d skipped); final verification failed: %w",
+					config.ErrorPrefix,
+					len(pending),
+					len(patchErrors),
+					skipped,
+					err,
+				)
+			}
+			verifiedMap, err := mapTerritoryAvailabilities(verifiedResp)
+			if err != nil {
+				return fmt.Errorf("%s: verify territory availabilities: %w", config.ErrorPrefix, err)
+			}
+
+			failedTerritories := make([]string, 0)
+			failureDetails := make([]string, 0)
+			for _, target := range pending {
+				verified, ok := verifiedMap[target.TerritoryID]
+				if ok && verified.Attributes.Available == availableValue {
+					continue
+				}
+				failedTerritories = append(failedTerritories, target.TerritoryID)
+				if patchErr := patchErrors[target.TerritoryID]; patchErr != nil {
+					failureDetails = append(failureDetails, fmt.Sprintf("%s: %v", target.TerritoryID, patchErr))
+				} else if !ok {
+					failureDetails = append(failureDetails, fmt.Sprintf("%s: missing from verification response", target.TerritoryID))
+				} else {
+					failureDetails = append(failureDetails, fmt.Sprintf("%s: requested state was not observed", target.TerritoryID))
 				}
 			}
 
+			updated := len(pending) - len(failedTerritories)
+			if len(failedTerritories) > 0 {
+				sort.Strings(failedTerritories)
+				sort.Strings(failureDetails)
+				return fmt.Errorf(
+					"%s: updated %d, skipped %d, failed %d (%s): %s",
+					config.ErrorPrefix,
+					updated,
+					skipped,
+					len(failedTerritories),
+					strings.Join(failedTerritories, ", "),
+					strings.Join(failureDetails, "; "),
+				)
+			}
+
+			fmt.Fprintf(os.Stderr, "Updated %d territories; %d already matched; verified %d requested territories.\n", updated, skipped, len(targets))
 			return printOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
@@ -188,16 +250,94 @@ func contextWithAvailabilityTimeout(ctx context.Context, allTerritories bool) (c
 	return contextWithTimeout(ctx)
 }
 
+type availabilityEditTarget struct {
+	TerritoryID    string
+	AvailabilityID string
+	Available      bool
+}
+
+type territoryAvailabilityUpdateResult struct {
+	TerritoryID string
+	Err         error
+}
+
+func updateTerritoryAvailabilityTargets(ctx context.Context, client *asc.Client, targets []availabilityEditTarget, available bool) map[string]error {
+	workerCount := min(bulkAvailabilityWorkers, len(targets))
+	jobs := make(chan availabilityEditTarget)
+	results := make(chan territoryAvailabilityUpdateResult, len(targets))
+
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for target := range jobs {
+				_, err := client.UpdateTerritoryAvailability(ctx, target.AvailabilityID, asc.TerritoryAvailabilityUpdateAttributes{
+					Available: &available,
+				})
+				results <- territoryAvailabilityUpdateResult{TerritoryID: target.TerritoryID, Err: err}
+			}
+		}()
+	}
+
+	go func() {
+		for _, target := range targets {
+			jobs <- target
+		}
+		close(jobs)
+		workers.Wait()
+		close(results)
+	}()
+
+	errs := make(map[string]error)
+	for result := range results {
+		if result.Err != nil {
+			errs[result.TerritoryID] = result.Err
+		}
+	}
+	return errs
+}
+
+func getAllTerritoryAvailabilities(ctx context.Context, client *asc.Client, availabilityID string) (*asc.TerritoryAvailabilitiesResponse, error) {
+	firstPage, err := client.GetTerritoryAvailabilities(ctx, availabilityID, asc.WithTerritoryAvailabilitiesLimit(200))
+	if err != nil {
+		return nil, err
+	}
+	paginated, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetTerritoryAvailabilities(ctx, availabilityID, asc.WithTerritoryAvailabilitiesNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, ok := paginated.(*asc.TerritoryAvailabilitiesResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected territory availabilities response")
+	}
+	return resp, nil
+}
+
 type territoryAvailabilityIDPayload struct {
 	Territory string `json:"t"`
 }
 
 // MapTerritoryAvailabilityIDs maps territory IDs to territory-availability IDs.
 func MapTerritoryAvailabilityIDs(resp *asc.TerritoryAvailabilitiesResponse) (map[string]string, error) {
+	availabilities, err := mapTerritoryAvailabilities(resp)
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]string, len(availabilities))
+	for territoryID, availability := range availabilities {
+		ids[territoryID] = availability.ID
+	}
+	return ids, nil
+}
+
+func mapTerritoryAvailabilities(resp *asc.TerritoryAvailabilitiesResponse) (map[string]asc.Resource[asc.TerritoryAvailabilityAttributes], error) {
 	if resp == nil {
 		return nil, fmt.Errorf("territory availabilities response is nil")
 	}
-	ids := make(map[string]string, len(resp.Data))
+	availabilities := make(map[string]asc.Resource[asc.TerritoryAvailabilityAttributes], len(resp.Data))
 	for _, item := range resp.Data {
 		territoryID := ""
 		if len(item.Relationships) > 0 {
@@ -214,9 +354,9 @@ func MapTerritoryAvailabilityIDs(resp *asc.TerritoryAvailabilitiesResponse) (map
 				return nil, fmt.Errorf("territory availability %q missing territory id", item.ID)
 			}
 		}
-		ids[territoryID] = item.ID
+		availabilities[territoryID] = item
 	}
-	return ids, nil
+	return availabilities, nil
 }
 
 func territoryIDFromAvailabilityID(availabilityID string) (string, bool) {

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -114,11 +114,6 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				return fmt.Errorf("%s: app availability ID missing from response", config.ErrorPrefix)
 			}
 
-			territoryResp, err := getAllTerritoryAvailabilities(requestCtx, client, availabilityID)
-			if err != nil {
-				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
-			}
-
 			if config.IncludeAvailableInNewTerritories && availableInNewTerritories.IsSet() {
 				availableInNewTerritoriesValue := availableInNewTerritories.Value()
 				if resp.Data.Attributes.AvailableInNewTerritories != availableInNewTerritoriesValue {
@@ -128,6 +123,11 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 						resp.Data.Attributes.AvailableInNewTerritories,
 					)
 				}
+			}
+
+			territoryResp, err := getAllTerritoryAvailabilities(requestCtx, client, availabilityID)
+			if err != nil {
+				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
 			}
 
 			territoryMap, err := mapTerritoryAvailabilities(territoryResp)
@@ -237,7 +237,7 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 				)
 			}
 
-			fmt.Fprintf(os.Stderr, "Updated %d territories; %d already matched; verified %d requested territories.\n", updated, skipped, len(targets))
+			fmt.Fprintf(os.Stderr, "Updated %d territories; %d already matched; verified %d updated territories.\n", updated, skipped, len(pending))
 			return printOutput(resp, *output.Output, *output.Pretty)
 		},
 	}


### PR DESCRIPTION
## What changed

- make `--available-in-new-territories` an optional guard for existing availability records instead of a required pseudo-setter
- skip territories already in the requested state and process remaining writes with deterministic selection and bounded concurrency
- retry the exact idempotent territory PATCH on transient App Store Connect failures
- continue after individual territory failures, then re-read Apple state and report verified updated, skipped, and failed territory counts
- preserve the existing success output shape for patch-release compatibility

## Root cause

The edit command iterated a Go map serially, stopped on the first PATCH error, and required a create-only `availableInNewTerritories` value even though the public API cannot update it. Territory PATCH requests also bypassed the clients transient retry policy. A single Apple 500 could therefore leave a large operation partially applied without a useful final-state report.

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary help and exit-code checks
- no-op live smoke against disposable app `6759231657`: USA already matched, zero writes requested, success output preserved

## API contract

Uses `PATCH /v1/territoryAvailabilities/{id}` with the exact `available` boolean and verifies through `GET /v2/appAvailabilities/{id}/territoryAvailabilities`. The OpenAPI snapshot exposes `availableInNewTerritories` only on the app-availability create schema, so the existing edit flag can verify but cannot change that policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Availability edits now update only territories that need changes and verify the final state.
  - Updates continue across territories when one fails, with per-territory results reported.
  - Transient update failures are retried automatically.

- **Bug Fixes**
  - Prevented unnecessary updates for territories already matching the requested availability.
  - Improved reporting for update failures and verification mismatches.

- **Documentation**
  - Clarified that `--available-in-new-territories` verifies the existing policy and does not modify it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->