### PR TITLE
apps wall: add Aanvi: Baby Memory Book

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -10,6 +10,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/5c/ce/67/5cce6782-729c-07af-1e0b-7322b8ffd914/SixtysixStreaksIcon-0-0-1x_U007emarketing-0-9-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Aanvi: Baby Memory Book",
+    "link": "https://apps.apple.com/us/app/aanvi-baby-memory-book/id6759002114?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/75/5c/d8/755cd8e5-854a-e583-2908-54e6dea0566f/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Accountable Ai - Habit Blocker",
     "link": "https://apps.apple.com/us/app/accountable-ai-habit-blocker/id6747360923?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/83/4f/eb/834feba8-5b75-ac68-d2f3-4a3c8ce5510f/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Aanvi: Baby Memory Book` to the Wall of Apps

## Entry

- App ID: 6759002114
- App: Aanvi: Baby Memory Book
- Link: https://apps.apple.com/us/app/aanvi-baby-memory-book/id6759002114?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Aanvi: Baby Memory Book” to the application directory.
  * Included its App Store listing and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->