### PR TITLE
feat: add official search optimization plan

### DIFF
--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -27,7 +27,7 @@ var rootUsageGroups = []rootCommandGroup{
 	},
 	{
 		title:    "ANALYTICS & FINANCE COMMANDS",
-		commands: []string{"analytics", "ads", "insights", "finance", "performance"},
+		commands: []string{"analytics", "ads", "optimize", "insights", "finance", "performance"},
 	},
 	{
 		title: "APP MANAGEMENT COMMANDS",

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -50,6 +50,7 @@ asc <subcommand> [flags]
 
 - `analytics` - Request and download analytics and sales reports.
 - `ads` - Manage Apple Ads API resources.
+- `optimize` - Build cross-API optimization plans. [experimental]
 - `insights` - Generate weekly and daily insights from App Store data sources.
 - `finance` - Download payments and financial reports.
 - `performance` - Access performance metrics and diagnostic logs.

--- a/docs/design/official-search-optimization-plan.md
+++ b/docs/design/official-search-optimization-plan.md
@@ -51,6 +51,7 @@ It composes these Platform API v1 operations:
 | Existing exclusions | `POST /v1/negative-keywords/query` |
 | App keyword discovery | `POST /v1/suggestions/keywords/query` |
 | App phrase discovery | `POST /v1/suggestions/phrases/query` |
+| New-campaign target CPA | `POST /v1/suggestions/target-cpas/query` |
 | Country/genre demand | `POST /v1/insights/apps/search-term-popularity/query` |
 | Paid competitive reach | `POST /v1/insights/apps/impression-share/query` |
 | Actual matched queries | `POST /v1/reports/apps/searchterms/query` |
@@ -60,18 +61,22 @@ It composes these Platform API v1 operations:
 
 List and report bodies use body pagination and fetch every page. The selected
 performance window ends yesterday. Search-term popularity uses the most recent
-complete Sunday-through-Saturday week because its time-range contract differs
-from Ads performance reports.
+published Sunday-through-Saturday week because its time-range contract differs
+from Ads performance reports. The workflow waits for Apple's Monday 07:00 UTC
+publication time before requesting the immediately preceding week.
 
 ## Report semantics
 
 The report contains one normalized row per search term. A row records source
 provenance instead of presenting unavailable fields as zero:
 
-- market popularity and genre rank come only from Search Term Popularity;
+- market popularity on Apple's 1–5 Campaign Management scale, its 1–100 scale,
+  and genre rank come from Search Term Popularity;
 - suggestion popularity is preserved separately because the suggestion
   response does not identify a source storefront;
 - impression share and share rank are paid, app-specific metrics;
+- the 1–5 popularity value carried by an Impression Share row is preserved
+  separately so overlapping official snapshots can be compared;
 - when Apple returns daily impression-share rows, the report selects the latest
   dated bucket deterministically and records that period;
 - impressions, taps, installs, and spend come from actual Search Terms reports;
@@ -98,12 +103,23 @@ Multiple actions can apply. Confidence is `proven` when installs exist,
 No proprietary difficulty, organic attribution, or app-specific popularity is
 invented.
 
+Actions that depend on proving absence are source-aware. `promote_exact` is
+suppressed when current targeting keywords are unavailable,
+`negative_candidate` is suppressed when existing negatives are unavailable,
+and `untested_candidate` is suppressed when search-term performance is
+unavailable. Partial rows remain usable, but missing evidence is never treated
+as an empty result.
+
 Apple's complete daily-budget and target-CPA recommendation objects are
-preserved in the report alongside their summary counts. The workflow does not
-reinterpret or apply them.
+preserved in the report alongside their summary counts. The app-and-country
+target-CPA suggestion for a new Maximize Conversions campaign is preserved as
+a separate raw official signal. The workflow does not reinterpret or apply any
+of them.
 
 Every Apple Ads source records `available`, `empty`, or `unavailable`. A source
 error produces a report notice and does not erase data from successful sources.
+Table and Markdown output render the source matrix and notices before the term
+plan; JSON retains the complete structured objects.
 The command fails if App Store Connect metadata cannot be resolved or if every
 Apple Ads intelligence source is unavailable. Privacy-suppressed and genuinely
 empty official responses remain successful empty sources.
@@ -144,9 +160,12 @@ RED-GREEN coverage includes:
 - one realistic joined result across suggestions, popularity, impression
   share, search-term performance, existing targeting, and metadata;
 - deterministic action precedence, provenance, missing data, zero installs,
-  saturated share, and existing keyword/negative suppression;
+  saturated share, existing keyword/negative suppression, and dependency-aware
+  suppression when absence cannot be proven;
 - Apple Ads method, path, context header, body filters, body pagination, and
-  API-error partial-result behavior;
+  API-error partial-result behavior, including schema-specific pagination;
+- Apple's Campaign Management-style 1–5 popularity, 1–100 popularity, genre
+  rank, and the app/country target-CPA suggestion;
 - JSON, table, and Markdown output;
 - artifact content, import compatibility, 100-character budgeting, and rooted
   write failures;

--- a/docs/design/official-search-optimization-plan.md
+++ b/docs/design/official-search-optimization-plan.md
@@ -16,13 +16,13 @@ under either `ads` or `metadata`:
 ```bash
 asc optimize search plan \
   --app "123456789" \
-  --version "4.4.4" \
+  --version "APP_VERSION" \
   --ad-account "987654321" \
   --country "US" \
   --genre "PRODUCTIVITY_UTILITIES" \
   --locale "en-US" \
   --window "30d" \
-  --out-dir ".asc/optimization/4.4.4" \
+  --out-dir ".asc/optimization/APP_VERSION" \
   --output markdown
 ```
 
@@ -31,6 +31,9 @@ Required inputs are `--app`, `--version`, `--ad-account`, `--country`,
 Ads profiles remain valid resolution sources. `--platform` defaults to `IOS`,
 and `--window` defaults to `30d` with an accepted range of 2 through 30 whole
 days. `--out-dir` is optional; omitting it keeps the command stdout-only.
+When an app has multiple App Info records, the command matches App Info to the
+selected version state; `--app-info` provides an explicit override when that
+match is ambiguous.
 
 The command supports JSON, table, and Markdown. Data is written only to stdout,
 diagnostics are written to stderr, and usage errors exit with code 2. The
@@ -41,6 +44,7 @@ command accepts no positional arguments.
 The workflow uses the existing typed App Store Connect client to resolve the
 selected version and read its version and app-info localizations. Apple Ads
 credentials remain independent from App Store Connect credentials.
+The report records the exact resolved version and App Info resource IDs.
 
 It composes these Platform API v1 operations:
 

--- a/docs/design/official-search-optimization-plan.md
+++ b/docs/design/official-search-optimization-plan.md
@@ -175,9 +175,12 @@ RED-GREEN coverage includes:
   write failures;
 - built-binary stdout, stderr, and exit-code checks.
 
-Credentialed verification is intentionally deferred. On a machine with both
-credential sets, run the command read-only first and verify source fill rates,
-country scoping, report latency, and score agreement for overlapping sources.
+Credentialed verification must remain read-only and cover at least two apps,
+including an app with multiple App Info records and an app with campaign data.
+Verify source fill rates, country scoping, report latency, artifact parsing,
+pagination, and score agreement for overlapping sources. Treat provider errors
+as explicit unavailable-source risk; do not infer successful coverage from a
+partial report or apply generated artifacts during verification.
 
 ## Alternatives
 

--- a/docs/design/official-search-optimization-plan.md
+++ b/docs/design/official-search-optimization-plan.md
@@ -1,0 +1,165 @@
+# Official search optimization plan
+
+## Goal
+
+Add an experimental, read-only workflow that turns the official Apple Ads
+Platform API v1 optimization surface into one evidence-based App Store search
+plan. The workflow joins Apple Ads demand and paid-performance data with the
+selected App Store Connect localization. It never calls Apple web-session or
+private endpoints and never mutates campaigns or App Store metadata.
+
+## Command placement and invocation
+
+The cross-API workflow lives under a new top-level `optimize` group rather than
+under either `ads` or `metadata`:
+
+```bash
+asc optimize search plan \
+  --app "123456789" \
+  --version "4.4.4" \
+  --ad-account "987654321" \
+  --country "US" \
+  --genre "PRODUCTIVITY_UTILITIES" \
+  --locale "en-US" \
+  --window "30d" \
+  --out-dir ".asc/optimization/4.4.4" \
+  --output markdown
+```
+
+Required inputs are `--app`, `--version`, `--ad-account`, `--country`,
+`--genre`, and `--locale`. `ASC_APP_ID`, `ASC_ADS_AD_ACCOUNT_ID`, and stored
+Ads profiles remain valid resolution sources. `--platform` defaults to `IOS`,
+and `--window` defaults to `30d` with an accepted range of 2 through 30 whole
+days. `--out-dir` is optional; omitting it keeps the command stdout-only.
+
+The command supports JSON, table, and Markdown. Data is written only to stdout,
+diagnostics are written to stderr, and usage errors exit with code 2. The
+command accepts no positional arguments.
+
+## Official API contract
+
+The workflow uses the existing typed App Store Connect client to resolve the
+selected version and read its version and app-info localizations. Apple Ads
+credentials remain independent from App Store Connect credentials.
+
+It composes these Platform API v1 operations:
+
+| Purpose | Method and endpoint |
+| --- | --- |
+| App campaign scope | `POST /v1/campaigns/query` |
+| Current targeting | `POST /v1/keywords/query` |
+| Existing exclusions | `POST /v1/negative-keywords/query` |
+| App keyword discovery | `POST /v1/suggestions/keywords/query` |
+| App phrase discovery | `POST /v1/suggestions/phrases/query` |
+| Country/genre demand | `POST /v1/insights/apps/search-term-popularity/query` |
+| Paid competitive reach | `POST /v1/insights/apps/impression-share/query` |
+| Actual matched queries | `POST /v1/reports/apps/searchterms/query` |
+| Placement eligibility | `POST /v1/eligibilities/apps/query` |
+| Budget signals | `POST /v1/recommendations/daily-budgets/query` |
+| Target-CPA signals | `POST /v1/recommendations/target-cpas/query` |
+
+List and report bodies use body pagination and fetch every page. The selected
+performance window ends yesterday. Search-term popularity uses the most recent
+complete Sunday-through-Saturday week because its time-range contract differs
+from Ads performance reports.
+
+## Report semantics
+
+The report contains one normalized row per search term. A row records source
+provenance instead of presenting unavailable fields as zero:
+
+- market popularity and genre rank come only from Search Term Popularity;
+- suggestion popularity is preserved separately because the suggestion
+  response does not identify a source storefront;
+- impression share and share rank are paid, app-specific metrics;
+- when Apple returns daily impression-share rows, the report selects the latest
+  dated bucket deterministically and records that period;
+- impressions, taps, installs, and spend come from actual Search Terms reports;
+- CPA is computed as local spend divided by total installs;
+- metadata coverage is an exact normalized phrase check across name, subtitle,
+  and comma-separated keyword values in the requested locale;
+- actions and confidence are deterministic client-side classifications.
+
+The initial action vocabulary is:
+
+- `promote_exact`: a broad-matched query has produced installs and is not an
+  existing exact keyword;
+- `negative_candidate`: at least 10 taps and no installs, excluding existing
+  negative keywords;
+- `metadata_candidate`: a converting term or app suggestion is absent from the
+  requested metadata locale;
+- `defend`: a converting term has paid impression share below 50 percent;
+- `saturated`: Apple reports the greater-than-90-percent share bucket;
+- `untested_candidate`: Apple suggests the term but the account has no
+  performance row for it.
+
+Multiple actions can apply. Confidence is `proven` when installs exist,
+`observed` when paid traffic exists, and `suggested` for discovery-only rows.
+No proprietary difficulty, organic attribution, or app-specific popularity is
+invented.
+
+Apple's complete daily-budget and target-CPA recommendation objects are
+preserved in the report alongside their summary counts. The workflow does not
+reinterpret or apply them.
+
+Every Apple Ads source records `available`, `empty`, or `unavailable`. A source
+error produces a report notice and does not erase data from successful sources.
+The command fails if App Store Connect metadata cannot be resolved or if every
+Apple Ads intelligence source is unavailable. Privacy-suppressed and genuinely
+empty official responses remain successful empty sources.
+
+## Artifacts
+
+When `--out-dir` is present, the operator-selected directory is the trusted
+`internal/rootfs` anchor. The command writes:
+
+- `report.json`: the complete canonical report;
+- `metadata-candidates.csv`: an import-compatible `locale,keywords` proposal
+  that preserves existing keywords and adds fitting candidates without
+  exceeding the 100-character field limit;
+- `exact-keywords.json`: a `KeywordCreateBulkRequest` for `promote_exact`
+  actions with known ad-group context;
+- `negative-keywords.json`: a `NegativeKeywordCreateBulkRequest` for
+  `negative_candidate` actions with known campaign/ad-group context.
+
+Artifacts are plans only. Operators apply them through the existing confirmed
+commands (`asc metadata keywords import/plan/apply`, `asc ads
+targeting-keywords create-bulk`, and `asc ads negative-keywords create-bulk`).
+`asc release stage` and `asc publish appstore --metadata-dir` remain the only
+release integration; this change does not add an implicit publish mutation.
+
+## Compatibility and lifecycle
+
+`optimize` is a new experimental root group, so there is no compatibility or
+deprecation impact. Existing raw Apple Ads and metadata commands do not change.
+The JSON report and artifacts include a schema version so future additions can
+remain explicit.
+
+## Tests and verification
+
+RED-GREEN coverage includes:
+
+- root registration, help, required flags, invalid country/locale/window, and
+  positional-argument rejection;
+- one realistic joined result across suggestions, popularity, impression
+  share, search-term performance, existing targeting, and metadata;
+- deterministic action precedence, provenance, missing data, zero installs,
+  saturated share, and existing keyword/negative suppression;
+- Apple Ads method, path, context header, body filters, body pagination, and
+  API-error partial-result behavior;
+- JSON, table, and Markdown output;
+- artifact content, import compatibility, 100-character budgeting, and rooted
+  write failures;
+- built-binary stdout, stderr, and exit-code checks.
+
+Credentialed verification is intentionally deferred. On a machine with both
+credential sets, run the command read-only first and verify source fill rates,
+country scoping, report latency, and score agreement for overlapping sources.
+
+## Alternatives
+
+Adding convenience flags to each raw endpoint would reduce JSON boilerplate
+but would still leave users to join incompatible response shapes themselves.
+Putting the workflow under `ads` would hide that App Store Connect metadata is
+an equal input. A cross-API `optimize` group makes the orchestration explicit
+without presenting the result as an Apple-provided recommendation.

--- a/docs/design/official-search-optimization-plan.md
+++ b/docs/design/official-search-optimization-plan.md
@@ -122,8 +122,23 @@ of them.
 
 Every Apple Ads source records `available`, `empty`, or `unavailable`. A source
 error produces a report notice and does not erase data from successful sources.
-Table and Markdown output render the source matrix and notices before the term
-plan; JSON retains the complete structured objects.
+Table and Markdown output render the source matrix, notices, and term plan; JSON
+retains the complete structured objects.
+
+The default TTY table is the compact human view. Its summary names the app and
+groups the version, platform, and market context; the term plan follows it so
+the primary result fits in one terminal capture. Source status and shortened
+one-line notices follow the plan, and the term table combines the two popularity
+scales in one `Popularity` column. Row-level source arrays and complete provider
+errors remain available in Markdown and JSON. This keeps the default output
+readable in a normal terminal without weakening the report used by scripts or
+audits.
+
+Compatibility is limited to presentation: no flag, exit code, report schema, or
+artifact changes. Keeping the original ten-column table was rejected because
+ordinary terms, actions, and source names push it well beyond a screenshot-sized
+terminal. Truncating report data was also rejected; only the TTY rendering is
+condensed.
 The command fails if App Store Connect metadata cannot be resolved or if every
 Apple Ads intelligence source is unavailable. Privacy-suppressed and genuinely
 empty official responses remain successful empty sources.

--- a/docs/release-notes-official-search-optimization.md
+++ b/docs/release-notes-official-search-optimization.md
@@ -1,0 +1,36 @@
+# Official search optimization plan
+
+Release 4.4.4 adds an experimental, read-only workflow that turns official
+Apple Ads Platform API v1 evidence and App Store Connect metadata into one
+reviewable search plan:
+
+```bash
+asc optimize search plan \
+  --app "APP_ID" \
+  --version "4.4.4" \
+  --ad-account "AD_ACCOUNT_ID" \
+  --country "US" \
+  --genre "PRODUCTIVITY_UTILITIES" \
+  --locale "en-US" \
+  --out-dir ".asc/optimization/4.4.4" \
+  --output markdown
+```
+
+The command keeps Apple's metrics semantically separate: popularity is market
+search demand, impression share is app-specific paid reach, search-term report
+rows are actual paid outcomes, and metadata coverage comes from the selected
+App Store localization. Deterministic actions identify converting broad terms,
+costly zero-install terms, metadata candidates, low-share opportunities, and
+already-saturated terms without inventing organic rank or proprietary
+difficulty scores.
+
+When `--out-dir` is set, the command writes a canonical report plus review-only
+metadata, exact-keyword, and negative-keyword import files. It never applies
+those files or mutates campaigns or App Store metadata. Partial Apple Ads
+source failures remain visible in the report, while successful official data
+is preserved.
+
+App Store Connect and Apple Ads credentials are independent. Run `asc auth`
+for App Store Connect and `asc ads auth login` for Apple Ads before using the
+workflow. Credentialed live verification is still recommended before relying
+on generated candidates in production.

--- a/docs/release-notes-official-search-optimization.md
+++ b/docs/release-notes-official-search-optimization.md
@@ -7,12 +7,12 @@ reviewable search plan:
 ```bash
 asc optimize search plan \
   --app "APP_ID" \
-  --version "4.4.4" \
+  --version "APP_VERSION" \
   --ad-account "AD_ACCOUNT_ID" \
   --country "US" \
   --genre "PRODUCTIVITY_UTILITIES" \
   --locale "en-US" \
-  --out-dir ".asc/optimization/4.4.4" \
+  --out-dir ".asc/optimization/APP_VERSION" \
   --output markdown
 ```
 
@@ -32,6 +32,11 @@ source failures remain visible in the report, while successful official data
 is preserved. Actions that require proving a keyword is absent are suppressed
 when their dependency is unavailable, and table or Markdown output shows the
 source matrix and notices directly.
+
+For apps with multiple App Info records, the command matches App Info to the
+selected version state. If that match is ambiguous, pass the explicit record
+with `--app-info`. The JSON report records both the resolved version ID and App
+Info ID so the evidence can be reproduced.
 
 The report also preserves Apple's app-and-country target-CPA suggestion for a
 new Maximize Conversions campaign separately from recommendations for existing

--- a/docs/release-notes-official-search-optimization.md
+++ b/docs/release-notes-official-search-optimization.md
@@ -16,10 +16,11 @@ asc optimize search plan \
   --output markdown
 ```
 
-The command keeps Apple's metrics semantically separate: popularity is market
-search demand, impression share is app-specific paid reach, search-term report
-rows are actual paid outcomes, and metadata coverage comes from the selected
-App Store localization. Deterministic actions identify converting broad terms,
+The command keeps Apple's metrics semantically separate: Apple's 1–5 and
+1–100 popularity scores are market search demand, impression share is
+app-specific paid reach, search-term report rows are actual paid outcomes, and
+metadata coverage comes from the selected App Store localization. Deterministic
+actions identify converting broad terms,
 costly zero-install terms, metadata candidates, low-share opportunities, and
 already-saturated terms without inventing organic rank or proprietary
 difficulty scores.
@@ -28,7 +29,13 @@ When `--out-dir` is set, the command writes a canonical report plus review-only
 metadata, exact-keyword, and negative-keyword import files. It never applies
 those files or mutates campaigns or App Store metadata. Partial Apple Ads
 source failures remain visible in the report, while successful official data
-is preserved.
+is preserved. Actions that require proving a keyword is absent are suppressed
+when their dependency is unavailable, and table or Markdown output shows the
+source matrix and notices directly.
+
+The report also preserves Apple's app-and-country target-CPA suggestion for a
+new Maximize Conversions campaign separately from recommendations for existing
+campaigns.
 
 App Store Connect and Apple Ads credentials are independent. Run `asc auth`
 for App Store Connect and `asc ads auth login` for Apple Ads before using the

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -559,6 +559,9 @@ func TestParsePlatformErrorAcceptsDirectEnvelopeAndStructuredInfo(t *testing.T) 
 	if apiErr.RateLimit.Limit != "50" {
 		t.Fatalf("rate limit = %+v", apiErr.RateLimit)
 	}
+	if got := apiErr.Error(); !strings.Contains(got, "BAD_FILTER") || !strings.Contains(got, "Invalid filter") || !strings.Contains(got, `"index":2`) {
+		t.Fatalf("APIError.Error() = %q, want structured validation details", got)
+	}
 }
 
 func TestParsePlatformErrorSurfacesDetailsOnlyEnvelope(t *testing.T) {
@@ -577,6 +580,8 @@ func TestParsePlatformErrorSurfacesDetailsOnlyEnvelope(t *testing.T) {
 	}
 	if got := apiErr.Error(); !strings.Contains(got, "BAD_FILTER") || !strings.Contains(got, "Invalid filter") {
 		t.Fatalf("APIError.Error() = %q, want structured detail", got)
+	} else if strings.Count(got, "BAD_FILTER") != 1 || strings.Count(got, "Invalid filter") != 1 {
+		t.Fatalf("APIError.Error() = %q, want detail surfaced once", got)
 	}
 }
 

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -585,6 +585,19 @@ func TestParsePlatformErrorSurfacesDetailsOnlyEnvelope(t *testing.T) {
 	}
 }
 
+func TestParsePlatformErrorDoesNotRepeatTopLevelDetail(t *testing.T) {
+	err := parseErrorForVersion(
+		[]byte(`{"code":"INVALID_VALUE","message":"One or more validation errors occurred.","details":[{"code":"INVALID_VALUE","message":"One or more validation errors occurred."}]}`),
+		400,
+		nil,
+		APIVersionPlatformV1,
+	)
+	got := err.Error()
+	if strings.Count(got, "INVALID_VALUE") != 1 || strings.Count(got, "One or more validation errors occurred.") != 1 {
+		t.Fatalf("APIError.Error() = %q, want repeated top-level detail surfaced once", got)
+	}
+}
+
 func TestEmptySuccessBodyIsVersionSpecific(t *testing.T) {
 	client, err := NewClient(Credentials{AccessToken: "ACCESS"}, WithHTTPClient(&http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/appleads/errors.go
+++ b/internal/appleads/errors.go
@@ -66,10 +66,40 @@ func (e *APIError) Error() string {
 	if message != "" {
 		parts = append(parts, message)
 	}
+	if details := formatAPIErrorDetails(e.Details, e.Field, e.Detail); details != "" {
+		parts = append(parts, details)
+	}
 	if len(parts) == 0 {
 		return "Apple Ads API request failed"
 	}
 	return strings.Join(parts, ": ")
+}
+
+func formatAPIErrorDetails(details []APIErrorDetail, surfacedCode, surfacedMessage string) string {
+	formatted := make([]string, 0, len(details))
+	for _, detail := range details {
+		parts := make([]string, 0, 3)
+		code := strings.TrimSpace(detail.Code)
+		message := strings.TrimSpace(detail.Message)
+		alreadySurfaced := code == strings.TrimSpace(surfacedCode) && message == strings.TrimSpace(surfacedMessage)
+		if !alreadySurfaced {
+			if code != "" {
+				parts = append(parts, code)
+			}
+			if message != "" {
+				parts = append(parts, message)
+			}
+		}
+		if len(detail.Info) > 0 {
+			if info, err := json.Marshal(detail.Info); err == nil {
+				parts = append(parts, string(info))
+			}
+		}
+		if len(parts) > 0 {
+			formatted = append(formatted, strings.Join(parts, ": "))
+		}
+	}
+	return strings.Join(formatted, "; ")
 }
 
 func (e *APIError) HTTPStatusCode() int {

--- a/internal/appleads/errors.go
+++ b/internal/appleads/errors.go
@@ -66,7 +66,14 @@ func (e *APIError) Error() string {
 	if message != "" {
 		parts = append(parts, message)
 	}
-	if details := formatAPIErrorDetails(e.Details, e.Field, e.Detail); details != "" {
+	surfacedCode := strings.TrimSpace(e.MessageCode)
+	if surfacedCode == "" {
+		surfacedCode = strings.TrimSpace(e.Code)
+	}
+	if surfacedCode == "" {
+		surfacedCode = strings.TrimSpace(e.Field)
+	}
+	if details := formatAPIErrorDetails(e.Details, surfacedCode, message); details != "" {
 		parts = append(parts, details)
 	}
 	if len(parts) == 0 {

--- a/internal/cli/ads/search_optimization.go
+++ b/internal/cli/ads/search_optimization.go
@@ -1,6 +1,7 @@
 package ads
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 // SearchOptimizationRequest identifies the official Apple Ads data window and
@@ -131,6 +133,7 @@ type SearchOptimizationData struct {
 	Eligibilities                  []SearchEligibility              `json:"eligibilities,omitempty"`
 	DailyBudgetRecommendationItems []json.RawMessage                `json:"dailyBudgetRecommendationItems,omitempty"`
 	TargetCPARecommendationItems   []json.RawMessage                `json:"targetCpaRecommendationItems,omitempty"`
+	TargetCPASuggestion            json.RawMessage                  `json:"targetCpaSuggestion,omitempty"`
 	DailyBudgetRecommendations     int                              `json:"dailyBudgetRecommendations"`
 	TargetCPARecommendations       int                              `json:"targetCpaRecommendations"`
 }
@@ -189,6 +192,10 @@ func fetchSearchOptimizationData(ctx context.Context, client *appleads.Client, r
 	phraseSuggestions, phraseErr := fetchOptimizationSuggestions(ctx, client, request, true)
 	data.Suggestions = append(data.Suggestions, phraseSuggestions...)
 	record("phrase_suggestions", len(phraseSuggestions), phraseErr, true)
+
+	var targetCPASuggestionErr error
+	data.TargetCPASuggestion, targetCPASuggestionErr = fetchOptimizationTargetCPASuggestion(ctx, client, request)
+	record("target_cpa_suggestion", optimizationRawObjectCount(data.TargetCPASuggestion), targetCPASuggestionErr, true)
 
 	data.Popularities, err = fetchOptimizationPopularity(ctx, client, request)
 	record("search_term_popularity", len(data.Popularities), err, true)
@@ -385,6 +392,29 @@ func fetchOptimizationRecommendations(ctx context.Context, client *appleads.Clie
 	return items, err
 }
 
+func fetchOptimizationTargetCPASuggestion(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest) (json.RawMessage, error) {
+	spec := mustOptimizationEndpoint("suggestions", "target-cpas", "find")
+	body := map[string]any{"filters": []any{
+		optimizationFilter("promotedObjectId", "EQUALS", []string{strings.TrimSpace(request.AppID)}),
+		optimizationFilter("promotedObjectType", "EQUALS", []string{"APPSTORE_APP"}),
+		optimizationFilter("countryOrRegion", "IN", []string{strings.ToUpper(strings.TrimSpace(request.Country))}),
+	}}
+	raw, err := executeOptimizationQuery(ctx, client, spec, body)
+	if err != nil {
+		return nil, err
+	}
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode %s response: %w", strings.Join(spec.CommandPath, " "), err)
+	}
+	if optimizationRawObjectCount(envelope.Result) == 0 {
+		return nil, nil
+	}
+	return envelope.Result, nil
+}
+
 func fetchOptimizationKeywords(ctx context.Context, client *appleads.Client, campaignID int64) ([]SearchTargetingKeyword, error) {
 	spec := mustOptimizationEndpoint("targeting-keywords", "find")
 	body := map[string]any{"filters": []any{optimizationFilter("campaignId", "EQUALS", campaignID)}}
@@ -454,7 +484,7 @@ func queryOptimizationList[T any](ctx context.Context, client *appleads.Client, 
 	offset := 0
 	for {
 		pageBody := cloneOptimizationBody(body)
-		pageBody["pagination"] = map[string]any{"offset": offset, "pageSize": pageSize, "fetchTotalCount": true}
+		pageBody["pagination"] = optimizationRequestPagination(spec, offset, pageSize)
 		raw, err := executeOptimizationQuery(ctx, client, spec, pageBody)
 		if err != nil {
 			return items, err
@@ -479,7 +509,7 @@ func queryOptimizationRows[T any](ctx context.Context, client *appleads.Client, 
 	offset := 0
 	for {
 		pageBody := cloneOptimizationBody(body)
-		pageBody["pagination"] = map[string]any{"offset": offset, "pageSize": pageSize, "fetchTotalCount": true}
+		pageBody["pagination"] = optimizationRequestPagination(spec, offset, pageSize)
 		raw, err := executeOptimizationQuery(ctx, client, spec, pageBody)
 		if err != nil {
 			return items, err
@@ -506,7 +536,9 @@ func executeOptimizationQuery(ctx context.Context, client *appleads.Client, spec
 	if err != nil {
 		return nil, err
 	}
-	return client.Do(ctx, spec, nil, nil, payload)
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+	return client.Do(requestCtx, spec, nil, nil, payload)
 }
 
 func optimizationPageComplete(offset, pageSize, count, total int) bool {
@@ -517,6 +549,22 @@ func optimizationPageComplete(offset, pageSize, count, total int) bool {
 		return offset+count >= total
 	}
 	return count < pageSize
+}
+
+func optimizationRequestPagination(spec appleads.EndpointSpec, offset, pageSize int) map[string]any {
+	pagination := map[string]any{"offset": offset, "pageSize": pageSize}
+	if spec.BodyType == "QueryRequest" {
+		pagination["fetchTotalCount"] = true
+	}
+	return pagination
+}
+
+func optimizationRawObjectCount(raw json.RawMessage) int {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) || bytes.Equal(trimmed, []byte("{}")) {
+		return 0
+	}
+	return 1
 }
 
 func cloneOptimizationBody(body map[string]any) map[string]any {

--- a/internal/cli/ads/search_optimization.go
+++ b/internal/cli/ads/search_optimization.go
@@ -1,0 +1,666 @@
+package ads
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+)
+
+// SearchOptimizationRequest identifies the official Apple Ads data window and
+// market used by the cross-API search optimization workflow.
+type SearchOptimizationRequest struct {
+	AppID           string
+	Country         string
+	Genre           string
+	Start           string
+	End             string
+	PopularityStart string
+	PopularityEnd   string
+}
+
+// SearchOptimizationSourceStatus describes the availability of one official
+// Apple Ads source. Empty responses are distinct from unavailable sources.
+type SearchOptimizationSourceStatus struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+	Error  string `json:"error,omitempty"`
+}
+
+// SearchSuggestion is one keyword or phrase returned by Apple's suggestion
+// endpoints. Popularity is kept separate from market-scoped popularity.
+type SearchSuggestion struct {
+	Text       string `json:"text"`
+	Popularity *int   `json:"popularity,omitempty"`
+	Kind       string `json:"kind"`
+}
+
+// SearchPopularity is one country-and-genre search demand snapshot.
+type SearchPopularity struct {
+	Term              string `json:"term"`
+	Country           string `json:"country,omitempty"`
+	Genre             string `json:"genre,omitempty"`
+	Week              string `json:"week,omitempty"`
+	Month             string `json:"month,omitempty"`
+	RankInGenre       *int   `json:"rankInGenre,omitempty"`
+	PopularityInGenre *int   `json:"popularityInGenre,omitempty"`
+	Popularity100     *int   `json:"popularity100,omitempty"`
+	Popularity5       *int   `json:"popularity5,omitempty"`
+}
+
+// SearchImpressionShare is one app-specific paid reach row.
+type SearchImpressionShare struct {
+	Term        string   `json:"term"`
+	Country     string   `json:"country,omitempty"`
+	Day         string   `json:"day,omitempty"`
+	Week        string   `json:"week,omitempty"`
+	Low         *float64 `json:"low,omitempty"`
+	High        *float64 `json:"high,omitempty"`
+	Rank        *int     `json:"rank,omitempty"`
+	Popularity5 *int     `json:"popularity5,omitempty"`
+}
+
+// SearchTermPerformance captures the actual user query and paid outcome from
+// Apple's app Search Terms report.
+type SearchTermPerformance struct {
+	Term          string `json:"term"`
+	KeywordText   string `json:"keywordText,omitempty"`
+	MatchType     string `json:"matchType,omitempty"`
+	Country       string `json:"country,omitempty"`
+	CampaignID    int64  `json:"campaignId,omitempty"`
+	AdGroupID     int64  `json:"adGroupId,omitempty"`
+	Impressions   int64  `json:"impressions"`
+	Taps          int64  `json:"taps"`
+	TapInstalls   int64  `json:"tapInstalls"`
+	TotalInstalls int64  `json:"totalInstalls"`
+	SpendAmount   string `json:"spendAmount,omitempty"`
+	SpendCurrency string `json:"spendCurrency,omitempty"`
+}
+
+// SearchCampaign is the app campaign context used to scope dependent queries.
+type SearchCampaign struct {
+	ID            int64    `json:"id"`
+	Name          string   `json:"name,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	DisplayStatus string   `json:"displayStatus,omitempty"`
+	Countries     []string `json:"countries,omitempty"`
+}
+
+// SearchTargetingKeyword is an existing paid targeting keyword.
+type SearchTargetingKeyword struct {
+	Text       string `json:"text"`
+	MatchType  string `json:"matchType"`
+	Status     string `json:"status,omitempty"`
+	CampaignID int64  `json:"campaignId"`
+	AdGroupID  int64  `json:"adGroupId"`
+}
+
+// SearchNegativeKeyword is an existing paid exclusion.
+type SearchNegativeKeyword struct {
+	Text       string `json:"text"`
+	MatchType  string `json:"matchType"`
+	Status     string `json:"status,omitempty"`
+	CampaignID int64  `json:"campaignId"`
+	AdGroupID  int64  `json:"adGroupId,omitempty"`
+}
+
+// SearchEligibility describes one placement/storefront eligibility row.
+type SearchEligibility struct {
+	Country         string   `json:"country,omitempty"`
+	SupplyPlacement string   `json:"supplyPlacement,omitempty"`
+	DeviceClass     string   `json:"deviceClass,omitempty"`
+	State           string   `json:"state"`
+	Reasons         []string `json:"reasons,omitempty"`
+}
+
+// SearchOptimizationData is the normalized official Apple Ads evidence used
+// by the top-level optimizer.
+type SearchOptimizationData struct {
+	Sources                        []SearchOptimizationSourceStatus `json:"sources"`
+	Suggestions                    []SearchSuggestion               `json:"suggestions,omitempty"`
+	Popularities                   []SearchPopularity               `json:"popularities,omitempty"`
+	ImpressionShares               []SearchImpressionShare          `json:"impressionShares,omitempty"`
+	SearchTerms                    []SearchTermPerformance          `json:"searchTerms,omitempty"`
+	Campaigns                      []SearchCampaign                 `json:"campaigns,omitempty"`
+	Keywords                       []SearchTargetingKeyword         `json:"keywords,omitempty"`
+	NegativeKeywords               []SearchNegativeKeyword          `json:"negativeKeywords,omitempty"`
+	Eligibilities                  []SearchEligibility              `json:"eligibilities,omitempty"`
+	DailyBudgetRecommendationItems []json.RawMessage                `json:"dailyBudgetRecommendationItems,omitempty"`
+	TargetCPARecommendationItems   []json.RawMessage                `json:"targetCpaRecommendationItems,omitempty"`
+	DailyBudgetRecommendations     int                              `json:"dailyBudgetRecommendations"`
+	TargetCPARecommendations       int                              `json:"targetCpaRecommendations"`
+}
+
+// CollectSearchOptimizationData resolves official Apple Ads authentication and
+// gathers the read-only evidence needed by `asc optimize search plan`.
+func CollectSearchOptimizationData(ctx context.Context, adsProfile, adAccount string, request SearchOptimizationRequest) (SearchOptimizationData, error) {
+	profile := strings.TrimSpace(adsProfile)
+	account := strings.TrimSpace(adAccount)
+	client, _, err := resolvePlatformClientAndAdAccountID(ctx, commonFlags{
+		AdsProfile: &profile,
+		AdAccount:  &account,
+	}, appleads.ContextAdAccount)
+	if err != nil {
+		return SearchOptimizationData{}, err
+	}
+	return fetchSearchOptimizationData(ctx, client, request)
+}
+
+func fetchSearchOptimizationData(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest) (SearchOptimizationData, error) {
+	data := SearchOptimizationData{}
+	successfulIntelligenceSources := 0
+	record := func(name string, count int, err error, intelligence bool) {
+		status := SearchOptimizationSourceStatus{Name: name, Count: count}
+		switch {
+		case err != nil:
+			status.Status = "unavailable"
+			status.Error = err.Error()
+		case count == 0:
+			status.Status = "empty"
+			if intelligence {
+				successfulIntelligenceSources++
+			}
+		default:
+			status.Status = "available"
+			if intelligence {
+				successfulIntelligenceSources++
+			}
+		}
+		data.Sources = append(data.Sources, status)
+	}
+
+	appID := strings.TrimSpace(request.AppID)
+	appIDNumber, err := strconv.ParseInt(appID, 10, 64)
+	if err != nil || appIDNumber <= 0 {
+		return data, fmt.Errorf("app ID must be a positive integer Adam ID")
+	}
+
+	data.Campaigns, err = fetchOptimizationCampaigns(ctx, client, request)
+	campaignErr := err
+	record("campaigns", len(data.Campaigns), campaignErr, false)
+
+	keywordSuggestions, keywordErr := fetchOptimizationSuggestions(ctx, client, request, false)
+	data.Suggestions = append(data.Suggestions, keywordSuggestions...)
+	record("keyword_suggestions", len(keywordSuggestions), keywordErr, true)
+	phraseSuggestions, phraseErr := fetchOptimizationSuggestions(ctx, client, request, true)
+	data.Suggestions = append(data.Suggestions, phraseSuggestions...)
+	record("phrase_suggestions", len(phraseSuggestions), phraseErr, true)
+
+	data.Popularities, err = fetchOptimizationPopularity(ctx, client, request)
+	record("search_term_popularity", len(data.Popularities), err, true)
+	data.ImpressionShares, err = fetchOptimizationImpressionShare(ctx, client, request)
+	record("impression_share", len(data.ImpressionShares), err, true)
+	data.Eligibilities, err = fetchOptimizationEligibility(ctx, client, request, appIDNumber)
+	record("eligibility", len(data.Eligibilities), err, true)
+
+	var dailyErr error
+	data.DailyBudgetRecommendationItems, dailyErr = fetchOptimizationRecommendations(ctx, client, request, "daily-budgets")
+	data.DailyBudgetRecommendations = len(data.DailyBudgetRecommendationItems)
+	record("daily_budget_recommendations", data.DailyBudgetRecommendations, dailyErr, true)
+	var targetErr error
+	data.TargetCPARecommendationItems, targetErr = fetchOptimizationRecommendations(ctx, client, request, "target-cpas")
+	data.TargetCPARecommendations = len(data.TargetCPARecommendationItems)
+	record("target_cpa_recommendations", data.TargetCPARecommendations, targetErr, true)
+
+	var keywordErrors, negativeErrors, searchTermErrors []string
+	if campaignErr != nil {
+		dependencyError := "campaign scope unavailable: " + campaignErr.Error()
+		keywordErrors = append(keywordErrors, dependencyError)
+		negativeErrors = append(negativeErrors, dependencyError)
+		searchTermErrors = append(searchTermErrors, dependencyError)
+	}
+	for _, campaign := range data.Campaigns {
+		keywords, keywordErr := fetchOptimizationKeywords(ctx, client, campaign.ID)
+		data.Keywords = append(data.Keywords, keywords...)
+		if keywordErr != nil {
+			keywordErrors = append(keywordErrors, fmt.Sprintf("campaign %d: %v", campaign.ID, keywordErr))
+		}
+
+		negatives, negativeErr := fetchOptimizationNegatives(ctx, client, campaign.ID)
+		data.NegativeKeywords = append(data.NegativeKeywords, negatives...)
+		if negativeErr != nil {
+			negativeErrors = append(negativeErrors, fmt.Sprintf("campaign %d: %v", campaign.ID, negativeErr))
+		}
+
+		terms, searchTermErr := fetchOptimizationSearchTerms(ctx, client, request, campaign.ID)
+		data.SearchTerms = append(data.SearchTerms, terms...)
+		if searchTermErr != nil {
+			searchTermErrors = append(searchTermErrors, fmt.Sprintf("campaign %d: %v", campaign.ID, searchTermErr))
+		}
+	}
+	record("targeting_keywords", len(data.Keywords), joinedOptimizationError(keywordErrors), false)
+	record("negative_keywords", len(data.NegativeKeywords), joinedOptimizationError(negativeErrors), false)
+	record("search_term_performance", len(data.SearchTerms), joinedOptimizationError(searchTermErrors), true)
+
+	if successfulIntelligenceSources == 0 {
+		return data, fmt.Errorf("all official Apple Ads optimization sources are unavailable")
+	}
+	return data, nil
+}
+
+func fetchOptimizationCampaigns(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest) ([]SearchCampaign, error) {
+	spec := mustOptimizationEndpoint("campaigns", "find")
+	body := map[string]any{"filters": []any{
+		optimizationFilter("promotedObjectType", "EQUALS", "APPSTORE_APP"),
+		optimizationFilter("promotedObjectId", "EQUALS", strings.TrimSpace(request.AppID)),
+	}}
+	var rows []campaignResponse
+	items, err := queryOptimizationList[campaignResponse](ctx, client, spec, body, 1000)
+	if err != nil {
+		return nil, err
+	}
+	rows = append(rows, items...)
+	result := make([]SearchCampaign, 0, len(rows))
+	for _, row := range rows {
+		countries := row.Targeting.CountryOrRegion.Include
+		if len(countries) > 0 && !containsFold(countries, request.Country) {
+			continue
+		}
+		result = append(result, SearchCampaign{
+			ID:            row.ID.Int64(),
+			Name:          row.Name,
+			Status:        row.Status,
+			DisplayStatus: row.DisplayStatus,
+			Countries:     countries,
+		})
+	}
+	return result, nil
+}
+
+func fetchOptimizationSuggestions(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest, phrases bool) ([]SearchSuggestion, error) {
+	path := []string{"suggestions", "keywords", "find"}
+	kind := "keyword"
+	if phrases {
+		path = []string{"suggestions", "phrases", "find"}
+		kind = "phrase"
+	}
+	spec := mustOptimizationEndpoint(path...)
+	filters := []any{
+		optimizationFilter("promotedObjectId", "EQUALS", []string{strings.TrimSpace(request.AppID)}),
+		optimizationFilter("promotedObjectType", "EQUALS", []string{"APPSTORE_APP"}),
+		optimizationFilter("countriesOrRegions", "IN", []string{strings.ToUpper(strings.TrimSpace(request.Country))}),
+	}
+	if phrases {
+		filters = append(filters, optimizationFilter("queryType", "EQUALS", []string{"SUGGESTION"}))
+	}
+	items, err := queryOptimizationList[suggestionResponse](ctx, client, spec, map[string]any{"filters": filters}, 1000)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SearchSuggestion, 0, len(items))
+	for _, item := range items {
+		text := strings.TrimSpace(item.Text)
+		if phrases {
+			text = strings.TrimSpace(item.Phrase)
+		}
+		if text != "" {
+			result = append(result, SearchSuggestion{Text: text, Popularity: item.Popularity, Kind: kind})
+		}
+	}
+	return result, nil
+}
+
+func fetchOptimizationPopularity(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest) ([]SearchPopularity, error) {
+	spec := mustOptimizationEndpoint("insights", "search-term-popularity", "find")
+	body := map[string]any{
+		"filters": []any{
+			optimizationFilter("countryOrRegion", "EQUALS", strings.ToUpper(strings.TrimSpace(request.Country))),
+			optimizationFilter("genre", "EQUALS", strings.ToUpper(strings.TrimSpace(request.Genre))),
+		},
+		"timeRange": map[string]any{"start": request.PopularityStart, "end": request.PopularityEnd, "timeZone": "UTC", "granularity": "WEEKLY_SUN_SAT"},
+		"sorting":   []any{map[string]any{"field": "rankInGenre", "sortOrder": "ASC"}},
+	}
+	items, err := queryOptimizationRows[popularityResponse](ctx, client, spec, body, 5000)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SearchPopularity, 0, len(items))
+	for _, item := range items {
+		if term := strings.TrimSpace(item.SearchTerm); term != "" {
+			result = append(result, SearchPopularity{
+				Term: term, Country: item.Country, Genre: item.Genre, Week: item.Week, Month: item.Month,
+				RankInGenre: item.RankInGenre, PopularityInGenre: item.PopularityInGenre,
+				Popularity100: item.Popularity100, Popularity5: item.Popularity5,
+			})
+		}
+	}
+	return result, nil
+}
+
+func fetchOptimizationImpressionShare(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest) ([]SearchImpressionShare, error) {
+	spec := mustOptimizationEndpoint("insights", "impression-share", "find")
+	body := map[string]any{
+		"filters": []any{
+			optimizationFilter("promotedObjectId", "EQUALS", strings.TrimSpace(request.AppID)),
+			optimizationFilter("countryOrRegion", "EQUALS", strings.ToUpper(strings.TrimSpace(request.Country))),
+		},
+		"options":   map[string]any{"impressionShareReportType": "ALL_SLOTS"},
+		"timeRange": map[string]any{"start": request.Start, "end": request.End, "timeZone": "UTC", "granularity": "DAILY"},
+	}
+	items, err := queryOptimizationRows[impressionShareResponse](ctx, client, spec, body, 5000)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SearchImpressionShare, 0, len(items))
+	for _, item := range items {
+		if term := strings.TrimSpace(item.SearchTerm); term != "" {
+			result = append(result, SearchImpressionShare{
+				Term: term, Country: item.Country, Day: item.Day, Week: item.Week,
+				Low: item.Low, High: item.High, Rank: item.Rank, Popularity5: item.Popularity5,
+			})
+		}
+	}
+	return result, nil
+}
+
+func fetchOptimizationEligibility(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest, appID int64) ([]SearchEligibility, error) {
+	spec := mustOptimizationEndpoint("apps", "eligibility", "find")
+	body := map[string]any{"filters": []any{optimizationFilter("adamId", "EQUALS", appID)}}
+	items, err := queryOptimizationList[eligibilityResponse](ctx, client, spec, body, 1000)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SearchEligibility, 0, len(items))
+	for _, item := range items {
+		if !strings.EqualFold(item.Country, request.Country) || item.SupplyPlacement != "APPSTORE_SEARCH_RESULTS" {
+			continue
+		}
+		result = append(result, SearchEligibility(item))
+	}
+	return result, nil
+}
+
+func fetchOptimizationRecommendations(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest, kind string) ([]json.RawMessage, error) {
+	spec := mustOptimizationEndpoint("recommendations", kind, "find")
+	body := map[string]any{"filters": []any{
+		optimizationFilter("promotedObjectId", "EQUALS", []string{strings.TrimSpace(request.AppID)}),
+		optimizationFilter("promotedObjectType", "EQUALS", []string{"APPSTORE_APP"}),
+		optimizationFilter("state", "EQUALS", []string{"AVAILABLE"}),
+	}}
+	items, err := queryOptimizationList[json.RawMessage](ctx, client, spec, body, 1000)
+	return items, err
+}
+
+func fetchOptimizationKeywords(ctx context.Context, client *appleads.Client, campaignID int64) ([]SearchTargetingKeyword, error) {
+	spec := mustOptimizationEndpoint("targeting-keywords", "find")
+	body := map[string]any{"filters": []any{optimizationFilter("campaignId", "EQUALS", campaignID)}}
+	items, err := queryOptimizationList[keywordResponse](ctx, client, spec, body, 1000)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SearchTargetingKeyword, 0, len(items))
+	for _, item := range items {
+		result = append(result, SearchTargetingKeyword{Text: item.Text, MatchType: item.MatchType, Status: item.Status, CampaignID: item.CampaignID.Int64(), AdGroupID: item.AdGroupID.Int64()})
+	}
+	return result, nil
+}
+
+func fetchOptimizationNegatives(ctx context.Context, client *appleads.Client, campaignID int64) ([]SearchNegativeKeyword, error) {
+	spec := mustOptimizationEndpoint("negative-keywords", "find")
+	queries := []map[string]any{
+		{"filters": []any{optimizationFilter("campaignId", "EQUALS", campaignID), map[string]any{"field": "adGroupId", "operator": "IS_NULL"}}},
+		{"filters": []any{optimizationFilter("campaignId", "EQUALS", campaignID), map[string]any{"field": "adGroupId", "operator": "IS_NOT_NULL"}}},
+	}
+	result := make([]SearchNegativeKeyword, 0)
+	for _, body := range queries {
+		items, err := queryOptimizationList[negativeKeywordResponse](ctx, client, spec, body, 1000)
+		if err != nil {
+			return result, err
+		}
+		for _, item := range items {
+			result = append(result, SearchNegativeKeyword{Text: item.Text, MatchType: item.MatchType, Status: item.Status, CampaignID: item.CampaignID.Int64(), AdGroupID: item.AdGroupID.Int64()})
+		}
+	}
+	return result, nil
+}
+
+func fetchOptimizationSearchTerms(ctx context.Context, client *appleads.Client, request SearchOptimizationRequest, campaignID int64) ([]SearchTermPerformance, error) {
+	spec := mustOptimizationEndpoint("reports", "apps", "search-terms")
+	body := map[string]any{
+		"filters":   []any{optimizationFilter("campaignId", "EQUALS", campaignID)},
+		"fields":    []string{"impressions", "taps", "localSpend", "tapInstalls", "totalInstalls"},
+		"groupBy":   []string{"countryOrRegion"},
+		"timeRange": map[string]any{"start": request.Start, "end": request.End, "timeZone": "ORTZ", "granularity": "DAILY"},
+	}
+	items, err := queryOptimizationRows[searchTermReportResponse](ctx, client, spec, body, 5000)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SearchTermPerformance, 0, len(items))
+	for _, item := range items {
+		country := strings.TrimSpace(item.Metadata.Country)
+		if country != "" && !strings.EqualFold(country, request.Country) {
+			continue
+		}
+		if term := strings.TrimSpace(item.Metadata.SearchTermText); term != "" {
+			result = append(result, SearchTermPerformance{
+				Term: term, KeywordText: item.Metadata.Keyword.Text, MatchType: item.Metadata.Keyword.MatchType,
+				Country: country, CampaignID: item.Metadata.CampaignID.Int64(), AdGroupID: item.Metadata.AdGroupID.Int64(),
+				Impressions: item.TotalMetrics.Impressions, Taps: item.TotalMetrics.Taps,
+				TapInstalls: item.TotalMetrics.TapInstalls, TotalInstalls: item.TotalMetrics.TotalInstalls,
+				SpendAmount: item.TotalMetrics.LocalSpend.Amount, SpendCurrency: item.TotalMetrics.LocalSpend.Currency,
+			})
+		}
+	}
+	return result, nil
+}
+
+func queryOptimizationList[T any](ctx context.Context, client *appleads.Client, spec appleads.EndpointSpec, body map[string]any, pageSize int) ([]T, error) {
+	items := make([]T, 0)
+	offset := 0
+	for {
+		pageBody := cloneOptimizationBody(body)
+		pageBody["pagination"] = map[string]any{"offset": offset, "pageSize": pageSize, "fetchTotalCount": true}
+		raw, err := executeOptimizationQuery(ctx, client, spec, pageBody)
+		if err != nil {
+			return items, err
+		}
+		var envelope struct {
+			Result     []T                    `json:"result"`
+			Pagination optimizationPagination `json:"pagination"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			return items, fmt.Errorf("decode %s response: %w", strings.Join(spec.CommandPath, " "), err)
+		}
+		items = append(items, envelope.Result...)
+		if optimizationPageComplete(offset, pageSize, len(envelope.Result), envelope.Pagination.TotalCount) {
+			return items, nil
+		}
+		offset += len(envelope.Result)
+	}
+}
+
+func queryOptimizationRows[T any](ctx context.Context, client *appleads.Client, spec appleads.EndpointSpec, body map[string]any, pageSize int) ([]T, error) {
+	items := make([]T, 0)
+	offset := 0
+	for {
+		pageBody := cloneOptimizationBody(body)
+		pageBody["pagination"] = map[string]any{"offset": offset, "pageSize": pageSize, "fetchTotalCount": true}
+		raw, err := executeOptimizationQuery(ctx, client, spec, pageBody)
+		if err != nil {
+			return items, err
+		}
+		var envelope struct {
+			Result struct {
+				Rows []T `json:"rows"`
+			} `json:"result"`
+			Pagination optimizationPagination `json:"pagination"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			return items, fmt.Errorf("decode %s response: %w", strings.Join(spec.CommandPath, " "), err)
+		}
+		items = append(items, envelope.Result.Rows...)
+		if optimizationPageComplete(offset, pageSize, len(envelope.Result.Rows), envelope.Pagination.TotalCount) {
+			return items, nil
+		}
+		offset += len(envelope.Result.Rows)
+	}
+}
+
+func executeOptimizationQuery(ctx context.Context, client *appleads.Client, spec appleads.EndpointSpec, body map[string]any) (appleads.RawResponse, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(ctx, spec, nil, nil, payload)
+}
+
+func optimizationPageComplete(offset, pageSize, count, total int) bool {
+	if count == 0 {
+		return true
+	}
+	if total > 0 {
+		return offset+count >= total
+	}
+	return count < pageSize
+}
+
+func cloneOptimizationBody(body map[string]any) map[string]any {
+	clone := make(map[string]any, len(body)+1)
+	for key, value := range body {
+		clone[key] = value
+	}
+	return clone
+}
+
+func mustOptimizationEndpoint(path ...string) appleads.EndpointSpec {
+	spec, ok := appleads.PlatformEndpointByCommandPath(path...)
+	if !ok {
+		panic("missing Platform API endpoint: " + strings.Join(path, " "))
+	}
+	return spec
+}
+
+func optimizationFilter(field, operator string, value any) map[string]any {
+	return map[string]any{"field": field, "operator": operator, "value": value}
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(want)) {
+			return true
+		}
+	}
+	return false
+}
+
+func joinedOptimizationError(messages []string) error {
+	if len(messages) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", strings.Join(messages, "; "))
+}
+
+type flexibleInt64 int64
+
+func (value *flexibleInt64) UnmarshalJSON(data []byte) error {
+	trimmed := strings.Trim(strings.TrimSpace(string(data)), `"`)
+	if trimmed == "" || trimmed == "null" {
+		*value = 0
+		return nil
+	}
+	parsed, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return err
+	}
+	*value = flexibleInt64(parsed)
+	return nil
+}
+
+func (value flexibleInt64) Int64() int64 { return int64(value) }
+
+type optimizationPagination struct {
+	TotalCount int `json:"totalCount"`
+}
+
+type suggestionResponse struct {
+	Text       string `json:"text"`
+	Phrase     string `json:"phrase"`
+	Popularity *int   `json:"popularity"`
+}
+
+type popularityResponse struct {
+	Week              string `json:"week"`
+	Month             string `json:"month"`
+	Country           string `json:"countryOrRegion"`
+	Genre             string `json:"genre"`
+	SearchTerm        string `json:"searchTerm"`
+	RankInGenre       *int   `json:"rankInGenre"`
+	PopularityInGenre *int   `json:"searchPopularityInGenre"`
+	Popularity100     *int   `json:"searchPopularity1to100"`
+	Popularity5       *int   `json:"searchPopularity1to5"`
+}
+
+type impressionShareResponse struct {
+	Day         string   `json:"day"`
+	Week        string   `json:"week"`
+	Country     string   `json:"countryOrRegion"`
+	SearchTerm  string   `json:"searchTerm"`
+	Low         *float64 `json:"lowImpressionShare"`
+	High        *float64 `json:"highImpressionShare"`
+	Rank        *int     `json:"rank"`
+	Popularity5 *int     `json:"searchPopularity1to5"`
+}
+
+type campaignResponse struct {
+	ID            flexibleInt64 `json:"id"`
+	Name          string        `json:"name"`
+	Status        string        `json:"status"`
+	DisplayStatus string        `json:"displayStatus"`
+	Targeting     struct {
+		CountryOrRegion struct {
+			Include []string `json:"include"`
+		} `json:"countryOrRegion"`
+	} `json:"targeting"`
+}
+
+type keywordResponse struct {
+	CampaignID flexibleInt64 `json:"campaignId"`
+	AdGroupID  flexibleInt64 `json:"adGroupId"`
+	Text       string        `json:"text"`
+	MatchType  string        `json:"matchType"`
+	Status     string        `json:"status"`
+}
+
+type negativeKeywordResponse struct {
+	CampaignID flexibleInt64 `json:"campaignId"`
+	AdGroupID  flexibleInt64 `json:"adGroupId"`
+	Text       string        `json:"text"`
+	MatchType  string        `json:"matchType"`
+	Status     string        `json:"status"`
+}
+
+type eligibilityResponse struct {
+	Country         string   `json:"countryOrRegion"`
+	SupplyPlacement string   `json:"supplyPlacement"`
+	DeviceClass     string   `json:"deviceClass"`
+	State           string   `json:"state"`
+	Reasons         []string `json:"reasons"`
+}
+
+type searchTermReportResponse struct {
+	Metadata struct {
+		SearchTermText string        `json:"searchTermText"`
+		CampaignID     flexibleInt64 `json:"campaignId"`
+		AdGroupID      flexibleInt64 `json:"adGroupId"`
+		Country        string        `json:"countryOrRegion"`
+		Keyword        struct {
+			Text      string `json:"text"`
+			MatchType string `json:"matchType"`
+		} `json:"keyword"`
+	} `json:"metadata"`
+	TotalMetrics struct {
+		LocalSpend struct {
+			Amount   string `json:"amount"`
+			Currency string `json:"currency"`
+		} `json:"localSpend"`
+		Impressions   int64 `json:"impressions"`
+		Taps          int64 `json:"taps"`
+		TapInstalls   int64 `json:"tapInstalls"`
+		TotalInstalls int64 `json:"totalInstalls"`
+	} `json:"totalMetrics"`
+}

--- a/internal/cli/ads/search_optimization.go
+++ b/internal/cli/ads/search_optimization.go
@@ -289,10 +289,11 @@ func fetchOptimizationSuggestions(ctx context.Context, client *appleads.Client, 
 	filters := []any{
 		optimizationFilter("promotedObjectId", "EQUALS", []string{strings.TrimSpace(request.AppID)}),
 		optimizationFilter("promotedObjectType", "EQUALS", []string{"APPSTORE_APP"}),
-		optimizationFilter("countriesOrRegions", "IN", []string{strings.ToUpper(strings.TrimSpace(request.Country))}),
 	}
 	if phrases {
 		filters = append(filters, optimizationFilter("queryType", "EQUALS", []string{"SUGGESTION"}))
+	} else {
+		filters = append(filters, optimizationFilter("countriesOrRegions", "IN", []string{strings.ToUpper(strings.TrimSpace(request.Country))}))
 	}
 	items, err := queryOptimizationList[suggestionResponse](ctx, client, spec, map[string]any{"filters": filters}, 1000)
 	if err != nil {

--- a/internal/cli/ads/search_optimization_test.go
+++ b/internal/cli/ads/search_optimization_test.go
@@ -49,7 +49,9 @@ func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFail
 			assertFilter(t, body, "countriesOrRegions", "US")
 			writeJSON(t, w, `{"result":[{"text":"habit tracker","popularity":80}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
 		case "/v1/suggestions/phrases/query":
-			assertFilter(t, body, "countriesOrRegions", "US")
+			if hasOptimizationFilter(body, "countriesOrRegions") {
+				t.Errorf("phrase suggestion request unexpectedly includes countriesOrRegions: %#v", body)
+			}
 			assertFilter(t, body, "queryType", "SUGGESTION")
 			http.Error(w, `{"errors":[{"message":"request unavailable"}]}`, http.StatusBadRequest)
 		case "/v1/suggestions/target-cpas/query":
@@ -194,6 +196,13 @@ func TestQueryOptimizationListPaginatesRequestBody(t *testing.T) {
 
 func TestFetchOptimizationPhraseSuggestionsReadsPhraseField(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if hasOptimizationFilter(body, "countriesOrRegions") {
+			t.Errorf("phrase suggestion request unexpectedly includes countriesOrRegions: %#v", body)
+		}
 		writeJSON(t, w, `{"result":[{"phrase":"best habit tracker","popularity":82}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
 	}))
 	defer server.Close()
@@ -214,6 +223,17 @@ func TestFetchOptimizationPhraseSuggestionsReadsPhraseField(t *testing.T) {
 	if len(items) != 1 || items[0].Text != "best habit tracker" || items[0].Kind != "phrase" || items[0].Popularity == nil || *items[0].Popularity != 82 {
 		t.Fatalf("phrase suggestions = %+v", items)
 	}
+}
+
+func hasOptimizationFilter(body map[string]any, field string) bool {
+	filters, _ := body["filters"].([]any)
+	for _, raw := range filters {
+		filter, _ := raw.(map[string]any)
+		if filter["field"] == field {
+			return true
+		}
+	}
+	return false
 }
 
 func TestExecuteOptimizationQueryAppliesRequestTimeout(t *testing.T) {

--- a/internal/cli/ads/search_optimization_test.go
+++ b/internal/cli/ads/search_optimization_test.go
@@ -53,7 +53,9 @@ func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFail
 				t.Errorf("phrase suggestion request unexpectedly includes countriesOrRegions: %#v", body)
 			}
 			assertFilter(t, body, "queryType", "SUGGESTION")
-			http.Error(w, `{"errors":[{"message":"request unavailable"}]}`, http.StatusBadRequest)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code":"INVALID_VALUE","message":"One or more validation errors occurred.","details":[{"code":"INVALID_FILTER","message":"Unsupported filter value","info":{"field":"filters[2].value"}}]}`))
 		case "/v1/suggestions/target-cpas/query":
 			assertFilter(t, body, "promotedObjectId", "123456789")
 			assertFilter(t, body, "promotedObjectType", "APPSTORE_APP")
@@ -148,7 +150,7 @@ func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFail
 		t.Fatalf("daily budget recommendation items = %s", data.DailyBudgetRecommendationItems)
 	}
 	phraseSource := findOptimizationSource(t, data.Sources, "phrase_suggestions")
-	if phraseSource.Status != "unavailable" || !strings.Contains(phraseSource.Error, "400") {
+	if phraseSource.Status != "unavailable" || !strings.Contains(phraseSource.Error, "INVALID_FILTER") || !strings.Contains(phraseSource.Error, `"field":"filters[2].value"`) {
 		t.Fatalf("phrase source = %+v", phraseSource)
 	}
 	if requests["/v1/negative-keywords/query"] != 2 {

--- a/internal/cli/ads/search_optimization_test.go
+++ b/internal/cli/ads/search_optimization_test.go
@@ -1,0 +1,237 @@
+package ads
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
+)
+
+func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFailures(t *testing.T) {
+	var mu sync.Mutex
+	requests := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s for %s, want POST", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("X-AP-Context"); got != "adAccountId=account-1;" {
+			t.Errorf("X-AP-Context = %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode %s body: %v", r.URL.Path, err)
+		}
+		mu.Lock()
+		requests[r.URL.Path]++
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case "/v1/campaigns/query":
+			assertFilter(t, body, "promotedObjectId", "123456789")
+			writeJSON(t, w, `{"result":[{"id":44,"name":"US Search","status":"ENABLED","displayStatus":"RUNNING","promotedObjectId":"123456789","targeting":{"countryOrRegion":{"include":["US"]}}}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
+		case "/v1/suggestions/keywords/query":
+			assertFilter(t, body, "countriesOrRegions", "US")
+			writeJSON(t, w, `{"result":[{"text":"habit tracker","popularity":80}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
+		case "/v1/suggestions/phrases/query":
+			http.Error(w, `{"errors":[{"message":"request unavailable"}]}`, http.StatusBadRequest)
+		case "/v1/insights/apps/search-term-popularity/query":
+			assertFilter(t, body, "genre", "PRODUCTIVITY_UTILITIES")
+			writeJSON(t, w, `{"result":{"rows":[{"week":"2026-08-09","countryOrRegion":"US","genre":"PRODUCTIVITY_UTILITIES","searchTerm":"habit tracker","rankInGenre":2,"searchPopularity1to100":88}]},"pagination":{"offset":0,"pageSize":5000,"totalCount":1}}`)
+		case "/v1/insights/apps/impression-share/query":
+			writeJSON(t, w, `{"result":{"rows":[{"day":"2026-08-17","promotedObjectId":"123456789","countryOrRegion":"US","searchTerm":"habit tracker","lowImpressionShare":0.07,"highImpressionShare":0.07,"rank":6,"searchPopularity1to5":4}]},"pagination":{"offset":0,"pageSize":5000,"totalCount":1}}`)
+		case "/v1/eligibilities/apps/query":
+			writeJSON(t, w, `{"result":[{"adamId":123456789,"supplyPlacement":"APPSTORE_SEARCH_RESULTS","supplySource":"APPSTORE","state":"ELIGIBLE","countryOrRegion":"US","deviceClass":"IPHONE"}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
+		case "/v1/recommendations/daily-budgets/query":
+			writeJSON(t, w, `{"result":[{"id":"budget-1","campaignId":44,"state":"AVAILABLE"}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
+		case "/v1/recommendations/target-cpas/query":
+			writeJSON(t, w, `{"result":[],"pagination":{"offset":0,"pageSize":1000,"totalCount":0}}`)
+		case "/v1/keywords/query":
+			assertFilter(t, body, "campaignId", float64(44))
+			writeJSON(t, w, `{"result":[{"id":88,"campaignId":44,"adGroupId":55,"text":"habits","matchType":"BROAD","status":"ENABLED"}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
+		case "/v1/negative-keywords/query":
+			writeJSON(t, w, `{"result":[],"pagination":{"offset":0,"pageSize":1000,"totalCount":0}}`)
+		case "/v1/reports/apps/searchterms/query":
+			assertFilter(t, body, "campaignId", float64(44))
+			writeJSON(t, w, `{"result":{"rows":[{"metadata":{"searchTermText":"habit tracker","keyword":{"id":88,"text":"habits","matchType":"BROAD"},"campaignId":44,"adGroupId":55,"countryOrRegion":"US"},"totalMetrics":{"localSpend":{"amount":"36.58","currency":"USD"},"impressions":1000,"taps":70,"tapInstalls":28,"totalInstalls":31}}]},"pagination":{"offset":0,"pageSize":5000,"totalCount":1}}`)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := appleads.NewClient(
+		appleads.Credentials{AccessToken: "token", AdAccountID: "account-1"},
+		appleads.WithPlatformBaseURL(server.URL+"/v1/"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := fetchSearchOptimizationData(context.Background(), client, SearchOptimizationRequest{
+		AppID:           "123456789",
+		Country:         "US",
+		Genre:           "PRODUCTIVITY_UTILITIES",
+		Start:           "2026-07-19",
+		End:             "2026-08-17",
+		PopularityStart: "2026-08-09",
+		PopularityEnd:   "2026-08-15",
+	})
+	if err != nil {
+		t.Fatalf("fetchSearchOptimizationData() error = %v", err)
+	}
+	if len(data.Suggestions) != 1 || data.Suggestions[0].Text != "habit tracker" {
+		t.Fatalf("suggestions = %+v", data.Suggestions)
+	}
+	if len(data.Popularities) != 1 || data.Popularities[0].Term != "habit tracker" {
+		t.Fatalf("popularities = %+v", data.Popularities)
+	}
+	if len(data.SearchTerms) != 1 || data.SearchTerms[0].TotalInstalls != 31 || data.SearchTerms[0].AdGroupID != 55 {
+		t.Fatalf("search terms = %+v", data.SearchTerms)
+	}
+	if data.DailyBudgetRecommendations != 1 || data.TargetCPARecommendations != 0 {
+		t.Fatalf("recommendations = (%d, %d)", data.DailyBudgetRecommendations, data.TargetCPARecommendations)
+	}
+	if len(data.DailyBudgetRecommendationItems) != 1 || !strings.Contains(string(data.DailyBudgetRecommendationItems[0]), "budget-1") {
+		t.Fatalf("daily budget recommendation items = %s", data.DailyBudgetRecommendationItems)
+	}
+	phraseSource := findOptimizationSource(t, data.Sources, "phrase_suggestions")
+	if phraseSource.Status != "unavailable" || !strings.Contains(phraseSource.Error, "400") {
+		t.Fatalf("phrase source = %+v", phraseSource)
+	}
+	if requests["/v1/negative-keywords/query"] != 2 {
+		t.Fatalf("negative keyword requests = %d, want campaign and ad-group scopes", requests["/v1/negative-keywords/query"])
+	}
+}
+
+func TestQueryOptimizationListPaginatesRequestBody(t *testing.T) {
+	var offsets []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Pagination struct {
+				Offset int `json:"offset"`
+			} `json:"pagination"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		offsets = append(offsets, body.Pagination.Offset)
+		if body.Pagination.Offset == 0 {
+			writeJSON(t, w, `{"result":[{"text":"one","popularity":1}],"pagination":{"offset":0,"pageSize":1,"totalCount":2}}`)
+			return
+		}
+		writeJSON(t, w, `{"result":[{"text":"two","popularity":2}],"pagination":{"offset":1,"pageSize":1,"totalCount":2}}`)
+	}))
+	defer server.Close()
+	client, err := appleads.NewClient(appleads.Credentials{AccessToken: "token", AdAccountID: "account-1"}, appleads.WithPlatformBaseURL(server.URL+"/v1/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec, ok := appleads.PlatformEndpointByCommandPath("suggestions", "keywords", "find")
+	if !ok {
+		t.Fatal("missing endpoint spec")
+	}
+	items, err := queryOptimizationList[SearchSuggestion](context.Background(), client, spec, map[string]any{}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 || len(offsets) != 2 || offsets[0] != 0 || offsets[1] != 1 {
+		t.Fatalf("items=%+v offsets=%v", items, offsets)
+	}
+}
+
+func TestFetchOptimizationPhraseSuggestionsReadsPhraseField(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"result":[{"phrase":"best habit tracker","popularity":82}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
+	}))
+	defer server.Close()
+	client, err := appleads.NewClient(
+		appleads.Credentials{AccessToken: "token", AdAccountID: "account-1"},
+		appleads.WithPlatformBaseURL(server.URL+"/v1/"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, err := fetchOptimizationSuggestions(context.Background(), client, SearchOptimizationRequest{
+		AppID: "123456789", Country: "US",
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Text != "best habit tracker" || items[0].Kind != "phrase" || items[0].Popularity == nil || *items[0].Popularity != 82 {
+		t.Fatalf("phrase suggestions = %+v", items)
+	}
+}
+
+func TestFetchSearchOptimizationDataFailsWhenEveryIntelligenceSourceIsUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errors":[{"message":"unavailable"}]}`, http.StatusBadRequest)
+	}))
+	defer server.Close()
+	client, err := appleads.NewClient(
+		appleads.Credentials{AccessToken: "token", AdAccountID: "account-1"},
+		appleads.WithPlatformBaseURL(server.URL+"/v1/"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := fetchSearchOptimizationData(context.Background(), client, SearchOptimizationRequest{
+		AppID: "123456789", Country: "US", Genre: "PRODUCTIVITY_UTILITIES",
+		Start: "2026-07-19", End: "2026-08-17", PopularityStart: "2026-08-09", PopularityEnd: "2026-08-15",
+	})
+	if err == nil || !strings.Contains(err.Error(), "all official Apple Ads optimization sources are unavailable") {
+		t.Fatalf("error = %v", err)
+	}
+	if source := findOptimizationSource(t, data.Sources, "search_term_performance"); source.Status != "unavailable" || !strings.Contains(source.Error, "campaign scope unavailable") {
+		t.Fatalf("search term source = %+v", source)
+	}
+}
+
+func assertFilter(t *testing.T, body map[string]any, field string, want any) {
+	t.Helper()
+	filters, _ := body["filters"].([]any)
+	for _, raw := range filters {
+		filter, _ := raw.(map[string]any)
+		if filter["field"] != field {
+			continue
+		}
+		value := filter["value"]
+		switch typed := value.(type) {
+		case []any:
+			for _, item := range typed {
+				if item == want {
+					return
+				}
+			}
+		default:
+			if typed == want {
+				return
+			}
+		}
+	}
+	t.Fatalf("body filters do not contain %s=%v: %#v", field, want, body)
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, payload string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(payload))
+}
+
+func findOptimizationSource(t *testing.T, sources []SearchOptimizationSourceStatus, name string) SearchOptimizationSourceStatus {
+	t.Helper()
+	for _, source := range sources {
+		if source.Name == name {
+			return source
+		}
+	}
+	t.Fatalf("missing source %q in %+v", name, sources)
+	return SearchOptimizationSourceStatus{}
+}

--- a/internal/cli/ads/search_optimization_test.go
+++ b/internal/cli/ads/search_optimization_test.go
@@ -163,10 +163,12 @@ func TestQueryOptimizationListPaginatesRequestBody(t *testing.T) {
 			Pagination map[string]any `json:"pagination"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatal(err)
+			t.Errorf("decode pagination request: %v", err)
+			http.Error(w, "invalid test request", http.StatusBadRequest)
+			return
 		}
 		if _, present := body.Pagination["fetchTotalCount"]; present {
-			t.Fatalf("recommendation-style pagination contains unsupported fetchTotalCount: %#v", body.Pagination)
+			t.Errorf("recommendation-style pagination contains unsupported fetchTotalCount: %#v", body.Pagination)
 		}
 		offset, _ := body.Pagination["offset"].(float64)
 		offsets = append(offsets, int(offset))
@@ -198,7 +200,9 @@ func TestFetchOptimizationPhraseSuggestionsReadsPhraseField(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatal(err)
+			t.Errorf("decode phrase-suggestion request: %v", err)
+			http.Error(w, "invalid test request", http.StatusBadRequest)
+			return
 		}
 		if hasOptimizationFilter(body, "countriesOrRegions") {
 			t.Errorf("phrase suggestion request unexpectedly includes countriesOrRegions: %#v", body)
@@ -312,31 +316,32 @@ func assertFilter(t *testing.T, body map[string]any, field string, want any) {
 			}
 		}
 	}
-	t.Fatalf("body filters do not contain %s=%v: %#v", field, want, body)
+	t.Errorf("body filters do not contain %s=%v: %#v", field, want, body)
 }
 
 func assertOptimizationPaginationShape(t *testing.T, path string, body map[string]any) {
 	t.Helper()
 	if path == "/v1/suggestions/target-cpas/query" {
 		if _, present := body["pagination"]; present {
-			t.Fatalf("%s body has unnecessary pagination: %#v", path, body)
+			t.Errorf("%s body has unnecessary pagination: %#v", path, body)
 		}
 		return
 	}
 	pagination, ok := body["pagination"].(map[string]any)
 	if !ok {
-		t.Fatalf("%s body has no pagination object: %#v", path, body)
+		t.Errorf("%s body has no pagination object: %#v", path, body)
+		return
 	}
 	if _, ok := pagination["offset"]; !ok {
-		t.Fatalf("%s pagination has no offset: %#v", path, pagination)
+		t.Errorf("%s pagination has no offset: %#v", path, pagination)
 	}
 	if _, ok := pagination["pageSize"]; !ok {
-		t.Fatalf("%s pagination has no pageSize: %#v", path, pagination)
+		t.Errorf("%s pagination has no pageSize: %#v", path, pagination)
 	}
 	_, hasFetchTotalCount := pagination["fetchTotalCount"]
 	expectsFetchTotalCount := path == "/v1/campaigns/query" || path == "/v1/keywords/query" || path == "/v1/negative-keywords/query"
 	if hasFetchTotalCount != expectsFetchTotalCount {
-		t.Fatalf("%s pagination fetchTotalCount present = %t, want %t: %#v", path, hasFetchTotalCount, expectsFetchTotalCount, pagination)
+		t.Errorf("%s pagination fetchTotalCount present = %t, want %t: %#v", path, hasFetchTotalCount, expectsFetchTotalCount, pagination)
 	}
 }
 
@@ -344,7 +349,7 @@ func assertNestedValue(t *testing.T, body map[string]any, object, field string, 
 	t.Helper()
 	nested, ok := body[object].(map[string]any)
 	if !ok || nested[field] != want {
-		t.Fatalf("%s.%s = %#v, want %#v in body %#v", object, field, nested[field], want, body)
+		t.Errorf("%s.%s = %#v, want %#v in body %#v", object, field, nested[field], want, body)
 	}
 }
 
@@ -352,11 +357,12 @@ func assertSorting(t *testing.T, body map[string]any, field, orderKey, order str
 	t.Helper()
 	sorting, ok := body["sorting"].([]any)
 	if !ok || len(sorting) != 1 {
-		t.Fatalf("sorting = %#v, want one entry", body["sorting"])
+		t.Errorf("sorting = %#v, want one entry", body["sorting"])
+		return
 	}
 	entry, ok := sorting[0].(map[string]any)
 	if !ok || entry["field"] != field || entry[orderKey] != order {
-		t.Fatalf("sorting = %#v, want %s %s=%s", sorting, field, orderKey, order)
+		t.Errorf("sorting = %#v, want %s %s=%s", sorting, field, orderKey, order)
 	}
 }
 
@@ -364,14 +370,15 @@ func assertArrayContains(t *testing.T, body map[string]any, field, want string) 
 	t.Helper()
 	items, ok := body[field].([]any)
 	if !ok {
-		t.Fatalf("%s = %#v, want array containing %q", field, body[field], want)
+		t.Errorf("%s = %#v, want array containing %q", field, body[field], want)
+		return
 	}
 	for _, item := range items {
 		if item == want {
 			return
 		}
 	}
-	t.Fatalf("%s = %#v, want array containing %q", field, items, want)
+	t.Errorf("%s = %#v, want array containing %q", field, items, want)
 }
 
 func writeJSON(t *testing.T, w http.ResponseWriter, payload string) {

--- a/internal/cli/ads/search_optimization_test.go
+++ b/internal/cli/ads/search_optimization_test.go
@@ -3,6 +3,7 @@ package ads
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,12 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
 )
+
+type searchOptimizationRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn searchOptimizationRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
 
 func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFailures(t *testing.T) {
 	var mu sync.Mutex
@@ -29,26 +36,55 @@ func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFail
 		mu.Lock()
 		requests[r.URL.Path]++
 		mu.Unlock()
+		assertOptimizationPaginationShape(t, r.URL.Path, body)
 
 		switch r.URL.Path {
 		case "/v1/campaigns/query":
+			assertFilter(t, body, "promotedObjectType", "APPSTORE_APP")
 			assertFilter(t, body, "promotedObjectId", "123456789")
 			writeJSON(t, w, `{"result":[{"id":44,"name":"US Search","status":"ENABLED","displayStatus":"RUNNING","promotedObjectId":"123456789","targeting":{"countryOrRegion":{"include":["US"]}}}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
 		case "/v1/suggestions/keywords/query":
+			assertFilter(t, body, "promotedObjectId", "123456789")
+			assertFilter(t, body, "promotedObjectType", "APPSTORE_APP")
 			assertFilter(t, body, "countriesOrRegions", "US")
 			writeJSON(t, w, `{"result":[{"text":"habit tracker","popularity":80}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
 		case "/v1/suggestions/phrases/query":
+			assertFilter(t, body, "countriesOrRegions", "US")
+			assertFilter(t, body, "queryType", "SUGGESTION")
 			http.Error(w, `{"errors":[{"message":"request unavailable"}]}`, http.StatusBadRequest)
+		case "/v1/suggestions/target-cpas/query":
+			assertFilter(t, body, "promotedObjectId", "123456789")
+			assertFilter(t, body, "promotedObjectType", "APPSTORE_APP")
+			assertFilter(t, body, "countryOrRegion", "US")
+			writeJSON(t, w, `{"result":{"promotedObjectId":"123456789","suggestedTargetCPA":{"amount":"1.20","currency":"USD"},"countryOrRegion":["US"],"appCategory":"Productivity"}}`)
 		case "/v1/insights/apps/search-term-popularity/query":
+			assertFilter(t, body, "countryOrRegion", "US")
 			assertFilter(t, body, "genre", "PRODUCTIVITY_UTILITIES")
-			writeJSON(t, w, `{"result":{"rows":[{"week":"2026-08-09","countryOrRegion":"US","genre":"PRODUCTIVITY_UTILITIES","searchTerm":"habit tracker","rankInGenre":2,"searchPopularity1to100":88}]},"pagination":{"offset":0,"pageSize":5000,"totalCount":1}}`)
+			assertNestedValue(t, body, "timeRange", "start", "2026-08-09")
+			assertNestedValue(t, body, "timeRange", "end", "2026-08-15")
+			assertNestedValue(t, body, "timeRange", "timeZone", "UTC")
+			assertNestedValue(t, body, "timeRange", "granularity", "WEEKLY_SUN_SAT")
+			assertSorting(t, body, "rankInGenre", "sortOrder", "ASC")
+			writeJSON(t, w, `{"result":{"rows":[{"week":"2026-08-09","countryOrRegion":"US","genre":"PRODUCTIVITY_UTILITIES","searchTerm":"habit tracker","rankInGenre":2,"searchPopularity1to100":88,"searchPopularity1to5":5}]},"pagination":{"offset":0,"pageSize":5000,"totalCount":1}}`)
 		case "/v1/insights/apps/impression-share/query":
+			assertFilter(t, body, "promotedObjectId", "123456789")
+			assertFilter(t, body, "countryOrRegion", "US")
+			assertNestedValue(t, body, "options", "impressionShareReportType", "ALL_SLOTS")
+			assertNestedValue(t, body, "timeRange", "timeZone", "UTC")
+			assertNestedValue(t, body, "timeRange", "granularity", "DAILY")
 			writeJSON(t, w, `{"result":{"rows":[{"day":"2026-08-17","promotedObjectId":"123456789","countryOrRegion":"US","searchTerm":"habit tracker","lowImpressionShare":0.07,"highImpressionShare":0.07,"rank":6,"searchPopularity1to5":4}]},"pagination":{"offset":0,"pageSize":5000,"totalCount":1}}`)
 		case "/v1/eligibilities/apps/query":
+			assertFilter(t, body, "adamId", float64(123456789))
 			writeJSON(t, w, `{"result":[{"adamId":123456789,"supplyPlacement":"APPSTORE_SEARCH_RESULTS","supplySource":"APPSTORE","state":"ELIGIBLE","countryOrRegion":"US","deviceClass":"IPHONE"}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
 		case "/v1/recommendations/daily-budgets/query":
+			assertFilter(t, body, "promotedObjectId", "123456789")
+			assertFilter(t, body, "promotedObjectType", "APPSTORE_APP")
+			assertFilter(t, body, "state", "AVAILABLE")
 			writeJSON(t, w, `{"result":[{"id":"budget-1","campaignId":44,"state":"AVAILABLE"}],"pagination":{"offset":0,"pageSize":1000,"totalCount":1}}`)
 		case "/v1/recommendations/target-cpas/query":
+			assertFilter(t, body, "promotedObjectId", "123456789")
+			assertFilter(t, body, "promotedObjectType", "APPSTORE_APP")
+			assertFilter(t, body, "state", "AVAILABLE")
 			writeJSON(t, w, `{"result":[],"pagination":{"offset":0,"pageSize":1000,"totalCount":0}}`)
 		case "/v1/keywords/query":
 			assertFilter(t, body, "campaignId", float64(44))
@@ -57,6 +93,12 @@ func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFail
 			writeJSON(t, w, `{"result":[],"pagination":{"offset":0,"pageSize":1000,"totalCount":0}}`)
 		case "/v1/reports/apps/searchterms/query":
 			assertFilter(t, body, "campaignId", float64(44))
+			assertNestedValue(t, body, "timeRange", "start", "2026-07-19")
+			assertNestedValue(t, body, "timeRange", "end", "2026-08-17")
+			assertNestedValue(t, body, "timeRange", "timeZone", "ORTZ")
+			assertNestedValue(t, body, "timeRange", "granularity", "DAILY")
+			assertArrayContains(t, body, "fields", "totalInstalls")
+			assertArrayContains(t, body, "groupBy", "countryOrRegion")
 			writeJSON(t, w, `{"result":{"rows":[{"metadata":{"searchTermText":"habit tracker","keyword":{"id":88,"text":"habits","matchType":"BROAD"},"campaignId":44,"adGroupId":55,"countryOrRegion":"US"},"totalMetrics":{"localSpend":{"amount":"36.58","currency":"USD"},"impressions":1000,"taps":70,"tapInstalls":28,"totalInstalls":31}}]},"pagination":{"offset":0,"pageSize":5000,"totalCount":1}}`)
 		default:
 			t.Errorf("unexpected path %s", r.URL.Path)
@@ -88,7 +130,7 @@ func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFail
 	if len(data.Suggestions) != 1 || data.Suggestions[0].Text != "habit tracker" {
 		t.Fatalf("suggestions = %+v", data.Suggestions)
 	}
-	if len(data.Popularities) != 1 || data.Popularities[0].Term != "habit tracker" {
+	if len(data.Popularities) != 1 || data.Popularities[0].Term != "habit tracker" || data.Popularities[0].Popularity5 == nil || *data.Popularities[0].Popularity5 != 5 {
 		t.Fatalf("popularities = %+v", data.Popularities)
 	}
 	if len(data.SearchTerms) != 1 || data.SearchTerms[0].TotalInstalls != 31 || data.SearchTerms[0].AdGroupID != 55 {
@@ -96,6 +138,9 @@ func TestFetchSearchOptimizationDataUsesOfficialEndpointsAndPreservesPartialFail
 	}
 	if data.DailyBudgetRecommendations != 1 || data.TargetCPARecommendations != 0 {
 		t.Fatalf("recommendations = (%d, %d)", data.DailyBudgetRecommendations, data.TargetCPARecommendations)
+	}
+	if len(data.TargetCPASuggestion) == 0 || !strings.Contains(string(data.TargetCPASuggestion), `"amount":"1.20"`) {
+		t.Fatalf("target CPA suggestion = %s", data.TargetCPASuggestion)
 	}
 	if len(data.DailyBudgetRecommendationItems) != 1 || !strings.Contains(string(data.DailyBudgetRecommendationItems[0]), "budget-1") {
 		t.Fatalf("daily budget recommendation items = %s", data.DailyBudgetRecommendationItems)
@@ -113,15 +158,17 @@ func TestQueryOptimizationListPaginatesRequestBody(t *testing.T) {
 	var offsets []int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
-			Pagination struct {
-				Offset int `json:"offset"`
-			} `json:"pagination"`
+			Pagination map[string]any `json:"pagination"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatal(err)
 		}
-		offsets = append(offsets, body.Pagination.Offset)
-		if body.Pagination.Offset == 0 {
+		if _, present := body.Pagination["fetchTotalCount"]; present {
+			t.Fatalf("recommendation-style pagination contains unsupported fetchTotalCount: %#v", body.Pagination)
+		}
+		offset, _ := body.Pagination["offset"].(float64)
+		offsets = append(offsets, int(offset))
+		if offset == 0 {
 			writeJSON(t, w, `{"result":[{"text":"one","popularity":1}],"pagination":{"offset":0,"pageSize":1,"totalCount":2}}`)
 			return
 		}
@@ -166,6 +213,35 @@ func TestFetchOptimizationPhraseSuggestionsReadsPhraseField(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].Text != "best habit tracker" || items[0].Kind != "phrase" || items[0].Popularity == nil || *items[0].Popularity != 82 {
 		t.Fatalf("phrase suggestions = %+v", items)
+	}
+}
+
+func TestExecuteOptimizationQueryAppliesRequestTimeout(t *testing.T) {
+	deadlinePresent := false
+	client, err := appleads.NewClient(
+		appleads.Credentials{AccessToken: "token", AdAccountID: "account-1"},
+		appleads.WithHTTPClient(&http.Client{Transport: searchOptimizationRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			_, deadlinePresent = request.Context().Deadline()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"result":[],"pagination":{"totalCount":0}}`)),
+			}, nil
+		})}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec, ok := appleads.PlatformEndpointByCommandPath("suggestions", "keywords", "find")
+	if !ok {
+		t.Fatal("missing endpoint spec")
+	}
+	if _, err := executeOptimizationQuery(context.Background(), client, spec, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if !deadlinePresent {
+		t.Fatal("optimization request context has no deadline")
 	}
 }
 
@@ -217,6 +293,65 @@ func assertFilter(t *testing.T, body map[string]any, field string, want any) {
 		}
 	}
 	t.Fatalf("body filters do not contain %s=%v: %#v", field, want, body)
+}
+
+func assertOptimizationPaginationShape(t *testing.T, path string, body map[string]any) {
+	t.Helper()
+	if path == "/v1/suggestions/target-cpas/query" {
+		if _, present := body["pagination"]; present {
+			t.Fatalf("%s body has unnecessary pagination: %#v", path, body)
+		}
+		return
+	}
+	pagination, ok := body["pagination"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s body has no pagination object: %#v", path, body)
+	}
+	if _, ok := pagination["offset"]; !ok {
+		t.Fatalf("%s pagination has no offset: %#v", path, pagination)
+	}
+	if _, ok := pagination["pageSize"]; !ok {
+		t.Fatalf("%s pagination has no pageSize: %#v", path, pagination)
+	}
+	_, hasFetchTotalCount := pagination["fetchTotalCount"]
+	expectsFetchTotalCount := path == "/v1/campaigns/query" || path == "/v1/keywords/query" || path == "/v1/negative-keywords/query"
+	if hasFetchTotalCount != expectsFetchTotalCount {
+		t.Fatalf("%s pagination fetchTotalCount present = %t, want %t: %#v", path, hasFetchTotalCount, expectsFetchTotalCount, pagination)
+	}
+}
+
+func assertNestedValue(t *testing.T, body map[string]any, object, field string, want any) {
+	t.Helper()
+	nested, ok := body[object].(map[string]any)
+	if !ok || nested[field] != want {
+		t.Fatalf("%s.%s = %#v, want %#v in body %#v", object, field, nested[field], want, body)
+	}
+}
+
+func assertSorting(t *testing.T, body map[string]any, field, orderKey, order string) {
+	t.Helper()
+	sorting, ok := body["sorting"].([]any)
+	if !ok || len(sorting) != 1 {
+		t.Fatalf("sorting = %#v, want one entry", body["sorting"])
+	}
+	entry, ok := sorting[0].(map[string]any)
+	if !ok || entry["field"] != field || entry[orderKey] != order {
+		t.Fatalf("sorting = %#v, want %s %s=%s", sorting, field, orderKey, order)
+	}
+}
+
+func assertArrayContains(t *testing.T, body map[string]any, field, want string) {
+	t.Helper()
+	items, ok := body[field].([]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want array containing %q", field, body[field], want)
+	}
+	for _, item := range items {
+		if item == want {
+			return
+		}
+	}
+	t.Fatalf("%s = %#v, want array containing %q", field, items, want)
 }
 
 func writeJSON(t *testing.T, w http.ResponseWriter, payload string) {

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -139,6 +139,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `review` - Manage App Store review details, attachments, and submissions.
 - `analytics` - Request and download analytics and sales reports.
 - `ads` - Manage Apple Ads API resources.
+- `optimize` - Build cross-API optimization plans. [experimental]
 - `performance` - Access performance metrics and diagnostic logs.
 - `finance` - Download payments and financial reports.
 - `apps` - List and manage apps in App Store Connect. App creation moved out of `asc apps`; use `asc web apps create` for the web-session path.

--- a/internal/cli/optimize/artifacts.go
+++ b/internal/cli/optimize/artifacts.go
@@ -1,0 +1,205 @@
+package optimize
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+)
+
+const (
+	searchPlanReportArtifact           = "report.json"
+	searchPlanMetadataArtifact         = "metadata-candidates.csv"
+	searchPlanExactKeywordsArtifact    = "exact-keywords.json"
+	searchPlanNegativeKeywordsArtifact = "negative-keywords.json"
+)
+
+func writeSearchPlanArtifacts(directory string, report SearchPlanReport) ([]string, error) {
+	root, err := rootfs.New(strings.TrimSpace(directory))
+	if err != nil {
+		return nil, fmt.Errorf("prepare --out-dir: %w", err)
+	}
+	artifactNames := []string{
+		searchPlanReportArtifact,
+		searchPlanMetadataArtifact,
+		searchPlanExactKeywordsArtifact,
+		searchPlanNegativeKeywordsArtifact,
+	}
+	report.Artifacts = make([]string, 0, len(artifactNames))
+	for _, name := range artifactNames {
+		report.Artifacts = append(report.Artifacts, filepath.Join(strings.TrimSpace(directory), name))
+	}
+
+	reportData, err := canonicalSearchPlanJSON(report)
+	if err != nil {
+		return nil, err
+	}
+	metadataData, err := buildMetadataCandidatesCSV(report)
+	if err != nil {
+		return nil, err
+	}
+	exactData, err := buildExactKeywordArtifact(report.Rows)
+	if err != nil {
+		return nil, err
+	}
+	negativeData, err := buildNegativeKeywordArtifact(report.Rows)
+	if err != nil {
+		return nil, err
+	}
+
+	files := []struct {
+		name string
+		data []byte
+	}{
+		{name: searchPlanReportArtifact, data: reportData},
+		{name: searchPlanMetadataArtifact, data: metadataData},
+		{name: searchPlanExactKeywordsArtifact, data: exactData},
+		{name: searchPlanNegativeKeywordsArtifact, data: negativeData},
+	}
+	for _, file := range files {
+		if err := root.WriteFile(file.name, file.data, 0o644); err != nil {
+			return nil, fmt.Errorf("write optimization artifact %q: %w", filepath.Join(directory, file.name), err)
+		}
+	}
+	return report.Artifacts, nil
+}
+
+func canonicalSearchPlanJSON(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func buildMetadataCandidatesCSV(report SearchPlanReport) ([]byte, error) {
+	keywords := splitMetadataKeywords(report.Metadata.Keywords)
+	seen := make(map[string]struct{}, len(keywords))
+	for _, keyword := range keywords {
+		seen[normalizeSearchTerm(keyword)] = struct{}{}
+	}
+	for _, row := range report.Rows {
+		if !containsString(row.Actions, "metadata_candidate") {
+			continue
+		}
+		term := strings.TrimSpace(row.Term)
+		key := normalizeSearchTerm(term)
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		candidate := strings.Join(append(append([]string(nil), keywords...), term), ",")
+		if utf8.RuneCountInString(candidate) > 100 {
+			continue
+		}
+		keywords = append(keywords, term)
+		seen[key] = struct{}{}
+	}
+
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+	if err := writer.Write([]string{"locale", "keywords"}); err != nil {
+		return nil, err
+	}
+	if err := writer.Write([]string{report.Locale, strings.Join(keywords, ",")}); err != nil {
+		return nil, err
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func splitMetadataKeywords(value string) []string {
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		key := normalizeSearchTerm(trimmed)
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
+}
+
+type bulkKeywordArtifact struct {
+	Items []bulkKeywordArtifactItem `json:"items"`
+}
+
+type bulkKeywordArtifactItem struct {
+	CorrelationID int                     `json:"correlationId"`
+	Data          bulkKeywordArtifactData `json:"data"`
+}
+
+type bulkKeywordArtifactData struct {
+	CampaignID int64  `json:"campaignId,omitempty"`
+	AdGroupID  int64  `json:"adGroupId,omitempty"`
+	Text       string `json:"text"`
+	MatchType  string `json:"matchType"`
+	Status     string `json:"status,omitempty"`
+}
+
+func buildExactKeywordArtifact(rows []SearchPlanRow) ([]byte, error) {
+	payload := bulkKeywordArtifact{Items: []bulkKeywordArtifactItem{}}
+	for _, row := range rows {
+		if !containsString(row.Actions, "promote_exact") || row.AdGroupID == nil {
+			continue
+		}
+		payload.Items = append(payload.Items, bulkKeywordArtifactItem{
+			CorrelationID: len(payload.Items),
+			Data: bulkKeywordArtifactData{
+				AdGroupID: *row.AdGroupID,
+				Text:      row.Term,
+				MatchType: "EXACT",
+			},
+		})
+	}
+	return canonicalSearchPlanJSON(payload)
+}
+
+func buildNegativeKeywordArtifact(rows []SearchPlanRow) ([]byte, error) {
+	payload := bulkKeywordArtifact{Items: []bulkKeywordArtifactItem{}}
+	for _, row := range rows {
+		if !containsString(row.Actions, "negative_candidate") || row.CampaignID == nil {
+			continue
+		}
+		item := bulkKeywordArtifactItem{
+			CorrelationID: len(payload.Items),
+			Data: bulkKeywordArtifactData{
+				CampaignID: *row.CampaignID,
+				Text:       row.Term,
+				MatchType:  "EXACT",
+				Status:     "ENABLED",
+			},
+		}
+		if row.AdGroupID != nil {
+			item.Data.AdGroupID = *row.AdGroupID
+		}
+		payload.Items = append(payload.Items, item)
+	}
+	return canonicalSearchPlanJSON(payload)
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/optimize/command.go
+++ b/internal/cli/optimize/command.go
@@ -1,0 +1,171 @@
+package optimize
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/ads"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+var searchPlanGenrePattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+var (
+	resolveSearchMetadataForPlan = resolveSearchMetadata
+	collectSearchDataForPlan     = ads.CollectSearchOptimizationData
+)
+
+// OptimizeCommand returns the experimental cross-API optimization group.
+func OptimizeCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("optimize", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:        "optimize",
+		ShortUsage:  "asc optimize <subcommand> [flags]",
+		ShortHelp:   "Build cross-API optimization plans. [experimental]",
+		LongHelp:    "Build read-only cross-API optimization plans from official Apple APIs. [experimental]",
+		FlagSet:     fs,
+		UsageFunc:   shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{SearchCommand()},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// SearchCommand returns the search optimization group.
+func SearchCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("search", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:        "search",
+		ShortUsage:  "asc optimize search <subcommand> [flags]",
+		ShortHelp:   "Build App Store search optimization plans. [experimental]",
+		LongHelp:    "Build App Store search optimization plans from official Apple APIs. [experimental]",
+		FlagSet:     fs,
+		UsageFunc:   shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{SearchPlanCommand()},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// SearchPlanCommand returns the official-only search optimization workflow.
+func SearchPlanCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("plan", flag.ExitOnError)
+	appID := fs.String("app", "", "App Store Connect app ID, bundle ID, or exact app name (required, or ASC_APP_ID env)")
+	version := fs.String("version", "", "App Store version string (required)")
+	platform := fs.String("platform", "IOS", "App Store platform: IOS, MAC_OS, TV_OS, VISION_OS")
+	adAccount := fs.String("ad-account", "", "Apple Ads ad account ID (or ASC_ADS_AD_ACCOUNT_ID/profile default)")
+	adsProfile := fs.String("ads-profile", "", "Use named Apple Ads authentication profile")
+	country := fs.String("country", "", "ISO alpha-2 Apple Ads country or region (required)")
+	genre := fs.String("genre", "", "Apple Ads search popularity genre (required)")
+	locale := fs.String("locale", "", "App Store metadata locale, for example en-US (required)")
+	windowValue := fs.String("window", "30d", "Paid performance window: 2d through 30d")
+	outDir := fs.String("out-dir", "", "Write reviewable plan artifacts to this directory")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "plan",
+		ShortUsage: "asc optimize search plan [flags]",
+		ShortHelp:  "Join official Apple Ads and App Store metadata into a search plan. [experimental]",
+		LongHelp: `Join the official Apple Ads Platform API v1 with App Store Connect metadata.
+
+This read-only workflow does not mutate campaigns or App Store metadata. It
+keeps keyword demand, app-specific paid reach, actual search-term outcomes,
+and metadata coverage distinct. Unavailable official sources are reported
+instead of replaced with invented values.
+
+When --out-dir is set, the command writes report.json, metadata-candidates.csv,
+exact-keywords.json, and negative-keywords.json as reviewable plans.
+
+Examples:
+  asc optimize search plan --app "123456789" --version "4.4.4" --ad-account "987654321" --country US --genre PRODUCTIVITY_UTILITIES --locale en-US
+  asc optimize search plan --app "123456789" --version "4.4.4" --ad-account "987654321" --country US --genre PRODUCTIVITY_UTILITIES --locale en-US --out-dir .asc/optimization/4.4.4 --output markdown`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("optimize search plan does not accept positional arguments")
+			}
+
+			resolvedAppSelector := shared.ResolveAppID(*appID)
+			if resolvedAppSelector == "" {
+				return shared.UsageError("--app is required (or set ASC_APP_ID)")
+			}
+			if strings.TrimSpace(*version) == "" {
+				return shared.UsageError("--version is required")
+			}
+			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			normalizedCountry := strings.ToUpper(strings.TrimSpace(*country))
+			if len(normalizedCountry) != 2 || normalizedCountry[0] < 'A' || normalizedCountry[0] > 'Z' || normalizedCountry[1] < 'A' || normalizedCountry[1] > 'Z' {
+				return shared.UsageError("--country must be an ISO alpha-2 code")
+			}
+			normalizedGenre := strings.ToUpper(strings.TrimSpace(*genre))
+			if normalizedGenre == "" || !searchPlanGenrePattern.MatchString(normalizedGenre) {
+				return shared.UsageError("--genre must be an Apple Ads genre identifier such as PRODUCTIVITY_UTILITIES")
+			}
+			normalizedLocale, err := shared.NormalizeAppStoreLocalizationLocale(*locale)
+			if err != nil {
+				return shared.UsageError("--locale " + err.Error())
+			}
+			window, err := resolveSearchPlanWindow(*windowValue, time.Now())
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			metadata, err := resolveSearchMetadataForPlan(ctx, resolvedAppSelector, strings.TrimSpace(*version), normalizedPlatform, normalizedLocale)
+			if err != nil {
+				return fmt.Errorf("optimize search plan: App Store Connect metadata: %w", err)
+			}
+			adsData, err := collectSearchDataForPlan(ctx, *adsProfile, *adAccount, ads.SearchOptimizationRequest{
+				AppID:           metadata.AppID,
+				Country:         normalizedCountry,
+				Genre:           normalizedGenre,
+				Start:           window.Start,
+				End:             window.End,
+				PopularityStart: window.PopularityStart,
+				PopularityEnd:   window.PopularityEnd,
+			})
+			if err != nil {
+				return fmt.Errorf("optimize search plan: Apple Ads: %w", err)
+			}
+
+			report := buildSearchPlan(searchPlanBuildInput{
+				GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+				AppID:       metadata.AppID,
+				Version:     strings.TrimSpace(*version),
+				VersionID:   metadata.VersionID,
+				Platform:    metadata.Platform,
+				Country:     normalizedCountry,
+				Genre:       normalizedGenre,
+				Locale:      normalizedLocale,
+				Window:      window,
+				Metadata:    metadata.Metadata,
+				Ads:         adsData,
+			})
+			if strings.TrimSpace(*outDir) != "" {
+				artifacts, artifactErr := writeSearchPlanArtifacts(strings.TrimSpace(*outDir), report)
+				if artifactErr != nil {
+					return fmt.Errorf("optimize search plan: %w", artifactErr)
+				}
+				report.Artifacts = artifacts
+			}
+			return shared.PrintOutputWithRenderers(
+				report,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderSearchPlanTable(report) },
+				func() error { return renderSearchPlanMarkdown(report) },
+			)
+		},
+	}
+}

--- a/internal/cli/optimize/command.go
+++ b/internal/cli/optimize/command.go
@@ -61,6 +61,7 @@ func SearchPlanCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID, bundle ID, or exact app name (required, or ASC_APP_ID env)")
 	version := fs.String("version", "", "App Store version string (required)")
 	platform := fs.String("platform", "IOS", "App Store platform: IOS, MAC_OS, TV_OS, VISION_OS")
+	appInfoID := fs.String("app-info", "", "App Info ID override when multiple records cannot be auto-resolved")
 	adAccount := fs.String("ad-account", "", "Apple Ads ad account ID (or ASC_ADS_AD_ACCOUNT_ID/profile default)")
 	adsProfile := fs.String("ads-profile", "", "Use named Apple Ads authentication profile")
 	country := fs.String("country", "", "ISO alpha-2 Apple Ads country or region (required)")
@@ -85,8 +86,8 @@ When --out-dir is set, the command writes report.json, metadata-candidates.csv,
 exact-keywords.json, and negative-keywords.json as reviewable plans.
 
 Examples:
-  asc optimize search plan --app "123456789" --version "4.4.4" --ad-account "987654321" --country US --genre PRODUCTIVITY_UTILITIES --locale en-US
-  asc optimize search plan --app "123456789" --version "4.4.4" --ad-account "987654321" --country US --genre PRODUCTIVITY_UTILITIES --locale en-US --out-dir .asc/optimization/4.4.4 --output markdown`,
+  asc optimize search plan --app "123456789" --version "1.2.0" --ad-account "987654321" --country US --genre PRODUCTIVITY_UTILITIES --locale en-US
+  asc optimize search plan --app "123456789" --version "1.2.0" --ad-account "987654321" --country US --genre PRODUCTIVITY_UTILITIES --locale en-US --out-dir .asc/optimization/1.2.0 --output markdown`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -122,7 +123,7 @@ Examples:
 				return shared.UsageError(err.Error())
 			}
 
-			metadata, err := resolveSearchMetadataForPlan(ctx, resolvedAppSelector, strings.TrimSpace(*version), normalizedPlatform, normalizedLocale)
+			metadata, err := resolveSearchMetadataForPlan(ctx, resolvedAppSelector, strings.TrimSpace(*version), normalizedPlatform, strings.TrimSpace(*appInfoID), normalizedLocale)
 			if err != nil {
 				return fmt.Errorf("optimize search plan: App Store Connect metadata: %w", err)
 			}
@@ -144,6 +145,7 @@ Examples:
 				AppID:       metadata.AppID,
 				Version:     strings.TrimSpace(*version),
 				VersionID:   metadata.VersionID,
+				AppInfoID:   metadata.AppInfoID,
 				Platform:    metadata.Platform,
 				Country:     normalizedCountry,
 				Genre:       normalizedGenre,

--- a/internal/cli/optimize/command_test.go
+++ b/internal/cli/optimize/command_test.go
@@ -30,10 +30,11 @@ func TestSearchPlanCommandHelpDescribesOfficialReadOnlyWorkflow(t *testing.T) {
 
 func TestSearchPlanCommandValidatesRequiredFlagsBeforeAuthentication(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
+	stubSearchPlanResolversToFail(t)
 	command := SearchPlanCommand()
 	err := command.ParseAndRun(context.Background(), nil)
-	if err == nil || !strings.Contains(err.Error(), "--app is required") {
-		t.Fatalf("error = %v, want --app required", err)
+	if err == nil || err.Error() != "--app is required (or set ASC_APP_ID)" {
+		t.Fatalf("error = %v, want exact --app usage error", err)
 	}
 	if !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("error = %v, want usage error", err)
@@ -47,15 +48,16 @@ func TestSearchPlanCommandRejectsInvalidCountryGenreLocaleAndWindow(t *testing.T
 		want string
 	}{
 		{name: "country", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "USA", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "en-US"}, want: "--country must be an ISO alpha-2 code"},
-		{name: "genre", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "bad genre", "--locale", "en-US"}, want: "--genre"},
-		{name: "locale", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "english"}, want: "--locale"},
-		{name: "window", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "en-US", "--window", "31d"}, want: "--window"},
+		{name: "genre", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "bad genre", "--locale", "en-US"}, want: "--genre must be an Apple Ads genre identifier such as PRODUCTIVITY_UTILITIES"},
+		{name: "locale", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "english"}, want: "--locale invalid locale \"english\": must match pattern like en or en-US"},
+		{name: "window", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "en-US", "--window", "31d"}, want: "--window must be a whole number of days from 2d through 30d"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			stubSearchPlanResolversToFail(t)
 			command := SearchPlanCommand()
 			err := command.ParseAndRun(context.Background(), test.args)
-			if err == nil || !strings.Contains(err.Error(), test.want) {
+			if err == nil || err.Error() != test.want {
 				t.Fatalf("error = %v, want %q", err, test.want)
 			}
 			if !errors.Is(err, flag.ErrHelp) {
@@ -66,10 +68,32 @@ func TestSearchPlanCommandRejectsInvalidCountryGenreLocaleAndWindow(t *testing.T
 }
 
 func TestSearchPlanCommandRejectsPositionalArguments(t *testing.T) {
+	stubSearchPlanResolversToFail(t)
 	command := SearchPlanCommand()
 	err := command.Exec(context.Background(), []string{"extra"})
-	if err == nil || !strings.Contains(err.Error(), "does not accept positional arguments") {
+	if err == nil || err.Error() != "optimize search plan does not accept positional arguments" {
 		t.Fatalf("error = %v", err)
+	}
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("error = %v, want usage error", err)
+	}
+}
+
+func stubSearchPlanResolversToFail(t *testing.T) {
+	t.Helper()
+	previousMetadata := resolveSearchMetadataForPlan
+	previousAds := collectSearchDataForPlan
+	t.Cleanup(func() {
+		resolveSearchMetadataForPlan = previousMetadata
+		collectSearchDataForPlan = previousAds
+	})
+	resolveSearchMetadataForPlan = func(context.Context, string, string, string, string, string) (resolvedSearchMetadata, error) {
+		t.Fatal("metadata resolver ran before usage validation")
+		return resolvedSearchMetadata{}, nil
+	}
+	collectSearchDataForPlan = func(context.Context, string, string, ads.SearchOptimizationRequest) (ads.SearchOptimizationData, error) {
+		t.Fatal("Apple Ads resolver ran before usage validation")
+		return ads.SearchOptimizationData{}, nil
 	}
 }
 

--- a/internal/cli/optimize/command_test.go
+++ b/internal/cli/optimize/command_test.go
@@ -91,12 +91,12 @@ func TestSearchPlanCommandRendersSupportedOutputsAndWritesArtifacts(t *testing.T
 		resolveSearchMetadataForPlan = previousMetadata
 		collectSearchDataForPlan = previousAds
 	})
-	resolveSearchMetadataForPlan = func(_ context.Context, appSelector, version, platform, locale string) (resolvedSearchMetadata, error) {
-		if appSelector != "123456789" || version != "4.4.4" || platform != "IOS" || locale != "en-US" {
-			t.Fatalf("metadata inputs = (%q, %q, %q, %q)", appSelector, version, platform, locale)
+	resolveSearchMetadataForPlan = func(_ context.Context, appSelector, version, platform, appInfoID, locale string) (resolvedSearchMetadata, error) {
+		if appSelector != "123456789" || version != "4.4.4" || platform != "IOS" || appInfoID != "info-live" || locale != "en-US" {
+			t.Fatalf("metadata inputs = (%q, %q, %q, %q, %q)", appSelector, version, platform, appInfoID, locale)
 		}
 		return resolvedSearchMetadata{
-			AppID: "123456789", VersionID: "version-1", Platform: "IOS",
+			AppID: "123456789", VersionID: "version-1", AppInfoID: "info-live", Platform: "IOS",
 			Metadata: searchMetadataSnapshot{Name: "Focus Keeper", Subtitle: "Habit tracker", Keywords: "focus,timer"},
 		}, nil
 	}
@@ -116,7 +116,7 @@ func TestSearchPlanCommandRendersSupportedOutputsAndWritesArtifacts(t *testing.T
 	}
 
 	baseArgs := []string{
-		"--app", "123456789", "--version", "4.4.4", "--ad-account", "987654321", "--ads-profile", "Ads",
+		"--app", "123456789", "--version", "4.4.4", "--app-info", "info-live", "--ad-account", "987654321", "--ads-profile", "Ads",
 		"--country", "us", "--genre", "productivity_utilities", "--locale", "en-US",
 	}
 	for _, format := range []string{"json", "table", "markdown"} {

--- a/internal/cli/optimize/command_test.go
+++ b/internal/cli/optimize/command_test.go
@@ -152,17 +152,27 @@ func TestSearchPlanCommandRendersSupportedOutputsAndWritesArtifacts(t *testing.T
 			stdout := captureSearchPlanStdout(t, func() error {
 				return SearchPlanCommand().ParseAndRun(context.Background(), args)
 			})
-			for _, want := range []string{"daily habits", "metadata_candidate", "untested_candidate", "phrase_suggestions", "unavailable", "request unavailable"} {
+			for _, want := range []string{"daily habits", "phrase_suggestions", "unavailable", "request unavailable"} {
 				if !strings.Contains(stdout, want) {
 					t.Fatalf("%s output missing %q:\n%s", format, want, stdout)
 				}
 			}
-			if format != "json" {
-				normalizedOutput := strings.ToLower(stdout)
-				for _, want := range []string{"Popularity 1-5", "Popularity 1-100", "Genre Rank", "Sources", "Notices"} {
-					if !strings.Contains(normalizedOutput, strings.ToLower(want)) {
-						t.Fatalf("%s output missing report section %q:\n%s", format, want, stdout)
-					}
+			normalizedOutput := strings.ToLower(stdout)
+			expectedByFormat := map[string][]string{
+				"json":     {"metadata_candidate", "untested_candidate"},
+				"table":    {"search optimization plan", "focus keeper", "popularity", "genre rank", "sources", "notices", "metadata · test"},
+				"markdown": {"popularity 1-5", "popularity 1-100", "genre rank", "sources", "notices", "metadata_candidate", "untested_candidate"},
+			}
+			for _, want := range expectedByFormat[format] {
+				if !strings.Contains(normalizedOutput, strings.ToLower(want)) {
+					t.Fatalf("%s output missing %q:\n%s", format, want, stdout)
+				}
+			}
+			if format == "table" {
+				planIndex := strings.Index(stdout, "SEARCH PLAN\n")
+				sourcesIndex := strings.Index(stdout, "SOURCES\n")
+				if planIndex < 0 || sourcesIndex < 0 || planIndex > sourcesIndex {
+					t.Fatalf("table must lead with the search plan before diagnostics:\n%s", stdout)
 				}
 			}
 			if format == "json" {

--- a/internal/cli/optimize/command_test.go
+++ b/internal/cli/optimize/command_test.go
@@ -105,8 +105,13 @@ func TestSearchPlanCommandRendersSupportedOutputsAndWritesArtifacts(t *testing.T
 			t.Fatalf("Ads inputs = (%q, %q, %+v)", profile, account, request)
 		}
 		return ads.SearchOptimizationData{
-			Sources:     []ads.SearchOptimizationSourceStatus{{Name: "keyword_suggestions", Status: "available", Count: 1}},
-			Suggestions: []ads.SearchSuggestion{{Text: "daily habits", Popularity: intPtr(72), Kind: "keyword"}},
+			Sources: []ads.SearchOptimizationSourceStatus{
+				{Name: "keyword_suggestions", Status: "available", Count: 1},
+				{Name: "phrase_suggestions", Status: "unavailable", Error: "request unavailable"},
+				{Name: "search_term_performance", Status: "empty"},
+			},
+			Suggestions:  []ads.SearchSuggestion{{Text: "daily habits", Popularity: intPtr(72), Kind: "keyword"}},
+			Popularities: []ads.SearchPopularity{{Term: "daily habits", Popularity100: intPtr(72), Popularity5: intPtr(4), RankInGenre: intPtr(8)}},
 		}, nil
 	}
 
@@ -123,9 +128,17 @@ func TestSearchPlanCommandRendersSupportedOutputsAndWritesArtifacts(t *testing.T
 			stdout := captureSearchPlanStdout(t, func() error {
 				return SearchPlanCommand().ParseAndRun(context.Background(), args)
 			})
-			for _, want := range []string{"daily habits", "metadata_candidate", "untested_candidate"} {
+			for _, want := range []string{"daily habits", "metadata_candidate", "untested_candidate", "phrase_suggestions", "unavailable", "request unavailable"} {
 				if !strings.Contains(stdout, want) {
 					t.Fatalf("%s output missing %q:\n%s", format, want, stdout)
+				}
+			}
+			if format != "json" {
+				normalizedOutput := strings.ToLower(stdout)
+				for _, want := range []string{"Popularity 1-5", "Popularity 1-100", "Genre Rank", "Sources", "Notices"} {
+					if !strings.Contains(normalizedOutput, strings.ToLower(want)) {
+						t.Fatalf("%s output missing report section %q:\n%s", format, want, stdout)
+					}
 				}
 			}
 			if format == "json" {

--- a/internal/cli/optimize/command_test.go
+++ b/internal/cli/optimize/command_test.go
@@ -1,0 +1,161 @@
+package optimize
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/ads"
+)
+
+func TestSearchPlanCommandHelpDescribesOfficialReadOnlyWorkflow(t *testing.T) {
+	command := SearchPlanCommand()
+	joined := command.ShortUsage + "\n" + command.LongHelp
+	for _, want := range []string{
+		"asc optimize search plan",
+		"official Apple Ads Platform API v1",
+		"does not mutate",
+		"--out-dir",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("help missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestSearchPlanCommandValidatesRequiredFlagsBeforeAuthentication(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	command := SearchPlanCommand()
+	err := command.ParseAndRun(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "--app is required") {
+		t.Fatalf("error = %v, want --app required", err)
+	}
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("error = %v, want usage error", err)
+	}
+}
+
+func TestSearchPlanCommandRejectsInvalidCountryGenreLocaleAndWindow(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "country", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "USA", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "en-US"}, want: "--country must be an ISO alpha-2 code"},
+		{name: "genre", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "bad genre", "--locale", "en-US"}, want: "--genre"},
+		{name: "locale", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "english"}, want: "--locale"},
+		{name: "window", args: []string{"--app", "1", "--version", "4.4.4", "--ad-account", "2", "--country", "US", "--genre", "PRODUCTIVITY_UTILITIES", "--locale", "en-US", "--window", "31d"}, want: "--window"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := SearchPlanCommand()
+			err := command.ParseAndRun(context.Background(), test.args)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("error = %v, want usage error", err)
+			}
+		})
+	}
+}
+
+func TestSearchPlanCommandRejectsPositionalArguments(t *testing.T) {
+	command := SearchPlanCommand()
+	err := command.Exec(context.Background(), []string{"extra"})
+	if err == nil || !strings.Contains(err.Error(), "does not accept positional arguments") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestOptimizeGroupsReturnHelp(t *testing.T) {
+	for _, command := range []*flag.FlagSet{OptimizeCommand().FlagSet, SearchCommand().FlagSet} {
+		if command == nil {
+			t.Fatal("group command is missing a FlagSet")
+		}
+	}
+	if err := OptimizeCommand().Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("optimize Exec error = %v, want flag.ErrHelp", err)
+	}
+}
+
+func TestSearchPlanCommandRendersSupportedOutputsAndWritesArtifacts(t *testing.T) {
+	previousMetadata := resolveSearchMetadataForPlan
+	previousAds := collectSearchDataForPlan
+	t.Cleanup(func() {
+		resolveSearchMetadataForPlan = previousMetadata
+		collectSearchDataForPlan = previousAds
+	})
+	resolveSearchMetadataForPlan = func(_ context.Context, appSelector, version, platform, locale string) (resolvedSearchMetadata, error) {
+		if appSelector != "123456789" || version != "4.4.4" || platform != "IOS" || locale != "en-US" {
+			t.Fatalf("metadata inputs = (%q, %q, %q, %q)", appSelector, version, platform, locale)
+		}
+		return resolvedSearchMetadata{
+			AppID: "123456789", VersionID: "version-1", Platform: "IOS",
+			Metadata: searchMetadataSnapshot{Name: "Focus Keeper", Subtitle: "Habit tracker", Keywords: "focus,timer"},
+		}, nil
+	}
+	collectSearchDataForPlan = func(_ context.Context, profile, account string, request ads.SearchOptimizationRequest) (ads.SearchOptimizationData, error) {
+		if profile != "Ads" || account != "987654321" || request.AppID != "123456789" || request.Country != "US" || request.Genre != "PRODUCTIVITY_UTILITIES" {
+			t.Fatalf("Ads inputs = (%q, %q, %+v)", profile, account, request)
+		}
+		return ads.SearchOptimizationData{
+			Sources:     []ads.SearchOptimizationSourceStatus{{Name: "keyword_suggestions", Status: "available", Count: 1}},
+			Suggestions: []ads.SearchSuggestion{{Text: "daily habits", Popularity: intPtr(72), Kind: "keyword"}},
+		}, nil
+	}
+
+	baseArgs := []string{
+		"--app", "123456789", "--version", "4.4.4", "--ad-account", "987654321", "--ads-profile", "Ads",
+		"--country", "us", "--genre", "productivity_utilities", "--locale", "en-US",
+	}
+	for _, format := range []string{"json", "table", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			args := append(append([]string(nil), baseArgs...), "--output", format)
+			if format == "json" {
+				args = append(args, "--out-dir", filepath.Join(t.TempDir(), "plan"))
+			}
+			stdout := captureSearchPlanStdout(t, func() error {
+				return SearchPlanCommand().ParseAndRun(context.Background(), args)
+			})
+			for _, want := range []string{"daily habits", "metadata_candidate", "untested_candidate"} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("%s output missing %q:\n%s", format, want, stdout)
+				}
+			}
+			if format == "json" {
+				outIndex := len(args) - 1
+				if _, err := os.Stat(filepath.Join(args[outIndex], searchPlanReportArtifact)); err != nil {
+					t.Fatalf("report artifact: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func captureSearchPlanStdout(t *testing.T, run func() error) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := os.Stdout
+	os.Stdout = writer
+	runErr := run()
+	_ = writer.Close()
+	os.Stdout = previous
+	data, readErr := io.ReadAll(reader)
+	_ = reader.Close()
+	if runErr != nil {
+		t.Fatalf("run error = %v", runErr)
+	}
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	return string(data)
+}

--- a/internal/cli/optimize/metadata.go
+++ b/internal/cli/optimize/metadata.go
@@ -1,0 +1,92 @@
+package optimize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type resolvedSearchMetadata struct {
+	AppID     string
+	VersionID string
+	Platform  string
+	Metadata  searchMetadataSnapshot
+}
+
+func resolveSearchMetadata(ctx context.Context, appSelector, version, platform, locale string) (resolvedSearchMetadata, error) {
+	client, err := shared.GetASCClient()
+	if err != nil {
+		return resolvedSearchMetadata{}, err
+	}
+
+	lookupCtx, cancel := shared.ContextWithTimeout(ctx)
+	appID, err := shared.ResolveAppIDWithLookup(lookupCtx, client, appSelector)
+	cancel()
+	if err != nil {
+		return resolvedSearchMetadata{}, fmt.Errorf("resolve app: %w", err)
+	}
+
+	versionCtx, cancel := shared.ContextWithTimeout(ctx)
+	versionID, err := shared.ResolveAppStoreVersionID(versionCtx, client, appID, version, platform)
+	cancel()
+	if err != nil {
+		return resolvedSearchMetadata{}, fmt.Errorf("resolve version: %w", err)
+	}
+
+	versionLocalizationCtx, cancel := shared.ContextWithTimeout(ctx)
+	versionLocalizations, err := client.GetAppStoreVersionLocalizations(
+		versionLocalizationCtx,
+		versionID,
+		asc.WithAppStoreVersionLocalizationLocales([]string{locale}),
+		asc.WithAppStoreVersionLocalizationsLimit(2),
+	)
+	cancel()
+	if err != nil {
+		return resolvedSearchMetadata{}, fmt.Errorf("read version localization %q: %w", locale, err)
+	}
+	if versionLocalizations == nil || len(versionLocalizations.Data) == 0 {
+		return resolvedSearchMetadata{}, fmt.Errorf("version localization %q not found", locale)
+	}
+	if len(versionLocalizations.Data) > 1 {
+		return resolvedSearchMetadata{}, fmt.Errorf("multiple version localizations found for locale %q", locale)
+	}
+
+	appInfoCtx, cancel := shared.ContextWithTimeout(ctx)
+	appInfoID, err := shared.ResolveAppInfoID(appInfoCtx, client, appID, "")
+	cancel()
+	if err != nil {
+		return resolvedSearchMetadata{}, fmt.Errorf("resolve app info: %w", err)
+	}
+
+	appInfoLocalizationCtx, cancel := shared.ContextWithTimeout(ctx)
+	appInfoLocalizations, err := client.GetAppInfoLocalizations(
+		appInfoLocalizationCtx,
+		appInfoID,
+		asc.WithAppInfoLocalizationLocales([]string{locale}),
+		asc.WithAppInfoLocalizationsLimit(2),
+	)
+	cancel()
+	if err != nil {
+		return resolvedSearchMetadata{}, fmt.Errorf("read app info localization %q: %w", locale, err)
+	}
+	if appInfoLocalizations == nil || len(appInfoLocalizations.Data) == 0 {
+		return resolvedSearchMetadata{}, fmt.Errorf("app info localization %q not found", locale)
+	}
+	if len(appInfoLocalizations.Data) > 1 {
+		return resolvedSearchMetadata{}, fmt.Errorf("multiple app info localizations found for locale %q", locale)
+	}
+
+	return resolvedSearchMetadata{
+		AppID:     appID,
+		VersionID: versionID,
+		Platform:  platform,
+		Metadata: searchMetadataSnapshot{
+			Name:     strings.TrimSpace(appInfoLocalizations.Data[0].Attributes.Name),
+			Subtitle: strings.TrimSpace(appInfoLocalizations.Data[0].Attributes.Subtitle),
+			Keywords: strings.TrimSpace(versionLocalizations.Data[0].Attributes.Keywords),
+		},
+	}, nil
+}

--- a/internal/cli/optimize/metadata.go
+++ b/internal/cli/optimize/metadata.go
@@ -12,11 +12,12 @@ import (
 type resolvedSearchMetadata struct {
 	AppID     string
 	VersionID string
+	AppInfoID string
 	Platform  string
 	Metadata  searchMetadataSnapshot
 }
 
-func resolveSearchMetadata(ctx context.Context, appSelector, version, platform, locale string) (resolvedSearchMetadata, error) {
+func resolveSearchMetadata(ctx context.Context, appSelector, version, platform, appInfoOverride, locale string) (resolvedSearchMetadata, error) {
 	client, err := shared.GetASCClient()
 	if err != nil {
 		return resolvedSearchMetadata{}, err
@@ -30,7 +31,7 @@ func resolveSearchMetadata(ctx context.Context, appSelector, version, platform, 
 	}
 
 	versionCtx, cancel := shared.ContextWithTimeout(ctx)
-	versionID, err := shared.ResolveAppStoreVersionID(versionCtx, client, appID, version, platform)
+	versionID, versionState, err := shared.ResolveAppStoreVersionIDAndState(versionCtx, client, appID, version, platform)
 	cancel()
 	if err != nil {
 		return resolvedSearchMetadata{}, fmt.Errorf("resolve version: %w", err)
@@ -55,7 +56,7 @@ func resolveSearchMetadata(ctx context.Context, appSelector, version, platform, 
 	}
 
 	appInfoCtx, cancel := shared.ContextWithTimeout(ctx)
-	appInfoID, err := shared.ResolveAppInfoID(appInfoCtx, client, appID, "")
+	appInfoID, err := resolveSearchAppInfoID(appInfoCtx, client, appID, appInfoOverride, versionState)
 	cancel()
 	if err != nil {
 		return resolvedSearchMetadata{}, fmt.Errorf("resolve app info: %w", err)
@@ -82,6 +83,7 @@ func resolveSearchMetadata(ctx context.Context, appSelector, version, platform, 
 	return resolvedSearchMetadata{
 		AppID:     appID,
 		VersionID: versionID,
+		AppInfoID: appInfoID,
 		Platform:  platform,
 		Metadata: searchMetadataSnapshot{
 			Name:     strings.TrimSpace(appInfoLocalizations.Data[0].Attributes.Name),
@@ -89,4 +91,31 @@ func resolveSearchMetadata(ctx context.Context, appSelector, version, platform, 
 			Keywords: strings.TrimSpace(versionLocalizations.Data[0].Attributes.Keywords),
 		},
 	}, nil
+}
+
+func resolveSearchAppInfoID(ctx context.Context, client *asc.Client, appID, appInfoOverride, versionState string) (string, error) {
+	if strings.TrimSpace(appInfoOverride) != "" {
+		return shared.ResolveOwnedAppInfoID(ctx, client, appID, appInfoOverride)
+	}
+
+	appInfos, err := client.GetAppInfos(ctx, appID)
+	if err != nil {
+		return "", err
+	}
+	if len(appInfos.Data) == 0 {
+		return "", fmt.Errorf("no app info found for app %q", appID)
+	}
+	if len(appInfos.Data) == 1 {
+		return strings.TrimSpace(appInfos.Data[0].ID), nil
+	}
+	candidates := asc.AppInfoCandidates(appInfos.Data)
+	if resolvedID, ok := asc.AutoResolveAppInfoIDByVersionState(candidates, versionState); ok {
+		return resolvedID, nil
+	}
+	return "", fmt.Errorf(
+		"multiple app infos found for app %q (%s); run `asc apps info list --app %q` and re-run with --app-info",
+		appID,
+		asc.FormatAppInfoCandidates(candidates),
+		appID,
+	)
 }

--- a/internal/cli/optimize/metadata_test.go
+++ b/internal/cli/optimize/metadata_test.go
@@ -34,15 +34,15 @@ func TestResolveSearchMetadataJoinsVersionAndAppInfoLocalizations(t *testing.T) 
 			if request.URL.Query().Get("filter[versionString]") != "4.4.4" || request.URL.Query().Get("filter[platform]") != "IOS" {
 				t.Fatalf("version query = %s", request.URL.RawQuery)
 			}
-			return searchMetadataResponse(`{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"platform":"IOS","versionString":"4.4.4"}}]}`), nil
+			return searchMetadataResponse(`{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"platform":"IOS","versionString":"4.4.4","appStoreState":"READY_FOR_SALE"}}]}`), nil
 		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
 			if request.URL.Query().Get("filter[locale]") != "en-US" {
 				t.Fatalf("version localization query = %s", request.URL.RawQuery)
 			}
 			return searchMetadataResponse(`{"data":[{"type":"appStoreVersionLocalizations","id":"version-loc-1","attributes":{"locale":"en-US","keywords":"focus,timer"}}]}`), nil
 		case "/v1/apps/123456789/appInfos":
-			return searchMetadataResponse(`{"data":[{"type":"appInfos","id":"info-1","attributes":{}}]}`), nil
-		case "/v1/appInfos/info-1/appInfoLocalizations":
+			return searchMetadataResponse(`{"data":[{"type":"appInfos","id":"info-rejected","attributes":{"appStoreState":"DEVELOPER_REJECTED"}},{"type":"appInfos","id":"info-live","attributes":{"appStoreState":"READY_FOR_DISTRIBUTION"}}]}`), nil
+		case "/v1/appInfos/info-live/appInfoLocalizations":
 			if request.URL.Query().Get("filter[locale]") != "en-US" {
 				t.Fatalf("app info localization query = %s", request.URL.RawQuery)
 			}
@@ -54,11 +54,11 @@ func TestResolveSearchMetadataJoinsVersionAndAppInfoLocalizations(t *testing.T) 
 	})
 	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) { return client, nil }))
 
-	result, err := resolveSearchMetadata(context.Background(), "123456789", "4.4.4", "IOS", "en-US")
+	result, err := resolveSearchMetadata(context.Background(), "123456789", "4.4.4", "IOS", "", "en-US")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.AppID != "123456789" || result.VersionID != "version-1" || result.Platform != "IOS" {
+	if result.AppID != "123456789" || result.VersionID != "version-1" || result.AppInfoID != "info-live" || result.Platform != "IOS" {
 		t.Fatalf("identity = %+v", result)
 	}
 	if result.Metadata.Name != "Focus Keeper" || result.Metadata.Subtitle != "Habit tracker" || result.Metadata.Keywords != "focus,timer" {

--- a/internal/cli/optimize/metadata_test.go
+++ b/internal/cli/optimize/metadata_test.go
@@ -1,0 +1,97 @@
+package optimize
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type searchMetadataRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn searchMetadataRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestResolveSearchMetadataJoinsVersionAndAppInfoLocalizations(t *testing.T) {
+	client := newSearchMetadataTestClient(t, func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet {
+			t.Fatalf("method = %s", request.Method)
+		}
+		switch request.URL.Path {
+		case "/v1/apps/123456789/appStoreVersions":
+			if request.URL.Query().Get("filter[versionString]") != "4.4.4" || request.URL.Query().Get("filter[platform]") != "IOS" {
+				t.Fatalf("version query = %s", request.URL.RawQuery)
+			}
+			return searchMetadataResponse(`{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"platform":"IOS","versionString":"4.4.4"}}]}`), nil
+		case "/v1/appStoreVersions/version-1/appStoreVersionLocalizations":
+			if request.URL.Query().Get("filter[locale]") != "en-US" {
+				t.Fatalf("version localization query = %s", request.URL.RawQuery)
+			}
+			return searchMetadataResponse(`{"data":[{"type":"appStoreVersionLocalizations","id":"version-loc-1","attributes":{"locale":"en-US","keywords":"focus,timer"}}]}`), nil
+		case "/v1/apps/123456789/appInfos":
+			return searchMetadataResponse(`{"data":[{"type":"appInfos","id":"info-1","attributes":{}}]}`), nil
+		case "/v1/appInfos/info-1/appInfoLocalizations":
+			if request.URL.Query().Get("filter[locale]") != "en-US" {
+				t.Fatalf("app info localization query = %s", request.URL.RawQuery)
+			}
+			return searchMetadataResponse(`{"data":[{"type":"appInfoLocalizations","id":"info-loc-1","attributes":{"locale":"en-US","name":"Focus Keeper","subtitle":"Habit tracker"}}]}`), nil
+		default:
+			t.Fatalf("unexpected request path %s", request.URL.Path)
+			return nil, nil
+		}
+	})
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) { return client, nil }))
+
+	result, err := resolveSearchMetadata(context.Background(), "123456789", "4.4.4", "IOS", "en-US")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AppID != "123456789" || result.VersionID != "version-1" || result.Platform != "IOS" {
+		t.Fatalf("identity = %+v", result)
+	}
+	if result.Metadata.Name != "Focus Keeper" || result.Metadata.Subtitle != "Habit tracker" || result.Metadata.Keywords != "focus,timer" {
+		t.Fatalf("metadata = %+v", result.Metadata)
+	}
+}
+
+func newSearchMetadataTestClient(t *testing.T, roundTrip searchMetadataRoundTripFunc) *asc.Client {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "AuthKey_TEST.p8")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client, err := asc.NewClientWithHTTPClient("TESTKEY", "TESTISSUER", keyPath, &http.Client{Transport: roundTrip})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func searchMetadataResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/internal/cli/optimize/output.go
+++ b/internal/cli/optimize/output.go
@@ -148,7 +148,14 @@ func formatSearchPlanSourceName(value string) string {
 
 func compactSearchPlanDiagnostic(value string) string {
 	compact := strings.TrimSpace(value)
-	if htmlIndex := strings.Index(strings.ToLower(compact), "<html"); htmlIndex >= 0 {
+	lower := strings.ToLower(compact)
+	htmlIndex := len(compact)
+	for _, marker := range []string{"<!doctype html", "<html", "<head", "<body"} {
+		if index := strings.Index(lower, marker); index >= 0 && index < htmlIndex {
+			htmlIndex = index
+		}
+	}
+	if htmlIndex < len(compact) {
 		compact = strings.TrimSpace(compact[:htmlIndex])
 	}
 	compact = strings.TrimSpace(strings.TrimSuffix(compact, ":"))

--- a/internal/cli/optimize/output.go
+++ b/internal/cli/optimize/output.go
@@ -1,24 +1,25 @@
 package optimize
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func renderSearchPlanTable(report SearchPlanReport) error {
-	asc.RenderTable(searchPlanHeaders(), searchPlanRows(report.Rows))
+	renderSearchPlanHuman(report, false)
 	return nil
 }
 
 func renderSearchPlanMarkdown(report SearchPlanReport) error {
-	asc.RenderMarkdown(searchPlanHeaders(), searchPlanRows(report.Rows))
+	renderSearchPlanHuman(report, true)
 	return nil
 }
 
 func searchPlanHeaders() []string {
-	return []string{"Term", "Popularity", "Share", "Installs", "CPA", "Actions", "Confidence", "Sources"}
+	return []string{"Term", "Popularity 1-5", "Popularity 1-100", "Genre Rank", "Share", "Installs", "CPA", "Actions", "Confidence", "Sources"}
 }
 
 func searchPlanRows(rows []SearchPlanRow) [][]string {
@@ -26,7 +27,9 @@ func searchPlanRows(rows []SearchPlanRow) [][]string {
 	for _, row := range rows {
 		result = append(result, []string{
 			row.Term,
+			formatSearchPlanPopularity5(row),
 			formatOptionalInt(row.Popularity100),
+			formatOptionalInt(row.RankInGenre),
 			formatSearchPlanShare(row.ImpressionShareLow, row.ImpressionShareHigh),
 			formatOptionalInt64(row.TotalInstalls),
 			formatSearchPlanMoney(row.CPA),
@@ -36,6 +39,53 @@ func searchPlanRows(rows []SearchPlanRow) [][]string {
 		})
 	}
 	return result
+}
+
+func renderSearchPlanHuman(report SearchPlanReport, markdown bool) {
+	shared.RenderSection("Summary", []string{"Field", "Value"}, [][]string{
+		{"App", report.AppID},
+		{"Version", report.Version},
+		{"Platform", report.Platform},
+		{"Store", report.Country},
+		{"Genre", report.Genre},
+		{"Locale", report.Locale},
+		{"Paid Window", formatSearchPlanWindow(report.Window.Start, report.Window.End)},
+		{"Popularity Window", formatSearchPlanWindow(report.Window.PopularityStart, report.Window.PopularityEnd)},
+		{"Terms", strconv.Itoa(report.Summary.Terms)},
+		{"Daily Budget Recommendations", strconv.Itoa(report.Summary.DailyBudgetRecommendations)},
+		{"Target CPA Recommendations", strconv.Itoa(report.Summary.TargetCPARecommendations)},
+	}, markdown)
+
+	sourceRows := make([][]string, 0, len(report.Sources))
+	for _, source := range report.Sources {
+		sourceRows = append(sourceRows, []string{source.Name, source.Status, strconv.Itoa(source.Count), source.Error})
+	}
+	shared.RenderSection("Sources", []string{"Source", "Status", "Count", "Error"}, sourceRows, markdown)
+
+	if len(report.Notices) > 0 {
+		noticeRows := make([][]string, 0, len(report.Notices))
+		for index, notice := range report.Notices {
+			noticeRows = append(noticeRows, []string{strconv.Itoa(index + 1), notice})
+		}
+		shared.RenderSection("Notices", []string{"#", "Notice"}, noticeRows, markdown)
+	}
+
+	shared.RenderSection("Search Plan", searchPlanHeaders(), searchPlanRows(report.Rows), markdown)
+
+	if len(report.Artifacts) > 0 {
+		artifactRows := make([][]string, 0, len(report.Artifacts))
+		for _, artifact := range report.Artifacts {
+			artifactRows = append(artifactRows, []string{artifact})
+		}
+		shared.RenderSection("Artifacts", []string{"Path"}, artifactRows, markdown)
+	}
+}
+
+func formatSearchPlanPopularity5(row SearchPlanRow) string {
+	if row.Popularity5 != nil {
+		return strconv.Itoa(*row.Popularity5)
+	}
+	return formatOptionalInt(row.ImpressionSharePopularity5)
 }
 
 func formatOptionalInt(value *int) string {
@@ -67,4 +117,11 @@ func formatSearchPlanMoney(value *SearchPlanMoney) string {
 		return "—"
 	}
 	return value.Amount + " " + value.Currency
+}
+
+func formatSearchPlanWindow(start, end string) string {
+	if start == "" && end == "" {
+		return "—"
+	}
+	return fmt.Sprintf("%s through %s", shared.OrNA(start), shared.OrNA(end))
 }

--- a/internal/cli/optimize/output.go
+++ b/internal/cli/optimize/output.go
@@ -1,0 +1,70 @@
+package optimize
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func renderSearchPlanTable(report SearchPlanReport) error {
+	asc.RenderTable(searchPlanHeaders(), searchPlanRows(report.Rows))
+	return nil
+}
+
+func renderSearchPlanMarkdown(report SearchPlanReport) error {
+	asc.RenderMarkdown(searchPlanHeaders(), searchPlanRows(report.Rows))
+	return nil
+}
+
+func searchPlanHeaders() []string {
+	return []string{"Term", "Popularity", "Share", "Installs", "CPA", "Actions", "Confidence", "Sources"}
+}
+
+func searchPlanRows(rows []SearchPlanRow) [][]string {
+	result := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, []string{
+			row.Term,
+			formatOptionalInt(row.Popularity100),
+			formatSearchPlanShare(row.ImpressionShareLow, row.ImpressionShareHigh),
+			formatOptionalInt64(row.TotalInstalls),
+			formatSearchPlanMoney(row.CPA),
+			strings.Join(row.Actions, ","),
+			row.Confidence,
+			strings.Join(row.Sources, ","),
+		})
+	}
+	return result
+}
+
+func formatOptionalInt(value *int) string {
+	if value == nil {
+		return "—"
+	}
+	return strconv.Itoa(*value)
+}
+
+func formatOptionalInt64(value *int64) string {
+	if value == nil {
+		return "—"
+	}
+	return strconv.FormatInt(*value, 10)
+}
+
+func formatSearchPlanShare(low, high *float64) string {
+	if low == nil || high == nil {
+		return "—"
+	}
+	if *low == *high {
+		return strconv.FormatFloat(*low*100, 'f', 0, 64) + "%"
+	}
+	return strconv.FormatFloat(*low*100, 'f', 0, 64) + "–" + strconv.FormatFloat(*high*100, 'f', 0, 64) + "%"
+}
+
+func formatSearchPlanMoney(value *SearchPlanMoney) string {
+	if value == nil {
+		return "—"
+	}
+	return value.Amount + " " + value.Currency
+}

--- a/internal/cli/optimize/output.go
+++ b/internal/cli/optimize/output.go
@@ -9,13 +9,156 @@ import (
 )
 
 func renderSearchPlanTable(report SearchPlanReport) error {
-	renderSearchPlanHuman(report, false)
+	shared.RenderSection("Search Optimization Plan", []string{"Field", "Value"}, searchPlanCompactSummaryRows(report), false)
+	shared.RenderSection("Search Plan", searchPlanCompactHeaders(), searchPlanCompactRows(report.Rows), false)
+
+	sourceRows := make([][]string, 0, len(report.Sources))
+	for _, source := range report.Sources {
+		sourceRows = append(sourceRows, []string{
+			formatSearchPlanSourceName(source.Name),
+			source.Status,
+			strconv.Itoa(source.Count),
+		})
+	}
+	shared.RenderSection("Sources", []string{"Source", "Status", "Rows"}, sourceRows, false)
+
+	if len(report.Notices) > 0 {
+		noticeRows := make([][]string, 0, len(report.Notices))
+		for index, notice := range report.Notices {
+			noticeRows = append(noticeRows, []string{strconv.Itoa(index + 1), compactSearchPlanDiagnostic(notice)})
+		}
+		shared.RenderSection("Notices", []string{"#", "Notice"}, noticeRows, false)
+	}
+
+	if len(report.Artifacts) > 0 {
+		artifactRows := make([][]string, 0, len(report.Artifacts))
+		for _, artifact := range report.Artifacts {
+			artifactRows = append(artifactRows, []string{artifact})
+		}
+		shared.RenderSection("Artifacts", []string{"Path"}, artifactRows, false)
+	}
 	return nil
 }
 
 func renderSearchPlanMarkdown(report SearchPlanReport) error {
 	renderSearchPlanHuman(report, true)
 	return nil
+}
+
+func searchPlanCompactSummaryRows(report SearchPlanReport) [][]string {
+	appName := strings.TrimSpace(report.Metadata.Name)
+	if appName == "" {
+		appName = report.AppID
+	}
+	return [][]string{
+		{"App", appName},
+		{"Version", strings.TrimSpace(report.Version) + " · " + formatSearchPlanPlatform(report.Platform)},
+		{"Market", strings.TrimSpace(report.Country) + " · " + strings.TrimSpace(report.Locale)},
+		{"Genre", formatSearchPlanSourceName(report.Genre)},
+		{"Paid Window", formatSearchPlanWindow(report.Window.Start, report.Window.End)},
+		{"Popularity Window", formatSearchPlanWindow(report.Window.PopularityStart, report.Window.PopularityEnd)},
+		{"Terms", strconv.Itoa(report.Summary.Terms)},
+		{"Source Coverage", fmt.Sprintf("%d available · %d empty · %d unavailable", report.Summary.AvailableSources, report.Summary.EmptySources, report.Summary.UnavailableSources)},
+	}
+}
+
+func searchPlanCompactHeaders() []string {
+	return []string{"Term", "Popularity", "Genre Rank", "Share", "Installs", "CPA", "Next Step", "Confidence"}
+}
+
+func searchPlanCompactRows(rows []SearchPlanRow) [][]string {
+	result := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, []string{
+			row.Term,
+			formatSearchPlanCompactPopularity(row),
+			formatOptionalInt(row.RankInGenre),
+			formatSearchPlanShare(row.ImpressionShareLow, row.ImpressionShareHigh),
+			formatOptionalInt64(row.TotalInstalls),
+			formatSearchPlanMoney(row.CPA),
+			formatSearchPlanCompactActions(row.Actions),
+			row.Confidence,
+		})
+	}
+	return result
+}
+
+func formatSearchPlanCompactPopularity(row SearchPlanRow) string {
+	popularity5 := row.Popularity5
+	if popularity5 == nil {
+		popularity5 = row.ImpressionSharePopularity5
+	}
+	if popularity5 == nil && row.Popularity100 == nil {
+		if row.SuggestionPopularity != nil {
+			return "suggested " + strconv.Itoa(*row.SuggestionPopularity)
+		}
+		return "—"
+	}
+	return formatOptionalInt(popularity5) + " / " + formatOptionalInt(row.Popularity100)
+}
+
+func formatSearchPlanCompactActions(actions []string) string {
+	labels := make([]string, 0, len(actions))
+	for _, action := range actions {
+		label := map[string]string{
+			"promote_exact":      "promote exact",
+			"negative_candidate": "add negative",
+			"metadata_candidate": "metadata",
+			"defend":             "defend",
+			"saturated":          "saturated",
+			"untested_candidate": "test",
+		}[action]
+		if label == "" {
+			label = strings.ReplaceAll(action, "_", " ")
+		}
+		labels = append(labels, label)
+	}
+	if len(labels) == 0 {
+		return "—"
+	}
+	return strings.Join(labels, " · ")
+}
+
+func formatSearchPlanPlatform(platform string) string {
+	switch strings.ToUpper(strings.TrimSpace(platform)) {
+	case "IOS":
+		return "iOS"
+	case "MAC_OS", "MACOS":
+		return "macOS"
+	case "TV_OS", "TVOS":
+		return "tvOS"
+	case "VISION_OS", "VISIONOS":
+		return "visionOS"
+	default:
+		return strings.TrimSpace(platform)
+	}
+}
+
+func formatSearchPlanSourceName(value string) string {
+	words := strings.Fields(strings.ReplaceAll(strings.ToLower(strings.TrimSpace(value)), "_", " "))
+	for index, word := range words {
+		if word == "cpa" {
+			words[index] = "CPA"
+			continue
+		}
+		words[index] = strings.ToUpper(word[:1]) + word[1:]
+	}
+	return strings.Join(words, " ")
+}
+
+func compactSearchPlanDiagnostic(value string) string {
+	compact := strings.TrimSpace(value)
+	if htmlIndex := strings.Index(strings.ToLower(compact), "<html"); htmlIndex >= 0 {
+		compact = strings.TrimSpace(compact[:htmlIndex])
+	}
+	compact = strings.TrimSpace(strings.TrimSuffix(compact, ":"))
+	compact = strings.Join(strings.Fields(compact), " ")
+	const maxRunes = 72
+	runes := []rune(compact)
+	if len(runes) > maxRunes {
+		compact = string(runes[:maxRunes-1]) + "…"
+	}
+	return compact
 }
 
 func searchPlanHeaders() []string {

--- a/internal/cli/optimize/output_test.go
+++ b/internal/cli/optimize/output_test.go
@@ -56,16 +56,22 @@ func TestSearchPlanCompactTableIsScreenshotFriendly(t *testing.T) {
 }
 
 func TestCompactSearchPlanDiagnosticRemovesProviderHTMLAndCapsLength(t *testing.T) {
-	errorText := "retry limit exceeded after 4 retries: HTTP 500: <html><head><title>500 Internal Server Error</title></head><body>Apple returned a very long response that must not stretch the terminal table beyond a useful screenshot width</body></html>"
-	got := compactSearchPlanDiagnostic(errorText)
-	if strings.Contains(got, "<html>") || strings.Contains(got, "Internal Server Error") {
-		t.Fatalf("compact diagnostic retained provider HTML: %q", got)
-	}
-	if len([]rune(got)) > 72 {
-		t.Fatalf("compact diagnostic length = %d, want <= 72: %q", len([]rune(got)), got)
-	}
-	if got != "retry limit exceeded after 4 retries: HTTP 500" {
-		t.Fatalf("compact diagnostic = %q", got)
+	for _, marker := range []string{
+		"<html><head><title>500 Internal Server Error</title></head>",
+		"<!DOCTYPE html><html><head><title>500 Internal Server Error</title></head>",
+		"<body>Apple returned a provider fragment",
+	} {
+		errorText := "retry limit exceeded after 4 retries: HTTP 500: " + marker + "Apple returned a very long response that must not stretch the terminal table beyond a useful screenshot width"
+		got := compactSearchPlanDiagnostic(errorText)
+		if strings.Contains(strings.ToLower(got), "html") || strings.Contains(got, "provider fragment") || strings.Contains(got, "Internal Server Error") {
+			t.Fatalf("compact diagnostic retained provider HTML from %q: %q", marker, got)
+		}
+		if len([]rune(got)) > 72 {
+			t.Fatalf("compact diagnostic length = %d, want <= 72: %q", len([]rune(got)), got)
+		}
+		if got != "retry limit exceeded after 4 retries: HTTP 500" {
+			t.Fatalf("compact diagnostic = %q", got)
+		}
 	}
 }
 

--- a/internal/cli/optimize/output_test.go
+++ b/internal/cli/optimize/output_test.go
@@ -1,0 +1,81 @@
+package optimize
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSearchPlanCompactTableIsScreenshotFriendly(t *testing.T) {
+	report := SearchPlanReport{
+		AppID:    "123456789",
+		Version:  "1.3.1",
+		Platform: "IOS",
+		Country:  "US",
+		Genre:    "PRODUCTIVITY_UTILITIES",
+		Locale:   "en-US",
+		Metadata: searchMetadataSnapshot{Name: "Zenther: AI Calorie Tracker"},
+		Summary: SearchPlanSummary{
+			Terms:              516,
+			AvailableSources:   5,
+			EmptySources:       5,
+			UnavailableSources: 2,
+		},
+	}
+
+	rows := searchPlanCompactSummaryRows(report)
+	for _, want := range []string{
+		"Zenther: AI Calorie Tracker",
+		"1.3.1 · iOS",
+		"US · en-US",
+		"5 available · 5 empty · 2 unavailable",
+	} {
+		if !tableRowsContain(rows, want) {
+			t.Fatalf("compact summary missing %q: %#v", want, rows)
+		}
+	}
+	if tableRowsContain(rows, report.AppID) {
+		t.Fatalf("compact summary exposes app ID: %#v", rows)
+	}
+
+	wantHeaders := []string{"Term", "Popularity", "Genre Rank", "Share", "Installs", "CPA", "Next Step", "Confidence"}
+	if got := searchPlanCompactHeaders(); !slices.Equal(got, wantHeaders) {
+		t.Fatalf("compact headers = %v, want %v", got, wantHeaders)
+	}
+	row := SearchPlanRow{
+		Term:          "calorie tracker",
+		Popularity5:   intPtr(4),
+		Popularity100: intPtr(79),
+		Actions:       []string{"metadata_candidate", "untested_candidate"},
+		Confidence:    "suggested",
+	}
+	got := searchPlanCompactRows([]SearchPlanRow{row})
+	if len(got) != 1 || !slices.Equal(got[0], []string{"calorie tracker", "4 / 79", "—", "—", "—", "—", "metadata · test", "suggested"}) {
+		t.Fatalf("compact row = %#v", got)
+	}
+}
+
+func TestCompactSearchPlanDiagnosticRemovesProviderHTMLAndCapsLength(t *testing.T) {
+	errorText := "retry limit exceeded after 4 retries: HTTP 500: <html><head><title>500 Internal Server Error</title></head><body>Apple returned a very long response that must not stretch the terminal table beyond a useful screenshot width</body></html>"
+	got := compactSearchPlanDiagnostic(errorText)
+	if strings.Contains(got, "<html>") || strings.Contains(got, "Internal Server Error") {
+		t.Fatalf("compact diagnostic retained provider HTML: %q", got)
+	}
+	if len([]rune(got)) > 72 {
+		t.Fatalf("compact diagnostic length = %d, want <= 72: %q", len([]rune(got)), got)
+	}
+	if got != "retry limit exceeded after 4 retries: HTTP 500" {
+		t.Fatalf("compact diagnostic = %q", got)
+	}
+}
+
+func tableRowsContain(rows [][]string, want string) bool {
+	for _, row := range rows {
+		for _, value := range row {
+			if value == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/cli/optimize/search_plan.go
+++ b/internal/cli/optimize/search_plan.go
@@ -1,0 +1,527 @@
+package optimize
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/ads"
+)
+
+const searchPlanSchemaVersion = "1"
+
+type searchPlanWindow struct {
+	Start           string `json:"start"`
+	End             string `json:"end"`
+	PopularityStart string `json:"popularityStart"`
+	PopularityEnd   string `json:"popularityEnd"`
+}
+
+type searchMetadataSnapshot struct {
+	Name     string `json:"name,omitempty"`
+	Subtitle string `json:"subtitle,omitempty"`
+	Keywords string `json:"keywords,omitempty"`
+}
+
+// SearchPlanMoney is one currency-qualified amount derived from official Ads
+// reporting data.
+type SearchPlanMoney struct {
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+// SearchPlanRow is one normalized term with explicit source provenance.
+type SearchPlanRow struct {
+	Term                  string           `json:"term"`
+	Popularity100         *int             `json:"popularity100,omitempty"`
+	PopularityInGenre     *int             `json:"popularityInGenre,omitempty"`
+	RankInGenre           *int             `json:"rankInGenre,omitempty"`
+	SuggestionPopularity  *int             `json:"suggestionPopularity,omitempty"`
+	ImpressionSharePeriod string           `json:"impressionSharePeriod,omitempty"`
+	ImpressionShareLow    *float64         `json:"impressionShareLow,omitempty"`
+	ImpressionShareHigh   *float64         `json:"impressionShareHigh,omitempty"`
+	ImpressionShareRank   *int             `json:"impressionShareRank,omitempty"`
+	Impressions           *int64           `json:"impressions,omitempty"`
+	Taps                  *int64           `json:"taps,omitempty"`
+	TapInstalls           *int64           `json:"tapInstalls,omitempty"`
+	TotalInstalls         *int64           `json:"totalInstalls,omitempty"`
+	Spend                 *SearchPlanMoney `json:"spend,omitempty"`
+	CPA                   *SearchPlanMoney `json:"cpa,omitempty"`
+	MatchedKeyword        string           `json:"matchedKeyword,omitempty"`
+	MatchType             string           `json:"matchType,omitempty"`
+	CampaignID            *int64           `json:"campaignId,omitempty"`
+	AdGroupID             *int64           `json:"adGroupId,omitempty"`
+	MetadataFields        []string         `json:"metadataFields,omitempty"`
+	Sources               []string         `json:"sources"`
+	Actions               []string         `json:"actions,omitempty"`
+	Confidence            string           `json:"confidence"`
+}
+
+// SearchPlanSummary summarizes evidence and recommendation coverage.
+type SearchPlanSummary struct {
+	Terms                      int            `json:"terms"`
+	Actions                    map[string]int `json:"actions"`
+	AvailableSources           int            `json:"availableSources"`
+	EmptySources               int            `json:"emptySources"`
+	UnavailableSources         int            `json:"unavailableSources"`
+	DailyBudgetRecommendations int            `json:"dailyBudgetRecommendations"`
+	TargetCPARecommendations   int            `json:"targetCpaRecommendations"`
+}
+
+// SearchPlanRecommendations preserves Apple's actionable recommendation
+// payloads without converting them into client-authored advice.
+type SearchPlanRecommendations struct {
+	DailyBudgets []json.RawMessage `json:"dailyBudgets,omitempty"`
+	TargetCPAs   []json.RawMessage `json:"targetCpas,omitempty"`
+}
+
+// SearchPlanReport is the stable JSON contract emitted by the workflow.
+type SearchPlanReport struct {
+	SchemaVersion   string                               `json:"schemaVersion"`
+	GeneratedAt     string                               `json:"generatedAt,omitempty"`
+	AppID           string                               `json:"appId"`
+	Version         string                               `json:"version"`
+	VersionID       string                               `json:"versionId,omitempty"`
+	Platform        string                               `json:"platform"`
+	Country         string                               `json:"country"`
+	Genre           string                               `json:"genre"`
+	Locale          string                               `json:"locale"`
+	Window          searchPlanWindow                     `json:"window"`
+	Metadata        searchMetadataSnapshot               `json:"metadata"`
+	Sources         []ads.SearchOptimizationSourceStatus `json:"sources"`
+	Eligibility     []ads.SearchEligibility              `json:"eligibility,omitempty"`
+	Campaigns       []ads.SearchCampaign                 `json:"campaigns,omitempty"`
+	Recommendations SearchPlanRecommendations            `json:"recommendations"`
+	Summary         SearchPlanSummary                    `json:"summary"`
+	Rows            []SearchPlanRow                      `json:"rows"`
+	Notices         []string                             `json:"notices,omitempty"`
+	Artifacts       []string                             `json:"artifacts,omitempty"`
+}
+
+type searchPlanBuildInput struct {
+	GeneratedAt string
+	AppID       string
+	Version     string
+	VersionID   string
+	Platform    string
+	Country     string
+	Genre       string
+	Locale      string
+	Window      searchPlanWindow
+	Metadata    searchMetadataSnapshot
+	Ads         ads.SearchOptimizationData
+}
+
+type searchPlanAccumulator struct {
+	row                 SearchPlanRow
+	hasSuggestion       bool
+	hasPerformance      bool
+	hasExistingExact    bool
+	hasExistingNegative bool
+	bestInstalls        int64
+	spendValue          float64
+	spendCurrency       string
+	spendValid          bool
+	spendMixedCurrency  bool
+}
+
+func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
+	terms := make(map[string]*searchPlanAccumulator)
+	get := func(term string) *searchPlanAccumulator {
+		key := normalizeSearchTerm(term)
+		if key == "" {
+			return nil
+		}
+		if existing := terms[key]; existing != nil {
+			return existing
+		}
+		entry := &searchPlanAccumulator{row: SearchPlanRow{Term: strings.TrimSpace(term)}}
+		terms[key] = entry
+		return entry
+	}
+
+	for _, suggestion := range input.Ads.Suggestions {
+		entry := get(suggestion.Text)
+		if entry == nil {
+			continue
+		}
+		entry.hasSuggestion = true
+		entry.row.Sources = appendUnique(entry.row.Sources, suggestion.Kind+"_suggestion")
+		if greaterIntPointer(suggestion.Popularity, entry.row.SuggestionPopularity) {
+			entry.row.SuggestionPopularity = copyIntPointer(suggestion.Popularity)
+		}
+	}
+	for _, popularity := range input.Ads.Popularities {
+		entry := get(popularity.Term)
+		if entry == nil {
+			continue
+		}
+		entry.row.Sources = appendUnique(entry.row.Sources, "search_term_popularity")
+		entry.row.Popularity100 = copyIntPointer(popularity.Popularity100)
+		entry.row.PopularityInGenre = copyIntPointer(popularity.PopularityInGenre)
+		entry.row.RankInGenre = copyIntPointer(popularity.RankInGenre)
+	}
+	for _, share := range input.Ads.ImpressionShares {
+		entry := get(share.Term)
+		if entry == nil {
+			continue
+		}
+		entry.row.Sources = appendUnique(entry.row.Sources, "impression_share")
+		period := strings.TrimSpace(share.Day)
+		if period == "" {
+			period = strings.TrimSpace(share.Week)
+		}
+		if entry.row.ImpressionSharePeriod == "" || period >= entry.row.ImpressionSharePeriod {
+			entry.row.ImpressionSharePeriod = period
+			entry.row.ImpressionShareLow = copyFloatPointer(share.Low)
+			entry.row.ImpressionShareHigh = copyFloatPointer(share.High)
+			entry.row.ImpressionShareRank = copyIntPointer(share.Rank)
+		}
+	}
+
+	for _, keyword := range input.Ads.Keywords {
+		if strings.EqualFold(keyword.MatchType, "EXACT") {
+			if entry := get(keyword.Text); entry != nil {
+				entry.hasExistingExact = true
+				entry.row.Sources = appendUnique(entry.row.Sources, "targeting_keyword")
+			}
+		}
+	}
+	for _, negative := range input.Ads.NegativeKeywords {
+		if entry := get(negative.Text); entry != nil {
+			entry.hasExistingNegative = true
+			entry.row.Sources = appendUnique(entry.row.Sources, "negative_keyword")
+		}
+	}
+	for _, performance := range input.Ads.SearchTerms {
+		entry := get(performance.Term)
+		if entry == nil {
+			continue
+		}
+		entry.hasPerformance = true
+		entry.row.Sources = appendUnique(entry.row.Sources, "search_term_performance")
+		addInt64Pointer(&entry.row.Impressions, performance.Impressions)
+		addInt64Pointer(&entry.row.Taps, performance.Taps)
+		addInt64Pointer(&entry.row.TapInstalls, performance.TapInstalls)
+		addInt64Pointer(&entry.row.TotalInstalls, performance.TotalInstalls)
+
+		if performance.TotalInstalls >= entry.bestInstalls {
+			entry.bestInstalls = performance.TotalInstalls
+			entry.row.MatchedKeyword = strings.TrimSpace(performance.KeywordText)
+			entry.row.MatchType = strings.ToUpper(strings.TrimSpace(performance.MatchType))
+			entry.row.CampaignID = int64PointerIfPositive(performance.CampaignID)
+			entry.row.AdGroupID = int64PointerIfPositive(performance.AdGroupID)
+		}
+		if amount, err := strconv.ParseFloat(strings.TrimSpace(performance.SpendAmount), 64); err == nil && amount >= 0 && !entry.spendMixedCurrency {
+			currency := strings.ToUpper(strings.TrimSpace(performance.SpendCurrency))
+			switch {
+			case !entry.spendValid:
+				entry.spendValid = true
+				entry.spendCurrency = currency
+				entry.spendValue = amount
+			case entry.spendCurrency == currency:
+				entry.spendValue += amount
+			default:
+				entry.spendValid = false
+				entry.spendMixedCurrency = true
+				entry.spendValue = 0
+				entry.spendCurrency = ""
+			}
+		}
+	}
+
+	rows := make([]SearchPlanRow, 0, len(terms))
+	for _, entry := range terms {
+		entry.row.MetadataFields = metadataCoverage(input.Metadata, entry.row.Term)
+		if entry.spendValid {
+			entry.row.Spend = &SearchPlanMoney{Amount: formatMoney(entry.spendValue), Currency: entry.spendCurrency}
+			if entry.row.TotalInstalls != nil && *entry.row.TotalInstalls > 0 {
+				entry.row.CPA = &SearchPlanMoney{Amount: formatMoney(entry.spendValue / float64(*entry.row.TotalInstalls)), Currency: entry.spendCurrency}
+			}
+		}
+		classifySearchPlanRow(entry)
+		sort.Strings(entry.row.Sources)
+		rows = append(rows, entry.row)
+	}
+	sortSearchPlanRows(rows)
+
+	report := SearchPlanReport{
+		SchemaVersion: searchPlanSchemaVersion,
+		GeneratedAt:   input.GeneratedAt,
+		AppID:         input.AppID,
+		Version:       input.Version,
+		VersionID:     input.VersionID,
+		Platform:      input.Platform,
+		Country:       input.Country,
+		Genre:         input.Genre,
+		Locale:        input.Locale,
+		Window:        input.Window,
+		Metadata:      input.Metadata,
+		Sources:       append([]ads.SearchOptimizationSourceStatus(nil), input.Ads.Sources...),
+		Eligibility:   append([]ads.SearchEligibility(nil), input.Ads.Eligibilities...),
+		Campaigns:     append([]ads.SearchCampaign(nil), input.Ads.Campaigns...),
+		Recommendations: SearchPlanRecommendations{
+			DailyBudgets: append([]json.RawMessage(nil), input.Ads.DailyBudgetRecommendationItems...),
+			TargetCPAs:   append([]json.RawMessage(nil), input.Ads.TargetCPARecommendationItems...),
+		},
+		Rows: rows,
+	}
+	report.Summary = summarizeSearchPlan(report.Rows, report.Sources, input.Ads)
+	report.Notices = searchPlanNotices(input.Ads)
+	return report
+}
+
+func resolveSearchPlanWindow(value string, now time.Time) (searchPlanWindow, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if !strings.HasSuffix(trimmed, "d") || len(trimmed) < 2 {
+		return searchPlanWindow{}, fmt.Errorf("--window must be a whole number of days from 2d through 30d")
+	}
+	days, err := strconv.Atoi(strings.TrimSuffix(trimmed, "d"))
+	if err != nil || days < 2 || days > 30 {
+		return searchPlanWindow{}, fmt.Errorf("--window must be a whole number of days from 2d through 30d")
+	}
+
+	utcNow := now.UTC()
+	today := time.Date(utcNow.Year(), utcNow.Month(), utcNow.Day(), 0, 0, 0, 0, time.UTC)
+	end := today.AddDate(0, 0, -1)
+	start := end.AddDate(0, 0, -(days - 1))
+
+	// Popularity snapshots require a complete Sunday-through-Saturday week.
+	popularityEnd := end
+	for popularityEnd.Weekday() != time.Saturday {
+		popularityEnd = popularityEnd.AddDate(0, 0, -1)
+	}
+	popularityStart := popularityEnd.AddDate(0, 0, -6)
+
+	return searchPlanWindow{
+		Start:           start.Format(time.DateOnly),
+		End:             end.Format(time.DateOnly),
+		PopularityStart: popularityStart.Format(time.DateOnly),
+		PopularityEnd:   popularityEnd.Format(time.DateOnly),
+	}, nil
+}
+
+func classifySearchPlanRow(entry *searchPlanAccumulator) {
+	row := &entry.row
+	installs := int64(0)
+	if row.TotalInstalls != nil {
+		installs = *row.TotalInstalls
+	}
+	if entry.hasPerformance && installs > 0 && strings.EqualFold(row.MatchType, "BROAD") && !entry.hasExistingExact {
+		row.Actions = append(row.Actions, "promote_exact")
+	}
+	if entry.hasPerformance && installs == 0 && row.Taps != nil && *row.Taps >= 10 && !entry.hasExistingNegative {
+		row.Actions = append(row.Actions, "negative_candidate")
+	}
+	if len(row.MetadataFields) == 0 && (installs > 0 || entry.hasSuggestion) {
+		row.Actions = append(row.Actions, "metadata_candidate")
+	}
+	if installs > 0 && row.ImpressionShareLow != nil && *row.ImpressionShareLow < 0.5 {
+		row.Actions = append(row.Actions, "defend")
+	}
+	if row.ImpressionShareLow != nil && row.ImpressionShareHigh != nil && *row.ImpressionShareLow >= 0.91 && *row.ImpressionShareHigh >= 1 {
+		row.Actions = append(row.Actions, "saturated")
+	}
+	if entry.hasSuggestion && !entry.hasPerformance {
+		row.Actions = append(row.Actions, "untested_candidate")
+	}
+	switch {
+	case installs > 0:
+		row.Confidence = "proven"
+	case entry.hasPerformance:
+		row.Confidence = "observed"
+	default:
+		row.Confidence = "suggested"
+	}
+}
+
+func summarizeSearchPlan(rows []SearchPlanRow, sources []ads.SearchOptimizationSourceStatus, data ads.SearchOptimizationData) SearchPlanSummary {
+	summary := SearchPlanSummary{
+		Terms:                      len(rows),
+		Actions:                    map[string]int{},
+		DailyBudgetRecommendations: data.DailyBudgetRecommendations,
+		TargetCPARecommendations:   data.TargetCPARecommendations,
+	}
+	for _, row := range rows {
+		for _, action := range row.Actions {
+			summary.Actions[action]++
+		}
+	}
+	for _, source := range sources {
+		switch source.Status {
+		case "available":
+			summary.AvailableSources++
+		case "empty":
+			summary.EmptySources++
+		case "unavailable":
+			summary.UnavailableSources++
+		}
+	}
+	return summary
+}
+
+func searchPlanNotices(data ads.SearchOptimizationData) []string {
+	notices := make([]string, 0)
+	for _, source := range data.Sources {
+		if source.Status == "unavailable" {
+			notices = append(notices, fmt.Sprintf("%s unavailable: %s", source.Name, source.Error))
+		}
+	}
+	for _, eligibility := range data.Eligibilities {
+		if strings.EqualFold(eligibility.State, "INELIGIBLE") {
+			notices = append(notices, fmt.Sprintf("app is ineligible for %s in %s on %s: %s", eligibility.SupplyPlacement, eligibility.Country, eligibility.DeviceClass, strings.Join(eligibility.Reasons, ", ")))
+		}
+	}
+	return notices
+}
+
+func sortSearchPlanRows(rows []SearchPlanRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		leftPriority := searchPlanActionPriority(rows[i].Actions)
+		rightPriority := searchPlanActionPriority(rows[j].Actions)
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		leftPopularity := pointerIntValue(rows[i].Popularity100, pointerIntValue(rows[i].SuggestionPopularity, -1))
+		rightPopularity := pointerIntValue(rows[j].Popularity100, pointerIntValue(rows[j].SuggestionPopularity, -1))
+		if leftPopularity != rightPopularity {
+			return leftPopularity > rightPopularity
+		}
+		leftInstalls := pointerInt64Value(rows[i].TotalInstalls, -1)
+		rightInstalls := pointerInt64Value(rows[j].TotalInstalls, -1)
+		if leftInstalls != rightInstalls {
+			return leftInstalls > rightInstalls
+		}
+		return cmp.Less(strings.ToLower(rows[i].Term), strings.ToLower(rows[j].Term))
+	})
+}
+
+func searchPlanActionPriority(actions []string) int {
+	priorities := map[string]int{
+		"promote_exact":      0,
+		"negative_candidate": 1,
+		"defend":             2,
+		"metadata_candidate": 3,
+		"saturated":          4,
+		"untested_candidate": 5,
+	}
+	priority := 99
+	for _, action := range actions {
+		if value, ok := priorities[action]; ok && value < priority {
+			priority = value
+		}
+	}
+	return priority
+}
+
+func metadataCoverage(metadata searchMetadataSnapshot, term string) []string {
+	fields := make([]string, 0, 3)
+	if normalizedPhraseContains(metadata.Name, term) {
+		fields = append(fields, "name")
+	}
+	if normalizedPhraseContains(metadata.Subtitle, term) {
+		fields = append(fields, "subtitle")
+	}
+	normalizedTerm := normalizeSearchTerm(term)
+	for _, keyword := range strings.Split(metadata.Keywords, ",") {
+		if normalizeSearchTerm(keyword) == normalizedTerm && normalizedTerm != "" {
+			fields = append(fields, "keywords")
+			break
+		}
+	}
+	return fields
+}
+
+func normalizedPhraseContains(field, term string) bool {
+	normalizedField := normalizeSearchTerm(field)
+	normalizedTerm := normalizeSearchTerm(term)
+	if normalizedField == "" || normalizedTerm == "" {
+		return false
+	}
+	return strings.Contains(" "+normalizedField+" ", " "+normalizedTerm+" ")
+}
+
+func normalizeSearchTerm(value string) string {
+	var builder strings.Builder
+	space := true
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(r)
+			space = false
+			continue
+		}
+		if !space {
+			builder.WriteByte(' ')
+			space = true
+		}
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func appendUnique(values []string, value string) []string {
+	if value == "" || slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
+}
+
+func addInt64Pointer(target **int64, value int64) {
+	if *target == nil {
+		copy := value
+		*target = &copy
+		return
+	}
+	**target += value
+}
+
+func int64PointerIfPositive(value int64) *int64 {
+	if value <= 0 {
+		return nil
+	}
+	copy := value
+	return &copy
+}
+
+func copyIntPointer(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func copyFloatPointer(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func greaterIntPointer(left, right *int) bool {
+	return left != nil && (right == nil || *left > *right)
+}
+
+func pointerIntValue(value *int, fallback int) int {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func pointerInt64Value(value *int64, fallback int64) int64 {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func formatMoney(value float64) string {
+	return strconv.FormatFloat(value, 'f', 2, 64)
+}

--- a/internal/cli/optimize/search_plan.go
+++ b/internal/cli/optimize/search_plan.go
@@ -130,6 +130,8 @@ type searchPlanAccumulator struct {
 	hasExistingExact    bool
 	hasExistingNegative bool
 	bestInstalls        int64
+	hasPopularity       bool
+	popularityPeriod    string
 	spendValue          float64
 	spendCurrency       string
 	spendValid          bool
@@ -179,6 +181,11 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 			continue
 		}
 		entry.row.Sources = appendUnique(entry.row.Sources, "search_term_popularity")
+		if !shouldSelectSearchPlanPopularity(entry, popularity) {
+			continue
+		}
+		entry.hasPopularity = true
+		entry.popularityPeriod = searchPlanPopularityPeriod(popularity)
 		entry.row.Popularity5 = copyIntPointer(popularity.Popularity5)
 		entry.row.Popularity100 = copyIntPointer(popularity.Popularity100)
 		entry.row.PopularityInGenre = copyIntPointer(popularity.PopularityInGenre)
@@ -295,6 +302,55 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 	report.Summary = summarizeSearchPlan(report.Rows, report.Sources, input.Ads)
 	report.Notices = searchPlanNotices(input.Ads)
 	return report
+}
+
+func shouldSelectSearchPlanPopularity(entry *searchPlanAccumulator, candidate ads.SearchPopularity) bool {
+	if !entry.hasPopularity {
+		return true
+	}
+	candidatePeriod := searchPlanPopularityPeriod(candidate)
+	if candidatePeriod != entry.popularityPeriod {
+		return candidatePeriod > entry.popularityPeriod
+	}
+	if comparison := compareOptionalInt(candidate.RankInGenre, entry.row.RankInGenre, false); comparison != 0 {
+		return comparison > 0
+	}
+	for _, values := range [][2]*int{
+		{candidate.Popularity100, entry.row.Popularity100},
+		{candidate.Popularity5, entry.row.Popularity5},
+		{candidate.PopularityInGenre, entry.row.PopularityInGenre},
+	} {
+		if comparison := compareOptionalInt(values[0], values[1], true); comparison != 0 {
+			return comparison > 0
+		}
+	}
+	return false
+}
+
+func searchPlanPopularityPeriod(popularity ads.SearchPopularity) string {
+	if week := strings.TrimSpace(popularity.Week); week != "" {
+		return week
+	}
+	return strings.TrimSpace(popularity.Month)
+}
+
+func compareOptionalInt(candidate, current *int, preferHigher bool) int {
+	switch {
+	case candidate != nil && current == nil:
+		return 1
+	case candidate == nil && current != nil:
+		return -1
+	case candidate == nil:
+		return 0
+	case *candidate == *current:
+		return 0
+	case preferHigher && *candidate > *current:
+		return 1
+	case !preferHigher && *candidate < *current:
+		return 1
+	default:
+		return -1
+	}
 }
 
 func shouldSelectSearchPlanContext(entry *searchPlanAccumulator, candidate ads.SearchTermPerformance) bool {

--- a/internal/cli/optimize/search_plan.go
+++ b/internal/cli/optimize/search_plan.go
@@ -91,6 +91,7 @@ type SearchPlanReport struct {
 	AppID           string                               `json:"appId"`
 	Version         string                               `json:"version"`
 	VersionID       string                               `json:"versionId,omitempty"`
+	AppInfoID       string                               `json:"appInfoId,omitempty"`
 	Platform        string                               `json:"platform"`
 	Country         string                               `json:"country"`
 	Genre           string                               `json:"genre"`
@@ -112,6 +113,7 @@ type searchPlanBuildInput struct {
 	AppID       string
 	Version     string
 	VersionID   string
+	AppInfoID   string
 	Platform    string
 	Country     string
 	Genre       string
@@ -227,7 +229,7 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 		addInt64Pointer(&entry.row.TapInstalls, performance.TapInstalls)
 		addInt64Pointer(&entry.row.TotalInstalls, performance.TotalInstalls)
 
-		if performance.TotalInstalls >= entry.bestInstalls {
+		if shouldSelectSearchPlanContext(entry, performance) {
 			entry.bestInstalls = performance.TotalInstalls
 			entry.row.MatchedKeyword = strings.TrimSpace(performance.KeywordText)
 			entry.row.MatchType = strings.ToUpper(strings.TrimSpace(performance.MatchType))
@@ -273,6 +275,7 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 		AppID:         input.AppID,
 		Version:       input.Version,
 		VersionID:     input.VersionID,
+		AppInfoID:     input.AppInfoID,
 		Platform:      input.Platform,
 		Country:       input.Country,
 		Genre:         input.Genre,
@@ -292,6 +295,39 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 	report.Summary = summarizeSearchPlan(report.Rows, report.Sources, input.Ads)
 	report.Notices = searchPlanNotices(input.Ads)
 	return report
+}
+
+func shouldSelectSearchPlanContext(entry *searchPlanAccumulator, candidate ads.SearchTermPerformance) bool {
+	if candidate.TotalInstalls != entry.bestInstalls {
+		return candidate.TotalInstalls > entry.bestInstalls
+	}
+
+	currentCampaignID := pointerInt64Value(entry.row.CampaignID, 0)
+	switch {
+	case currentCampaignID == 0 && candidate.CampaignID > 0:
+		return true
+	case candidate.CampaignID == 0 && currentCampaignID > 0:
+		return false
+	case candidate.CampaignID != currentCampaignID:
+		return candidate.CampaignID < currentCampaignID
+	}
+
+	currentAdGroupID := pointerInt64Value(entry.row.AdGroupID, 0)
+	switch {
+	case currentAdGroupID == 0 && candidate.AdGroupID > 0:
+		return true
+	case candidate.AdGroupID == 0 && currentAdGroupID > 0:
+		return false
+	case candidate.AdGroupID != currentAdGroupID:
+		return candidate.AdGroupID < currentAdGroupID
+	}
+
+	currentKeyword := strings.ToLower(strings.TrimSpace(entry.row.MatchedKeyword))
+	candidateKeyword := strings.ToLower(strings.TrimSpace(candidate.KeywordText))
+	if candidateKeyword != currentKeyword {
+		return currentKeyword == "" || candidateKeyword < currentKeyword
+	}
+	return strings.ToUpper(strings.TrimSpace(candidate.MatchType)) < strings.ToUpper(strings.TrimSpace(entry.row.MatchType))
 }
 
 func resolveSearchPlanWindow(value string, now time.Time) (searchPlanWindow, error) {

--- a/internal/cli/optimize/search_plan.go
+++ b/internal/cli/optimize/search_plan.go
@@ -38,29 +38,31 @@ type SearchPlanMoney struct {
 
 // SearchPlanRow is one normalized term with explicit source provenance.
 type SearchPlanRow struct {
-	Term                  string           `json:"term"`
-	Popularity100         *int             `json:"popularity100,omitempty"`
-	PopularityInGenre     *int             `json:"popularityInGenre,omitempty"`
-	RankInGenre           *int             `json:"rankInGenre,omitempty"`
-	SuggestionPopularity  *int             `json:"suggestionPopularity,omitempty"`
-	ImpressionSharePeriod string           `json:"impressionSharePeriod,omitempty"`
-	ImpressionShareLow    *float64         `json:"impressionShareLow,omitempty"`
-	ImpressionShareHigh   *float64         `json:"impressionShareHigh,omitempty"`
-	ImpressionShareRank   *int             `json:"impressionShareRank,omitempty"`
-	Impressions           *int64           `json:"impressions,omitempty"`
-	Taps                  *int64           `json:"taps,omitempty"`
-	TapInstalls           *int64           `json:"tapInstalls,omitempty"`
-	TotalInstalls         *int64           `json:"totalInstalls,omitempty"`
-	Spend                 *SearchPlanMoney `json:"spend,omitempty"`
-	CPA                   *SearchPlanMoney `json:"cpa,omitempty"`
-	MatchedKeyword        string           `json:"matchedKeyword,omitempty"`
-	MatchType             string           `json:"matchType,omitempty"`
-	CampaignID            *int64           `json:"campaignId,omitempty"`
-	AdGroupID             *int64           `json:"adGroupId,omitempty"`
-	MetadataFields        []string         `json:"metadataFields,omitempty"`
-	Sources               []string         `json:"sources"`
-	Actions               []string         `json:"actions,omitempty"`
-	Confidence            string           `json:"confidence"`
+	Term                       string           `json:"term"`
+	Popularity5                *int             `json:"popularity5,omitempty"`
+	Popularity100              *int             `json:"popularity100,omitempty"`
+	PopularityInGenre          *int             `json:"popularityInGenre,omitempty"`
+	RankInGenre                *int             `json:"rankInGenre,omitempty"`
+	SuggestionPopularity       *int             `json:"suggestionPopularity,omitempty"`
+	ImpressionSharePeriod      string           `json:"impressionSharePeriod,omitempty"`
+	ImpressionSharePopularity5 *int             `json:"impressionSharePopularity5,omitempty"`
+	ImpressionShareLow         *float64         `json:"impressionShareLow,omitempty"`
+	ImpressionShareHigh        *float64         `json:"impressionShareHigh,omitempty"`
+	ImpressionShareRank        *int             `json:"impressionShareRank,omitempty"`
+	Impressions                *int64           `json:"impressions,omitempty"`
+	Taps                       *int64           `json:"taps,omitempty"`
+	TapInstalls                *int64           `json:"tapInstalls,omitempty"`
+	TotalInstalls              *int64           `json:"totalInstalls,omitempty"`
+	Spend                      *SearchPlanMoney `json:"spend,omitempty"`
+	CPA                        *SearchPlanMoney `json:"cpa,omitempty"`
+	MatchedKeyword             string           `json:"matchedKeyword,omitempty"`
+	MatchType                  string           `json:"matchType,omitempty"`
+	CampaignID                 *int64           `json:"campaignId,omitempty"`
+	AdGroupID                  *int64           `json:"adGroupId,omitempty"`
+	MetadataFields             []string         `json:"metadataFields,omitempty"`
+	Sources                    []string         `json:"sources"`
+	Actions                    []string         `json:"actions,omitempty"`
+	Confidence                 string           `json:"confidence"`
 }
 
 // SearchPlanSummary summarizes evidence and recommendation coverage.
@@ -77,8 +79,9 @@ type SearchPlanSummary struct {
 // SearchPlanRecommendations preserves Apple's actionable recommendation
 // payloads without converting them into client-authored advice.
 type SearchPlanRecommendations struct {
-	DailyBudgets []json.RawMessage `json:"dailyBudgets,omitempty"`
-	TargetCPAs   []json.RawMessage `json:"targetCpas,omitempty"`
+	DailyBudgets        []json.RawMessage `json:"dailyBudgets,omitempty"`
+	TargetCPAs          []json.RawMessage `json:"targetCpas,omitempty"`
+	TargetCPASuggestion json.RawMessage   `json:"targetCpaSuggestion,omitempty"`
 }
 
 // SearchPlanReport is the stable JSON contract emitted by the workflow.
@@ -131,7 +134,18 @@ type searchPlanAccumulator struct {
 	spendMixedCurrency  bool
 }
 
+type searchPlanEvidence struct {
+	targetingKeywordsComplete bool
+	negativeKeywordsComplete  bool
+	searchTermsComplete       bool
+}
+
 func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
+	evidence := searchPlanEvidence{
+		targetingKeywordsComplete: searchPlanSourceComplete(input.Ads.Sources, "targeting_keywords"),
+		negativeKeywordsComplete:  searchPlanSourceComplete(input.Ads.Sources, "negative_keywords"),
+		searchTermsComplete:       searchPlanSourceComplete(input.Ads.Sources, "search_term_performance"),
+	}
 	terms := make(map[string]*searchPlanAccumulator)
 	get := func(term string) *searchPlanAccumulator {
 		key := normalizeSearchTerm(term)
@@ -163,6 +177,7 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 			continue
 		}
 		entry.row.Sources = appendUnique(entry.row.Sources, "search_term_popularity")
+		entry.row.Popularity5 = copyIntPointer(popularity.Popularity5)
 		entry.row.Popularity100 = copyIntPointer(popularity.Popularity100)
 		entry.row.PopularityInGenre = copyIntPointer(popularity.PopularityInGenre)
 		entry.row.RankInGenre = copyIntPointer(popularity.RankInGenre)
@@ -182,6 +197,7 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 			entry.row.ImpressionShareLow = copyFloatPointer(share.Low)
 			entry.row.ImpressionShareHigh = copyFloatPointer(share.High)
 			entry.row.ImpressionShareRank = copyIntPointer(share.Rank)
+			entry.row.ImpressionSharePopularity5 = copyIntPointer(share.Popularity5)
 		}
 	}
 
@@ -245,7 +261,7 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 				entry.row.CPA = &SearchPlanMoney{Amount: formatMoney(entry.spendValue / float64(*entry.row.TotalInstalls)), Currency: entry.spendCurrency}
 			}
 		}
-		classifySearchPlanRow(entry)
+		classifySearchPlanRow(entry, evidence)
 		sort.Strings(entry.row.Sources)
 		rows = append(rows, entry.row)
 	}
@@ -267,8 +283,9 @@ func buildSearchPlan(input searchPlanBuildInput) SearchPlanReport {
 		Eligibility:   append([]ads.SearchEligibility(nil), input.Ads.Eligibilities...),
 		Campaigns:     append([]ads.SearchCampaign(nil), input.Ads.Campaigns...),
 		Recommendations: SearchPlanRecommendations{
-			DailyBudgets: append([]json.RawMessage(nil), input.Ads.DailyBudgetRecommendationItems...),
-			TargetCPAs:   append([]json.RawMessage(nil), input.Ads.TargetCPARecommendationItems...),
+			DailyBudgets:        append([]json.RawMessage(nil), input.Ads.DailyBudgetRecommendationItems...),
+			TargetCPAs:          append([]json.RawMessage(nil), input.Ads.TargetCPARecommendationItems...),
+			TargetCPASuggestion: append(json.RawMessage(nil), input.Ads.TargetCPASuggestion...),
 		},
 		Rows: rows,
 	}
@@ -292,10 +309,14 @@ func resolveSearchPlanWindow(value string, now time.Time) (searchPlanWindow, err
 	end := today.AddDate(0, 0, -1)
 	start := end.AddDate(0, 0, -(days - 1))
 
-	// Popularity snapshots require a complete Sunday-through-Saturday week.
+	// Popularity snapshots publish at 07:00 UTC on the Monday after each week.
 	popularityEnd := end
 	for popularityEnd.Weekday() != time.Saturday {
 		popularityEnd = popularityEnd.AddDate(0, 0, -1)
+	}
+	publicationTime := popularityEnd.AddDate(0, 0, 2).Add(7 * time.Hour)
+	if utcNow.Before(publicationTime) {
+		popularityEnd = popularityEnd.AddDate(0, 0, -7)
 	}
 	popularityStart := popularityEnd.AddDate(0, 0, -6)
 
@@ -307,16 +328,16 @@ func resolveSearchPlanWindow(value string, now time.Time) (searchPlanWindow, err
 	}, nil
 }
 
-func classifySearchPlanRow(entry *searchPlanAccumulator) {
+func classifySearchPlanRow(entry *searchPlanAccumulator, evidence searchPlanEvidence) {
 	row := &entry.row
 	installs := int64(0)
 	if row.TotalInstalls != nil {
 		installs = *row.TotalInstalls
 	}
-	if entry.hasPerformance && installs > 0 && strings.EqualFold(row.MatchType, "BROAD") && !entry.hasExistingExact {
+	if evidence.targetingKeywordsComplete && entry.hasPerformance && installs > 0 && strings.EqualFold(row.MatchType, "BROAD") && !entry.hasExistingExact {
 		row.Actions = append(row.Actions, "promote_exact")
 	}
-	if entry.hasPerformance && installs == 0 && row.Taps != nil && *row.Taps >= 10 && !entry.hasExistingNegative {
+	if evidence.negativeKeywordsComplete && entry.hasPerformance && installs == 0 && row.Taps != nil && *row.Taps >= 10 && !entry.hasExistingNegative {
 		row.Actions = append(row.Actions, "negative_candidate")
 	}
 	if len(row.MetadataFields) == 0 && (installs > 0 || entry.hasSuggestion) {
@@ -328,7 +349,7 @@ func classifySearchPlanRow(entry *searchPlanAccumulator) {
 	if row.ImpressionShareLow != nil && row.ImpressionShareHigh != nil && *row.ImpressionShareLow >= 0.91 && *row.ImpressionShareHigh >= 1 {
 		row.Actions = append(row.Actions, "saturated")
 	}
-	if entry.hasSuggestion && !entry.hasPerformance {
+	if evidence.searchTermsComplete && entry.hasSuggestion && !entry.hasPerformance {
 		row.Actions = append(row.Actions, "untested_candidate")
 	}
 	switch {
@@ -339,6 +360,15 @@ func classifySearchPlanRow(entry *searchPlanAccumulator) {
 	default:
 		row.Confidence = "suggested"
 	}
+}
+
+func searchPlanSourceComplete(sources []ads.SearchOptimizationSourceStatus, name string) bool {
+	for _, source := range sources {
+		if source.Name == name {
+			return source.Status == "available" || source.Status == "empty"
+		}
+	}
+	return false
 }
 
 func summarizeSearchPlan(rows []SearchPlanRow, sources []ads.SearchOptimizationSourceStatus, data ads.SearchOptimizationData) SearchPlanSummary {

--- a/internal/cli/optimize/search_plan.go
+++ b/internal/cli/optimize/search_plan.go
@@ -429,7 +429,7 @@ func classifySearchPlanRow(entry *searchPlanAccumulator, evidence searchPlanEvid
 	if evidence.targetingKeywordsComplete && entry.hasPerformance && installs > 0 && strings.EqualFold(row.MatchType, "BROAD") && !entry.hasExistingExact {
 		row.Actions = append(row.Actions, "promote_exact")
 	}
-	if evidence.negativeKeywordsComplete && entry.hasPerformance && installs == 0 && row.Taps != nil && *row.Taps >= 10 && !entry.hasExistingNegative {
+	if evidence.searchTermsComplete && evidence.negativeKeywordsComplete && entry.hasPerformance && installs == 0 && row.Taps != nil && *row.Taps >= 10 && !entry.hasExistingNegative {
 		row.Actions = append(row.Actions, "negative_candidate")
 	}
 	if len(row.MetadataFields) == 0 && (installs > 0 || entry.hasSuggestion) {

--- a/internal/cli/optimize/search_plan_test.go
+++ b/internal/cli/optimize/search_plan_test.go
@@ -1,0 +1,287 @@
+package optimize
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/ads"
+)
+
+func TestBuildSearchPlanJoinsOfficialEvidenceWithoutInventingMissingValues(t *testing.T) {
+	input := searchPlanBuildInput{
+		AppID:     "123456789",
+		Version:   "4.4.4",
+		VersionID: "version-1",
+		Platform:  "IOS",
+		Country:   "US",
+		Genre:     "PRODUCTIVITY_UTILITIES",
+		Locale:    "en-US",
+		Window: searchPlanWindow{
+			Start: "2026-07-19",
+			End:   "2026-08-17",
+		},
+		Metadata: searchMetadataSnapshot{
+			Name:     "Focus Keeper",
+			Subtitle: "A simple habit tracker",
+			Keywords: "focus,timer",
+		},
+		Ads: ads.SearchOptimizationData{
+			DailyBudgetRecommendationItems: []json.RawMessage{json.RawMessage(`{"id":"budget-1"}`)},
+			DailyBudgetRecommendations:     1,
+			Sources: []ads.SearchOptimizationSourceStatus{
+				{Name: "keyword_suggestions", Status: "available", Count: 2},
+				{Name: "search_term_popularity", Status: "available", Count: 3},
+				{Name: "impression_share", Status: "available", Count: 2},
+				{Name: "search_term_performance", Status: "available", Count: 3},
+			},
+			Suggestions: []ads.SearchSuggestion{
+				{Text: "daily habits", Popularity: intPtr(72), Kind: "keyword"},
+				{Text: "mood journal", Popularity: intPtr(69), Kind: "phrase"},
+			},
+			Popularities: []ads.SearchPopularity{
+				{Term: "habit tracker", Popularity100: intPtr(88), RankInGenre: intPtr(1)},
+				{Term: "daily habits", Popularity100: intPtr(72), RankInGenre: intPtr(8)},
+				{Term: "free planner", Popularity100: intPtr(64), RankInGenre: intPtr(15)},
+			},
+			ImpressionShares: []ads.SearchImpressionShare{
+				{Term: "habit tracker", Low: floatPtr(0.07), High: floatPtr(0.07), Rank: intPtr(6)},
+				{Term: "mood journal", Low: floatPtr(0.91), High: floatPtr(1), Rank: intPtr(1)},
+			},
+			SearchTerms: []ads.SearchTermPerformance{
+				{Term: "habit tracker", KeywordText: "habits", MatchType: "BROAD", CampaignID: 44, AdGroupID: 55, Impressions: 1000, Taps: 70, TotalInstalls: 31, SpendAmount: "36.58", SpendCurrency: "USD"},
+				{Term: "free planner", KeywordText: "planner", MatchType: "BROAD", CampaignID: 44, AdGroupID: 55, Impressions: 500, Taps: 12, TotalInstalls: 0, SpendAmount: "8.40", SpendCurrency: "USD"},
+				{Term: "mood journal", KeywordText: "mood journal", MatchType: "EXACT", CampaignID: 44, AdGroupID: 55, Impressions: 800, Taps: 50, TotalInstalls: 18, SpendAmount: "18.00", SpendCurrency: "USD"},
+			},
+			Keywords: []ads.SearchTargetingKeyword{
+				{Text: "mood journal", MatchType: "EXACT", CampaignID: 44, AdGroupID: 55},
+			},
+		},
+	}
+
+	report := buildSearchPlan(input)
+	if report.SchemaVersion != "1" {
+		t.Fatalf("SchemaVersion = %q, want 1", report.SchemaVersion)
+	}
+	if len(report.Recommendations.DailyBudgets) != 1 || !strings.Contains(string(report.Recommendations.DailyBudgets[0]), "budget-1") {
+		t.Fatalf("recommendations = %+v", report.Recommendations)
+	}
+
+	habit := findSearchPlanRow(t, report.Rows, "habit tracker")
+	if habit.Popularity100 == nil || *habit.Popularity100 != 88 {
+		t.Fatalf("habit popularity = %v, want 88", habit.Popularity100)
+	}
+	if habit.CPA == nil || habit.CPA.Amount != "1.18" || habit.CPA.Currency != "USD" {
+		t.Fatalf("habit CPA = %+v, want USD 1.18", habit.CPA)
+	}
+	if !slices.Contains(habit.MetadataFields, "subtitle") {
+		t.Fatalf("habit metadata fields = %v, want subtitle", habit.MetadataFields)
+	}
+	assertActions(t, habit.Actions, "promote_exact", "defend")
+	if slices.Contains(habit.Actions, "metadata_candidate") {
+		t.Fatalf("habit actions = %v, must not duplicate covered metadata", habit.Actions)
+	}
+	if habit.Confidence != "proven" {
+		t.Fatalf("habit confidence = %q, want proven", habit.Confidence)
+	}
+
+	daily := findSearchPlanRow(t, report.Rows, "daily habits")
+	assertActions(t, daily.Actions, "metadata_candidate", "untested_candidate")
+	if daily.TotalInstalls != nil {
+		t.Fatalf("daily habits installs = %v, want unavailable rather than zero", daily.TotalInstalls)
+	}
+	if daily.SuggestionPopularity == nil || *daily.SuggestionPopularity != 72 {
+		t.Fatalf("daily suggestion popularity = %v, want 72", daily.SuggestionPopularity)
+	}
+
+	negative := findSearchPlanRow(t, report.Rows, "free planner")
+	assertActions(t, negative.Actions, "negative_candidate")
+	if negative.TotalInstalls == nil || *negative.TotalInstalls != 0 {
+		t.Fatalf("free planner installs = %v, want observed zero", negative.TotalInstalls)
+	}
+
+	saturated := findSearchPlanRow(t, report.Rows, "mood journal")
+	assertActions(t, saturated.Actions, "saturated", "metadata_candidate")
+	if slices.Contains(saturated.Actions, "promote_exact") {
+		t.Fatalf("mood actions = %v, existing exact target must suppress promotion", saturated.Actions)
+	}
+}
+
+func TestBuildSearchPlanSuppressesExistingNegativeCandidate(t *testing.T) {
+	report := buildSearchPlan(searchPlanBuildInput{
+		Metadata: searchMetadataSnapshot{},
+		Ads: ads.SearchOptimizationData{
+			SearchTerms:      []ads.SearchTermPerformance{{Term: "free planner", CampaignID: 44, AdGroupID: 55, Taps: 20, TotalInstalls: 0}},
+			NegativeKeywords: []ads.SearchNegativeKeyword{{Text: "free planner", CampaignID: 44, AdGroupID: 55, MatchType: "EXACT"}},
+		},
+	})
+	row := findSearchPlanRow(t, report.Rows, "free planner")
+	if slices.Contains(row.Actions, "negative_candidate") {
+		t.Fatalf("actions = %v, existing negative must suppress candidate", row.Actions)
+	}
+}
+
+func TestBuildSearchPlanUsesLatestImpressionSharePeriod(t *testing.T) {
+	report := buildSearchPlan(searchPlanBuildInput{
+		Ads: ads.SearchOptimizationData{ImpressionShares: []ads.SearchImpressionShare{
+			{Term: "habit tracker", Day: "2026-08-17", Low: floatPtr(0.3), High: floatPtr(0.4), Rank: intPtr(3)},
+			{Term: "habit tracker", Day: "2026-08-16", Low: floatPtr(0.8), High: floatPtr(0.9), Rank: intPtr(1)},
+		}},
+	})
+	row := findSearchPlanRow(t, report.Rows, "habit tracker")
+	if row.ImpressionSharePeriod != "2026-08-17" || row.ImpressionShareLow == nil || *row.ImpressionShareLow != 0.3 || row.ImpressionShareRank == nil || *row.ImpressionShareRank != 3 {
+		t.Fatalf("latest impression share = %+v", row)
+	}
+}
+
+func TestWriteSearchPlanArtifactsAreReviewableAndImportCompatible(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "optimization")
+	report := SearchPlanReport{
+		SchemaVersion: "1",
+		AppID:         "123456789",
+		Version:       "4.4.4",
+		Locale:        "en-US",
+		Metadata:      searchMetadataSnapshot{Keywords: "focus,timer"},
+		Rows: []SearchPlanRow{
+			{Term: "daily habits", Actions: []string{"metadata_candidate", "untested_candidate"}, AdGroupID: int64Ptr(55)},
+			{Term: "habit tracker", Actions: []string{"promote_exact"}, CampaignID: int64Ptr(44), AdGroupID: int64Ptr(55)},
+			{Term: "free planner", Actions: []string{"negative_candidate"}, CampaignID: int64Ptr(44), AdGroupID: int64Ptr(55)},
+		},
+	}
+
+	artifacts, err := writeSearchPlanArtifacts(dir, report)
+	if err != nil {
+		t.Fatalf("writeSearchPlanArtifacts() error = %v", err)
+	}
+	if len(artifacts) != 4 {
+		t.Fatalf("artifacts = %v, want four files", artifacts)
+	}
+
+	reportData, err := os.ReadFile(filepath.Join(dir, "report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded SearchPlanReport
+	if err := json.Unmarshal(reportData, &decoded); err != nil || decoded.SchemaVersion != "1" {
+		t.Fatalf("report artifact decode = (%+v, %v)", decoded, err)
+	}
+
+	csvFile, err := os.Open(filepath.Join(dir, "metadata-candidates.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := csv.NewReader(csvFile).ReadAll()
+	_ = csvFile.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || strings.Join(rows[0], ",") != "locale,keywords" || rows[1][0] != "en-US" {
+		t.Fatalf("metadata CSV = %#v", rows)
+	}
+	if got := rows[1][1]; got != "focus,timer,daily habits" {
+		t.Fatalf("metadata keywords = %q", got)
+	}
+
+	assertBulkArtifact(t, filepath.Join(dir, "exact-keywords.json"), "habit tracker", "EXACT")
+	assertBulkArtifact(t, filepath.Join(dir, "negative-keywords.json"), "free planner", "EXACT")
+}
+
+func TestMetadataCandidateArtifactHonorsKeywordLimitAndDuplicates(t *testing.T) {
+	report := SearchPlanReport{
+		Locale:   "en-US",
+		Metadata: searchMetadataSnapshot{Keywords: strings.Repeat("a", 95)},
+		Rows: []SearchPlanRow{
+			{Term: "tool", Actions: []string{"metadata_candidate"}},
+			{Term: "tool", Actions: []string{"metadata_candidate"}},
+			{Term: "x", Actions: []string{"metadata_candidate"}},
+		},
+	}
+	data, err := buildMetadataCandidatesCSV(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Repeat("a", 95) + ",tool"
+	if len(rows) != 2 || rows[1][1] != want {
+		t.Fatalf("metadata candidates = %#v, want %q", rows, want)
+	}
+}
+
+func TestWriteSearchPlanArtifactsRejectsFileAsOutputDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, []byte("occupied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeSearchPlanArtifacts(path, SearchPlanReport{}); err == nil {
+		t.Fatal("writeSearchPlanArtifacts() succeeded with a file as --out-dir")
+	}
+}
+
+func TestResolveSearchPlanWindowRejectsNonWholeOrOutOfRangeDuration(t *testing.T) {
+	for _, value := range []string{"1d", "31d", "36h", "nonsense"} {
+		if _, err := resolveSearchPlanWindow(value, time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)); err == nil {
+			t.Fatalf("resolveSearchPlanWindow(%q) succeeded, want error", value)
+		}
+	}
+	window, err := resolveSearchPlanWindow("30d", time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if window.Start != "2026-07-19" || window.End != "2026-08-17" || window.PopularityStart != "2026-08-09" || window.PopularityEnd != "2026-08-15" {
+		t.Fatalf("window = %+v", window)
+	}
+}
+
+func findSearchPlanRow(t *testing.T, rows []SearchPlanRow, term string) SearchPlanRow {
+	t.Helper()
+	for _, row := range rows {
+		if row.Term == term {
+			return row
+		}
+	}
+	t.Fatalf("missing row %q in %+v", term, rows)
+	return SearchPlanRow{}
+}
+
+func assertActions(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	for _, action := range want {
+		if !slices.Contains(got, action) {
+			t.Fatalf("actions = %v, want %q", got, action)
+		}
+	}
+}
+
+func assertBulkArtifact(t *testing.T, path, text, matchType string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Items []struct {
+			Data struct {
+				Text      string `json:"text"`
+				MatchType string `json:"matchType"`
+			} `json:"data"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].Data.Text != text || payload.Items[0].Data.MatchType != matchType {
+		t.Fatalf("bulk artifact %s = %+v", path, payload)
+	}
+}
+
+func intPtr(value int) *int           { return &value }
+func int64Ptr(value int64) *int64     { return &value }
+func floatPtr(value float64) *float64 { return &value }

--- a/internal/cli/optimize/search_plan_test.go
+++ b/internal/cli/optimize/search_plan_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -184,6 +185,28 @@ func TestBuildSearchPlanUsesLatestImpressionSharePeriod(t *testing.T) {
 	}
 }
 
+func TestBuildSearchPlanUsesLatestPopularityPeriodDeterministically(t *testing.T) {
+	build := func(popularities []ads.SearchPopularity) SearchPlanRow {
+		report := buildSearchPlan(searchPlanBuildInput{
+			Ads: ads.SearchOptimizationData{Popularities: popularities},
+		})
+		return findSearchPlanRow(t, report.Rows, "habit tracker")
+	}
+	old := ads.SearchPopularity{Term: "habit tracker", Week: "2026-08-02", Popularity5: intPtr(5), Popularity100: intPtr(95), RankInGenre: intPtr(1)}
+	newerWeak := ads.SearchPopularity{Term: "habit tracker", Week: "2026-08-09", Popularity5: intPtr(3), Popularity100: intPtr(70), RankInGenre: intPtr(5)}
+	newerStrong := ads.SearchPopularity{Term: "habit tracker", Week: "2026-08-09", Popularity5: intPtr(4), Popularity100: intPtr(85), RankInGenre: intPtr(2)}
+
+	for _, popularities := range [][]ads.SearchPopularity{
+		{old, newerWeak, newerStrong},
+		{newerStrong, newerWeak, old},
+	} {
+		row := build(popularities)
+		if row.Popularity5 == nil || *row.Popularity5 != 4 || row.Popularity100 == nil || *row.Popularity100 != 85 || row.RankInGenre == nil || *row.RankInGenre != 2 {
+			t.Fatalf("selected popularity = %+v, want latest period with stable best rank", row)
+		}
+	}
+}
+
 func TestBuildSearchPlanChoosesStableCampaignContextForEqualPerformance(t *testing.T) {
 	build := func(performance []ads.SearchTermPerformance) SearchPlanRow {
 		report := buildSearchPlan(searchPlanBuildInput{
@@ -258,8 +281,8 @@ func TestWriteSearchPlanArtifactsAreReviewableAndImportCompatible(t *testing.T) 
 		t.Fatalf("metadata keywords = %q", got)
 	}
 
-	assertBulkArtifact(t, filepath.Join(dir, "exact-keywords.json"), "habit tracker", "EXACT")
-	assertBulkArtifact(t, filepath.Join(dir, "negative-keywords.json"), "free planner", "EXACT")
+	assertJSONArtifact(t, filepath.Join(dir, "exact-keywords.json"), `{"items":[{"correlationId":0,"data":{"adGroupId":55,"text":"habit tracker","matchType":"EXACT"}}]}`)
+	assertJSONArtifact(t, filepath.Join(dir, "negative-keywords.json"), `{"items":[{"correlationId":0,"data":{"campaignId":44,"adGroupId":55,"text":"free planner","matchType":"EXACT","status":"ENABLED"}}]}`)
 }
 
 func TestMetadataCandidateArtifactHonorsKeywordLimitAndDuplicates(t *testing.T) {
@@ -355,25 +378,22 @@ func assertActions(t *testing.T, got []string, want ...string) {
 	}
 }
 
-func assertBulkArtifact(t *testing.T, path, text, matchType string) {
+func assertJSONArtifact(t *testing.T, path, want string) {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var payload struct {
-		Items []struct {
-			Data struct {
-				Text      string `json:"text"`
-				MatchType string `json:"matchType"`
-			} `json:"data"`
-		} `json:"items"`
-	}
-	if err := json.Unmarshal(data, &payload); err != nil {
+	var gotValue any
+	var wantValue any
+	if err := json.Unmarshal(data, &gotValue); err != nil {
 		t.Fatal(err)
 	}
-	if len(payload.Items) != 1 || payload.Items[0].Data.Text != text || payload.Items[0].Data.MatchType != matchType {
-		t.Fatalf("bulk artifact %s = %+v", path, payload)
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("artifact %s = %s, want %s", path, data, want)
 	}
 }
 

--- a/internal/cli/optimize/search_plan_test.go
+++ b/internal/cli/optimize/search_plan_test.go
@@ -184,6 +184,25 @@ func TestBuildSearchPlanUsesLatestImpressionSharePeriod(t *testing.T) {
 	}
 }
 
+func TestBuildSearchPlanChoosesStableCampaignContextForEqualPerformance(t *testing.T) {
+	build := func(performance []ads.SearchTermPerformance) SearchPlanRow {
+		report := buildSearchPlan(searchPlanBuildInput{
+			Ads: ads.SearchOptimizationData{SearchTerms: performance},
+		})
+		return findSearchPlanRow(t, report.Rows, "habit tracker")
+	}
+	first := ads.SearchTermPerformance{Term: "habit tracker", KeywordText: "habits", MatchType: "BROAD", CampaignID: 11, AdGroupID: 101, TotalInstalls: 3}
+	second := ads.SearchTermPerformance{Term: "habit tracker", KeywordText: "tracker", MatchType: "BROAD", CampaignID: 22, AdGroupID: 202, TotalInstalls: 3}
+
+	forward := build([]ads.SearchTermPerformance{first, second})
+	reverse := build([]ads.SearchTermPerformance{second, first})
+	for _, row := range []SearchPlanRow{forward, reverse} {
+		if row.CampaignID == nil || *row.CampaignID != 11 || row.AdGroupID == nil || *row.AdGroupID != 101 || row.MatchedKeyword != "habits" {
+			t.Fatalf("selected context = %+v, want stable lowest campaign/ad group", row)
+		}
+	}
+}
+
 func TestSearchPlanRowsUseImpressionSharePopularityAsOneToFiveFallback(t *testing.T) {
 	rows := searchPlanRows([]SearchPlanRow{{Term: "habit tracker", ImpressionSharePopularity5: intPtr(4)}})
 	if len(rows) != 1 || len(rows[0]) < 2 || rows[0][1] != "4" {

--- a/internal/cli/optimize/search_plan_test.go
+++ b/internal/cli/optimize/search_plan_test.go
@@ -140,6 +140,23 @@ func TestBuildSearchPlanSuppressesExistingNegativeCandidate(t *testing.T) {
 	}
 }
 
+func TestBuildSearchPlanSuppressesNegativeCandidateWhenSearchTermEvidenceIsIncomplete(t *testing.T) {
+	report := buildSearchPlan(searchPlanBuildInput{
+		Metadata: searchMetadataSnapshot{},
+		Ads: ads.SearchOptimizationData{
+			Sources: []ads.SearchOptimizationSourceStatus{
+				{Name: "negative_keywords", Status: "empty"},
+				{Name: "search_term_performance", Status: "unavailable", Error: "one campaign failed"},
+			},
+			SearchTerms: []ads.SearchTermPerformance{{Term: "free planner", CampaignID: 44, AdGroupID: 55, Taps: 20, TotalInstalls: 0}},
+		},
+	})
+	row := findSearchPlanRow(t, report.Rows, "free planner")
+	if slices.Contains(row.Actions, "negative_candidate") {
+		t.Fatalf("actions = %v, incomplete search-term evidence must suppress negative candidate", row.Actions)
+	}
+}
+
 func TestBuildSearchPlanDoesNotInferAbsenceFromUnavailableSources(t *testing.T) {
 	report := buildSearchPlan(searchPlanBuildInput{
 		Metadata: searchMetadataSnapshot{},

--- a/internal/cli/optimize/search_plan_test.go
+++ b/internal/cli/optimize/search_plan_test.go
@@ -32,6 +32,7 @@ func TestBuildSearchPlanJoinsOfficialEvidenceWithoutInventingMissingValues(t *te
 			Keywords: "focus,timer",
 		},
 		Ads: ads.SearchOptimizationData{
+			TargetCPASuggestion:            json.RawMessage(`{"suggestedTargetCPA":{"amount":"1.20","currency":"USD"}}`),
 			DailyBudgetRecommendationItems: []json.RawMessage{json.RawMessage(`{"id":"budget-1"}`)},
 			DailyBudgetRecommendations:     1,
 			Sources: []ads.SearchOptimizationSourceStatus{
@@ -39,18 +40,20 @@ func TestBuildSearchPlanJoinsOfficialEvidenceWithoutInventingMissingValues(t *te
 				{Name: "search_term_popularity", Status: "available", Count: 3},
 				{Name: "impression_share", Status: "available", Count: 2},
 				{Name: "search_term_performance", Status: "available", Count: 3},
+				{Name: "targeting_keywords", Status: "available", Count: 1},
+				{Name: "negative_keywords", Status: "empty"},
 			},
 			Suggestions: []ads.SearchSuggestion{
 				{Text: "daily habits", Popularity: intPtr(72), Kind: "keyword"},
 				{Text: "mood journal", Popularity: intPtr(69), Kind: "phrase"},
 			},
 			Popularities: []ads.SearchPopularity{
-				{Term: "habit tracker", Popularity100: intPtr(88), RankInGenre: intPtr(1)},
+				{Term: "habit tracker", Popularity100: intPtr(88), Popularity5: intPtr(5), RankInGenre: intPtr(1)},
 				{Term: "daily habits", Popularity100: intPtr(72), RankInGenre: intPtr(8)},
 				{Term: "free planner", Popularity100: intPtr(64), RankInGenre: intPtr(15)},
 			},
 			ImpressionShares: []ads.SearchImpressionShare{
-				{Term: "habit tracker", Low: floatPtr(0.07), High: floatPtr(0.07), Rank: intPtr(6)},
+				{Term: "habit tracker", Low: floatPtr(0.07), High: floatPtr(0.07), Rank: intPtr(6), Popularity5: intPtr(4)},
 				{Term: "mood journal", Low: floatPtr(0.91), High: floatPtr(1), Rank: intPtr(1)},
 			},
 			SearchTerms: []ads.SearchTermPerformance{
@@ -71,10 +74,19 @@ func TestBuildSearchPlanJoinsOfficialEvidenceWithoutInventingMissingValues(t *te
 	if len(report.Recommendations.DailyBudgets) != 1 || !strings.Contains(string(report.Recommendations.DailyBudgets[0]), "budget-1") {
 		t.Fatalf("recommendations = %+v", report.Recommendations)
 	}
+	if !strings.Contains(string(report.Recommendations.TargetCPASuggestion), `"amount":"1.20"`) {
+		t.Fatalf("target CPA suggestion = %s", report.Recommendations.TargetCPASuggestion)
+	}
 
 	habit := findSearchPlanRow(t, report.Rows, "habit tracker")
 	if habit.Popularity100 == nil || *habit.Popularity100 != 88 {
 		t.Fatalf("habit popularity = %v, want 88", habit.Popularity100)
+	}
+	if habit.Popularity5 == nil || *habit.Popularity5 != 5 {
+		t.Fatalf("habit 1-to-5 popularity = %v, want 5", habit.Popularity5)
+	}
+	if habit.ImpressionSharePopularity5 == nil || *habit.ImpressionSharePopularity5 != 4 {
+		t.Fatalf("habit impression-share popularity = %v, want 4", habit.ImpressionSharePopularity5)
 	}
 	if habit.CPA == nil || habit.CPA.Amount != "1.18" || habit.CPA.Currency != "USD" {
 		t.Fatalf("habit CPA = %+v, want USD 1.18", habit.CPA)
@@ -116,6 +128,7 @@ func TestBuildSearchPlanSuppressesExistingNegativeCandidate(t *testing.T) {
 	report := buildSearchPlan(searchPlanBuildInput{
 		Metadata: searchMetadataSnapshot{},
 		Ads: ads.SearchOptimizationData{
+			Sources:          []ads.SearchOptimizationSourceStatus{{Name: "negative_keywords", Status: "available", Count: 1}},
 			SearchTerms:      []ads.SearchTermPerformance{{Term: "free planner", CampaignID: 44, AdGroupID: 55, Taps: 20, TotalInstalls: 0}},
 			NegativeKeywords: []ads.SearchNegativeKeyword{{Text: "free planner", CampaignID: 44, AdGroupID: 55, MatchType: "EXACT"}},
 		},
@@ -126,16 +139,55 @@ func TestBuildSearchPlanSuppressesExistingNegativeCandidate(t *testing.T) {
 	}
 }
 
+func TestBuildSearchPlanDoesNotInferAbsenceFromUnavailableSources(t *testing.T) {
+	report := buildSearchPlan(searchPlanBuildInput{
+		Metadata: searchMetadataSnapshot{},
+		Ads: ads.SearchOptimizationData{
+			Sources: []ads.SearchOptimizationSourceStatus{
+				{Name: "targeting_keywords", Status: "unavailable", Error: "denied"},
+				{Name: "negative_keywords", Status: "unavailable", Error: "denied"},
+				{Name: "search_term_performance", Status: "unavailable", Error: "denied"},
+			},
+			Suggestions: []ads.SearchSuggestion{{Text: "untested term", Kind: "keyword"}},
+			SearchTerms: []ads.SearchTermPerformance{
+				{Term: "converting broad", MatchType: "BROAD", CampaignID: 44, AdGroupID: 55, Taps: 20, TotalInstalls: 3},
+				{Term: "waste term", MatchType: "BROAD", CampaignID: 44, AdGroupID: 55, Taps: 20, TotalInstalls: 0},
+			},
+		},
+	})
+
+	for _, test := range []struct {
+		term   string
+		action string
+	}{
+		{term: "converting broad", action: "promote_exact"},
+		{term: "waste term", action: "negative_candidate"},
+		{term: "untested term", action: "untested_candidate"},
+	} {
+		row := findSearchPlanRow(t, report.Rows, test.term)
+		if slices.Contains(row.Actions, test.action) {
+			t.Fatalf("%q actions = %v; unavailable source must suppress %q", test.term, row.Actions, test.action)
+		}
+	}
+}
+
 func TestBuildSearchPlanUsesLatestImpressionSharePeriod(t *testing.T) {
 	report := buildSearchPlan(searchPlanBuildInput{
 		Ads: ads.SearchOptimizationData{ImpressionShares: []ads.SearchImpressionShare{
-			{Term: "habit tracker", Day: "2026-08-17", Low: floatPtr(0.3), High: floatPtr(0.4), Rank: intPtr(3)},
-			{Term: "habit tracker", Day: "2026-08-16", Low: floatPtr(0.8), High: floatPtr(0.9), Rank: intPtr(1)},
+			{Term: "habit tracker", Day: "2026-08-17", Low: floatPtr(0.3), High: floatPtr(0.4), Rank: intPtr(3), Popularity5: intPtr(4)},
+			{Term: "habit tracker", Day: "2026-08-16", Low: floatPtr(0.8), High: floatPtr(0.9), Rank: intPtr(1), Popularity5: intPtr(5)},
 		}},
 	})
 	row := findSearchPlanRow(t, report.Rows, "habit tracker")
-	if row.ImpressionSharePeriod != "2026-08-17" || row.ImpressionShareLow == nil || *row.ImpressionShareLow != 0.3 || row.ImpressionShareRank == nil || *row.ImpressionShareRank != 3 {
+	if row.ImpressionSharePeriod != "2026-08-17" || row.ImpressionShareLow == nil || *row.ImpressionShareLow != 0.3 || row.ImpressionShareRank == nil || *row.ImpressionShareRank != 3 || row.ImpressionSharePopularity5 == nil || *row.ImpressionSharePopularity5 != 4 {
 		t.Fatalf("latest impression share = %+v", row)
+	}
+}
+
+func TestSearchPlanRowsUseImpressionSharePopularityAsOneToFiveFallback(t *testing.T) {
+	rows := searchPlanRows([]SearchPlanRow{{Term: "habit tracker", ImpressionSharePopularity5: intPtr(4)}})
+	if len(rows) != 1 || len(rows[0]) < 2 || rows[0][1] != "4" {
+		t.Fatalf("rendered rows = %#v, want impression-share popularity fallback", rows)
 	}
 }
 
@@ -237,6 +289,30 @@ func TestResolveSearchPlanWindowRejectsNonWholeOrOutOfRangeDuration(t *testing.T
 	}
 	if window.Start != "2026-07-19" || window.End != "2026-08-17" || window.PopularityStart != "2026-08-09" || window.PopularityEnd != "2026-08-15" {
 		t.Fatalf("window = %+v", window)
+	}
+}
+
+func TestResolveSearchPlanWindowWaitsForWeeklyPopularityPublication(t *testing.T) {
+	tests := []struct {
+		name      string
+		now       time.Time
+		wantStart string
+		wantEnd   string
+	}{
+		{name: "Sunday before publication", now: time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC), wantStart: "2026-08-02", wantEnd: "2026-08-08"},
+		{name: "Monday before publication", now: time.Date(2026, 8, 17, 6, 59, 0, 0, time.UTC), wantStart: "2026-08-02", wantEnd: "2026-08-08"},
+		{name: "Monday after publication", now: time.Date(2026, 8, 17, 7, 0, 0, 0, time.UTC), wantStart: "2026-08-09", wantEnd: "2026-08-15"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			window, err := resolveSearchPlanWindow("30d", test.now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if window.PopularityStart != test.wantStart || window.PopularityEnd != test.wantEnd {
+				t.Fatalf("popularity window = %s through %s, want %s through %s", window.PopularityStart, window.PopularityEnd, test.wantStart, test.wantEnd)
+			}
+		})
 	}
 }
 

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -49,6 +49,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/nominations"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/notarization"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/notify"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/optimize"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/passtypeids"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/performance"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/preorders"
@@ -128,6 +129,7 @@ func NewCatalog(version string) *Catalog {
 		commandFactory("review", "Manage App Store review details, attachments, and submissions.", reviews.ReviewCommand),
 		commandFactory("analytics", "Request and download analytics and sales reports.", analytics.AnalyticsCommand),
 		commandFactory("ads", "Manage Apple Ads API resources.", ads.AdsCommand),
+		commandFactory("optimize", "Build cross-API optimization plans. [experimental]", optimize.OptimizeCommand),
 		commandFactory("performance", "Access performance metrics and diagnostic logs.", performance.PerformanceCommand),
 		commandFactory("finance", "Download payments and financial reports.", finance.FinanceCommand),
 		commandFactory("apps", "List and manage apps in App Store Connect.", apps.AppsCommand),

--- a/internal/cli/registry/registry_test.go
+++ b/internal/cli/registry/registry_test.go
@@ -39,7 +39,7 @@ func TestSubcommandsIncludesCoreEntries(t *testing.T) {
 		names[name] = struct{}{}
 	}
 
-	required := []string{"auth", "doctor", "account", "ads", "insights", "builds", "reviews", "version", "completion"}
+	required := []string{"auth", "doctor", "account", "ads", "optimize", "insights", "builds", "reviews", "version", "completion"}
 	for _, name := range required {
 		if _, ok := names[name]; !ok {
 			t.Fatalf("expected root subcommands to include %q", name)


### PR DESCRIPTION
## Summary

- add experimental `asc optimize search plan` as an official-only cross-API workflow
- join App Store Connect name, subtitle, and keyword metadata with all relevant Apple Ads search signals: keyword and phrase suggestions, target-CPA suggestion, country-and-genre popularity, impression share, search-term performance, campaign targeting and negatives, eligibility, plus daily-budget and target-CPA recommendations
- preserve distinct Apple measures instead of blending them: Campaign Management-compatible popularity 1–5, suggestion popularity 1–100, genre popularity/rank, and app-specific impression share
- emit deterministic `promote_exact`, `negative_candidate`, `metadata_candidate`, `defend`, `saturated`, and `untested_candidate` actions with explicit provenance and confidence
- optionally write a canonical report plus review-only metadata, exact-keyword, and negative-keyword import artifacts
- preserve partial official source failures without inventing unavailable values or calling private web endpoints

## Why this is valuable for 4.4.4

The raw Platform API v1 commands expose strong data, but users still have to reconcile different response shapes and App Store metadata themselves. This gives the release one high-level outcome: a read-only, auditable plan that connects search demand, app-specific paid reach, actual outcomes, and current metadata while remaining entirely inside supported Apple APIs.

## Safety and compatibility

- read-only; no campaign or App Store mutation
- new experimental root group, so existing commands are unchanged
- Apple Ads authentication stays separate from App Store Connect authentication
- report fields distinguish market popularity from app-specific paid metrics
- absence-based actions are suppressed when their required source is unavailable
- human output includes source status, partial-failure notices, summary, plan, and artifact paths
- artifacts require an explicit existing apply command and confirmation where applicable

## Contract fixes from audit

- use schema-correct pagination per endpoint instead of sending `fetchTotalCount` to report and suggestion request types that reject it
- omit the unsupported country filter from phrase-suggestion requests while retaining the documented keyword-suggestion country filter
- select the latest published weekly popularity snapshot, accounting for Monday 07:00 UTC publication
- resolve duplicate normalized popularity rows deterministically by latest period, then best rank and popularity values
- put a bounded timeout on every Apple Ads request
- retain the raw official target-CPA suggestion
- expose both popularity scales and the genre rank in structured and human output
- resolve App Info by the selected version state, provide `--app-info` for ambiguous cases, and record the exact version and App Info resource IDs
- choose paid campaign/ad-group context deterministically when report rows have equal installs
- suppress absence-based actions whenever their prerequisite source is unavailable
- test every request path, filters, time windows, pagination shape, partial-source behavior, and response preservation

## Verification

- `make format`
- `make check-docs` — command docs, repository docs, website docs, website commands, agent skills, and OpenAPI artifacts are current
- `make lint` — 0 issues
- `ASC_BYPASS_KEYCHAIN=1 make test` — complete repository suite passed
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/ads ./internal/cli/optimize`
- `ASC_BYPASS_KEYCHAIN=1 go test -count=25 ./internal/cli/ads ./internal/cli/optimize`
- `make build`
- built-binary help across `asc`, `asc optimize`, `asc optimize search`, and `asc optimize search plan`
- built-binary usage-error smoke: exit code 2, empty stdout, diagnostic on stderr
- `git diff --check` and credential-pattern scan

## Credentialed live verification

Read-only runs completed against two apps owned by both configured accounts; no Apple Ads or App Store Connect mutations were made.

- Zenther, US / `en-US`, 2-day paid window: 516 normalized terms, 500 Search Term Popularity rows, 498 rows with the 1–5 score, four existing paused campaigns, and all four artifacts written and parsed.
- Gradient Match Game, GB / `en-GB`, 7-day paid window: 518 normalized terms, 500 Search Term Popularity rows, 499 rows with the 1–5 score, zero-campaign path exercised, and multiple App Info records resolved to the record matching the selected released version.
- Both runs preserved exact resolved version and App Info IDs in `report.json`; artifacts were valid JSON/CSV and written with mode `0644`.
- Keyword suggestions, Search Term Popularity, eligibility, campaign/targeting discovery where present, pagination, metadata joins, partial-source reporting, and artifact generation all worked live.
- Apple returned HTTP 500 for the exact documented phrase-suggestion request and HTTP 400 `INVALID_VALUE` for Impression Share on this account. Both remain visible as unavailable sources without discarding successful data or manufacturing absence-based actions. The account has no recent active campaign delivery with which to prove a successful Impression Share response.

Example:

```bash
asc optimize search plan \
  --app "APP_ID" \
  --version "APP_VERSION" \
  --ad-account "AD_ACCOUNT_ID" \
  --country "US" \
  --genre "PRODUCTIVITY_UTILITIES" \
  --locale "en-US" \
  --out-dir ".asc/optimization/APP_VERSION" \
  --output markdown
```

### Terminal presentation
- Default TTY output now leads with a compact, screenshot-ready app summary and search plan.
- Markdown and JSON retain complete row provenance and provider diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the experimental, read-only `optimize search plan` command.
  - Combines advertising performance data with App Store metadata to produce deterministic keyword recommendations.
  - Supports table, human-readable, Markdown, and JSON output formats.
  - Generates reviewable metadata and keyword import artifacts.
  - Reports unavailable data sources while continuing with partial results.
- **Bug Fixes**
  - Improved API error messages with structured validation details.
- **Documentation**
  - Added command reference, design documentation, and release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->