### PR TITLE
Add verified remove-from-sale command

### DIFF
--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -1,0 +1,308 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func TestPricingAvailabilityRemoveFromSaleUpdatesAndVerifiesTerritories(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var mu sync.Mutex
+	states := map[string]bool{"USA": true, "FRA": false}
+	var patches atomic.Int32
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			mu.Lock()
+			defer mu.Unlock()
+			return territoryAvailabilityResponse(t, states), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
+			var payload struct {
+				Data struct {
+					ID         string `json:"id"`
+					Attributes struct {
+						Available *bool `json:"available"`
+					} `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode PATCH: %v", err)
+			}
+			if payload.Data.ID != "ta-usa" || payload.Data.Attributes.Available == nil || *payload.Data.Attributes.Available {
+				t.Fatalf("unexpected PATCH payload: %+v", payload)
+			}
+			patches.Add(1)
+			mu.Lock()
+			states["USA"] = false
+			mu.Unlock()
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if got := patches.Load(); got != 1 {
+		t.Fatalf("PATCH count = %d, want 1", got)
+	}
+	var result struct {
+		AppID                          string   `json:"appId"`
+		AvailabilityID                 string   `json:"availabilityId"`
+		Status                         string   `json:"status"`
+		AvailableInNewTerritories      bool     `json:"availableInNewTerritories"`
+		TotalTerritories               int      `json:"totalTerritories"`
+		UpdatedTerritories             int      `json:"updatedTerritories"`
+		AlreadyUnavailableTerritories  int      `json:"alreadyUnavailableTerritories"`
+		VerifiedUnavailableTerritories int      `json:"verifiedUnavailableTerritories"`
+		FailedTerritories              []string `json:"failedTerritories"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode result %q: %v", stdout, err)
+	}
+	if result.AppID != "app-1" || result.AvailabilityID != "availability-1" || result.Status != "removedFromSale" {
+		t.Fatalf("unexpected identity result: %+v", result)
+	}
+	if !result.AvailableInNewTerritories {
+		t.Fatalf("expected preserved new-territory policy, got %+v", result)
+	}
+	if result.TotalTerritories != 2 || result.UpdatedTerritories != 1 || result.AlreadyUnavailableTerritories != 1 || result.VerifiedUnavailableTerritories != 2 || len(result.FailedTerritories) != 0 {
+		t.Fatalf("unexpected counts: %+v", result)
+	}
+	if !strings.Contains(stderr, "preserved availableInNewTerritories=true") {
+		t.Fatalf("expected preserved-policy caveat, got %q", stderr)
+	}
+}
+
+func TestPricingAvailabilityRemoveFromSaleRequiresConfirmWithUsageExit(t *testing.T) {
+	stdout, stderr := captureOutput(t, func() {
+		if code := rootcmd.Run([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1"}, "1.2.3"); code != rootcmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("expected confirmation diagnostic, got %q", stderr)
+	}
+}
+
+func TestPricingAvailabilityRemoveFromSaleOutputFormats(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			return territoryAvailabilityResponse(t, map[string]bool{"USA": false, "FRA": false}), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{format: "table", want: "Availability ID"},
+		{format: "markdown", want: "| Field"},
+	}
+	for _, test := range tests {
+		t.Run(test.format, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm", "--output", test.format}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			if !strings.Contains(stdout, test.want) {
+				t.Fatalf("%s output missing %q: %s", test.format, test.want, stdout)
+			}
+		})
+	}
+}
+
+func TestPricingAvailabilityRemoveFromSaleNoOp(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	var patches atomic.Int32
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			return territoryAvailabilityResponse(t, map[string]bool{"USA": false, "FRA": false}), nil
+		case req.Method == http.MethodPatch:
+			patches.Add(1)
+			return nil, fmt.Errorf("unexpected PATCH %s", req.URL.Path)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if got := patches.Load(); got != 0 {
+		t.Fatalf("PATCH count = %d, want 0", got)
+	}
+	if !strings.Contains(stdout, `"updatedTerritories":0`) || !strings.Contains(stdout, `"alreadyUnavailableTerritories":2`) {
+		t.Fatalf("unexpected no-op result: %s", stdout)
+	}
+}
+
+func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var mu sync.Mutex
+	states := map[string]bool{"USA": true, "FRA": true}
+	var patches atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			mu.Lock()
+			defer mu.Unlock()
+			return territoryAvailabilityResponse(t, states), nil
+		case req.Method == http.MethodPatch && strings.HasPrefix(req.URL.Path, "/v1/territoryAvailabilities/ta-"):
+			patches.Add(1)
+			territory := strings.ToUpper(strings.TrimPrefix(req.URL.Path, "/v1/territoryAvailabilities/ta-"))
+			if territory == "FRA" {
+				return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","title":"Invalid"}]}`), nil
+			}
+			mu.Lock()
+			states[territory] = false
+			mu.Unlock()
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	_, _ = captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected partial failure")
+		}
+		if !strings.Contains(err.Error(), "updated 1, skipped 0, failed 1 (FRA)") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitError {
+			t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitError)
+		}
+	})
+	if got := patches.Load(); got != 2 {
+		t.Fatalf("PATCH count = %d, want 2", got)
+	}
+}
+
+func TestPricingAvailabilityRemoveFromSaleFinalReadbackIncludesInitiallyUnavailableTerritories(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	var territoryReads atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			if territoryReads.Add(1) == 1 {
+				return territoryAvailabilityResponse(t, map[string]bool{"USA": true, "FRA": false}), nil
+			}
+			return territoryAvailabilityResponse(t, map[string]bool{"USA": false, "FRA": true}), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	_, _ = captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected final-readback failure")
+		}
+		if !strings.Contains(err.Error(), "updated 1, skipped 1, failed 1 (FRA)") || !strings.Contains(err.Error(), "state changed during verification") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func territoryAvailabilityResponse(t *testing.T, states map[string]bool) *http.Response {
+	t.Helper()
+	territories := []string{"USA", "FRA"}
+	data := make([]map[string]any, 0, len(territories))
+	for _, territory := range territories {
+		data = append(data, map[string]any{
+			"type":       "territoryAvailabilities",
+			"id":         "ta-" + strings.ToLower(territory),
+			"attributes": map[string]any{"available": states[territory]},
+			"relationships": map[string]any{
+				"territory": map[string]any{"data": map[string]any{"type": "territories", "id": territory}},
+			},
+		})
+	}
+	body, err := json.Marshal(map[string]any{"data": data, "links": map[string]string{"next": ""}})
+	if err != nil {
+		t.Fatalf("marshal territory response: %v", err)
+	}
+	return jsonHTTPResponse(http.StatusOK, string(body))
+}

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -230,7 +230,7 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	_, _ = captureOutput(t, func() {
+	stdout, _ := captureOutput(t, func() {
 		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -247,6 +247,24 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 	})
 	if got := patches.Load(); got != 2 {
 		t.Fatalf("PATCH count = %d, want 2", got)
+	}
+	var result struct {
+		Status                         string   `json:"status"`
+		TotalTerritories               int      `json:"totalTerritories"`
+		UpdatedTerritories             int      `json:"updatedTerritories"`
+		VerifiedUnavailableTerritories int      `json:"verifiedUnavailableTerritories"`
+		FailedTerritories              []string `json:"failedTerritories"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode partial-failure result %q: %v", stdout, err)
+	}
+	if result.Status != "partialFailure" ||
+		result.TotalTerritories != 2 ||
+		result.UpdatedTerritories != 1 ||
+		result.VerifiedUnavailableTerritories != 1 ||
+		len(result.FailedTerritories) != 1 ||
+		result.FailedTerritories[0] != "FRA" {
+		t.Fatalf("unexpected partial-failure result: %+v", result)
 	}
 }
 

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -42,10 +42,12 @@ func TestPricingAvailabilityRemoveFromSaleUpdatesAndVerifiesTerritories(t *testi
 				} `json:"data"`
 			}
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode PATCH: %v", err)
+				t.Errorf("decode PATCH: %v", err)
+				return nil, fmt.Errorf("decode PATCH: %w", err)
 			}
 			if payload.Data.ID != "ta-usa" || payload.Data.Attributes.Available == nil || *payload.Data.Attributes.Available {
-				t.Fatalf("unexpected PATCH payload: %+v", payload)
+				t.Errorf("unexpected PATCH payload: %+v", payload)
+				return nil, fmt.Errorf("unexpected PATCH payload")
 			}
 			patches.Add(1)
 			mu.Lock()

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -45,6 +45,7 @@ Examples:
   asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true
   asc pricing availability edit --app "123456789" --all-territories --available true
+  asc pricing availability remove-from-sale --app "123456789" --confirm
   asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -602,6 +603,7 @@ Examples:
   asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true
   asc pricing availability edit --app "123456789" --all-territories --available true
+  asc pricing availability remove-from-sale --app "123456789" --confirm
   asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -609,6 +611,7 @@ Examples:
 			PricingAvailabilityCreateCommand(),
 			PricingAvailabilityTerritoryAvailabilitiesCommand(),
 			PricingAvailabilitySetCommand(),
+			PricingAvailabilityRemoveFromSaleCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
@@ -866,5 +869,12 @@ Note:
   App Store Connect.`,
 		ErrorPrefix:                      "pricing availability edit",
 		IncludeAvailableInNewTerritories: true,
+	})
+}
+
+// PricingAvailabilityRemoveFromSaleCommand returns the remove-from-sale subcommand.
+func PricingAvailabilityRemoveFromSaleCommand() *ffcli.Command {
+	return shared.NewAvailabilityRemoveFromSaleCommand(shared.AvailabilityRemoveFromSaleCommandConfig{
+		ClientFactory: pricingAvailabilityClientFactory,
 	})
 }

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestPricingPricePointsCommand_MissingApp(t *testing.T) {
@@ -364,6 +366,50 @@ func TestPricingAvailabilityCommand_RegistersCreate(t *testing.T) {
 	t.Fatal("expected pricing availability create to be registered")
 }
 
+func TestPricingAvailabilityCommand_RegistersRemoveFromSale(t *testing.T) {
+	cmd := PricingAvailabilityCommand()
+
+	for _, subcommand := range cmd.Subcommands {
+		if subcommand.Name == "remove-from-sale" {
+			if !strings.Contains(cmd.LongHelp, "pricing availability remove-from-sale") {
+				t.Fatalf("expected availability help to mention remove-from-sale, got %q", cmd.LongHelp)
+			}
+			return
+		}
+	}
+
+	t.Fatal("expected pricing availability remove-from-sale to be registered")
+}
+
+func TestPricingAvailabilityRemoveFromSaleCommand_MissingConfirmBeforeAuth(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	called := false
+	originalFactory := pricingAvailabilityClientFactory
+	pricingAvailabilityClientFactory = func() (*asc.Client, error) {
+		called = true
+		return nil, errors.New("unexpected auth")
+	}
+	t.Cleanup(func() { pricingAvailabilityClientFactory = originalFactory })
+
+	cmd := PricingAvailabilityRemoveFromSaleCommand()
+	if err := cmd.FlagSet.Parse([]string{"--app", "APP"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	stderr := capturePricingStderr(t, func() {
+		err := cmd.Exec(context.Background(), nil)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
+		}
+	})
+	if called {
+		t.Fatal("client factory called before --confirm validation")
+	}
+	if !strings.Contains(stderr, "--confirm is required") {
+		t.Fatalf("expected confirmation diagnostic, got %q", stderr)
+	}
+}
+
 func TestPricingAvailabilitySetCommand_HelpMentionsAllTerritories(t *testing.T) {
 	cmd := PricingAvailabilitySetCommand()
 
@@ -391,6 +437,7 @@ func TestPricingCommands_DefaultOutputJSON(t *testing.T) {
 		{"availability create", PricingAvailabilityCreateCommand},
 		{"availability territory-availabilities", PricingAvailabilityTerritoryAvailabilitiesCommand},
 		{"availability set", PricingAvailabilitySetCommand},
+		{"availability remove-from-sale", PricingAvailabilityRemoveFromSaleCommand},
 	}
 
 	for _, tc := range commands {

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -35,6 +35,24 @@ type AvailabilitySetCommandConfig struct {
 	IncludeAvailableInNewTerritories bool
 }
 
+// AvailabilityRemoveFromSaleCommandConfig configures the remove-from-sale command.
+type AvailabilityRemoveFromSaleCommandConfig struct {
+	ClientFactory func() (*asc.Client, error)
+}
+
+// AvailabilityRemoveFromSaleResult summarizes a verified remove-from-sale operation.
+type AvailabilityRemoveFromSaleResult struct {
+	AppID                          string   `json:"appId"`
+	AvailabilityID                 string   `json:"availabilityId"`
+	Status                         string   `json:"status"`
+	AvailableInNewTerritories      bool     `json:"availableInNewTerritories"`
+	TotalTerritories               int      `json:"totalTerritories"`
+	UpdatedTerritories             int      `json:"updatedTerritories"`
+	AlreadyUnavailableTerritories  int      `json:"alreadyUnavailableTerritories"`
+	VerifiedUnavailableTerritories int      `json:"verifiedUnavailableTerritories"`
+	FailedTerritories              []string `json:"failedTerritories"`
+}
+
 // NewAvailabilitySetCommand builds a shared availability set command.
 func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Command {
 	fs := flag.NewFlagSet(config.FlagSetName, flag.ExitOnError)
@@ -94,153 +112,300 @@ func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Comma
 			requestCtx, cancel := contextWithAvailabilityTimeout(ctx, *allTerritories)
 			defer cancel()
 
-			resp, err := client.GetAppAvailabilityV2(requestCtx, resolvedAppID)
-			if err != nil {
-				if isAppAvailabilityMissing(err) {
-					return NewErrorWithCause(
-						fmt.Errorf(
-							"%s: app availability not found for app %q; this command only updates existing app availability, so use \"asc pricing availability create\" first. If Apple rejects public-API bootstrap, authenticate with \"asc web auth login --apple-id EMAIL\" and use \"asc web apps availability create\", or configure Pricing and Availability in App Store Connect: %w",
-							config.ErrorPrefix,
-							resolvedAppID,
-							asc.ErrNotFound,
-						),
-						err,
-					)
-				}
-				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
-			}
-			availabilityID := strings.TrimSpace(resp.Data.ID)
-			if availabilityID == "" {
-				return fmt.Errorf("%s: app availability ID missing from response", config.ErrorPrefix)
-			}
-
+			var expectedAvailableInNewTerritories *bool
 			if config.IncludeAvailableInNewTerritories && availableInNewTerritories.IsSet() {
-				availableInNewTerritoriesValue := availableInNewTerritories.Value()
-				if resp.Data.Attributes.AvailableInNewTerritories != availableInNewTerritoriesValue {
-					return fmt.Errorf(
-						"%s: --available-in-new-territories does not match the existing policy (current value: %t); the public API cannot change this setting",
-						config.ErrorPrefix,
-						resp.Data.Attributes.AvailableInNewTerritories,
-					)
-				}
+				value := availableInNewTerritories.Value()
+				expectedAvailableInNewTerritories = &value
 			}
-
-			territoryResp, err := getAllTerritoryAvailabilities(requestCtx, client, availabilityID)
+			resp, _, err := executeTerritoryAvailabilityUpdate(requestCtx, client, availabilityUpdateRequest{
+				AppID:                             resolvedAppID,
+				Territories:                       territories,
+				AllTerritories:                    *allTerritories,
+				Available:                         availableValue,
+				ExpectedAvailableInNewTerritories: expectedAvailableInNewTerritories,
+				ErrorPrefix:                       config.ErrorPrefix,
+			})
 			if err != nil {
-				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
+				return err
 			}
-
-			territoryMap, err := mapTerritoryAvailabilities(territoryResp)
-			if err != nil {
-				return fmt.Errorf("%s: %w", config.ErrorPrefix, err)
-			}
-
-			var targets []availabilityEditTarget
-			if *allTerritories {
-				territoryIDs := make([]string, 0, len(territoryMap))
-				for territoryID := range territoryMap {
-					territoryIDs = append(territoryIDs, territoryID)
-				}
-				sort.Strings(territoryIDs)
-				targets = make([]availabilityEditTarget, 0, len(territoryIDs))
-				for _, territoryID := range territoryIDs {
-					availability := territoryMap[territoryID]
-					targets = append(targets, availabilityEditTarget{
-						TerritoryID:    territoryID,
-						AvailabilityID: availability.ID,
-						Available:      availability.Attributes.Available,
-					})
-				}
-			} else {
-				missingTerritories := make([]string, 0)
-				targets = make([]availabilityEditTarget, 0, len(territories))
-				for _, territoryID := range territories {
-					availability, ok := territoryMap[territoryID]
-					if !ok {
-						missingTerritories = append(missingTerritories, territoryID)
-						continue
-					}
-					targets = append(targets, availabilityEditTarget{
-						TerritoryID:    territoryID,
-						AvailabilityID: availability.ID,
-						Available:      availability.Attributes.Available,
-					})
-				}
-				if len(missingTerritories) > 0 {
-					return fmt.Errorf("%s: territory availability not found for territories: %s", config.ErrorPrefix, strings.Join(missingTerritories, ", "))
-				}
-			}
-
-			pending := make([]availabilityEditTarget, 0, len(targets))
-			skipped := 0
-			for _, target := range targets {
-				if target.Available == availableValue {
-					skipped++
-					continue
-				}
-				pending = append(pending, target)
-			}
-
-			if len(pending) == 0 {
-				fmt.Fprintf(os.Stderr, "Updated 0 territories; %d already matched.\n", skipped)
-				return printOutput(resp, *output.Output, *output.Pretty)
-			}
-
-			fmt.Fprintf(os.Stderr, "Updating availability for %d territories (%d already matched)...\n", len(pending), skipped)
-			patchErrors := updateTerritoryAvailabilityTargets(requestCtx, client, pending, availableValue)
-
-			verifiedResp, err := getAllTerritoryAvailabilities(requestCtx, client, availabilityID)
-			if err != nil {
-				return fmt.Errorf(
-					"%s: attempted %d territory updates (%d request failures, %d skipped); final verification failed: %w",
-					config.ErrorPrefix,
-					len(pending),
-					len(patchErrors),
-					skipped,
-					err,
-				)
-			}
-			verifiedMap, err := mapTerritoryAvailabilities(verifiedResp)
-			if err != nil {
-				return fmt.Errorf("%s: verify territory availabilities: %w", config.ErrorPrefix, err)
-			}
-
-			failedTerritories := make([]string, 0)
-			failureDetails := make([]string, 0)
-			for _, target := range pending {
-				verified, ok := verifiedMap[target.TerritoryID]
-				if ok && verified.Attributes.Available == availableValue {
-					continue
-				}
-				failedTerritories = append(failedTerritories, target.TerritoryID)
-				if patchErr := patchErrors[target.TerritoryID]; patchErr != nil {
-					failureDetails = append(failureDetails, fmt.Sprintf("%s: %v", target.TerritoryID, patchErr))
-				} else if !ok {
-					failureDetails = append(failureDetails, fmt.Sprintf("%s: missing from verification response", target.TerritoryID))
-				} else {
-					failureDetails = append(failureDetails, fmt.Sprintf("%s: requested state was not observed", target.TerritoryID))
-				}
-			}
-
-			updated := len(pending) - len(failedTerritories)
-			if len(failedTerritories) > 0 {
-				sort.Strings(failedTerritories)
-				sort.Strings(failureDetails)
-				return fmt.Errorf(
-					"%s: updated %d, skipped %d, failed %d (%s): %s",
-					config.ErrorPrefix,
-					updated,
-					skipped,
-					len(failedTerritories),
-					strings.Join(failedTerritories, ", "),
-					strings.Join(failureDetails, "; "),
-				)
-			}
-
-			fmt.Fprintf(os.Stderr, "Updated %d territories; %d already matched; verified %d updated territories.\n", updated, skipped, len(pending))
 			return printOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+// NewAvailabilityRemoveFromSaleCommand builds a command that makes every
+// existing territory unavailable while preserving the app's new-territory policy.
+func NewAvailabilityRemoveFromSaleCommand(config AvailabilityRemoveFromSaleCommandConfig) *ffcli.Command {
+	fs := flag.NewFlagSet("pricing availability remove-from-sale", flag.ExitOnError)
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	confirm := fs.Bool("confirm", false, "Confirm removal from sale in all current territories")
+	output := BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "remove-from-sale",
+		ShortUsage: "asc pricing availability remove-from-sale --app \"APP_ID\" --confirm",
+		ShortHelp:  "Remove an app from sale in all current territories.",
+		LongHelp: `Remove an app from sale in all current territories.
+
+This command uses the public App Store Connect API. It makes every existing
+territory unavailable and verifies the final state. It does not delete the app
+record, and it preserves the existing availableInNewTerritories policy because
+Apple does not expose an update operation for that setting.
+
+Examples:
+  asc pricing availability remove-from-sale --app "123456789" --confirm`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return UsageError("pricing availability remove-from-sale does not accept positional arguments")
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return MissingRequiredUsageError("--confirm")
+			}
+			resolvedAppID := resolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return MissingRequiredUsageError("--app")
+			}
+			if config.ClientFactory == nil {
+				return fmt.Errorf("pricing availability remove-from-sale: client factory is not configured")
+			}
+			client, err := config.ClientFactory()
+			if err != nil {
+				return fmt.Errorf("pricing availability remove-from-sale: %w", err)
+			}
+
+			requestCtx, cancel := contextWithAvailabilityTimeout(ctx, true)
+			defer cancel()
+			_, summary, err := executeTerritoryAvailabilityUpdate(requestCtx, client, availabilityUpdateRequest{
+				AppID:          resolvedAppID,
+				AllTerritories: true,
+				Available:      false,
+				ErrorPrefix:    "pricing availability remove-from-sale",
+			})
+			if err != nil {
+				return err
+			}
+
+			result := AvailabilityRemoveFromSaleResult{
+				AppID:                          resolvedAppID,
+				AvailabilityID:                 summary.AvailabilityID,
+				Status:                         "removedFromSale",
+				AvailableInNewTerritories:      summary.AvailableInNewTerritories,
+				TotalTerritories:               summary.TotalTerritories,
+				UpdatedTerritories:             summary.UpdatedTerritories,
+				AlreadyUnavailableTerritories:  summary.SkippedTerritories,
+				VerifiedUnavailableTerritories: summary.VerifiedTerritories,
+				FailedTerritories:              append([]string{}, summary.FailedTerritories...),
+			}
+			fmt.Fprintf(
+				os.Stderr,
+				"App %s is unavailable in all %d current territories; preserved availableInNewTerritories=%t.\n",
+				resolvedAppID,
+				result.VerifiedUnavailableTerritories,
+				result.AvailableInNewTerritories,
+			)
+			if result.AvailableInNewTerritories {
+				fmt.Fprintln(os.Stderr, "Warning: Apple may automatically enable future App Store territories under the preserved policy.")
+			}
+			return PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error {
+					renderAvailabilityRemoveFromSaleResult(result, false)
+					return nil
+				},
+				func() error {
+					renderAvailabilityRemoveFromSaleResult(result, true)
+					return nil
+				},
+			)
+		},
+	}
+}
+
+type availabilityUpdateRequest struct {
+	AppID                             string
+	Territories                       []string
+	AllTerritories                    bool
+	Available                         bool
+	ExpectedAvailableInNewTerritories *bool
+	ErrorPrefix                       string
+}
+
+type availabilityUpdateSummary struct {
+	AvailabilityID            string
+	AvailableInNewTerritories bool
+	TotalTerritories          int
+	UpdatedTerritories        int
+	SkippedTerritories        int
+	VerifiedTerritories       int
+	FailedTerritories         []string
+}
+
+func executeTerritoryAvailabilityUpdate(ctx context.Context, client *asc.Client, request availabilityUpdateRequest) (*asc.AppAvailabilityV2Response, availabilityUpdateSummary, error) {
+	summary := availabilityUpdateSummary{}
+	resp, err := client.GetAppAvailabilityV2(ctx, request.AppID)
+	if err != nil {
+		if isAppAvailabilityMissing(err) {
+			return nil, summary, NewErrorWithCause(
+				fmt.Errorf(
+					"%s: app availability not found for app %q; this command only updates existing app availability, so use \"asc pricing availability create\" first. If Apple rejects public-API bootstrap, authenticate with \"asc web auth login --apple-id EMAIL\" and use \"asc web apps availability create\", or configure Pricing and Availability in App Store Connect: %w",
+					request.ErrorPrefix,
+					request.AppID,
+					asc.ErrNotFound,
+				),
+				err,
+			)
+		}
+		return nil, summary, fmt.Errorf("%s: %w", request.ErrorPrefix, err)
+	}
+	availabilityID := strings.TrimSpace(resp.Data.ID)
+	if availabilityID == "" {
+		return nil, summary, fmt.Errorf("%s: app availability ID missing from response", request.ErrorPrefix)
+	}
+	summary.AvailabilityID = availabilityID
+	summary.AvailableInNewTerritories = resp.Data.Attributes.AvailableInNewTerritories
+
+	if request.ExpectedAvailableInNewTerritories != nil && resp.Data.Attributes.AvailableInNewTerritories != *request.ExpectedAvailableInNewTerritories {
+		return nil, summary, fmt.Errorf(
+			"%s: --available-in-new-territories does not match the existing policy (current value: %t); the public API cannot change this setting",
+			request.ErrorPrefix,
+			resp.Data.Attributes.AvailableInNewTerritories,
+		)
+	}
+
+	territoryResp, err := getAllTerritoryAvailabilities(ctx, client, availabilityID)
+	if err != nil {
+		return nil, summary, fmt.Errorf("%s: %w", request.ErrorPrefix, err)
+	}
+	territoryMap, err := mapTerritoryAvailabilities(territoryResp)
+	if err != nil {
+		return nil, summary, fmt.Errorf("%s: %w", request.ErrorPrefix, err)
+	}
+
+	var targets []availabilityEditTarget
+	if request.AllTerritories {
+		territoryIDs := make([]string, 0, len(territoryMap))
+		for territoryID := range territoryMap {
+			territoryIDs = append(territoryIDs, territoryID)
+		}
+		sort.Strings(territoryIDs)
+		targets = make([]availabilityEditTarget, 0, len(territoryIDs))
+		for _, territoryID := range territoryIDs {
+			availability := territoryMap[territoryID]
+			targets = append(targets, availabilityEditTarget{TerritoryID: territoryID, AvailabilityID: availability.ID, Available: availability.Attributes.Available})
+		}
+	} else {
+		missingTerritories := make([]string, 0)
+		targets = make([]availabilityEditTarget, 0, len(request.Territories))
+		for _, territoryID := range request.Territories {
+			availability, ok := territoryMap[territoryID]
+			if !ok {
+				missingTerritories = append(missingTerritories, territoryID)
+				continue
+			}
+			targets = append(targets, availabilityEditTarget{TerritoryID: territoryID, AvailabilityID: availability.ID, Available: availability.Attributes.Available})
+		}
+		if len(missingTerritories) > 0 {
+			return nil, summary, fmt.Errorf("%s: territory availability not found for territories: %s", request.ErrorPrefix, strings.Join(missingTerritories, ", "))
+		}
+	}
+
+	summary.TotalTerritories = len(targets)
+	pending := make([]availabilityEditTarget, 0, len(targets))
+	for _, target := range targets {
+		if target.Available == request.Available {
+			summary.SkippedTerritories++
+			continue
+		}
+		pending = append(pending, target)
+	}
+	if len(pending) == 0 {
+		summary.VerifiedTerritories = summary.SkippedTerritories
+		fmt.Fprintf(os.Stderr, "Updated 0 territories; %d already matched.\n", summary.SkippedTerritories)
+		return resp, summary, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Updating availability for %d territories (%d already matched)...\n", len(pending), summary.SkippedTerritories)
+	patchErrors := updateTerritoryAvailabilityTargets(ctx, client, pending, request.Available)
+	verifiedResp, err := getAllTerritoryAvailabilities(ctx, client, availabilityID)
+	if err != nil {
+		return nil, summary, fmt.Errorf(
+			"%s: attempted %d territory updates (%d request failures, %d skipped); final verification failed: %w",
+			request.ErrorPrefix,
+			len(pending),
+			len(patchErrors),
+			summary.SkippedTerritories,
+			err,
+		)
+	}
+	verifiedMap, err := mapTerritoryAvailabilities(verifiedResp)
+	if err != nil {
+		return nil, summary, fmt.Errorf("%s: verify territory availabilities: %w", request.ErrorPrefix, err)
+	}
+
+	failureDetails := make([]string, 0)
+	for _, target := range targets {
+		verified, ok := verifiedMap[target.TerritoryID]
+		if ok && verified.Attributes.Available == request.Available {
+			if target.Available != request.Available {
+				summary.UpdatedTerritories++
+			}
+			continue
+		}
+		summary.FailedTerritories = append(summary.FailedTerritories, target.TerritoryID)
+		if patchErr := patchErrors[target.TerritoryID]; patchErr != nil {
+			failureDetails = append(failureDetails, fmt.Sprintf("%s: %v", target.TerritoryID, patchErr))
+		} else if !ok {
+			failureDetails = append(failureDetails, fmt.Sprintf("%s: missing from verification response", target.TerritoryID))
+		} else if target.Available == request.Available {
+			failureDetails = append(failureDetails, fmt.Sprintf("%s: state changed during verification", target.TerritoryID))
+		} else {
+			failureDetails = append(failureDetails, fmt.Sprintf("%s: requested state was not observed", target.TerritoryID))
+		}
+	}
+
+	summary.VerifiedTerritories = len(targets) - len(summary.FailedTerritories)
+	if len(summary.FailedTerritories) > 0 {
+		sort.Strings(summary.FailedTerritories)
+		sort.Strings(failureDetails)
+		return nil, summary, fmt.Errorf(
+			"%s: updated %d, skipped %d, failed %d (%s): %s",
+			request.ErrorPrefix,
+			summary.UpdatedTerritories,
+			summary.SkippedTerritories,
+			len(summary.FailedTerritories),
+			strings.Join(summary.FailedTerritories, ", "),
+			strings.Join(failureDetails, "; "),
+		)
+	}
+
+	fmt.Fprintf(os.Stderr, "Updated %d territories; %d already matched; verified %d updated territories.\n", summary.UpdatedTerritories, summary.SkippedTerritories, len(pending))
+	return resp, summary, nil
+}
+
+func renderAvailabilityRemoveFromSaleResult(result AvailabilityRemoveFromSaleResult, markdown bool) {
+	headers := []string{"Field", "Value"}
+	rows := [][]string{
+		{"App ID", result.AppID},
+		{"Availability ID", result.AvailabilityID},
+		{"Status", result.Status},
+		{"Available in new territories", fmt.Sprintf("%t", result.AvailableInNewTerritories)},
+		{"Total territories", fmt.Sprintf("%d", result.TotalTerritories)},
+		{"Updated territories", fmt.Sprintf("%d", result.UpdatedTerritories)},
+		{"Already unavailable", fmt.Sprintf("%d", result.AlreadyUnavailableTerritories)},
+		{"Verified unavailable", fmt.Sprintf("%d", result.VerifiedUnavailableTerritories)},
+		{"Failed territories", strings.Join(result.FailedTerritories, ", ")},
+	}
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return
+	}
+	asc.RenderTable(headers, rows)
 }
 
 func contextWithAvailabilityTimeout(ctx context.Context, allTerritories bool) (context.Context, context.CancelFunc) {

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -179,20 +180,24 @@ Examples:
 
 			requestCtx, cancel := contextWithAvailabilityTimeout(ctx, true)
 			defer cancel()
-			_, summary, err := executeTerritoryAvailabilityUpdate(requestCtx, client, availabilityUpdateRequest{
+			_, summary, updateErr := executeTerritoryAvailabilityUpdate(requestCtx, client, availabilityUpdateRequest{
 				AppID:          resolvedAppID,
 				AllTerritories: true,
 				Available:      false,
 				ErrorPrefix:    "pricing availability remove-from-sale",
 			})
-			if err != nil {
-				return err
+			if updateErr != nil && len(summary.FailedTerritories) == 0 {
+				return updateErr
 			}
 
+			status := "removedFromSale"
+			if updateErr != nil {
+				status = "partialFailure"
+			}
 			result := AvailabilityRemoveFromSaleResult{
 				AppID:                          resolvedAppID,
 				AvailabilityID:                 summary.AvailabilityID,
-				Status:                         "removedFromSale",
+				Status:                         status,
 				AvailableInNewTerritories:      summary.AvailableInNewTerritories,
 				TotalTerritories:               summary.TotalTerritories,
 				UpdatedTerritories:             summary.UpdatedTerritories,
@@ -200,17 +205,28 @@ Examples:
 				VerifiedUnavailableTerritories: summary.VerifiedTerritories,
 				FailedTerritories:              append([]string{}, summary.FailedTerritories...),
 			}
-			fmt.Fprintf(
-				os.Stderr,
-				"App %s is unavailable in all %d current territories; preserved availableInNewTerritories=%t.\n",
-				resolvedAppID,
-				result.VerifiedUnavailableTerritories,
-				result.AvailableInNewTerritories,
-			)
+			if updateErr != nil {
+				fmt.Fprintf(
+					os.Stderr,
+					"App %s removal is incomplete: %d of %d current territories are verified unavailable; preserved availableInNewTerritories=%t.\n",
+					resolvedAppID,
+					result.VerifiedUnavailableTerritories,
+					result.TotalTerritories,
+					result.AvailableInNewTerritories,
+				)
+			} else {
+				fmt.Fprintf(
+					os.Stderr,
+					"App %s is unavailable in all %d current territories; preserved availableInNewTerritories=%t.\n",
+					resolvedAppID,
+					result.VerifiedUnavailableTerritories,
+					result.AvailableInNewTerritories,
+				)
+			}
 			if result.AvailableInNewTerritories {
 				fmt.Fprintln(os.Stderr, "Warning: Apple may automatically enable future App Store territories under the preserved policy.")
 			}
-			return PrintOutputWithRenderers(
+			renderErr := PrintOutputWithRenderers(
 				result,
 				*output.Output,
 				*output.Pretty,
@@ -223,6 +239,7 @@ Examples:
 					return nil
 				},
 			)
+			return errors.Join(updateErr, renderErr)
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- add `asc pricing availability remove-from-sale --app APP_ID --confirm` using the public App Store Connect API
- reuse the resilient bulk availability engine for bounded concurrency, transient retries, no-op skips, continuation, and full final readback
- preserve and report `availableInNewTerritories`, with a warning when future territories may be enabled automatically
- return structured JSON, table, and Markdown summaries without deleting the app record

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused availability tests under `go test -race`
- built-binary help and missing-confirm exit-code check
- live disposable-app smoke: corrected 3 remaining on-sale territories, verified 175/175 unavailable, then verified a zero-PATCH no-op rerun

## Safety

`--confirm` is required before auth or network access. This changes territory availability only; it does not delete the App Store Connect app record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `pricing availability remove-from-sale` CLI command.
  - Removes availability across existing territories while preserving the new-territory policy.
  - Supports confirmation and JSON, table, and Markdown output formats.
  - Reports updated, skipped, verified, and failed territories with status details.
  - Handles no-op operations and partial update results.

- **Bug Fixes**
  - Added final verification to detect incomplete or inconsistent availability updates.
  - Validates confirmation before connecting to the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->