### PR TITLE
Add published apps audit command

### DIFF
--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -43,6 +43,7 @@ func AppsCommand() *ffcli.Command {
 Examples:
   asc apps
   asc apps list --bundle-id "com.example.app"
+  asc apps published
   asc web apps create --name "My App" --bundle-id "com.example.app" --sku "MYAPP123"
   asc apps wall
   asc apps wall submit --app "1234567890" --confirm
@@ -69,6 +70,7 @@ Examples:
 		UsageFunc: shared.VisibleUsageFunc,
 		Subcommands: []*ffcli.Command{
 			AppsListCommand(),
+			AppsPublishedCommand(),
 			AppsWallCommand(),
 			AppsPublicCommand(),
 			AppsRegistryCommand(),

--- a/internal/cli/apps/published.go
+++ b/internal/cli/apps/published.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -203,7 +204,7 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 func auditPublishedApp(ctx context.Context, client *asc.Client, appID string) (string, int, error) {
 	availability, err := client.GetAppAvailabilityV2(ctx, appID)
 	if err != nil {
-		if shared.IsAppAvailabilityMissing(err) {
+		if isPublishedAuditAvailabilityMissing(err) {
 			return "", 0, nil
 		}
 		return "", 0, fmt.Errorf("fetch availability: %w", err)
@@ -235,6 +236,20 @@ func auditPublishedApp(ctx context.Context, client *asc.Client, appID string) (s
 		}
 	}
 	return availabilityID, publishedTerritoryCount, nil
+}
+
+func isPublishedAuditAvailabilityMissing(err error) bool {
+	if err == nil || !errors.Is(err, asc.ErrNotFound) {
+		return false
+	}
+	var apiErr *asc.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	description := strings.ToLower(strings.Join([]string{apiErr.Code, apiErr.Title, apiErr.Detail}, " "))
+	return strings.Contains(description, "appavailabilities") ||
+		strings.Contains(description, "app availability") ||
+		strings.Contains(description, "appavailabilityv2")
 }
 
 func hasAvailableContentStatus(statuses []string) bool {

--- a/internal/cli/apps/published.go
+++ b/internal/cli/apps/published.go
@@ -103,6 +103,7 @@ Examples:
 	}
 }
 
+// fetchAllAppsForPublishedAudit retrieves every app record across all result pages.
 func fetchAllAppsForPublishedAudit(ctx context.Context, client *asc.Client) (*asc.AppsResponse, error) {
 	firstPage, err := client.GetApps(ctx, asc.WithAppsLimit(200), asc.WithAppsSort("name"))
 	if err != nil {
@@ -128,6 +129,7 @@ type publishedAppAuditResult struct {
 	Err            error
 }
 
+// auditPublishedApps audits app availability concurrently and returns published apps.
 func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []asc.Resource[asc.AppAttributes]) (AppsPublishedReport, error) {
 	report := AppsPublishedReport{
 		AuditedAppCount: len(appResources),
@@ -201,6 +203,7 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 	return report, nil
 }
 
+// auditPublishedApp returns an app's availability ID and published-territory count.
 func auditPublishedApp(ctx context.Context, client *asc.Client, appID string) (string, int, error) {
 	availability, err := client.GetAppAvailabilityV2(ctx, appID)
 	if err != nil {
@@ -238,6 +241,7 @@ func auditPublishedApp(ctx context.Context, client *asc.Client, appID string) (s
 	return availabilityID, publishedTerritoryCount, nil
 }
 
+// isPublishedAuditAvailabilityMissing reports resource-specific missing availability.
 func isPublishedAuditAvailabilityMissing(err error) bool {
 	if err == nil || !errors.Is(err, asc.ErrNotFound) {
 		return false
@@ -252,6 +256,7 @@ func isPublishedAuditAvailabilityMissing(err error) bool {
 		strings.Contains(description, "appavailabilityv2")
 }
 
+// hasAvailableContentStatus reports whether any content status is AVAILABLE.
 func hasAvailableContentStatus(statuses []string) bool {
 	for _, status := range statuses {
 		if strings.EqualFold(strings.TrimSpace(status), "AVAILABLE") {
@@ -261,6 +266,7 @@ func hasAvailableContentStatus(statuses []string) bool {
 	return false
 }
 
+// renderAppsPublishedReport writes table or Markdown rows and their audit totals.
 func renderAppsPublishedReport(report AppsPublishedReport, markdown bool) error {
 	headers := []string{"ID", "Name", "Bundle ID", "SKU", "Availability ID", "Published Territories"}
 	rows := make([][]string, 0, len(report.Apps))
@@ -276,12 +282,20 @@ func renderAppsPublishedReport(report AppsPublishedReport, markdown bool) error 
 	}
 	if markdown {
 		asc.RenderMarkdown(headers, rows)
-		return nil
+	} else {
+		asc.RenderTable(headers, rows)
 	}
-	asc.RenderTable(headers, rows)
+	fmt.Fprintf(
+		os.Stdout,
+		"\nAudited %d app records; found %d published %s.\n",
+		report.AuditedAppCount,
+		report.PublishedAppCount,
+		pluralizeApp(report.PublishedAppCount),
+	)
 	return nil
 }
 
+// pluralizeApp returns the singular or plural app label for a count.
 func pluralizeApp(count int) string {
 	if count == 1 {
 		return "app"

--- a/internal/cli/apps/published.go
+++ b/internal/cli/apps/published.go
@@ -51,8 +51,10 @@ func AppsPublishedCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "published",
 		ShortUsage: "asc apps published [flags]",
-		ShortHelp:  "List published apps and their published-territory counts.",
-		LongHelp: `List published apps and their published-territory counts.
+		ShortHelp:  "[experimental] List published apps and their published-territory counts.",
+		LongHelp: `[experimental] List published apps and their published-territory counts.
+
+This command is experimental.
 
 The command audits every App Store Connect app record and all of its territory
 availability pages. An app is published when at least one territory reports the
@@ -85,13 +87,15 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("apps published: %w", err)
 			}
-			fmt.Fprintf(
-				os.Stderr,
-				"Audited %d app records; found %d published %s.\n",
-				report.AuditedAppCount,
-				report.PublishedAppCount,
-				pluralizeApp(report.PublishedAppCount),
-			)
+			if strings.EqualFold(strings.TrimSpace(*output.Output), "json") {
+				fmt.Fprintf(
+					os.Stderr,
+					"Audited %d app records; found %d published %s.\n",
+					report.AuditedAppCount,
+					report.PublishedAppCount,
+					pluralizeApp(report.PublishedAppCount),
+				)
+			}
 			return shared.PrintOutputWithRenderers(
 				report,
 				*output.Output,

--- a/internal/cli/apps/published.go
+++ b/internal/cli/apps/published.go
@@ -1,0 +1,275 @@
+package apps
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const (
+	appsPublishedAuditTimeout = 5 * time.Minute
+	appsPublishedWorkers      = 4
+)
+
+var appsPublishedClientFactory = shared.GetASCClient
+
+// PublishedApp describes an App Store Connect app with live published territory coverage.
+type PublishedApp struct {
+	ID                      string `json:"id"`
+	Name                    string `json:"name"`
+	BundleID                string `json:"bundleId"`
+	SKU                     string `json:"sku"`
+	PrimaryLocale           string `json:"primaryLocale,omitempty"`
+	AvailabilityID          string `json:"availabilityId"`
+	PublishedTerritoryCount int    `json:"publishedTerritoryCount"`
+}
+
+// AppsPublishedReport summarizes a complete account-wide published-app audit.
+type AppsPublishedReport struct {
+	AuditedAppCount   int            `json:"auditedAppCount"`
+	PublishedAppCount int            `json:"publishedAppCount"`
+	Apps              []PublishedApp `json:"apps"`
+}
+
+// AppsPublishedCommand returns the account-wide published-app audit command.
+func AppsPublishedCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps published", flag.ExitOnError)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "published",
+		ShortUsage: "asc apps published [flags]",
+		ShortHelp:  "List published apps and their published-territory counts.",
+		LongHelp: `List published apps and their published-territory counts.
+
+The command audits every App Store Connect app record and all of its territory
+availability pages. An app is published when at least one territory reports the
+AVAILABLE content status. Apps without a published territory are omitted from
+the result, while the report includes the total number of audited app records.
+
+Examples:
+  asc apps published
+  asc apps published --output table
+  asc apps published --output markdown`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("apps published does not accept positional arguments")
+			}
+			client, err := appsPublishedClientFactory()
+			if err != nil {
+				return fmt.Errorf("apps published: %w", err)
+			}
+
+			requestCtx, cancel := shared.ContextWithResolvedTimeout(ctx, appsPublishedAuditTimeout)
+			defer cancel()
+			appsResponse, err := fetchAllAppsForPublishedAudit(requestCtx, client)
+			if err != nil {
+				return fmt.Errorf("apps published: fetch apps: %w", err)
+			}
+
+			report, err := auditPublishedApps(requestCtx, client, appsResponse.Data)
+			if err != nil {
+				return fmt.Errorf("apps published: %w", err)
+			}
+			fmt.Fprintf(
+				os.Stderr,
+				"Audited %d app records; found %d published %s.\n",
+				report.AuditedAppCount,
+				report.PublishedAppCount,
+				pluralizeApp(report.PublishedAppCount),
+			)
+			return shared.PrintOutputWithRenderers(
+				report,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderAppsPublishedReport(report, false) },
+				func() error { return renderAppsPublishedReport(report, true) },
+			)
+		},
+	}
+}
+
+func fetchAllAppsForPublishedAudit(ctx context.Context, client *asc.Client) (*asc.AppsResponse, error) {
+	firstPage, err := client.GetApps(ctx, asc.WithAppsLimit(200), asc.WithAppsSort("name"))
+	if err != nil {
+		return nil, err
+	}
+	allPages, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetApps(ctx, asc.WithAppsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+	response, ok := allPages.(*asc.AppsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected apps response type %T", allPages)
+	}
+	return response, nil
+}
+
+type publishedAppAuditResult struct {
+	App            asc.Resource[asc.AppAttributes]
+	AvailabilityID string
+	TerritoryCount int
+	Err            error
+}
+
+func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []asc.Resource[asc.AppAttributes]) (AppsPublishedReport, error) {
+	report := AppsPublishedReport{
+		AuditedAppCount: len(appResources),
+		Apps:            make([]PublishedApp, 0),
+	}
+	if len(appResources) == 0 {
+		return report, nil
+	}
+
+	workerCount := min(appsPublishedWorkers, len(appResources))
+	jobs := make(chan asc.Resource[asc.AppAttributes])
+	results := make(chan publishedAppAuditResult, len(appResources))
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for app := range jobs {
+				availabilityID, territoryCount, err := auditPublishedApp(ctx, client, app.ID)
+				results <- publishedAppAuditResult{
+					App:            app,
+					AvailabilityID: availabilityID,
+					TerritoryCount: territoryCount,
+					Err:            err,
+				}
+			}
+		}()
+	}
+	go func() {
+		for _, app := range appResources {
+			jobs <- app
+		}
+		close(jobs)
+		workers.Wait()
+		close(results)
+	}()
+
+	failures := make([]string, 0)
+	for result := range results {
+		if result.Err != nil {
+			failures = append(failures, fmt.Sprintf("%s (%s): %v", result.App.Attributes.Name, result.App.ID, result.Err))
+			continue
+		}
+		if result.TerritoryCount == 0 {
+			continue
+		}
+		report.Apps = append(report.Apps, PublishedApp{
+			ID:                      result.App.ID,
+			Name:                    result.App.Attributes.Name,
+			BundleID:                result.App.Attributes.BundleID,
+			SKU:                     result.App.Attributes.SKU,
+			PrimaryLocale:           result.App.Attributes.PrimaryLocale,
+			AvailabilityID:          result.AvailabilityID,
+			PublishedTerritoryCount: result.TerritoryCount,
+		})
+	}
+	if len(failures) > 0 {
+		sort.Strings(failures)
+		return AppsPublishedReport{}, fmt.Errorf("audit failed for %d of %d apps: %s", len(failures), len(appResources), strings.Join(failures, "; "))
+	}
+
+	sort.Slice(report.Apps, func(i, j int) bool {
+		left := strings.ToLower(strings.TrimSpace(report.Apps[i].Name))
+		right := strings.ToLower(strings.TrimSpace(report.Apps[j].Name))
+		if left != right {
+			return left < right
+		}
+		return report.Apps[i].ID < report.Apps[j].ID
+	})
+	report.PublishedAppCount = len(report.Apps)
+	return report, nil
+}
+
+func auditPublishedApp(ctx context.Context, client *asc.Client, appID string) (string, int, error) {
+	availability, err := client.GetAppAvailabilityV2(ctx, appID)
+	if err != nil {
+		if shared.IsAppAvailabilityMissing(err) {
+			return "", 0, nil
+		}
+		return "", 0, fmt.Errorf("fetch availability: %w", err)
+	}
+	availabilityID := strings.TrimSpace(availability.Data.ID)
+	if availabilityID == "" {
+		return "", 0, fmt.Errorf("availability response did not include an ID")
+	}
+
+	firstPage, err := client.GetTerritoryAvailabilities(ctx, availabilityID, asc.WithTerritoryAvailabilitiesLimit(200))
+	if err != nil {
+		return availabilityID, 0, fmt.Errorf("fetch territory availabilities: %w", err)
+	}
+	allPages, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetTerritoryAvailabilities(ctx, availabilityID, asc.WithTerritoryAvailabilitiesNextURL(nextURL))
+	})
+	if err != nil {
+		return availabilityID, 0, fmt.Errorf("fetch territory availabilities: %w", err)
+	}
+	territories, ok := allPages.(*asc.TerritoryAvailabilitiesResponse)
+	if !ok {
+		return availabilityID, 0, fmt.Errorf("unexpected territory availabilities response type %T", allPages)
+	}
+
+	publishedTerritoryCount := 0
+	for _, territory := range territories.Data {
+		if hasAvailableContentStatus(territory.Attributes.ContentStatuses) {
+			publishedTerritoryCount++
+		}
+	}
+	return availabilityID, publishedTerritoryCount, nil
+}
+
+func hasAvailableContentStatus(statuses []string) bool {
+	for _, status := range statuses {
+		if strings.EqualFold(strings.TrimSpace(status), "AVAILABLE") {
+			return true
+		}
+	}
+	return false
+}
+
+func renderAppsPublishedReport(report AppsPublishedReport, markdown bool) error {
+	headers := []string{"ID", "Name", "Bundle ID", "SKU", "Availability ID", "Published Territories"}
+	rows := make([][]string, 0, len(report.Apps))
+	for _, app := range report.Apps {
+		rows = append(rows, []string{
+			app.ID,
+			app.Name,
+			app.BundleID,
+			app.SKU,
+			app.AvailabilityID,
+			strconv.Itoa(app.PublishedTerritoryCount),
+		})
+	}
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return nil
+	}
+	asc.RenderTable(headers, rows)
+	return nil
+}
+
+func pluralizeApp(count int) string {
+	if count == 1 {
+		return "app"
+	}
+	return "apps"
+}

--- a/internal/cli/apps/published_test.go
+++ b/internal/cli/apps/published_test.go
@@ -25,6 +25,12 @@ func TestAppsCommandRegistersPublished(t *testing.T) {
 
 func TestAppsPublishedCommandDefaultsToJSON(t *testing.T) {
 	cmd := AppsPublishedCommand()
+	if !strings.HasPrefix(cmd.ShortHelp, "[experimental]") {
+		t.Fatalf("short help = %q, want experimental marker", cmd.ShortHelp)
+	}
+	if !strings.HasPrefix(cmd.LongHelp, "[experimental]") || !strings.Contains(cmd.LongHelp, "This command is experimental.") {
+		t.Fatalf("long help = %q, want experimental lifecycle notice", cmd.LongHelp)
+	}
 	output := cmd.FlagSet.Lookup("output")
 	if output == nil {
 		t.Fatal("expected --output flag")

--- a/internal/cli/apps/published_test.go
+++ b/internal/cli/apps/published_test.go
@@ -1,0 +1,30 @@
+package apps
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppsCommandRegistersPublished(t *testing.T) {
+	cmd := AppsCommand()
+	for _, subcommand := range cmd.Subcommands {
+		if subcommand.Name == "published" {
+			if !strings.Contains(cmd.LongHelp, "asc apps published") {
+				t.Fatalf("apps help does not mention published: %q", cmd.LongHelp)
+			}
+			return
+		}
+	}
+	t.Fatal("expected apps published subcommand")
+}
+
+func TestAppsPublishedCommandDefaultsToJSON(t *testing.T) {
+	cmd := AppsPublishedCommand()
+	output := cmd.FlagSet.Lookup("output")
+	if output == nil {
+		t.Fatal("expected --output flag")
+	}
+	if output.DefValue != "json" {
+		t.Fatalf("default output = %q, want json", output.DefValue)
+	}
+}

--- a/internal/cli/apps/published_test.go
+++ b/internal/cli/apps/published_test.go
@@ -1,8 +1,13 @@
 package apps
 
 import (
+	"context"
+	"errors"
+	"flag"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func TestAppsCommandRegistersPublished(t *testing.T) {
@@ -26,5 +31,27 @@ func TestAppsPublishedCommandDefaultsToJSON(t *testing.T) {
 	}
 	if output.DefValue != "json" {
 		t.Fatalf("default output = %q, want json", output.DefValue)
+	}
+}
+
+func TestAppsPublishedCommandRejectsPositionalArgumentsBeforeClientCreation(t *testing.T) {
+	originalFactory := appsPublishedClientFactory
+	t.Cleanup(func() { appsPublishedClientFactory = originalFactory })
+
+	clientFactoryCalls := 0
+	appsPublishedClientFactory = func() (*asc.Client, error) {
+		clientFactoryCalls++
+		return nil, errors.New("client factory must not be called")
+	}
+
+	err := AppsPublishedCommand().Exec(context.Background(), []string{"unexpected"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", err)
+	}
+	if err.Error() != "apps published does not accept positional arguments" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clientFactoryCalls != 0 {
+		t.Fatalf("client factory calls = %d, want 0", clientFactoryCalls)
 	}
 }

--- a/internal/cli/cmdtest/apps_published_test.go
+++ b/internal/cli/cmdtest/apps_published_test.go
@@ -214,7 +214,57 @@ func TestAppsPublishedOutputFormatsAndDeterministicOrder(t *testing.T) {
 			if alphaIndex > zuluIndex {
 				t.Fatalf("published apps are not sorted by name: %s", stdout)
 			}
+			if !strings.Contains(stdout, "Audited 2 app records; found 2 published apps.") {
+				t.Fatalf("%s output missing audit totals: %s", test.format, stdout)
+			}
 		})
+	}
+}
+
+func TestAppsPublishedRetriesRateLimitedAvailabilityReads(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var availabilityReads atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[{"type":"apps","id":"app-1","attributes":{"name":"Retried","bundleId":"com.example.retried","sku":"RETRIED"}}],
+				"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			if availabilityReads.Add(1) == 1 {
+				return jsonHTTPResponse(http.StatusTooManyRequests, `{"errors":[{"status":"429","code":"RATE_LIMIT_EXCEEDED","title":"Too Many Requests"}]}`), nil
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"contentStatuses":["AVAILABLE"]}}],"links":{"next":""}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"apps", "published"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if availabilityReads.Load() != 2 {
+		t.Fatalf("availability reads = %d, want 2", availabilityReads.Load())
+	}
+	if !strings.Contains(stdout, `"publishedAppCount":1`) {
+		t.Fatalf("unexpected output: %s", stdout)
 	}
 }
 

--- a/internal/cli/cmdtest/apps_published_test.go
+++ b/internal/cli/cmdtest/apps_published_test.go
@@ -147,7 +147,7 @@ func TestAppsPublishedAggregatesNamedAppErrorsAndContinues(t *testing.T) {
 				],"links":{"next":""}
 			}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/bad-app/appAvailabilityV2":
-			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","title":"Broken availability"}]}`), nil
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No apps resource exists"}]}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/good-app/appAvailabilityV2":
 			healthyAppRead.Add(1)
 			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No appAvailabilities resource exists"}]}`), nil
@@ -166,7 +166,7 @@ func TestAppsPublishedAggregatesNamedAppErrorsAndContinues(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected audit error")
 		}
-		if !strings.Contains(err.Error(), `Broken (bad-app)`) || !strings.Contains(err.Error(), "Broken availability") {
+		if !strings.Contains(err.Error(), `Broken (bad-app)`) || !strings.Contains(err.Error(), "No apps resource exists") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -206,7 +206,12 @@ func TestAppsPublishedOutputFormatsAndDeterministicOrder(t *testing.T) {
 			if !strings.Contains(stdout, test.want) {
 				t.Fatalf("%s output missing %q: %s", test.format, test.want, stdout)
 			}
-			if strings.Index(stdout, "Alpha") > strings.Index(stdout, "Zulu") {
+			alphaIndex := strings.Index(stdout, "Alpha")
+			zuluIndex := strings.Index(stdout, "Zulu")
+			if alphaIndex < 0 || zuluIndex < 0 {
+				t.Fatalf("%s output missing published apps: %s", test.format, stdout)
+			}
+			if alphaIndex > zuluIndex {
 				t.Fatalf("published apps are not sorted by name: %s", stdout)
 			}
 		})

--- a/internal/cli/cmdtest/apps_published_test.go
+++ b/internal/cli/cmdtest/apps_published_test.go
@@ -195,7 +195,7 @@ func TestAppsPublishedOutputFormatsAndDeterministicOrder(t *testing.T) {
 		t.Run(test.format, func(t *testing.T) {
 			root := RootCommand("1.2.3")
 			root.FlagSet.SetOutput(io.Discard)
-			stdout, _ := captureOutput(t, func() {
+			stdout, stderr := captureOutput(t, func() {
 				if err := root.Parse([]string{"apps", "published", "--output", test.format}); err != nil {
 					t.Fatalf("parse error: %v", err)
 				}
@@ -214,8 +214,12 @@ func TestAppsPublishedOutputFormatsAndDeterministicOrder(t *testing.T) {
 			if alphaIndex > zuluIndex {
 				t.Fatalf("published apps are not sorted by name: %s", stdout)
 			}
-			if !strings.Contains(stdout, "Audited 2 app records; found 2 published apps.") {
+			const summary = "Audited 2 app records; found 2 published apps."
+			if !strings.Contains(stdout, summary) {
 				t.Fatalf("%s output missing audit totals: %s", test.format, stdout)
+			}
+			if count := strings.Count(stdout+stderr, summary); count != 1 {
+				t.Fatalf("%s output contains audit totals %d times, want 1; stdout=%q stderr=%q", test.format, count, stdout, stderr)
 			}
 		})
 	}

--- a/internal/cli/cmdtest/apps_published_test.go
+++ b/internal/cli/cmdtest/apps_published_test.go
@@ -1,0 +1,236 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAppsPublishedAuditsEveryAppAndPaginatesTerritories(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var appPageTwoReads atomic.Int32
+	var appTwoTerritoryReads atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps" && req.URL.Query().Get("cursor") == "":
+			if req.URL.Query().Get("limit") != "200" {
+				t.Errorf("apps limit = %q, want 200", req.URL.Query().Get("limit"))
+			}
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"apps","id":"app-2","attributes":{"name":"Zulu","bundleId":"com.example.zulu","sku":"ZULU","primaryLocale":"en-US"}},
+					{"type":"apps","id":"app-1","attributes":{"name":"Alpha","bundleId":"com.example.alpha","sku":"ALPHA","primaryLocale":"en-US"}}
+				],
+				"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps?cursor=Mg"}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps" && req.URL.Query().Get("cursor") == "Mg":
+			appPageTwoReads.Add(1)
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[{"type":"apps","id":"app-3","attributes":{"name":"No Availability","bundleId":"com.example.none","sku":"NONE","primaryLocale":"en-US"}}],
+				"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-2/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-2","attributes":{"availableInNewTerritories":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-3/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No appAvailabilities resource exists"}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities" && req.URL.Query().Get("cursor") == "":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false,"contentStatuses":["AVAILABLE"]},"relationships":{"territory":{"data":{"type":"territories","id":"USA"}}}},
+					{"type":"territoryAvailabilities","id":"ta-fra","attributes":{"available":true,"contentStatuses":["MISSING_AGREEMENT"]},"relationships":{"territory":{"data":{"type":"territories","id":"FRA"}}}}
+				],
+				"links":{"next":"https://api.appstoreconnect.apple.com/v2/appAvailabilities/availability-1/territoryAvailabilities?cursor=MQ"}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities" && req.URL.Query().Get("cursor") == "MQ":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[{"type":"territoryAvailabilities","id":"ta-gbr","attributes":{"available":false,"contentStatuses":["AVAILABLE","BETA"]},"relationships":{"territory":{"data":{"type":"territories","id":"GBR"}}}}],
+				"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-2/territoryAvailabilities":
+			appTwoTerritoryReads.Add(1)
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[{"type":"territoryAvailabilities","id":"ta-deu","attributes":{"available":true,"contentStatuses":["PROCESSING"]},"relationships":{"territory":{"data":{"type":"territories","id":"DEU"}}}}],
+				"links":{"next":""}
+			}`), nil
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"apps", "published", "--pretty"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var report struct {
+		AuditedAppCount   int `json:"auditedAppCount"`
+		PublishedAppCount int `json:"publishedAppCount"`
+		Apps              []struct {
+			ID                      string `json:"id"`
+			Name                    string `json:"name"`
+			AvailabilityID          string `json:"availabilityId"`
+			PublishedTerritoryCount int    `json:"publishedTerritoryCount"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode output %q: %v", stdout, err)
+	}
+	if report.AuditedAppCount != 3 || report.PublishedAppCount != 1 || len(report.Apps) != 1 {
+		t.Fatalf("unexpected totals: %+v", report)
+	}
+	if report.Apps[0].ID != "app-1" || report.Apps[0].Name != "Alpha" || report.Apps[0].AvailabilityID != "availability-1" || report.Apps[0].PublishedTerritoryCount != 2 {
+		t.Fatalf("unexpected published app: %+v", report.Apps[0])
+	}
+	if appPageTwoReads.Load() != 1 || appTwoTerritoryReads.Load() != 1 {
+		t.Fatalf("expected complete audit, page2=%d app2-territories=%d", appPageTwoReads.Load(), appTwoTerritoryReads.Load())
+	}
+	if !strings.Contains(stderr, "Audited 3 app records; found 1 published app") {
+		t.Fatalf("unexpected summary: %q", stderr)
+	}
+}
+
+func TestAppsPublishedEmptyAccount(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/apps" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":""}}`), nil
+		}
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"apps", "published"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stdout != `{"auditedAppCount":0,"publishedAppCount":0,"apps":[]}`+"\n" {
+		t.Fatalf("unexpected empty report: %q", stdout)
+	}
+}
+
+func TestAppsPublishedAggregatesNamedAppErrorsAndContinues(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	var healthyAppRead atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"apps","id":"bad-app","attributes":{"name":"Broken","bundleId":"com.example.broken","sku":"BROKEN"}},
+					{"type":"apps","id":"good-app","attributes":{"name":"Healthy","bundleId":"com.example.healthy","sku":"HEALTHY"}}
+				],"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/bad-app/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","title":"Broken availability"}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/good-app/appAvailabilityV2":
+			healthyAppRead.Add(1)
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No appAvailabilities resource exists"}]}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"apps", "published"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected audit error")
+		}
+		if !strings.Contains(err.Error(), `Broken (bad-app)`) || !strings.Contains(err.Error(), "Broken availability") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected no partial stdout, got %q", stdout)
+	}
+	if healthyAppRead.Load() != 1 {
+		t.Fatalf("healthy app was not audited: %d", healthyAppRead.Load())
+	}
+}
+
+func TestAppsPublishedOutputFormatsAndDeterministicOrder(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = publishedAppsTwoAppTransport(t)
+
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{format: "table", want: "Published Territories"},
+		{format: "markdown", want: "| ID"},
+	}
+	for _, test := range tests {
+		t.Run(test.format, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse([]string{"apps", "published", "--output", test.format}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			if !strings.Contains(stdout, test.want) {
+				t.Fatalf("%s output missing %q: %s", test.format, test.want, stdout)
+			}
+			if strings.Index(stdout, "Alpha") > strings.Index(stdout, "Zulu") {
+				t.Fatalf("published apps are not sorted by name: %s", stdout)
+			}
+		})
+	}
+}
+
+func publishedAppsTwoAppTransport(t *testing.T) http.RoundTripper {
+	t.Helper()
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"apps","id":"z-app","attributes":{"name":"Zulu","bundleId":"com.example.zulu","sku":"ZULU"}},
+					{"type":"apps","id":"a-app","attributes":{"name":"Alpha","bundleId":"com.example.alpha","sku":"ALPHA"}}
+				],"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/apps/") && strings.HasSuffix(req.URL.Path, "/appAvailabilityV2"):
+			appID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/apps/"), "/appAvailabilityV2")
+			return jsonHTTPResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appAvailabilities","id":"availability-%s","attributes":{"availableInNewTerritories":false}}}`, appID)), nil
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v2/appAvailabilities/availability-"):
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true,"contentStatuses":["AVAILABLE"]}}],"links":{"next":""}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- add `asc apps published` as a dedicated account-wide audit instead of overloading `apps list` pagination semantics
- paginate all app records and every territory-availability page internally with bounded read concurrency
- classify publication from the `AVAILABLE` content status and return each published app with its exact published-territory count
- include audited/published totals in JSON, deterministic app ordering, and table/Markdown renderers
- treat missing availability as unpublished while aggregating named API failures instead of silently undercounting

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused apps/cmd tests under `go test -race`
- built-binary help and JSON output checks
- live account audit: 50 records, 5 published apps (Chroma 174, Descent 174, Meshing 175, Presset 175, Zenther 175)

## API behavior

This is read-only and uses the public App Store Connect API. It does not rely on `attributes.available` alone; a territory counts only when `contentStatuses` contains `AVAILABLE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `apps published` command to audit app availability across territories.
  * Reports published apps with territory counts, names, locales, and identifiers.
  * Excludes unpublished apps and supports paginated app and territory data.
  * Supports JSON, table, and Markdown output formats.
  * Sorts results consistently and reports audit errors while continuing processing.
* **Documentation**
  * Added command help and usage details for `apps published`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->