### PR TITLE
feat(cli): agent-grade tester lookup, truncation warnings, and output contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Use these skills for their matching workflows instead of expanding this always-l
 - Use `--paginate` when callers request every page.
 - Write data to stdout and errors or diagnostics to stderr.
 - Never accept and silently ignore an unsupported flag or value.
+- JSON output shape is part of the command contract: reads of ASC collections/resources print Apple's envelope unmodified; mutation receipts and computed results use exported camelCase structs in internal/asc/output_*.go with a registered renderer; added fields are additive and removals follow the stability ladder.
 
 ## Discover current behavior
 

--- a/commands/testflight.mdx
+++ b/commands/testflight.mdx
@@ -58,12 +58,16 @@ build page. A partial lookup prints the matches and per-group failures with
 
 ### Testers
 
-List testers, add new testers, and manage their group/build access:
+List testers, add new testers, and manage their group/build access. `list`
+accepts `--email`, `--first-name`, and `--last-name` exact-match filters, and
+`testers groups list` shows the groups a tester belongs to:
 
 ```bash  theme={null}
 asc testflight testers list --app APP_ID
+asc testflight testers list --app APP_ID --first-name "Ada" --last-name "Lovelace"
 asc testflight testers add --app APP_ID --email user@example.com --group "Beta"
 asc testflight testers view --id TESTER_ID
+asc testflight testers groups list --id TESTER_ID
 asc testflight testers add-groups --id TESTER_ID --group GROUP_ID
 ```
 
@@ -90,9 +94,14 @@ asc testflight notifications send --build-id BUILD_ID
 
 ### Metrics and config
 
+Tester usage metrics report tester IDs; pass `--resolve-testers` to enrich the
+output with a `testers` sidecar that maps each ID to email and name (extra API
+calls):
+
 ```bash  theme={null}
 asc testflight metrics group-testers --group GROUP_ID
 asc testflight metrics app-testers --app APP_ID
+asc testflight metrics app-testers --app APP_ID --resolve-testers
 asc testflight config export --app APP_ID --output ./testflight.yaml
 ```
 

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -2369,6 +2369,45 @@ func TestGetBetaTesters_WithAppFilter(t *testing.T) {
 	}
 }
 
+func TestGetBetaTesters_WithNameAndIDFilters(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"betaTesters","id":"1","attributes":{"firstName":"Ada","lastName":"Lovelace"}}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaTesters" {
+			t.Fatalf("expected path /v1/betaTesters, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("filter[apps]") != "123" {
+			t.Fatalf("expected filter[apps]=123, got %q", values.Get("filter[apps]"))
+		}
+		if values.Get("filter[firstName]") != "Ada" {
+			t.Fatalf("expected filter[firstName]=Ada, got %q", values.Get("filter[firstName]"))
+		}
+		if values.Get("filter[lastName]") != "Lovelace" {
+			t.Fatalf("expected filter[lastName]=Lovelace, got %q", values.Get("filter[lastName]"))
+		}
+		if values.Get("filter[id]") != "tester-1,tester-2" {
+			t.Fatalf("expected filter[id]=tester-1,tester-2, got %q", values.Get("filter[id]"))
+		}
+		if values.Get("filter[email]") != "" {
+			t.Fatalf("expected no filter[email], got %q", values.Get("filter[email]"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetBetaTesters(
+		context.Background(),
+		"123",
+		WithBetaTestersFirstName(" Ada "),
+		WithBetaTestersLastName(" Lovelace "),
+		WithBetaTestersIDs([]string{"tester-1", "tester-2"}),
+	); err != nil {
+		t.Fatalf("GetBetaTesters() error: %v", err)
+	}
+}
+
 func TestGetBetaTesters_WithBuildFilter(t *testing.T) {
 	// API only allows one relationship filter; build filter takes precedence over apps.
 	response := jsonResponse(http.StatusOK, `{"data":[{"type":"betaTesters","id":"1","attributes":{"email":"tester@example.com"}}]}`)

--- a/internal/asc/client_pagination.go
+++ b/internal/asc/client_pagination.go
@@ -199,6 +199,29 @@ func initializeEmptyDataSlice(responseValue reflect.Value) {
 	}
 }
 
+// PageDataLen reports how many items a page's Data collection holds.
+// It returns ok=false when the page is nil (including a typed nil pointer) or
+// when GetData does not expose a countable item slice — byte slices such as
+// json.RawMessage are payloads, not item lists, so they are not counted.
+func PageDataLen(page PaginatedResponse) (int, bool) {
+	if page == nil {
+		return 0, false
+	}
+
+	// Handle typed nil (non-nil interface containing nil pointer) before
+	// invoking interface methods, mirroring the PaginateAll guard.
+	pageValue := reflect.ValueOf(page)
+	if pageValue.Kind() == reflect.Pointer && pageValue.IsNil() {
+		return 0, false
+	}
+
+	data := reflect.ValueOf(page.GetData())
+	if !data.IsValid() || data.Kind() != reflect.Slice || data.Type().Elem().Kind() == reflect.Uint8 {
+		return 0, false
+	}
+	return data.Len(), true
+}
+
 // aggregatePageData appends page data to result by reflecting on the shared Data field.
 // This keeps pagination aggregation generic while still validating type compatibility.
 func aggregatePageData(result, page PaginatedResponse) error {

--- a/internal/asc/client_pagination_test.go
+++ b/internal/asc/client_pagination_test.go
@@ -292,6 +292,83 @@ type unsupportedPaginatedResponse struct {
 func (r *unsupportedPaginatedResponse) GetLinks() *Links { return &r.links }
 func (r *unsupportedPaginatedResponse) GetData() any     { return r.data }
 
+// rawDataPaginatedResponse is a test-only type whose GetData returns raw JSON
+// bytes instead of an item slice.
+type rawDataPaginatedResponse struct {
+	links Links
+	data  json.RawMessage
+}
+
+func (r *rawDataPaginatedResponse) GetLinks() *Links { return &r.links }
+func (r *rawDataPaginatedResponse) GetData() any     { return r.data }
+
+// nonSliceDataPaginatedResponse is a test-only type whose GetData does not
+// return a slice at all.
+type nonSliceDataPaginatedResponse struct {
+	links Links
+}
+
+func (r *nonSliceDataPaginatedResponse) GetLinks() *Links { return &r.links }
+func (r *nonSliceDataPaginatedResponse) GetData() any     { return "not a slice" }
+
+func TestPageDataLen(t *testing.T) {
+	t.Run("counts resource slice", func(t *testing.T) {
+		page := makeBetaGroupsPage(1, 3, 2)
+		count, ok := PageDataLen(page)
+		if !ok || count != 3 {
+			t.Fatalf("PageDataLen() = (%d, %t), want (3, true)", count, ok)
+		}
+	})
+
+	t.Run("counts empty resource slice", func(t *testing.T) {
+		page := &BetaGroupsResponse{Data: []Resource[BetaGroupAttributes]{}}
+		count, ok := PageDataLen(page)
+		if !ok || count != 0 {
+			t.Fatalf("PageDataLen() = (%d, %t), want (0, true)", count, ok)
+		}
+	})
+
+	t.Run("counts non-resource item slice", func(t *testing.T) {
+		page := &unsupportedPaginatedResponse{data: []string{"a", "b"}}
+		count, ok := PageDataLen(page)
+		if !ok || count != 2 {
+			t.Fatalf("PageDataLen() = (%d, %t), want (2, true)", count, ok)
+		}
+	})
+
+	t.Run("nil interface not counted", func(t *testing.T) {
+		count, ok := PageDataLen(nil)
+		if ok || count != 0 {
+			t.Fatalf("PageDataLen(nil) = (%d, %t), want (0, false)", count, ok)
+		}
+	})
+
+	t.Run("typed nil not counted", func(t *testing.T) {
+		var typedNil *BetaGroupsResponse
+		var page PaginatedResponse = typedNil
+		count, ok := PageDataLen(page)
+		if ok || count != 0 {
+			t.Fatalf("PageDataLen(typed nil) = (%d, %t), want (0, false)", count, ok)
+		}
+	})
+
+	t.Run("raw JSON data not counted as bytes", func(t *testing.T) {
+		page := &rawDataPaginatedResponse{data: json.RawMessage(`[{"id":"a"},{"id":"b"}]`)}
+		count, ok := PageDataLen(page)
+		if ok || count != 0 {
+			t.Fatalf("PageDataLen(raw JSON data) = (%d, %t), want (0, false)", count, ok)
+		}
+	})
+
+	t.Run("non-slice data not counted", func(t *testing.T) {
+		page := &nonSliceDataPaginatedResponse{}
+		count, ok := PageDataLen(page)
+		if ok || count != 0 {
+			t.Fatalf("PageDataLen(non-slice data) = (%d, %t), want (0, false)", count, ok)
+		}
+	})
+}
+
 func TestPaginateAll_ContextCancelled(t *testing.T) {
 	firstPage := &AppsResponse{
 		Data: []Resource[AppAttributes]{

--- a/internal/asc/client_query_testflight.go
+++ b/internal/asc/client_query_testflight.go
@@ -78,6 +78,9 @@ type betaGroupTestersQuery struct {
 type betaTestersQuery struct {
 	listQuery
 	email        string
+	firstName    string
+	lastName     string
+	ids          []string
 	groupIDs     []string
 	filterBuilds string
 }
@@ -217,6 +220,13 @@ func buildBetaTestersQuery(appID string, query *betaTestersQuery) (string, error
 	if strings.TrimSpace(query.email) != "" {
 		values.Set("filter[email]", strings.TrimSpace(query.email))
 	}
+	if strings.TrimSpace(query.firstName) != "" {
+		values.Set("filter[firstName]", strings.TrimSpace(query.firstName))
+	}
+	if strings.TrimSpace(query.lastName) != "" {
+		values.Set("filter[lastName]", strings.TrimSpace(query.lastName))
+	}
+	addCSV(values, "filter[id]", query.ids)
 	addLimit(values, query.limit)
 	return values.Encode(), nil
 }
@@ -636,6 +646,27 @@ func WithBetaTestersNextURL(next string) BetaTestersOption {
 func WithBetaTestersEmail(email string) BetaTestersOption {
 	return func(q *betaTestersQuery) {
 		q.email = strings.TrimSpace(email)
+	}
+}
+
+// WithBetaTestersFirstName filters beta testers by first name.
+func WithBetaTestersFirstName(firstName string) BetaTestersOption {
+	return func(q *betaTestersQuery) {
+		q.firstName = strings.TrimSpace(firstName)
+	}
+}
+
+// WithBetaTestersLastName filters beta testers by last name.
+func WithBetaTestersLastName(lastName string) BetaTestersOption {
+	return func(q *betaTestersQuery) {
+		q.lastName = strings.TrimSpace(lastName)
+	}
+}
+
+// WithBetaTestersIDs filters beta testers by tester ID(s).
+func WithBetaTestersIDs(ids []string) BetaTestersOption {
+	return func(q *betaTestersQuery) {
+		q.ids = normalizeList(ids)
 	}
 }
 

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -822,6 +822,9 @@ func TestBuildBetaTestersQuery(t *testing.T) {
 	opts := []BetaTestersOption{
 		WithBetaTestersLimit(25),
 		WithBetaTestersEmail("tester@example.com"),
+		WithBetaTestersFirstName("Ada"),
+		WithBetaTestersLastName("Lovelace"),
+		WithBetaTestersIDs([]string{"tester-1", " tester-2 "}),
 	}
 	for _, opt := range opts {
 		opt(query)
@@ -840,6 +843,15 @@ func TestBuildBetaTestersQuery(t *testing.T) {
 	}
 	if got := values.Get("filter[email]"); got != "tester@example.com" {
 		t.Fatalf("expected filter[email]=tester@example.com, got %q", got)
+	}
+	if got := values.Get("filter[firstName]"); got != "Ada" {
+		t.Fatalf("expected filter[firstName]=Ada, got %q", got)
+	}
+	if got := values.Get("filter[lastName]"); got != "Lovelace" {
+		t.Fatalf("expected filter[lastName]=Lovelace, got %q", got)
+	}
+	if got := values.Get("filter[id]"); got != "tester-1,tester-2" {
+		t.Fatalf("expected filter[id]=tester-1,tester-2, got %q", got)
 	}
 	if got := values.Get("filter[betaGroups]"); got != "" {
 		t.Fatalf("expected no filter[betaGroups], got %q", got)

--- a/internal/asc/metrics_beta.go
+++ b/internal/asc/metrics_beta.go
@@ -27,3 +27,66 @@ func (r BetaTesterUsagesResponse) MarshalJSON() ([]byte, error) {
 	}
 	return r.Data, nil
 }
+
+// GetLinks parses the wrapped payload's links so single-page prints can
+// participate in pagination warnings; printed output stays the raw payload.
+func (r *BetaTesterUsagesResponse) GetLinks() *Links {
+	return rawEnvelopeLinks(r.rawPayload())
+}
+
+// GetData exposes the wrapped payload's data array for page-size reporting.
+func (r *BetaTesterUsagesResponse) GetData() any {
+	return rawEnvelopeData(r.rawPayload())
+}
+
+func (r *BetaTesterUsagesResponse) rawPayload() json.RawMessage {
+	if r == nil {
+		return nil
+	}
+	return r.Data
+}
+
+// GetLinks parses the wrapped payload's links so single-page prints can
+// participate in pagination warnings; printed output stays the raw payload.
+func (r *BetaBuildUsagesResponse) GetLinks() *Links {
+	return rawEnvelopeLinks(r.rawPayload())
+}
+
+// GetData exposes the wrapped payload's data array for page-size reporting.
+func (r *BetaBuildUsagesResponse) GetData() any {
+	return rawEnvelopeData(r.rawPayload())
+}
+
+func (r *BetaBuildUsagesResponse) rawPayload() json.RawMessage {
+	if r == nil {
+		return nil
+	}
+	return r.Data
+}
+
+func rawEnvelopeLinks(payload json.RawMessage) *Links {
+	if len(payload) == 0 {
+		return nil
+	}
+	var envelope struct {
+		Links Links `json:"links"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil
+	}
+	links := envelope.Links
+	return &links
+}
+
+func rawEnvelopeData(payload json.RawMessage) any {
+	if len(payload) == 0 {
+		return nil
+	}
+	var envelope struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil
+	}
+	return envelope.Data
+}

--- a/internal/asc/metrics_beta_links_test.go
+++ b/internal/asc/metrics_beta_links_test.go
@@ -1,0 +1,38 @@
+package asc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBetaTesterUsagesResponsePaginationAccessors(t *testing.T) {
+	payload := json.RawMessage(`{"data":[{"id":"a"},{"id":"b"}],"links":{"next":"https://api.appstoreconnect.apple.com/next"}}`)
+	resp := &BetaTesterUsagesResponse{Data: payload}
+
+	links := resp.GetLinks()
+	if links == nil || links.Next != "https://api.appstoreconnect.apple.com/next" {
+		t.Fatalf("GetLinks() = %+v, want next URL", links)
+	}
+	if n, ok := PageDataLen(resp); !ok || n != 2 {
+		t.Fatalf("PageDataLen = %d ok=%t, want 2 true", n, ok)
+	}
+
+	var nilResp *BetaTesterUsagesResponse
+	if nilResp.GetLinks() != nil || nilResp.GetData() != nil {
+		t.Fatal("nil receiver should return nil accessors")
+	}
+
+	empty := &BetaTesterUsagesResponse{}
+	if empty.GetLinks() != nil {
+		t.Fatal("empty payload should return nil links")
+	}
+}
+
+func TestBetaBuildUsagesResponsePaginationAccessors(t *testing.T) {
+	payload := json.RawMessage(`{"data":[{"id":"a"}],"links":{"next":""}}`)
+	resp := &BetaBuildUsagesResponse{Data: payload}
+	links := resp.GetLinks()
+	if links == nil || links.Next != "" {
+		t.Fatalf("GetLinks() = %+v, want empty next", links)
+	}
+}

--- a/internal/asc/output_beta.go
+++ b/internal/asc/output_beta.go
@@ -1,7 +1,9 @@
 package asc
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -295,4 +297,86 @@ func testFlightSyncSummaryRows(summary *TestFlightSyncSummary) ([]string, [][]st
 		fmt.Sprintf("%d", summary.Testers),
 	}}
 	return headers, rows
+}
+
+// BetaTesterUsagesPage is the printed page for tester usage metrics: the raw
+// metric data plus an optional resolved-testers sidecar keyed by tester ID.
+// The data elements stay byte-identical to Apple's response.
+type BetaTesterUsagesPage struct {
+	Data     []json.RawMessage                    `json:"data"`
+	Links    Links                                `json:"links"`
+	Included json.RawMessage                      `json:"included,omitempty"`
+	Meta     json.RawMessage                      `json:"meta,omitempty"`
+	Testers  map[string]BetaTesterUsageTesterInfo `json:"testers,omitempty"`
+}
+
+// BetaTesterUsageTesterInfo describes one resolved beta tester in the
+// testers sidecar keyed by tester ID.
+type BetaTesterUsageTesterInfo struct {
+	ID         string `json:"id"`
+	Email      string `json:"email,omitempty"`
+	FirstName  string `json:"firstName,omitempty"`
+	LastName   string `json:"lastName,omitempty"`
+	State      string `json:"state,omitempty"`
+	InviteType string `json:"inviteType,omitempty"`
+}
+
+func betaTesterUsagesPageTables(v *BetaTesterUsagesPage, render func([]string, [][]string)) error {
+	type metricEntry struct {
+		DataPoints []struct {
+			Start  string `json:"start"`
+			End    string `json:"end"`
+			Values struct {
+				SessionCount  *int `json:"sessionCount"`
+				CrashCount    *int `json:"crashCount"`
+				FeedbackCount *int `json:"feedbackCount"`
+			} `json:"values"`
+		} `json:"dataPoints"`
+		Dimensions struct {
+			BetaTesters struct {
+				Data string `json:"data"`
+			} `json:"betaTesters"`
+		} `json:"dimensions"`
+	}
+	formatCount := func(n *int) string {
+		if n == nil {
+			return ""
+		}
+		return fmt.Sprintf("%d", *n)
+	}
+	rows := make([][]string, 0, len(v.Data))
+	for _, raw := range v.Data {
+		var entry metricEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			continue
+		}
+		for _, point := range entry.DataPoints {
+			rows = append(rows, []string{
+				entry.Dimensions.BetaTesters.Data,
+				point.Start,
+				point.End,
+				formatCount(point.Values.SessionCount),
+				formatCount(point.Values.CrashCount),
+				formatCount(point.Values.FeedbackCount),
+			})
+		}
+	}
+	render([]string{"Tester ID", "Start", "End", "Sessions", "Crashes", "Feedback"}, rows)
+
+	if len(v.Testers) > 0 {
+		ids := make([]string, 0, len(v.Testers))
+		for id := range v.Testers {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		testerRows := make([][]string, 0, len(ids))
+		for _, id := range ids {
+			tester := v.Testers[id]
+			testerRows = append(testerRows, []string{
+				tester.ID, tester.Email, tester.FirstName, tester.LastName, tester.State,
+			})
+		}
+		render([]string{"Tester ID", "Email", "First Name", "Last Name", "State"}, testerRows)
+	}
+	return nil
 }

--- a/internal/asc/output_beta.go
+++ b/internal/asc/output_beta.go
@@ -380,3 +380,19 @@ func betaTesterUsagesPageTables(v *BetaTesterUsagesPage, render func([]string, [
 	}
 	return nil
 }
+
+// GetLinks lets the usages page participate in pagination warnings.
+func (p *BetaTesterUsagesPage) GetLinks() *Links {
+	if p == nil {
+		return nil
+	}
+	return &p.Links
+}
+
+// GetData exposes the page's data array for page-size reporting.
+func (p *BetaTesterUsagesPage) GetData() any {
+	if p == nil {
+		return nil
+	}
+	return p.Data
+}

--- a/internal/asc/output_beta.go
+++ b/internal/asc/output_beta.go
@@ -84,6 +84,48 @@ type BetaFeedbackSubmissionDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
+// BetaTestersExportSummary represents CLI output for beta tester CSV exports.
+type BetaTestersExportSummary struct {
+	AppID         string `json:"appId"`
+	OutputFile    string `json:"outputFile"`
+	Total         int    `json:"total"`
+	IncludeGroups bool   `json:"includeGroups"`
+}
+
+// BetaTestersImportFailure records one CSV row that could not be imported.
+type BetaTestersImportFailure struct {
+	Row   int    `json:"row"`
+	Email string `json:"email,omitempty"`
+	Error string `json:"error"`
+}
+
+// BetaTestersImportSummary represents CLI output for beta tester CSV imports.
+type BetaTestersImportSummary struct {
+	AppID           string                     `json:"appId"`
+	InputFile       string                     `json:"inputFile"`
+	DryRun          bool                       `json:"dryRun"`
+	Invite          bool                       `json:"invite"`
+	SkipExisting    bool                       `json:"skipExisting"`
+	ContinueOnError bool                       `json:"continueOnError"`
+	AppliedGroup    string                     `json:"appliedGroup,omitempty"`
+	Total           int                        `json:"total"`
+	Created         int                        `json:"created"`
+	Existed         int                        `json:"existed"`
+	Updated         int                        `json:"updated"`
+	Invited         int                        `json:"invited"`
+	Failed          int                        `json:"failed"`
+	Failures        []BetaTestersImportFailure `json:"failures,omitempty"`
+}
+
+// TestFlightSyncSummary represents CLI output for testflight sync pull.
+type TestFlightSyncSummary struct {
+	File    string `json:"file"`
+	App     string `json:"app"`
+	Groups  int    `json:"groups"`
+	Builds  int    `json:"builds"`
+	Testers int    `json:"testers"`
+}
+
 func formatBetaTesterName(attr BetaTesterAttributes) string {
 	first := strings.TrimSpace(attr.FirstName)
 	last := strings.TrimSpace(attr.LastName)
@@ -200,5 +242,57 @@ func betaFeedbackSubmissionDeleteResultRows(result *BetaFeedbackSubmissionDelete
 func betaTesterInvitationResultRows(result *BetaTesterInvitationResult) ([]string, [][]string) {
 	headers := []string{"Invitation ID", "Tester ID", "App ID", "Email"}
 	rows := [][]string{{result.InvitationID, result.TesterID, result.AppID, result.Email}}
+	return headers, rows
+}
+
+func betaTestersExportSummaryRows(summary *BetaTestersExportSummary) ([]string, [][]string) {
+	headers := []string{"App ID", "Output File", "Total", "Include Groups"}
+	rows := [][]string{{
+		summary.AppID,
+		summary.OutputFile,
+		fmt.Sprintf("%d", summary.Total),
+		fmt.Sprintf("%t", summary.IncludeGroups),
+	}}
+	return headers, rows
+}
+
+func betaTestersImportSummaryRows(summary *BetaTestersImportSummary) ([]string, [][]string) {
+	headers := []string{"App ID", "Input File", "Dry Run", "Total", "Created", "Existed", "Updated", "Invited", "Failed"}
+	rows := [][]string{{
+		summary.AppID,
+		summary.InputFile,
+		fmt.Sprintf("%t", summary.DryRun),
+		fmt.Sprintf("%d", summary.Total),
+		fmt.Sprintf("%d", summary.Created),
+		fmt.Sprintf("%d", summary.Existed),
+		fmt.Sprintf("%d", summary.Updated),
+		fmt.Sprintf("%d", summary.Invited),
+		fmt.Sprintf("%d", summary.Failed),
+	}}
+	return headers, rows
+}
+
+func betaTestersImportFailureRows(failures []BetaTestersImportFailure) ([]string, [][]string) {
+	headers := []string{"Row", "Email", "Error"}
+	rows := make([][]string, 0, len(failures))
+	for _, failure := range failures {
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", failure.Row),
+			failure.Email,
+			compactWhitespace(failure.Error),
+		})
+	}
+	return headers, rows
+}
+
+func testFlightSyncSummaryRows(summary *TestFlightSyncSummary) ([]string, [][]string) {
+	headers := []string{"File", "App", "Groups", "Builds", "Testers"}
+	rows := [][]string{{
+		summary.File,
+		compactWhitespace(summary.App),
+		fmt.Sprintf("%d", summary.Groups),
+		fmt.Sprintf("%d", summary.Builds),
+		fmt.Sprintf("%d", summary.Testers),
+	}}
 	return headers, rows
 }

--- a/internal/asc/output_beta_test.go
+++ b/internal/asc/output_beta_test.go
@@ -1,0 +1,193 @@
+package asc
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestBetaTestersImportSummaryJSONByteCompat pins the exported
+// BetaTestersImportSummary JSON to the exact bytes previously produced by the
+// unexported testflight.betaTestersImportSummary struct, proving the move to
+// internal/asc changed code organization only, not output.
+func TestBetaTestersImportSummaryJSONByteCompat(t *testing.T) {
+	t.Run("all fields including failures", func(t *testing.T) {
+		summary := &BetaTestersImportSummary{
+			AppID:           "app-1",
+			InputFile:       "testers.csv",
+			DryRun:          true,
+			Invite:          false,
+			SkipExisting:    false,
+			ContinueOnError: true,
+			AppliedGroup:    "Beta",
+			Total:           3,
+			Created:         1,
+			Existed:         1,
+			Updated:         1,
+			Invited:         0,
+			Failed:          1,
+			Failures: []BetaTestersImportFailure{
+				{Row: 2, Email: "bad@example.com", Error: "invalid email format"},
+			},
+		}
+		got, err := json.Marshal(summary)
+		if err != nil {
+			t.Fatalf("marshal import summary: %v", err)
+		}
+		// Fixture: byte-for-byte JSON emitted by the pre-move unexported struct.
+		want := `{"appId":"app-1","inputFile":"testers.csv","dryRun":true,"invite":false,"skipExisting":false,` +
+			`"continueOnError":true,"appliedGroup":"Beta","total":3,"created":1,"existed":1,"updated":1,` +
+			`"invited":0,"failed":1,"failures":[{"row":2,"email":"bad@example.com","error":"invalid email format"}]}`
+		if string(got) != want {
+			t.Fatalf("import summary JSON drifted:\n got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("omitempty fields stay absent", func(t *testing.T) {
+		summary := &BetaTestersImportSummary{
+			AppID:           "app-1",
+			InputFile:       "testers.csv",
+			ContinueOnError: true,
+			Total:           1,
+			Existed:         1,
+		}
+		got, err := json.Marshal(summary)
+		if err != nil {
+			t.Fatalf("marshal import summary: %v", err)
+		}
+		want := `{"appId":"app-1","inputFile":"testers.csv","dryRun":false,"invite":false,"skipExisting":false,` +
+			`"continueOnError":true,"total":1,"created":0,"existed":1,"updated":0,"invited":0,"failed":0}`
+		if string(got) != want {
+			t.Fatalf("import summary JSON drifted:\n got: %s\nwant: %s", got, want)
+		}
+	})
+}
+
+func TestBetaTestersExportSummaryJSONByteCompat(t *testing.T) {
+	summary := &BetaTestersExportSummary{
+		AppID:         "app-1",
+		OutputFile:    "testers.csv",
+		Total:         12,
+		IncludeGroups: true,
+	}
+	got, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal export summary: %v", err)
+	}
+	want := `{"appId":"app-1","outputFile":"testers.csv","total":12,"includeGroups":true}`
+	if string(got) != want {
+		t.Fatalf("export summary JSON drifted:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestTestFlightSyncSummaryJSONByteCompat(t *testing.T) {
+	summary := &TestFlightSyncSummary{
+		File:    "testflight.yaml",
+		App:     "Example App",
+		Groups:  2,
+		Builds:  3,
+		Testers: 4,
+	}
+	got, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal sync summary: %v", err)
+	}
+	want := `{"file":"testflight.yaml","app":"Example App","groups":2,"builds":3,"testers":4}`
+	if string(got) != want {
+		t.Fatalf("sync summary JSON drifted:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBetaTestersSummaryRows(t *testing.T) {
+	t.Run("export summary", func(t *testing.T) {
+		headers, rows := betaTestersExportSummaryRows(&BetaTestersExportSummary{
+			AppID:         "app-1",
+			OutputFile:    "testers.csv",
+			Total:         12,
+			IncludeGroups: true,
+		})
+		wantHeaders := []string{"App ID", "Output File", "Total", "Include Groups"}
+		wantRow := []string{"app-1", "testers.csv", "12", "true"}
+		assertSingleRowEquals(t, headers, rows, wantHeaders, wantRow)
+	})
+
+	t.Run("import summary and failures", func(t *testing.T) {
+		summary := &BetaTestersImportSummary{
+			AppID:     "app-1",
+			InputFile: "testers.csv",
+			DryRun:    true,
+			Total:     2,
+			Created:   1,
+			Failed:    1,
+			Failures: []BetaTestersImportFailure{
+				{Row: 2, Email: "bad@example.com", Error: "invalid email format"},
+			},
+		}
+		headers, rows := betaTestersImportSummaryRows(summary)
+		wantHeaders := []string{"App ID", "Input File", "Dry Run", "Total", "Created", "Existed", "Updated", "Invited", "Failed"}
+		wantRow := []string{"app-1", "testers.csv", "true", "2", "1", "0", "0", "0", "1"}
+		assertSingleRowEquals(t, headers, rows, wantHeaders, wantRow)
+
+		failureHeaders, failureRows := betaTestersImportFailureRows(summary.Failures)
+		wantFailureHeaders := []string{"Row", "Email", "Error"}
+		wantFailureRow := []string{"2", "bad@example.com", "invalid email format"}
+		assertSingleRowEquals(t, failureHeaders, failureRows, wantFailureHeaders, wantFailureRow)
+	})
+
+	t.Run("sync summary", func(t *testing.T) {
+		headers, rows := testFlightSyncSummaryRows(&TestFlightSyncSummary{
+			File:    "testflight.yaml",
+			App:     "Example App",
+			Groups:  2,
+			Builds:  3,
+			Testers: 4,
+		})
+		wantHeaders := []string{"File", "App", "Groups", "Builds", "Testers"}
+		wantRow := []string{"testflight.yaml", "Example App", "2", "3", "4"}
+		assertSingleRowEquals(t, headers, rows, wantHeaders, wantRow)
+	})
+}
+
+// TestBetaTestersImportSummaryDirectRendererRegistered proves the moved import
+// summary renders both the summary table and the failures table through the
+// registry (multi-table direct renderer).
+func TestBetaTestersImportSummaryDirectRendererRegistered(t *testing.T) {
+	ensureOutputRegistryPopulated()
+
+	summary := &BetaTestersImportSummary{
+		AppID:     "app-1",
+		InputFile: "testers.csv",
+		Total:     1,
+		Failed:    1,
+		Failures: []BetaTestersImportFailure{
+			{Row: 1, Email: "bad@example.com", Error: "invalid email format"},
+		},
+	}
+
+	var tables [][]string
+	err := renderByRegistry(summary, func(headers []string, rows [][]string) {
+		tables = append(tables, headers)
+	})
+	if err != nil {
+		t.Fatalf("renderByRegistry returned error: %v", err)
+	}
+	if len(tables) != 2 {
+		t.Fatalf("expected summary and failures tables, got %d tables", len(tables))
+	}
+	if !reflect.DeepEqual(tables[1], []string{"Row", "Email", "Error"}) {
+		t.Fatalf("unexpected failures headers: %v", tables[1])
+	}
+
+	t.Run("failures table skipped when empty", func(t *testing.T) {
+		var count int
+		err := renderByRegistry(&BetaTestersImportSummary{AppID: "app-1"}, func([]string, [][]string) {
+			count++
+		})
+		if err != nil {
+			t.Fatalf("renderByRegistry returned error: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("expected only the summary table, got %d tables", count)
+		}
+	})
+}

--- a/internal/asc/output_builds.go
+++ b/internal/asc/output_builds.go
@@ -88,6 +88,35 @@ type BuildExpireAllResult struct {
 	Failures            []BuildExpireAllFailure `json:"failures,omitempty"`
 }
 
+// DSYMDownloadResult is the structured output for dSYM downloads.
+type DSYMDownloadResult struct {
+	BuildID     string             `json:"buildId"`
+	Version     string             `json:"version,omitempty"`
+	BuildNumber string             `json:"buildNumber,omitempty"`
+	Dir         string             `json:"dir"`
+	Files       []DSYMDownloadFile `json:"files"`
+}
+
+// DSYMDownloadFile describes one downloaded dSYM file.
+type DSYMDownloadFile struct {
+	BundleID string `json:"bundleId,omitempty"`
+	FileName string `json:"fileName"`
+	FilePath string `json:"filePath"`
+	FileSize int64  `json:"fileSize"`
+}
+
+// BuildWaitResult represents CLI output for builds wait: the resolved build
+// resource plus computed wait metadata.
+type BuildWaitResult struct {
+	Data            Resource[BuildAttributes] `json:"data"`
+	Links           Links                     `json:"links,omitempty"`
+	BuildID         string                    `json:"buildId"`
+	Version         string                    `json:"version,omitempty"`
+	BuildNumber     string                    `json:"buildNumber,omitempty"`
+	ProcessingState string                    `json:"processingState"`
+	Elapsed         string                    `json:"elapsed"`
+}
+
 // formatEncryptionStatus formats the UsesNonExemptEncryption field for display.
 // Returns "required" if true (needs encryption declaration), "exempt" if false,
 // or "n/a" if null (no information available).
@@ -363,6 +392,33 @@ func buildsNextBuildNumberRows(result *BuildsNextBuildNumberResult) ([]string, [
 		buildsLatestNextValue(result.LatestObservedBuildNumber),
 		result.NextBuildNumber,
 		buildsLatestNextSources(result.SourcesConsidered),
+	}}
+	return headers, rows
+}
+
+func dsymDownloadResultRows(result *DSYMDownloadResult) ([]string, [][]string) {
+	headers := []string{"Build ID", "Bundle ID", "File Name", "File Size", "Dir"}
+	rows := make([][]string, 0, len(result.Files))
+	for _, file := range result.Files {
+		rows = append(rows, []string{
+			result.BuildID,
+			file.BundleID,
+			file.FileName,
+			fmt.Sprintf("%d", file.FileSize),
+			result.Dir,
+		})
+	}
+	return headers, rows
+}
+
+func buildWaitResultRows(result *BuildWaitResult) ([]string, [][]string) {
+	headers := []string{"Build ID", "Version", "Build Number", "Processing State", "Elapsed"}
+	rows := [][]string{{
+		result.BuildID,
+		result.Version,
+		result.BuildNumber,
+		result.ProcessingState,
+		result.Elapsed,
 	}}
 	return headers, rows
 }

--- a/internal/asc/output_builds_test.go
+++ b/internal/asc/output_builds_test.go
@@ -81,6 +81,111 @@ func TestBuildsRowsWithPreReleaseVersion(t *testing.T) {
 	}
 }
 
+// TestDSYMDownloadResultJSONByteCompat pins the exported DSYMDownloadResult
+// JSON to the exact bytes previously produced by the struct declared in
+// internal/cli/builds/builds_dsyms.go, proving the move to internal/asc
+// changed code organization only, not output.
+func TestDSYMDownloadResultJSONByteCompat(t *testing.T) {
+	t.Run("all fields", func(t *testing.T) {
+		result := &DSYMDownloadResult{
+			BuildID:     "build-1",
+			Version:     "1.2.3",
+			BuildNumber: "42",
+			Dir:         "./dsyms",
+			Files: []DSYMDownloadFile{
+				{
+					BundleID: "com.example.app",
+					FileName: "com.example.app-1.2.3-42.dSYM.zip",
+					FilePath: "dsyms/com.example.app-1.2.3-42.dSYM.zip",
+					FileSize: 1024,
+				},
+			},
+		}
+		got, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("marshal dSYM result: %v", err)
+		}
+		// Fixture: byte-for-byte JSON emitted by the pre-move struct.
+		want := `{"buildId":"build-1","version":"1.2.3","buildNumber":"42","dir":"./dsyms",` +
+			`"files":[{"bundleId":"com.example.app","fileName":"com.example.app-1.2.3-42.dSYM.zip",` +
+			`"filePath":"dsyms/com.example.app-1.2.3-42.dSYM.zip","fileSize":1024}]}`
+		if string(got) != want {
+			t.Fatalf("dSYM result JSON drifted:\n got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("omitempty fields stay absent and files stay non-null", func(t *testing.T) {
+		result := &DSYMDownloadResult{
+			BuildID: "build-1",
+			Dir:     ".",
+			Files:   []DSYMDownloadFile{},
+		}
+		got, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("marshal dSYM result: %v", err)
+		}
+		want := `{"buildId":"build-1","dir":".","files":[]}`
+		if string(got) != want {
+			t.Fatalf("dSYM result JSON drifted:\n got: %s\nwant: %s", got, want)
+		}
+	})
+}
+
+func TestDSYMDownloadResultRows(t *testing.T) {
+	result := &DSYMDownloadResult{
+		BuildID: "build-1",
+		Dir:     "./dsyms",
+		Files: []DSYMDownloadFile{
+			{BundleID: "com.example.app", FileName: "a.dSYM.zip", FilePath: "./dsyms/a.dSYM.zip", FileSize: 1024},
+			{FileName: "b.dSYM.zip", FilePath: "./dsyms/b.dSYM.zip", FileSize: 2048},
+		},
+	}
+
+	headers, rows := dsymDownloadResultRows(result)
+	wantHeaders := []string{"Build ID", "Bundle ID", "File Name", "File Size", "Dir"}
+	if len(headers) != len(wantHeaders) {
+		t.Fatalf("unexpected headers: %v", headers)
+	}
+	for i, want := range wantHeaders {
+		if headers[i] != want {
+			t.Fatalf("headers[%d] = %q, want %q", i, headers[i], want)
+		}
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected one row per file, got %d", len(rows))
+	}
+	if rows[0][0] != "build-1" || rows[0][1] != "com.example.app" || rows[0][3] != "1024" {
+		t.Fatalf("unexpected first row: %v", rows[0])
+	}
+	if rows[1][1] != "" || rows[1][2] != "b.dSYM.zip" || rows[1][4] != "./dsyms" {
+		t.Fatalf("unexpected second row: %v", rows[1])
+	}
+}
+
+func TestBuildWaitResultRows(t *testing.T) {
+	result := &BuildWaitResult{
+		BuildID:         "build-1",
+		Version:         "1.2.3",
+		BuildNumber:     "42",
+		ProcessingState: "VALID",
+		Elapsed:         "1m30s",
+	}
+
+	headers, rows := buildWaitResultRows(result)
+	if len(headers) != 5 {
+		t.Fatalf("unexpected headers: %v", headers)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	want := []string{"build-1", "1.2.3", "42", "VALID", "1m30s"}
+	for i, cell := range want {
+		if rows[0][i] != cell {
+			t.Fatalf("rows[0][%d] = %q, want %q", i, rows[0][i], cell)
+		}
+	}
+}
+
 func TestBuildsRowsWithoutPreReleaseVersion(t *testing.T) {
 	resp := &BuildsResponse{
 		Data: []Resource[BuildAttributes]{

--- a/internal/asc/output_list.go
+++ b/internal/asc/output_list.go
@@ -1,0 +1,46 @@
+package asc
+
+import "github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc/types"
+
+// ListEnvelope wraps Apple's collection envelope with computed pagination
+// fields. The JSON shape is an additive superset of the raw envelope: the
+// embedded Response's data/links/included/meta keys marshal unmodified at the
+// top level, and totalCount/hasMore are added alongside them. Existing
+// consumers of the raw envelope keep working; new consumers can rely on the
+// computed fields without parsing meta.paging themselves.
+type ListEnvelope[T any] struct {
+	types.Response[T]
+	TotalCount int  `json:"totalCount"`
+	HasMore    bool `json:"hasMore"`
+}
+
+// ItemList is the envelope for computed collection results that do not come
+// from a single ASC response (merged, filtered, or lookup-derived items).
+// It intentionally mirrors ListEnvelope's computed fields so consumers read
+// totalCount/hasMore identically for both shapes; adding fields here must
+// remain additive and removals follow the stability ladder.
+type ItemList[T any] struct {
+	Items      []T  `json:"items"`
+	TotalCount int  `json:"totalCount"`
+	HasMore    bool `json:"hasMore"`
+}
+
+// NewListEnvelope builds an additive superset of the given collection
+// response. TotalCount comes from meta.paging.total when present and falls
+// back to len(r.Data) when the API omits it; HasMore reflects whether a next
+// page link exists. The embedded response is copied unmodified so the raw
+// envelope keys marshal byte-identically to the original.
+func NewListEnvelope[T any](r *types.Response[T]) ListEnvelope[T] {
+	if r == nil {
+		return ListEnvelope[T]{}
+	}
+	total, ok := types.ParsePagingTotalOK(r.Meta)
+	if !ok {
+		total = len(r.Data)
+	}
+	return ListEnvelope[T]{
+		Response:   *r,
+		TotalCount: total,
+		HasMore:    r.Links.Next != "",
+	}
+}

--- a/internal/asc/output_list_test.go
+++ b/internal/asc/output_list_test.go
@@ -1,0 +1,208 @@
+package asc
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+type listEnvelopeTestAttrs struct {
+	Name string `json:"name"`
+}
+
+func listEnvelopeTestResponse() *Response[listEnvelopeTestAttrs] {
+	return &Response[listEnvelopeTestAttrs]{
+		Data: []Resource[listEnvelopeTestAttrs]{
+			{Type: "apps", ID: "app-1", Attributes: listEnvelopeTestAttrs{Name: "First"}},
+			{Type: "apps", ID: "app-2", Attributes: listEnvelopeTestAttrs{Name: "Second"}},
+		},
+		Links: Links{
+			Self: "https://api.example.test/v1/apps",
+			Next: "https://api.example.test/v1/apps?cursor=abc",
+		},
+		Included: json.RawMessage(`[{"type":"betaGroups","id":"group-1"}]`),
+		Meta:     json.RawMessage(`{"paging":{"total":7,"limit":2}}`),
+	}
+}
+
+func TestNewListEnvelopeMarshalShape(t *testing.T) {
+	resp := listEnvelopeTestResponse()
+	envelope := NewListEnvelope(resp)
+
+	if envelope.TotalCount != 7 {
+		t.Fatalf("TotalCount = %d, want 7 (meta.paging.total)", envelope.TotalCount)
+	}
+	if !envelope.HasMore {
+		t.Fatal("HasMore = false, want true when links.next is set")
+	}
+
+	envelopeJSON, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	responseJSON, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+
+	var envelopeMap map[string]json.RawMessage
+	if err := json.Unmarshal(envelopeJSON, &envelopeMap); err != nil {
+		t.Fatalf("unmarshal envelope JSON: %v", err)
+	}
+	var responseMap map[string]json.RawMessage
+	if err := json.Unmarshal(responseJSON, &responseMap); err != nil {
+		t.Fatalf("unmarshal response JSON: %v", err)
+	}
+
+	// Additive superset: every raw envelope key marshals byte-identically.
+	for key, want := range responseMap {
+		got, ok := envelopeMap[key]
+		if !ok {
+			t.Fatalf("envelope JSON missing raw envelope key %q", key)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("envelope key %q = %s, want %s", key, got, want)
+		}
+	}
+
+	// Exactly two additive fields beyond the raw envelope.
+	if len(envelopeMap) != len(responseMap)+2 {
+		t.Fatalf("envelope has %d keys, want %d (raw envelope keys + totalCount + hasMore)",
+			len(envelopeMap), len(responseMap)+2)
+	}
+	if string(envelopeMap["totalCount"]) != "7" {
+		t.Fatalf("totalCount JSON = %s, want 7", envelopeMap["totalCount"])
+	}
+	if string(envelopeMap["hasMore"]) != "true" {
+		t.Fatalf("hasMore JSON = %s, want true", envelopeMap["hasMore"])
+	}
+}
+
+func TestNewListEnvelopeTotalCountAndHasMore(t *testing.T) {
+	cases := []struct {
+		name          string
+		mutate        func(*Response[listEnvelopeTestAttrs])
+		wantTotal     int
+		wantHasMore   bool
+		wantDataCount int
+	}{
+		{
+			name:          "meta paging total wins over data length",
+			mutate:        func(*Response[listEnvelopeTestAttrs]) {},
+			wantTotal:     7,
+			wantHasMore:   true,
+			wantDataCount: 2,
+		},
+		{
+			name: "missing meta falls back to len(data)",
+			mutate: func(r *Response[listEnvelopeTestAttrs]) {
+				r.Meta = nil
+			},
+			wantTotal:     2,
+			wantHasMore:   true,
+			wantDataCount: 2,
+		},
+		{
+			name: "unparseable meta falls back to len(data)",
+			mutate: func(r *Response[listEnvelopeTestAttrs]) {
+				r.Meta = json.RawMessage(`{"paging":`)
+			},
+			wantTotal:     2,
+			wantHasMore:   true,
+			wantDataCount: 2,
+		},
+		{
+			name: "meta without paging total falls back to len(data)",
+			mutate: func(r *Response[listEnvelopeTestAttrs]) {
+				r.Meta = json.RawMessage(`{"paging":{"limit":2}}`)
+			},
+			wantTotal:     2,
+			wantHasMore:   true,
+			wantDataCount: 2,
+		},
+		{
+			name: "no next link means no more pages",
+			mutate: func(r *Response[listEnvelopeTestAttrs]) {
+				r.Links.Next = ""
+			},
+			wantTotal:     7,
+			wantHasMore:   false,
+			wantDataCount: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := listEnvelopeTestResponse()
+			tc.mutate(resp)
+
+			envelope := NewListEnvelope(resp)
+			if envelope.TotalCount != tc.wantTotal {
+				t.Fatalf("TotalCount = %d, want %d", envelope.TotalCount, tc.wantTotal)
+			}
+			if envelope.HasMore != tc.wantHasMore {
+				t.Fatalf("HasMore = %t, want %t", envelope.HasMore, tc.wantHasMore)
+			}
+			if len(envelope.Data) != tc.wantDataCount {
+				t.Fatalf("len(Data) = %d, want %d", len(envelope.Data), tc.wantDataCount)
+			}
+			if !reflect.DeepEqual(envelope.Response, *resp) {
+				t.Fatal("embedded response was not copied unmodified")
+			}
+		})
+	}
+
+	t.Run("nil response yields zero envelope", func(t *testing.T) {
+		envelope := NewListEnvelope[listEnvelopeTestAttrs](nil)
+		if envelope.TotalCount != 0 || envelope.HasMore || len(envelope.Data) != 0 {
+			t.Fatalf("expected zero envelope for nil response, got %+v", envelope)
+		}
+	})
+}
+
+func TestItemListMarshalShape(t *testing.T) {
+	list := ItemList[listEnvelopeTestAttrs]{
+		Items:      []listEnvelopeTestAttrs{{Name: "Only"}},
+		TotalCount: 4,
+		HasMore:    true,
+	}
+	got, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal item list: %v", err)
+	}
+	want := `{"items":[{"name":"Only"}],"totalCount":4,"hasMore":true}`
+	if string(got) != want {
+		t.Fatalf("item list JSON = %s, want %s", got, want)
+	}
+}
+
+// TestListEnvelopeRegistryFallback documents the soft table-output contract for
+// ListEnvelope: instantiations are not pre-registered, and renderByRegistry
+// intentionally falls back to JSON output for unregistered types. Commands that
+// want a table for a ListEnvelope instantiation must register a renderer for
+// that concrete instantiation; until they do, --output table degrades to JSON
+// rather than failing.
+func TestListEnvelopeRegistryFallback(t *testing.T) {
+	envelope := NewListEnvelope(listEnvelopeTestResponse())
+
+	output := captureStdout(t, func() error {
+		return renderByRegistry(&envelope, RenderTable)
+	})
+	if output == "" {
+		t.Fatal("expected JSON fallback output")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("expected JSON fallback for unregistered ListEnvelope, got: %s", output)
+	}
+	if _, ok := parsed["data"]; !ok {
+		t.Fatalf("fallback JSON missing raw envelope data key: %s", output)
+	}
+	if got, ok := parsed["totalCount"].(float64); !ok || int(got) != 7 {
+		t.Fatalf("fallback JSON totalCount = %v, want 7: %s", parsed["totalCount"], output)
+	}
+	if got, ok := parsed["hasMore"].(bool); !ok || !got {
+		t.Fatalf("fallback JSON hasMore = %v, want true: %s", parsed["hasMore"], output)
+	}
+}

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -137,6 +137,8 @@ func registerAllOutputRenderers() {
 	registerRows(buildIconsRows)
 	registerRowsWithSingleResourceAdapter(buildUploadsRows)
 	registerRows(buildsNextBuildNumberRows)
+	registerRows(dsymDownloadResultRows)
+	registerRows(buildWaitResultRows)
 	registerRowsWithSingleResourceAdapter(buildUploadFilesRows)
 	registerDirect(func(v *AppClipDomainStatusResult, render func([]string, [][]string)) error {
 		h, r := appClipDomainStatusMainRows(v)
@@ -420,6 +422,17 @@ func registerAllOutputRenderers() {
 	registerRows(betaAppLocalizationDeleteResultRows)
 	registerRows(betaBuildLocalizationDeleteResultRows)
 	registerRows(betaTesterInvitationResultRows)
+	registerRows(betaTestersExportSummaryRows)
+	registerDirect(func(v *BetaTestersImportSummary, render func([]string, [][]string)) error {
+		h, r := betaTestersImportSummaryRows(v)
+		render(h, r)
+		if len(v.Failures) > 0 {
+			fh, fr := betaTestersImportFailureRows(v.Failures)
+			render(fh, fr)
+		}
+		return nil
+	})
+	registerRows(testFlightSyncSummaryRows)
 	registerRows(promotedPurchaseDeleteResultRows)
 	registerRows(appPromotedPurchasesLinkResultRows)
 	registerRows(sandboxTesterClearHistoryResultRows)

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -432,6 +432,7 @@ func registerAllOutputRenderers() {
 		}
 		return nil
 	})
+	registerDirect(betaTesterUsagesPageTables)
 	registerRows(testFlightSyncSummaryRows)
 	registerRows(promotedPurchaseDeleteResultRows)
 	registerRows(appPromotedPurchasesLinkResultRows)

--- a/internal/asc/types/resources.go
+++ b/internal/asc/types/resources.go
@@ -219,6 +219,11 @@ func (r *Response[T]) GetLinks() *Links {
 	return &r.Links
 }
 
+// GetMeta returns the raw metadata field (e.g. paging totals).
+func (r *Response[T]) GetMeta() json.RawMessage {
+	return r.Meta
+}
+
 // GetData returns the data field for aggregation.
 func (r *Response[T]) GetData() any {
 	return r.Data

--- a/internal/asc/types/resources_test.go
+++ b/internal/asc/types/resources_test.go
@@ -36,6 +36,25 @@ func TestResponseAccessors(t *testing.T) {
 	}
 }
 
+func TestResponseGetMeta(t *testing.T) {
+	r := &Response[struct{ Name string }]{
+		Meta: json.RawMessage(`{"paging":{"total":42,"limit":5}}`),
+	}
+
+	meta := r.GetMeta()
+	if string(meta) != `{"paging":{"total":42,"limit":5}}` {
+		t.Fatalf("unexpected meta payload: %s", meta)
+	}
+	if total, ok := ParsePagingTotalOK(meta); !ok || total != 42 {
+		t.Fatalf("expected paging total 42 from GetMeta, got %d (ok=%t)", total, ok)
+	}
+
+	empty := &Response[struct{ Name string }]{}
+	if got := empty.GetMeta(); len(got) != 0 {
+		t.Fatalf("expected empty meta, got %s", got)
+	}
+}
+
 func TestLinkagesResponseAccessors(t *testing.T) {
 	r := &LinkagesResponse{
 		Data: []ResourceData{

--- a/internal/cli/builds/builds_dsyms.go
+++ b/internal/cli/builds/builds_dsyms.go
@@ -22,23 +22,6 @@ import (
 // Tests can replace this via SetDSYMHTTPClient.
 var dsymHTTPClient = &http.Client{}
 
-// DSYMDownloadResult is the structured output for dSYM downloads.
-type DSYMDownloadResult struct {
-	BuildID     string             `json:"buildId"`
-	Version     string             `json:"version,omitempty"`
-	BuildNumber string             `json:"buildNumber,omitempty"`
-	Dir         string             `json:"dir"`
-	Files       []DSYMDownloadFile `json:"files"`
-}
-
-// DSYMDownloadFile describes one downloaded dSYM file.
-type DSYMDownloadFile struct {
-	BundleID string `json:"bundleId,omitempty"`
-	FileName string `json:"fileName"`
-	FilePath string `json:"filePath"`
-	FileSize int64  `json:"fileSize"`
-}
-
 type dsymBundleInfo struct {
 	BundleID string
 	DSYMURL  *string
@@ -154,12 +137,12 @@ Examples:
 			downloadable := filterBundlesWithDSYM(bundles)
 			if len(downloadable) == 0 {
 				fmt.Fprintln(os.Stderr, "No dSYM files available for this build")
-				result := DSYMDownloadResult{
+				result := asc.DSYMDownloadResult{
 					BuildID:     resolvedBuildID,
 					Version:     appVersion,
 					BuildNumber: buildVersion,
 					Dir:         dirValue,
-					Files:       []DSYMDownloadFile{},
+					Files:       []asc.DSYMDownloadFile{},
 				}
 				return shared.PrintOutputWithRenderers(
 					result,
@@ -174,7 +157,7 @@ Examples:
 				return fmt.Errorf("builds dsyms: failed to create output directory: %w", err)
 			}
 
-			files := make([]DSYMDownloadFile, 0, len(downloadable))
+			files := make([]asc.DSYMDownloadFile, 0, len(downloadable))
 			for i, bundle := range downloadable {
 				fileName := dsymFileName(bundle.BundleID, appVersion, buildVersion, resolvedBuildID, i)
 				filePath := filepath.Join(dirValue, fileName)
@@ -188,7 +171,7 @@ Examples:
 
 				fmt.Fprintf(os.Stderr, "  Saved %s (%d bytes)\n", filePath, size)
 
-				files = append(files, DSYMDownloadFile{
+				files = append(files, asc.DSYMDownloadFile{
 					BundleID: bundle.BundleID,
 					FileName: fileName,
 					FilePath: filePath,
@@ -196,7 +179,7 @@ Examples:
 				})
 			}
 
-			result := DSYMDownloadResult{
+			result := asc.DSYMDownloadResult{
 				BuildID:     resolvedBuildID,
 				Version:     appVersion,
 				BuildNumber: buildVersion,
@@ -289,7 +272,7 @@ func SetDSYMHTTPClient(c *http.Client) func() {
 	return func() { dsymHTTPClient = prev }
 }
 
-func printDSYMResultTable(result DSYMDownloadResult) error {
+func printDSYMResultTable(result asc.DSYMDownloadResult) error {
 	fmt.Printf("Build ID: %s\n", result.BuildID)
 	if result.Version != "" {
 		fmt.Printf("Version: %s (%s)\n", result.Version, result.BuildNumber)
@@ -310,7 +293,7 @@ func printDSYMResultTable(result DSYMDownloadResult) error {
 	return nil
 }
 
-func printDSYMResultMarkdown(result DSYMDownloadResult) error {
+func printDSYMResultMarkdown(result asc.DSYMDownloadResult) error {
 	fmt.Printf("**Build ID:** %s\n\n", result.BuildID)
 	if result.Version != "" {
 		fmt.Printf("**Version:** %s (%s)\n\n", result.Version, result.BuildNumber)

--- a/internal/cli/builds/builds_wait.go
+++ b/internal/cli/builds/builds_wait.go
@@ -182,7 +182,7 @@ Examples:
 			if processingState == "" {
 				processingState = "UNKNOWN"
 			}
-			result := &buildWaitResult{
+			result := &asc.BuildWaitResult{
 				Data:            buildResp.Data,
 				Links:           buildResp.Links,
 				BuildID:         strings.TrimSpace(buildResp.Data.ID),
@@ -209,16 +209,6 @@ type appBuildWaitSelector struct {
 	BuildNumber string
 	Platform    string
 	Since       *time.Time
-}
-
-type buildWaitResult struct {
-	Data            asc.Resource[asc.BuildAttributes] `json:"data"`
-	Links           asc.Links                         `json:"links,omitempty"`
-	BuildID         string                            `json:"buildId"`
-	Version         string                            `json:"version,omitempty"`
-	BuildNumber     string                            `json:"buildNumber,omitempty"`
-	ProcessingState string                            `json:"processingState"`
-	Elapsed         string                            `json:"elapsed"`
 }
 
 func waitForBuildDiscovery(

--- a/internal/cli/builds/builds_wait.go
+++ b/internal/cli/builds/builds_wait.go
@@ -194,10 +194,7 @@ Examples:
 				result.Version = versionValue
 			}
 
-			if format == "json" {
-				return shared.PrintOutput(result, format, *output.Pretty)
-			}
-			return shared.PrintOutput(buildResp, format, *output.Pretty)
+			return shared.PrintOutput(result, format, *output.Pretty)
 		},
 	}
 }

--- a/internal/cli/cmdtest/price_points_equalizations_pagination_test.go
+++ b/internal/cli/cmdtest/price_points_equalizations_pagination_test.go
@@ -336,7 +336,7 @@ func TestPricePointEqualizationsWithoutPaginateUsesSinglePage(t *testing.T) {
 				}
 			})
 
-			wantWarning := "Warning: showing 1 results; more pages exist — pass --paginate for all (or --next for the next page)\n"
+			wantWarning := "Warning: showing 1 results; more pages exist (use --paginate or --next where supported)\n"
 			if stderr != wantWarning {
 				t.Fatalf("expected truncation warning on stderr, got %q", stderr)
 			}

--- a/internal/cli/cmdtest/price_points_equalizations_pagination_test.go
+++ b/internal/cli/cmdtest/price_points_equalizations_pagination_test.go
@@ -336,8 +336,9 @@ func TestPricePointEqualizationsWithoutPaginateUsesSinglePage(t *testing.T) {
 				}
 			})
 
-			if stderr != "" {
-				t.Fatalf("expected empty stderr, got %q", stderr)
+			wantWarning := "Warning: showing 1 results; more pages exist — pass --paginate for all (or --next for the next page)\n"
+			if stderr != wantWarning {
+				t.Fatalf("expected truncation warning on stderr, got %q", stderr)
 			}
 			if requestCount != 1 {
 				t.Fatalf("expected exactly one request without --paginate, got %d", requestCount)

--- a/internal/cli/cmdtest/subscriptions_price_points_test.go
+++ b/internal/cli/cmdtest/subscriptions_price_points_test.go
@@ -619,8 +619,9 @@ func TestSubscriptionsPricePointsEqualizationsWithoutPaginateUsesSinglePage(t *t
 		}
 	})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	wantWarning := "Warning: showing 1 results; more pages exist — pass --paginate for all (or --next for the next page)\n"
+	if stderr != wantWarning {
+		t.Fatalf("expected truncation warning on stderr, got %q", stderr)
 	}
 	if requests != 1 {
 		t.Fatalf("expected exactly one request without --paginate, got %d", requests)

--- a/internal/cli/cmdtest/subscriptions_price_points_test.go
+++ b/internal/cli/cmdtest/subscriptions_price_points_test.go
@@ -619,7 +619,7 @@ func TestSubscriptionsPricePointsEqualizationsWithoutPaginateUsesSinglePage(t *t
 		}
 	})
 
-	wantWarning := "Warning: showing 1 results; more pages exist — pass --paginate for all (or --next for the next page)\n"
+	wantWarning := "Warning: showing 1 results; more pages exist (use --paginate or --next where supported)\n"
 	if stderr != wantWarning {
 		t.Fatalf("expected truncation warning on stderr, got %q", stderr)
 	}

--- a/internal/cli/cmdtest/testflight_metrics_pagination_signals_test.go
+++ b/internal/cli/cmdtest/testflight_metrics_pagination_signals_test.go
@@ -1,0 +1,122 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTestFlightMetricsAppTestersSinglePageWarnsOnMorePages(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+	t.Setenv("ASC_KEY_ID", "TEST_KEY")
+	t.Setenv("ASC_ISSUER_ID", "TEST_ISSUER")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"data":[{"id":"usage-1"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps/app-123/metrics/betaTesterUsages?page=2"}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "app-testers", "--app", "app-123"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"usage-1"`) {
+		t.Fatalf("expected metric data in stdout, got %q", stdout)
+	}
+	wantWarning := "Warning: showing 1 results; more pages exist (use --paginate or --next where supported)\n"
+	if stderr != wantWarning {
+		t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
+	}
+}
+
+func TestTestFlightMetricsResolveTestersMergesIncludedAcrossPages(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+	t.Setenv("ASC_KEY_ID", "TEST_KEY")
+	t.Setenv("ASC_ISSUER_ID", "TEST_ISSUER")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
+
+	secondURL := "https://api.appstoreconnect.apple.com/v1/apps/app-123/metrics/betaTesterUsages?page=2"
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			body := `{"data":[{"dataPoints":[{"start":"2026-05-20","end":"2026-08-18","values":{"sessionCount":3}}],"dimensions":{"betaTesters":{"data":"tester-1"}}}],"included":[{"type":"betaTesters","id":"tester-1","attributes":{"firstName":"Ada","lastName":"Lovelace","email":"ada@example.com","state":"INSTALLED"}}],"links":{"next":"` + secondURL + `"}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			body := `{"data":[{"dataPoints":[{"start":"2026-05-20","end":"2026-08-18","values":{"sessionCount":9}}],"dimensions":{"betaTesters":{"data":"tester-2"}}}],"included":[{"type":"betaTesters","id":"tester-2","attributes":{"firstName":"Grace","lastName":"Hopper","email":"grace@example.com","state":"INVITED"}}],"links":{"next":""}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Errorf("unexpected request %d to %s — included resources should satisfy resolution without tester fetches", callCount, req.URL.String())
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "app-testers", "--app", "app-123", "--paginate", "--resolve-testers"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if callCount != 2 {
+		t.Fatalf("expected exactly 2 metric page fetches, got %d", callCount)
+	}
+	for _, want := range []string{`"ada@example.com"`, `"grace@example.com"`, `"tester-1"`, `"tester-2"`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected %s in resolved output, got %q", want, stdout)
+		}
+	}
+}

--- a/internal/cli/cmdtest/testflight_metrics_resolve_testers_test.go
+++ b/internal/cli/cmdtest/testflight_metrics_resolve_testers_test.go
@@ -1,0 +1,201 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const resolveTestersMetricsBody = `{
+  "data": [
+    {
+      "dataPoints": [{"start": "2026-08-01", "end": "2026-08-07", "values": {"crashCount": 0, "sessionCount": 3, "feedbackCount": 1}}],
+      "dimensions": {"betaTesters": {"data": "tester-1"}}
+    },
+    {
+      "dataPoints": [{"start": "2026-08-01", "end": "2026-08-07", "values": {"crashCount": 1, "sessionCount": 5, "feedbackCount": 0}}],
+      "dimensions": {"betaTesters": {"data": "tester-2"}}
+    }
+  ],
+  "included": [
+    {"type": "betaTesters", "id": "tester-1", "attributes": {"firstName": "Ada", "lastName": "Lovelace", "email": "ada@example.com", "inviteType": "EMAIL", "state": "INSTALLED"}}
+  ],
+  "links": {"next": ""}
+}`
+
+func setResolveTestersEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ASC_APP_ID", "")
+
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "key.p8")
+	writeECDSAPEM(t, keyPath)
+	t.Setenv("ASC_KEY_ID", "TEST_KEY")
+	t.Setenv("ASC_ISSUER_ID", "TEST_ISSUER")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
+}
+
+func TestTestFlightMetricsBetaTesterUsagesResolveTesters(t *testing.T) {
+	setResolveTestersEnv(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/apps/app-123/metrics/betaTesterUsages" {
+				t.Fatalf("expected metrics path, got %s", req.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(resolveTestersMetricsBody)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("expected GET, got %s", req.Method)
+			}
+			if req.URL.Path != "/v1/betaTesters" {
+				t.Fatalf("expected path /v1/betaTesters, got %s", req.URL.Path)
+			}
+			values := req.URL.Query()
+			// tester-1 is satisfied from the metrics page's included resources,
+			// so only tester-2 needs a follow-up lookup.
+			if got := values.Get("filter[id]"); got != "tester-2" {
+				t.Fatalf("expected filter[id]=tester-2, got %q", got)
+			}
+			if got := values.Get("limit"); got != "200" {
+				t.Fatalf("expected limit=200, got %q", got)
+			}
+			body := `{"data":[{"type":"betaTesters","id":"tester-2","attributes":{"firstName":"Grace","lastName":"Hopper","email":"grace@example.com","inviteType":"PUBLIC_LINK","state":"INVITED"}}],"links":{"next":""}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request %d to %s", callCount, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "app-testers", "--app", "app-123", "--resolve-testers"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 requests, got %d", callCount)
+	}
+
+	var printed struct {
+		Data    []json.RawMessage `json:"data"`
+		Testers map[string]struct {
+			ID         string `json:"id"`
+			Email      string `json:"email"`
+			FirstName  string `json:"firstName"`
+			LastName   string `json:"lastName"`
+			State      string `json:"state"`
+			InviteType string `json:"inviteType"`
+		} `json:"testers"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &printed); err != nil {
+		t.Fatalf("failed to parse printed JSON: %v\noutput: %q", err, stdout)
+	}
+	if len(printed.Data) != 2 {
+		t.Fatalf("expected 2 data rows, got %d", len(printed.Data))
+	}
+	if len(printed.Testers) != 2 {
+		t.Fatalf("expected 2 resolved testers, got %d", len(printed.Testers))
+	}
+
+	included, ok := printed.Testers["tester-1"]
+	if !ok {
+		t.Fatalf("expected tester-1 in testers sidecar, got %q", stdout)
+	}
+	if included.ID != "tester-1" || included.Email != "ada@example.com" || included.FirstName != "Ada" || included.LastName != "Lovelace" || included.State != "INSTALLED" || included.InviteType != "EMAIL" {
+		t.Fatalf("unexpected tester-1 sidecar entry: %+v", included)
+	}
+
+	fetched, ok := printed.Testers["tester-2"]
+	if !ok {
+		t.Fatalf("expected tester-2 in testers sidecar, got %q", stdout)
+	}
+	if fetched.ID != "tester-2" || fetched.Email != "grace@example.com" || fetched.FirstName != "Grace" || fetched.LastName != "Hopper" || fetched.State != "INVITED" || fetched.InviteType != "PUBLIC_LINK" {
+		t.Fatalf("unexpected tester-2 sidecar entry: %+v", fetched)
+	}
+}
+
+func TestTestFlightMetricsBetaTesterUsagesWithoutResolveTestersOmitsSidecar(t *testing.T) {
+	setResolveTestersEnv(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	callCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		if callCount > 1 {
+			t.Fatalf("unexpected request %d to %s", callCount, req.URL.String())
+		}
+		if req.URL.Path != "/v1/apps/app-123/metrics/betaTesterUsages" {
+			t.Fatalf("expected metrics path, got %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(resolveTestersMetricsBody)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "app-testers", "--app", "app-123"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "\"tester-1\"") || !strings.Contains(stdout, "\"tester-2\"") {
+		t.Fatalf("expected raw usage rows in output, got %q", stdout)
+	}
+
+	var printed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &printed); err != nil {
+		t.Fatalf("failed to parse printed JSON: %v\noutput: %q", err, stdout)
+	}
+	if _, ok := printed["testers"]; ok {
+		t.Fatalf("expected no testers key without --resolve-testers, got %q", stdout)
+	}
+}

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -5,11 +5,13 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"net/url"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -1138,14 +1140,19 @@ func printOutput(data any, format string, pretty bool) error {
 	}
 	switch format {
 	case "json":
-		return printJSONOutput(data, pretty)
+		err = printJSONOutput(data, pretty)
 	case "markdown":
-		return asc.PrintMarkdown(data)
+		err = asc.PrintMarkdown(data)
 	case "table":
-		return asc.PrintTable(data)
+		err = asc.PrintTable(data)
 	default:
 		return fmt.Errorf("unsupported format: %s", format)
 	}
+	if err != nil {
+		return err
+	}
+	warnMorePages(data)
+	return nil
 }
 
 func printOutputWithRenderers(data any, format string, pretty bool, tableRenderer, markdownRenderer func() error) error {
@@ -1155,20 +1162,58 @@ func printOutputWithRenderers(data any, format string, pretty bool, tableRendere
 	}
 	switch format {
 	case "json":
-		return printJSONOutput(data, pretty)
+		err = printJSONOutput(data, pretty)
 	case "table":
 		if tableRenderer == nil {
 			return fmt.Errorf("table renderer is required")
 		}
-		return tableRenderer()
+		err = tableRenderer()
 	case "markdown":
 		if markdownRenderer == nil {
 			return fmt.Errorf("markdown renderer is required")
 		}
-		return markdownRenderer()
+		err = markdownRenderer()
 	default:
 		return fmt.Errorf("unsupported format: %s", format)
 	}
+	if err != nil {
+		return err
+	}
+	warnMorePages(data)
+	return nil
+}
+
+// warnMorePages emits a stderr notice when rendered output is a single page of
+// a larger collection. PaginateAll clears links.next on aggregated results, so
+// a non-empty next link at print time means the output is one unpaginated page.
+func warnMorePages(data any) {
+	page, ok := data.(asc.PaginatedResponse)
+	if !ok {
+		return
+	}
+	// Guard typed nil (non-nil interface containing nil pointer) before
+	// calling interface methods that dereference the receiver.
+	pageValue := reflect.ValueOf(page)
+	if pageValue.Kind() == reflect.Pointer && pageValue.IsNil() {
+		return
+	}
+	links := page.GetLinks()
+	if links == nil || links.Next == "" {
+		return
+	}
+
+	count, countOK := asc.PageDataLen(page)
+	if countOK {
+		if withMeta, hasMeta := page.(interface{ GetMeta() json.RawMessage }); hasMeta {
+			if total, totalOK := asc.ParsePagingTotalOK(withMeta.GetMeta()); totalOK {
+				fmt.Fprintf(os.Stderr, "Warning: showing %d of %d results; pass --paginate for all (or --next for the next page)\n", count, total)
+				return
+			}
+		}
+		fmt.Fprintf(os.Stderr, "Warning: showing %d results; more pages exist — pass --paginate for all (or --next for the next page)\n", count)
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Warning: more pages exist; pass --paginate for all (or --next for the next page)")
 }
 
 func printJSONOutput(data any, pretty bool) error {

--- a/internal/cli/shared/shared.go
+++ b/internal/cli/shared/shared.go
@@ -1206,14 +1206,14 @@ func warnMorePages(data any) {
 	if countOK {
 		if withMeta, hasMeta := page.(interface{ GetMeta() json.RawMessage }); hasMeta {
 			if total, totalOK := asc.ParsePagingTotalOK(withMeta.GetMeta()); totalOK {
-				fmt.Fprintf(os.Stderr, "Warning: showing %d of %d results; pass --paginate for all (or --next for the next page)\n", count, total)
+				fmt.Fprintf(os.Stderr, "Warning: showing %d of %d results; more pages exist (use --paginate or --next where supported)\n", count, total)
 				return
 			}
 		}
-		fmt.Fprintf(os.Stderr, "Warning: showing %d results; more pages exist — pass --paginate for all (or --next for the next page)\n", count)
+		fmt.Fprintf(os.Stderr, "Warning: showing %d results; more pages exist (use --paginate or --next where supported)\n", count)
 		return
 	}
-	fmt.Fprintln(os.Stderr, "Warning: more pages exist; pass --paginate for all (or --next for the next page)")
+	fmt.Fprintln(os.Stderr, "Warning: more pages exist (use --paginate or --next where supported)")
 }
 
 func printJSONOutput(data any, pretty bool) error {

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -712,7 +712,7 @@ func TestPrintOutput_WarnsWithTotalWhenMorePagesExist(t *testing.T) {
 		}
 	})
 
-	want := "Warning: showing 2 of 7 results; pass --paginate for all (or --next for the next page)\n"
+	want := "Warning: showing 2 of 7 results; more pages exist (use --paginate or --next where supported)\n"
 	if stderr != want {
 		t.Fatalf("stderr = %q, want %q", stderr, want)
 	}
@@ -737,7 +737,7 @@ func TestPrintOutput_WarnsWithCountWhenTotalUnavailable(t *testing.T) {
 		}
 	})
 
-	want := "Warning: showing 3 results; more pages exist — pass --paginate for all (or --next for the next page)\n"
+	want := "Warning: showing 3 results; more pages exist (use --paginate or --next where supported)\n"
 	if stderr != want {
 		t.Fatalf("stderr = %q, want %q", stderr, want)
 	}
@@ -810,7 +810,7 @@ func TestPrintOutput_GenericWarningWhenCountUnavailable(t *testing.T) {
 		}
 	})
 
-	want := "Warning: more pages exist; pass --paginate for all (or --next for the next page)\n"
+	want := "Warning: more pages exist (use --paginate or --next where supported)\n"
 	if stderr != want {
 		t.Fatalf("stderr = %q, want %q", stderr, want)
 	}
@@ -831,7 +831,7 @@ func TestPrintOutputWithRenderers_WarnsAfterTableRender(t *testing.T) {
 		}
 	})
 
-	want := "Warning: showing 1 of 9 results; pass --paginate for all (or --next for the next page)\n"
+	want := "Warning: showing 1 of 9 results; more pages exist (use --paginate or --next where supported)\n"
 	if stderr != want {
 		t.Fatalf("stderr = %q, want %q", stderr, want)
 	}

--- a/internal/cli/shared/shared_test.go
+++ b/internal/cli/shared/shared_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -19,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
 )
@@ -675,6 +677,184 @@ func TestPrintOutputWithRenderers_RequiresMarkdownRenderer(t *testing.T) {
 	err := PrintOutputWithRenderers(struct{}{}, "markdown", false, func() error { return nil }, nil)
 	if err == nil || !strings.Contains(err.Error(), "markdown renderer is required") {
 		t.Fatalf("expected markdown renderer required error, got %v", err)
+	}
+}
+
+type testPageAttributes struct {
+	Name string `json:"name"`
+}
+
+func makeTruncatedTestPage(items int, next string, meta string) *asc.Response[testPageAttributes] {
+	data := make([]asc.Resource[testPageAttributes], 0, items)
+	for i := range items {
+		data = append(data, asc.Resource[testPageAttributes]{
+			Type:       asc.ResourceTypeApps,
+			ID:         fmt.Sprintf("item-%d", i),
+			Attributes: testPageAttributes{Name: fmt.Sprintf("Item %d", i)},
+		})
+	}
+	page := &asc.Response[testPageAttributes]{
+		Data:  data,
+		Links: asc.Links{Next: next},
+	}
+	if meta != "" {
+		page.Meta = json.RawMessage(meta)
+	}
+	return page
+}
+
+func TestPrintOutput_WarnsWithTotalWhenMorePagesExist(t *testing.T) {
+	page := makeTruncatedTestPage(2, "https://api.appstoreconnect.apple.com/v1/apps?cursor=abc", `{"paging":{"total":7,"limit":2}}`)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := PrintOutput(page, "json", false); err != nil {
+			t.Errorf("PrintOutput() error = %v", err)
+		}
+	})
+
+	want := "Warning: showing 2 of 7 results; pass --paginate for all (or --next for the next page)\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if !strings.Contains(stdout, `"item-0"`) || !strings.Contains(stdout, `"item-1"`) {
+		t.Fatalf("expected JSON payload on stdout, got %q", stdout)
+	}
+	if strings.Contains(stdout, "Warning") {
+		t.Fatalf("warning must not leak into stdout, got %q", stdout)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("stdout is no longer valid JSON: %v (%q)", err, stdout)
+	}
+}
+
+func TestPrintOutput_WarnsWithCountWhenTotalUnavailable(t *testing.T) {
+	page := makeTruncatedTestPage(3, "https://api.appstoreconnect.apple.com/v1/apps?cursor=abc", "")
+
+	_, stderr := captureOutput(t, func() {
+		if err := PrintOutput(page, "json", false); err != nil {
+			t.Errorf("PrintOutput() error = %v", err)
+		}
+	})
+
+	want := "Warning: showing 3 results; more pages exist — pass --paginate for all (or --next for the next page)\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+}
+
+func TestPrintOutput_NoWarningWhenNoNextLink(t *testing.T) {
+	// PaginateAll erases links.next on aggregated results, so this models a
+	// fully paginated response.
+	page := makeTruncatedTestPage(4, "", `{"paging":{"total":4,"limit":200}}`)
+
+	_, stderr := captureOutput(t, func() {
+		if err := PrintOutput(page, "json", false); err != nil {
+			t.Errorf("PrintOutput() error = %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected no warning for aggregated page, got %q", stderr)
+	}
+}
+
+func TestPrintOutput_NoWarningForNonPaginatedData(t *testing.T) {
+	_, stderr := captureOutput(t, func() {
+		if err := PrintOutput(map[string]string{"status": "ok"}, "json", false); err != nil {
+			t.Errorf("PrintOutput() error = %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected no warning for non-paginated data, got %q", stderr)
+	}
+}
+
+func TestPrintOutput_TypedNilPaginatedResponseDoesNotPanic(t *testing.T) {
+	var typedNil *asc.Response[testPageAttributes]
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := PrintOutput(typedNil, "json", false); err != nil {
+			t.Errorf("PrintOutput() error = %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected no warning for typed nil response, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "null") {
+		t.Fatalf("expected null JSON output for typed nil, got %q", stdout)
+	}
+}
+
+// rawOnlyPage implements asc.PaginatedResponse without a countable item slice
+// to exercise the generic truncation notice.
+type rawOnlyPage struct {
+	links asc.Links
+	data  json.RawMessage
+}
+
+func (r *rawOnlyPage) GetLinks() *asc.Links { return &r.links }
+func (r *rawOnlyPage) GetData() any         { return r.data }
+
+func TestPrintOutput_GenericWarningWhenCountUnavailable(t *testing.T) {
+	page := &rawOnlyPage{
+		links: asc.Links{Next: "https://api.appstoreconnect.apple.com/v1/apps?cursor=abc"},
+		data:  json.RawMessage(`[{"id":"a"}]`),
+	}
+
+	_, stderr := captureOutput(t, func() {
+		if err := PrintOutput(page, "json", false); err != nil {
+			t.Errorf("PrintOutput() error = %v", err)
+		}
+	})
+
+	want := "Warning: more pages exist; pass --paginate for all (or --next for the next page)\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+}
+
+func TestPrintOutputWithRenderers_WarnsAfterTableRender(t *testing.T) {
+	page := makeTruncatedTestPage(1, "https://api.appstoreconnect.apple.com/v1/apps?cursor=abc", `{"paging":{"total":9,"limit":1}}`)
+
+	_, stderr := captureOutput(t, func() {
+		if err := PrintOutputWithRenderers(
+			page,
+			"table",
+			false,
+			func() error { return nil },
+			func() error { t.Error("markdown renderer should not run"); return nil },
+		); err != nil {
+			t.Errorf("PrintOutputWithRenderers() error = %v", err)
+		}
+	})
+
+	want := "Warning: showing 1 of 9 results; pass --paginate for all (or --next for the next page)\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+}
+
+func TestPrintOutputWithRenderers_NoWarningWhenRendererFails(t *testing.T) {
+	page := makeTruncatedTestPage(1, "https://api.appstoreconnect.apple.com/v1/apps?cursor=abc", "")
+
+	_, stderr := captureOutput(t, func() {
+		err := PrintOutputWithRenderers(
+			page,
+			"table",
+			false,
+			func() error { return errors.New("render failed") },
+			func() error { return nil },
+		)
+		if err == nil || !strings.Contains(err.Error(), "render failed") {
+			t.Errorf("expected renderer error, got %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected no warning after failed render, got %q", stderr)
 	}
 }
 

--- a/internal/cli/testflight/beta_groups.go
+++ b/internal/cli/testflight/beta_groups.go
@@ -287,16 +287,7 @@ Examples:
 					}
 				}
 
-				filtered := *groups
-				filtered.Data = make([]asc.Resource[asc.BetaGroupAttributes], 0, len(groups.Data))
-				for _, g := range groups.Data {
-					if g.Attributes.IsInternalGroup == *internalFilter {
-						filtered.Data = append(filtered.Data, g)
-					}
-				}
-				if *limit > 0 && len(filtered.Data) > *limit {
-					filtered.Data = filtered.Data[:*limit]
-				}
+				filtered := filterBetaGroupsByInternal(groups, *internalFilter, *limit)
 
 				return shared.PrintOutput(&filtered, *output.Output, *output.Pretty)
 			}
@@ -327,6 +318,27 @@ Examples:
 			return shared.PrintOutput(groups, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+// filterBetaGroupsByInternal keeps only groups whose isInternalGroup matches
+// internal, truncating to limit when limit > 0. The app-scoped endpoint cannot
+// filter server-side, so every page is fetched and the limit is applied here;
+// when that truncation drops matches, warn on stderr so callers know the
+// printed set is incomplete.
+func filterBetaGroupsByInternal(groups *asc.BetaGroupsResponse, internal bool, limit int) asc.BetaGroupsResponse {
+	filtered := *groups
+	filtered.Data = make([]asc.Resource[asc.BetaGroupAttributes], 0, len(groups.Data))
+	for _, g := range groups.Data {
+		if g.Attributes.IsInternalGroup == internal {
+			filtered.Data = append(filtered.Data, g)
+		}
+	}
+	if limit > 0 && len(filtered.Data) > limit {
+		total := len(filtered.Data)
+		filtered.Data = filtered.Data[:limit]
+		fmt.Fprintf(os.Stderr, "Warning: showing %d of %d filtered groups (--limit %d); rerun without --limit for all\n", limit, total, limit)
+	}
+	return filtered
 }
 
 // BuildGroupsListCommandConfig configures the build-centric beta-group lookup

--- a/internal/cli/testflight/beta_groups_test.go
+++ b/internal/cli/testflight/beta_groups_test.go
@@ -1,0 +1,117 @@
+package testflight
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		_ = r.Close()
+		done <- buf.String()
+	}()
+
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+
+	_ = w.Close()
+	return <-done
+}
+
+func makeBetaGroupsFixture(internalCount, externalCount int) *asc.BetaGroupsResponse {
+	data := make([]asc.Resource[asc.BetaGroupAttributes], 0, internalCount+externalCount)
+	for i := range internalCount {
+		data = append(data, asc.Resource[asc.BetaGroupAttributes]{
+			Type:       asc.ResourceTypeBetaGroups,
+			ID:         fmt.Sprintf("internal-%d", i),
+			Attributes: asc.BetaGroupAttributes{Name: fmt.Sprintf("Internal %d", i), IsInternalGroup: true},
+		})
+	}
+	for i := range externalCount {
+		data = append(data, asc.Resource[asc.BetaGroupAttributes]{
+			Type:       asc.ResourceTypeBetaGroups,
+			ID:         fmt.Sprintf("external-%d", i),
+			Attributes: asc.BetaGroupAttributes{Name: fmt.Sprintf("External %d", i), IsInternalGroup: false},
+		})
+	}
+	return &asc.BetaGroupsResponse{Data: data}
+}
+
+func TestFilterBetaGroupsByInternal_WarnsWhenLimitTruncates(t *testing.T) {
+	groups := makeBetaGroupsFixture(5, 2)
+
+	var filtered asc.BetaGroupsResponse
+	stderr := captureStderr(t, func() {
+		filtered = filterBetaGroupsByInternal(groups, true, 2)
+	})
+
+	if len(filtered.Data) != 2 {
+		t.Fatalf("expected 2 groups after truncation, got %d", len(filtered.Data))
+	}
+	for _, g := range filtered.Data {
+		if !g.Attributes.IsInternalGroup {
+			t.Fatalf("expected only internal groups, got %q", g.ID)
+		}
+	}
+	want := "Warning: showing 2 of 5 filtered groups (--limit 2); rerun without --limit for all\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+}
+
+func TestFilterBetaGroupsByInternal_NoWarningWithoutTruncation(t *testing.T) {
+	groups := makeBetaGroupsFixture(2, 3)
+
+	var filtered asc.BetaGroupsResponse
+	stderr := captureStderr(t, func() {
+		filtered = filterBetaGroupsByInternal(groups, true, 5)
+	})
+
+	if len(filtered.Data) != 2 {
+		t.Fatalf("expected 2 internal groups, got %d", len(filtered.Data))
+	}
+	if stderr != "" {
+		t.Fatalf("expected no warning when limit is not exceeded, got %q", stderr)
+	}
+}
+
+func TestFilterBetaGroupsByInternal_NoWarningWithoutLimit(t *testing.T) {
+	groups := makeBetaGroupsFixture(1, 4)
+
+	var filtered asc.BetaGroupsResponse
+	stderr := captureStderr(t, func() {
+		filtered = filterBetaGroupsByInternal(groups, false, 0)
+	})
+
+	if len(filtered.Data) != 4 {
+		t.Fatalf("expected 4 external groups, got %d", len(filtered.Data))
+	}
+	for _, g := range filtered.Data {
+		if g.Attributes.IsInternalGroup {
+			t.Fatalf("expected only external groups, got %q", g.ID)
+		}
+	}
+	if stderr != "" {
+		t.Fatalf("expected no warning without --limit, got %q", stderr)
+	}
+}

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -27,6 +27,7 @@ func BetaTestersCommand() *ffcli.Command {
 Examples:
   asc testflight beta-testers list --app "APP_ID"
   asc testflight beta-testers view --id "TESTER_ID"
+  asc testflight beta-testers beta-groups list --id "TESTER_ID"
   asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta"
   asc testflight beta-testers add --app "APP_ID" --email "tester@example.com" --group "Beta,iOS 27"
   asc testflight beta-testers export --app "APP_ID" --output "./testflight-testers.csv"
@@ -74,6 +75,8 @@ func BetaTestersListCommand() *ffcli.Command {
 	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID to filter")
 	group := fs.String("group", "", "Beta group name or ID to filter")
 	email := fs.String("email", "", "Filter by tester email")
+	firstName := fs.String("first-name", "", "Filter by tester first name (exact match)")
+	lastName := fs.String("last-name", "", "Filter by tester last name (exact match)")
 	output := shared.BindOutputFlags(fs)
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -89,6 +92,7 @@ Examples:
   asc testflight beta-testers list --app "APP_ID"
   asc testflight beta-testers list --app "APP_ID" --build-id "BUILD_ID"
   asc testflight beta-testers list --app "APP_ID" --group "Beta"
+  asc testflight beta-testers list --app "APP_ID" --first-name "Ada" --last-name "Lovelace"
   asc testflight beta-testers list --app "APP_ID" --limit 25
   asc testflight beta-testers list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
@@ -142,6 +146,14 @@ Examples:
 				opts = append(opts, asc.WithBetaTestersEmail(*email))
 			}
 
+			if strings.TrimSpace(*firstName) != "" {
+				opts = append(opts, asc.WithBetaTestersFirstName(*firstName))
+			}
+
+			if strings.TrimSpace(*lastName) != "" {
+				opts = append(opts, asc.WithBetaTestersLastName(*lastName))
+			}
+
 			if strings.TrimSpace(*group) != "" && strings.TrimSpace(*next) == "" {
 				groupID, err := resolveBetaGroupID(requestCtx, client, resolvedAppID, *group)
 				if err != nil {
@@ -192,7 +204,9 @@ func BetaTestersGetCommand() *ffcli.Command {
 		LongHelp: `View a TestFlight beta tester by ID.
 
 Examples:
-  asc testflight beta-testers view --id "TESTER_ID"`,
+  asc testflight beta-testers view --id "TESTER_ID"
+
+See also: asc testflight beta-testers beta-groups list --id "TESTER_ID" for the tester's group membership.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -27,36 +27,6 @@ type betaTestersCSVRow struct {
 	groups    []string // raw group values (names or IDs), trimmed
 }
 
-type betaTestersExportSummary struct {
-	AppID         string `json:"appId"`
-	OutputFile    string `json:"outputFile"`
-	Total         int    `json:"total"`
-	IncludeGroups bool   `json:"includeGroups"`
-}
-
-type betaTestersImportFailure struct {
-	Row   int    `json:"row"`
-	Email string `json:"email,omitempty"`
-	Error string `json:"error"`
-}
-
-type betaTestersImportSummary struct {
-	AppID           string                     `json:"appId"`
-	InputFile       string                     `json:"inputFile"`
-	DryRun          bool                       `json:"dryRun"`
-	Invite          bool                       `json:"invite"`
-	SkipExisting    bool                       `json:"skipExisting"`
-	ContinueOnError bool                       `json:"continueOnError"`
-	AppliedGroup    string                     `json:"appliedGroup,omitempty"`
-	Total           int                        `json:"total"`
-	Created         int                        `json:"created"`
-	Existed         int                        `json:"existed"`
-	Updated         int                        `json:"updated"`
-	Invited         int                        `json:"invited"`
-	Failed          int                        `json:"failed"`
-	Failures        []betaTestersImportFailure `json:"failures,omitempty"`
-}
-
 // BetaTestersExportCommand writes beta testers to a CSV file.
 func BetaTestersExportCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("export", flag.ExitOnError)
@@ -232,7 +202,7 @@ Examples:
 				return fmt.Errorf("beta-testers export: %w", err)
 			}
 
-			summary := &betaTestersExportSummary{
+			summary := &asc.BetaTestersExportSummary{
 				AppID:         resolvedAppID,
 				OutputFile:    filepath.Clean(outputValue),
 				Total:         len(rows),
@@ -364,7 +334,7 @@ Examples:
 			}
 
 			seenInput := make(map[string]int) // emailLower -> first row index seen
-			summary := &betaTestersImportSummary{
+			summary := &asc.BetaTestersImportSummary{
 				AppID:           resolvedAppID,
 				InputFile:       filepath.Clean(inputValue),
 				DryRun:          *dryRun,
@@ -381,7 +351,7 @@ Examples:
 				emailValue := strings.TrimSpace(row.email)
 				if emailValue == "" {
 					summary.Failed++
-					summary.Failures = append(summary.Failures, betaTestersImportFailure{
+					summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 						Row:   rowNumber,
 						Error: "email is required",
 					})
@@ -392,7 +362,7 @@ Examples:
 				}
 				if !isValidTesterEmail(emailValue) {
 					summary.Failed++
-					summary.Failures = append(summary.Failures, betaTestersImportFailure{
+					summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 						Row:   rowNumber,
 						Email: emailValue,
 						Error: "invalid email format",
@@ -406,7 +376,7 @@ Examples:
 				emailLower := strings.ToLower(emailValue)
 				if firstSeen, exists := seenInput[emailLower]; exists {
 					summary.Failed++
-					summary.Failures = append(summary.Failures, betaTestersImportFailure{
+					summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 						Row:   rowNumber,
 						Email: emailValue,
 						Error: fmt.Sprintf("duplicate email in input (already seen at row %d)", firstSeen),
@@ -423,7 +393,7 @@ Examples:
 					groupIDs, err = groupResolver.ResolveAll(row.groups)
 					if err != nil {
 						summary.Failed++
-						summary.Failures = append(summary.Failures, betaTestersImportFailure{
+						summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 							Row:   rowNumber,
 							Email: emailValue,
 							Error: err.Error(),
@@ -463,7 +433,7 @@ Examples:
 							continue
 						}
 						summary.Failed++
-						summary.Failures = append(summary.Failures, betaTestersImportFailure{
+						summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 							Row:   rowNumber,
 							Email: emailValue,
 							Error: err.Error(),
@@ -487,7 +457,7 @@ Examples:
 				cancel()
 				if err != nil {
 					summary.Failed++
-					summary.Failures = append(summary.Failures, betaTestersImportFailure{
+					summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 						Row:   rowNumber,
 						Email: emailValue,
 						Error: err.Error(),
@@ -501,7 +471,7 @@ Examples:
 				testerID := strings.TrimSpace(created.Data.ID)
 				if testerID == "" {
 					summary.Failed++
-					summary.Failures = append(summary.Failures, betaTestersImportFailure{
+					summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 						Row:   rowNumber,
 						Email: emailValue,
 						Error: "created tester returned empty id",
@@ -520,7 +490,7 @@ Examples:
 					cancel()
 					if err != nil {
 						summary.Failed++
-						summary.Failures = append(summary.Failures, betaTestersImportFailure{
+						summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 							Row:   rowNumber,
 							Email: emailValue,
 							Error: err.Error(),
@@ -532,7 +502,7 @@ Examples:
 					}
 					if invitation == nil || strings.TrimSpace(invitation.Data.ID) == "" {
 						summary.Failed++
-						summary.Failures = append(summary.Failures, betaTestersImportFailure{
+						summary.Failures = append(summary.Failures, asc.BetaTestersImportFailure{
 							Row:   rowNumber,
 							Email: emailValue,
 							Error: "invitation returned empty id",
@@ -566,7 +536,7 @@ Examples:
 	}
 }
 
-func renderImportSummaryTables(summary *betaTestersImportSummary, markdown bool) error {
+func renderImportSummaryTables(summary *asc.BetaTestersImportSummary, markdown bool) error {
 	if summary == nil {
 		return fmt.Errorf("summary is nil")
 	}

--- a/internal/cli/testflight/metrics_beta_tester_usages.go
+++ b/internal/cli/testflight/metrics_beta_tester_usages.go
@@ -15,25 +15,6 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-type betaTesterUsagesPage struct {
-	Data     []json.RawMessage                    `json:"data"`
-	Links    asc.Links                            `json:"links"`
-	Included json.RawMessage                      `json:"included,omitempty"`
-	Meta     json.RawMessage                      `json:"meta,omitempty"`
-	Testers  map[string]betaTesterUsageTesterInfo `json:"testers,omitempty"`
-}
-
-// betaTesterUsageTesterInfo describes one resolved beta tester in the testers
-// sidecar keyed by tester ID.
-type betaTesterUsageTesterInfo struct {
-	ID         string `json:"id"`
-	Email      string `json:"email,omitempty"`
-	FirstName  string `json:"firstName,omitempty"`
-	LastName   string `json:"lastName,omitempty"`
-	State      string `json:"state,omitempty"`
-	InviteType string `json:"inviteType,omitempty"`
-}
-
 const (
 	// betaTesterResolveChunkSize bounds how many tester IDs are packed into a
 	// single filter[id] lookup on GET /v1/betaTesters.
@@ -210,12 +191,12 @@ func normalizeBetaTesterUsageGroupBy(value string) string {
 	}
 }
 
-func paginateBetaTesterUsages(ctx context.Context, client *asc.Client, appID string, firstPage *asc.BetaTesterUsagesResponse) (*betaTesterUsagesPage, error) {
+func paginateBetaTesterUsages(ctx context.Context, client *asc.Client, appID string, firstPage *asc.BetaTesterUsagesResponse) (*asc.BetaTesterUsagesPage, error) {
 	if firstPage == nil {
 		return nil, nil
 	}
 
-	combined := &betaTesterUsagesPage{}
+	combined := &asc.BetaTesterUsagesPage{}
 	seenNext := make(map[string]struct{})
 	pageNumber := 1
 	current := firstPage
@@ -254,12 +235,12 @@ func paginateBetaTesterUsages(ctx context.Context, client *asc.Client, appID str
 	return combined, nil
 }
 
-func parseBetaTesterUsagesPage(data json.RawMessage) (*betaTesterUsagesPage, error) {
+func parseBetaTesterUsagesPage(data json.RawMessage) (*asc.BetaTesterUsagesPage, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("empty response body")
 	}
 
-	var page betaTesterUsagesPage
+	var page asc.BetaTesterUsagesPage
 	if err := json.Unmarshal(data, &page); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
@@ -272,7 +253,7 @@ func parseBetaTesterUsagesPage(data json.RawMessage) (*betaTesterUsagesPage, err
 // as-is; the remainder are batch-fetched from GET /v1/betaTesters via
 // filter[id]. Resolution is capped at betaTesterResolveMaxIDs unique IDs; IDs
 // beyond the cap are skipped with a stderr warning.
-func resolveBetaTesterUsageTesters(ctx context.Context, client *asc.Client, page *betaTesterUsagesPage) error {
+func resolveBetaTesterUsageTesters(ctx context.Context, client *asc.Client, page *asc.BetaTesterUsagesPage) error {
 	if page == nil {
 		return nil
 	}
@@ -295,7 +276,7 @@ func resolveBetaTesterUsageTesters(ctx context.Context, client *asc.Client, page
 		wanted[id] = struct{}{}
 	}
 
-	testers := make(map[string]betaTesterUsageTesterInfo, len(ids))
+	testers := make(map[string]asc.BetaTesterUsageTesterInfo, len(ids))
 	addTester := func(resource asc.Resource[asc.BetaTesterAttributes]) {
 		id := strings.TrimSpace(resource.ID)
 		if id == "" {
@@ -304,7 +285,7 @@ func resolveBetaTesterUsageTesters(ctx context.Context, client *asc.Client, page
 		if _, ok := wanted[id]; !ok {
 			return
 		}
-		testers[id] = betaTesterUsageTesterInfo{
+		testers[id] = asc.BetaTesterUsageTesterInfo{
 			ID:         id,
 			Email:      resource.Attributes.Email,
 			FirstName:  resource.Attributes.FirstName,

--- a/internal/cli/testflight/metrics_beta_tester_usages.go
+++ b/internal/cli/testflight/metrics_beta_tester_usages.go
@@ -200,6 +200,7 @@ func paginateBetaTesterUsages(ctx context.Context, client *asc.Client, appID str
 	seenNext := make(map[string]struct{})
 	pageNumber := 1
 	current := firstPage
+	var mergedIncluded []json.RawMessage
 
 	for {
 		parsed, err := parseBetaTesterUsagesPage(current.Data)
@@ -208,8 +209,12 @@ func paginateBetaTesterUsages(ctx context.Context, client *asc.Client, appID str
 		}
 
 		combined.Data = append(combined.Data, parsed.Data...)
-		if len(combined.Included) == 0 && len(parsed.Included) > 0 {
-			combined.Included = parsed.Included
+		if len(parsed.Included) > 0 {
+			var pageIncluded []json.RawMessage
+			if err := json.Unmarshal(parsed.Included, &pageIncluded); err != nil {
+				return nil, fmt.Errorf("page %d: parse included: %w", pageNumber, err)
+			}
+			mergedIncluded = append(mergedIncluded, pageIncluded...)
 		}
 		if len(combined.Meta) == 0 && len(parsed.Meta) > 0 {
 			combined.Meta = parsed.Meta
@@ -230,6 +235,14 @@ func paginateBetaTesterUsages(ctx context.Context, client *asc.Client, appID str
 			return combined, fmt.Errorf("page %d: %w", pageNumber, err)
 		}
 		current = nextPage
+	}
+
+	if len(mergedIncluded) > 0 {
+		encoded, err := json.Marshal(mergedIncluded)
+		if err != nil {
+			return nil, fmt.Errorf("encode included resources: %w", err)
+		}
+		combined.Included = encoded
 	}
 
 	return combined, nil

--- a/internal/cli/testflight/metrics_beta_tester_usages.go
+++ b/internal/cli/testflight/metrics_beta_tester_usages.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -15,10 +16,32 @@ import (
 )
 
 type betaTesterUsagesPage struct {
-	Data  []json.RawMessage `json:"data"`
-	Links asc.Links         `json:"links"`
-	Meta  json.RawMessage   `json:"meta,omitempty"`
+	Data     []json.RawMessage                    `json:"data"`
+	Links    asc.Links                            `json:"links"`
+	Included json.RawMessage                      `json:"included,omitempty"`
+	Meta     json.RawMessage                      `json:"meta,omitempty"`
+	Testers  map[string]betaTesterUsageTesterInfo `json:"testers,omitempty"`
 }
+
+// betaTesterUsageTesterInfo describes one resolved beta tester in the testers
+// sidecar keyed by tester ID.
+type betaTesterUsageTesterInfo struct {
+	ID         string `json:"id"`
+	Email      string `json:"email,omitempty"`
+	FirstName  string `json:"firstName,omitempty"`
+	LastName   string `json:"lastName,omitempty"`
+	State      string `json:"state,omitempty"`
+	InviteType string `json:"inviteType,omitempty"`
+}
+
+const (
+	// betaTesterResolveChunkSize bounds how many tester IDs are packed into a
+	// single filter[id] lookup on GET /v1/betaTesters.
+	betaTesterResolveChunkSize = 50
+	// betaTesterResolveMaxIDs caps how many unique tester IDs --resolve-testers
+	// resolves, bounding the API fan-out on very large metric responses.
+	betaTesterResolveMaxIDs = 500
+)
 
 func TestFlightMetricsAppTestersCommand() *ffcli.Command {
 	cmd := rewriteCommandTree(
@@ -41,7 +64,8 @@ func TestFlightMetricsAppTestersCommand() *ffcli.Command {
 Examples:
   asc testflight metrics app-testers --app "APP_ID"
   asc testflight metrics app-testers --app "APP_ID" --period "P30D"
-  asc testflight metrics app-testers --app "APP_ID" --filter-tester "TESTER_ID"`
+  asc testflight metrics app-testers --app "APP_ID" --filter-tester "TESTER_ID"
+  asc testflight metrics app-testers --app "APP_ID" --resolve-testers`
 	if groupByFlag := cmd.FlagSet.Lookup("group-by"); groupByFlag != nil {
 		groupByFlag.Usage = "Group results by dimension (testers)"
 		groupByFlag.DefValue = "testers"
@@ -76,6 +100,7 @@ func TestFlightMetricsBetaTesterUsagesCommand() *ffcli.Command {
 	period := fs.String("period", "", "Reporting period: "+strings.Join(betaTesterUsagePeriodList(), ", "))
 	groupBy := fs.String("group-by", "testers", "Group results by dimension (testers)")
 	filterTester := fs.String("filter-tester", "", "Filter by beta tester ID")
+	resolveTesters := fs.Bool("resolve-testers", false, "Resolve tester IDs to email and name (extra API calls)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -92,7 +117,8 @@ Requires either --group-by or --filter-tester (or both).
 Examples:
   asc testflight metrics beta-tester-usages --app "APP_ID"
   asc testflight metrics beta-tester-usages --app "APP_ID" --period "P30D"
-  asc testflight metrics beta-tester-usages --app "APP_ID" --filter-tester "TESTER_ID"`,
+  asc testflight metrics beta-tester-usages --app "APP_ID" --filter-tester "TESTER_ID"
+  asc testflight metrics beta-tester-usages --app "APP_ID" --resolve-testers`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -145,12 +171,29 @@ Examples:
 					return fmt.Errorf("testflight metrics beta-tester-usages: %w", err)
 				}
 
+				if *resolveTesters {
+					if err := resolveBetaTesterUsageTesters(ctx, client, combined); err != nil {
+						return fmt.Errorf("testflight metrics beta-tester-usages: %w", err)
+					}
+				}
+
 				return shared.PrintOutput(combined, *output.Output, *output.Pretty)
 			}
 
 			resp, err := client.GetAppBetaTesterUsagesMetrics(requestCtx, resolvedAppID, opts...)
 			if err != nil {
 				return fmt.Errorf("testflight metrics beta-tester-usages: failed to fetch: %w", err)
+			}
+
+			if *resolveTesters {
+				page, err := parseBetaTesterUsagesPage(resp.Data)
+				if err != nil {
+					return fmt.Errorf("testflight metrics beta-tester-usages: %w", err)
+				}
+				if err := resolveBetaTesterUsageTesters(ctx, client, page); err != nil {
+					return fmt.Errorf("testflight metrics beta-tester-usages: %w", err)
+				}
+				return shared.PrintOutput(page, *output.Output, *output.Pretty)
 			}
 
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
@@ -184,6 +227,9 @@ func paginateBetaTesterUsages(ctx context.Context, client *asc.Client, appID str
 		}
 
 		combined.Data = append(combined.Data, parsed.Data...)
+		if len(combined.Included) == 0 && len(parsed.Included) > 0 {
+			combined.Included = parsed.Included
+		}
 		if len(combined.Meta) == 0 && len(parsed.Meta) > 0 {
 			combined.Meta = parsed.Meta
 		}
@@ -218,4 +264,154 @@ func parseBetaTesterUsagesPage(data json.RawMessage) (*betaTesterUsagesPage, err
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 	return &page, nil
+}
+
+// resolveBetaTesterUsageTesters fills page.Testers with tester details for the
+// unique tester IDs referenced by the page's dimensions.betaTesters.data
+// values. Testers already present in the page's included resources are used
+// as-is; the remainder are batch-fetched from GET /v1/betaTesters via
+// filter[id]. Resolution is capped at betaTesterResolveMaxIDs unique IDs; IDs
+// beyond the cap are skipped with a stderr warning.
+func resolveBetaTesterUsageTesters(ctx context.Context, client *asc.Client, page *betaTesterUsagesPage) error {
+	if page == nil {
+		return nil
+	}
+
+	ids, err := betaTesterUsageTesterIDs(page.Data)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		fmt.Fprintln(os.Stderr, "Warning: --resolve-testers found no tester IDs in the metrics response; nothing to resolve")
+		return nil
+	}
+	if len(ids) > betaTesterResolveMaxIDs {
+		fmt.Fprintf(os.Stderr, "Warning: --resolve-testers resolves at most %d unique testers; skipping resolution for %d of %d\n", betaTesterResolveMaxIDs, len(ids)-betaTesterResolveMaxIDs, len(ids))
+		ids = ids[:betaTesterResolveMaxIDs]
+	}
+
+	wanted := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		wanted[id] = struct{}{}
+	}
+
+	testers := make(map[string]betaTesterUsageTesterInfo, len(ids))
+	addTester := func(resource asc.Resource[asc.BetaTesterAttributes]) {
+		id := strings.TrimSpace(resource.ID)
+		if id == "" {
+			return
+		}
+		if _, ok := wanted[id]; !ok {
+			return
+		}
+		testers[id] = betaTesterUsageTesterInfo{
+			ID:         id,
+			Email:      resource.Attributes.Email,
+			FirstName:  resource.Attributes.FirstName,
+			LastName:   resource.Attributes.LastName,
+			State:      string(resource.Attributes.State),
+			InviteType: string(resource.Attributes.InviteType),
+		}
+	}
+
+	if len(page.Included) > 0 {
+		var included []asc.Resource[asc.BetaTesterAttributes]
+		if err := json.Unmarshal(page.Included, &included); err != nil {
+			return fmt.Errorf("parse included resources: %w", err)
+		}
+		for _, resource := range included {
+			if resource.Type != asc.ResourceTypeBetaTesters {
+				continue
+			}
+			addTester(resource)
+		}
+	}
+
+	var missing []string
+	for _, id := range ids {
+		if _, ok := testers[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+
+	for chunk := range slices.Chunk(missing, betaTesterResolveChunkSize) {
+		fetched, err := fetchBetaTestersByIDs(ctx, client, chunk)
+		if err != nil {
+			return fmt.Errorf("resolve testers: %w", err)
+		}
+		for _, resource := range fetched {
+			addTester(resource)
+		}
+	}
+
+	unresolved := 0
+	for _, id := range ids {
+		if _, ok := testers[id]; !ok {
+			unresolved++
+		}
+	}
+	if unresolved > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: --resolve-testers could not resolve %d of %d tester ID(s)\n", unresolved, len(ids))
+	}
+
+	page.Testers = testers
+	return nil
+}
+
+// betaTesterUsageTesterIDs extracts the unique beta tester IDs referenced by
+// usage metric rows, in first-seen order.
+func betaTesterUsageTesterIDs(rows []json.RawMessage) ([]string, error) {
+	seen := make(map[string]struct{}, len(rows))
+	ids := make([]string, 0, len(rows))
+	for i, row := range rows {
+		var parsed struct {
+			Dimensions struct {
+				BetaTesters struct {
+					Data string `json:"data"`
+				} `json:"betaTesters"`
+			} `json:"dimensions"`
+		}
+		if err := json.Unmarshal(row, &parsed); err != nil {
+			return nil, fmt.Errorf("parse data[%d] dimensions: %w", i, err)
+		}
+		id := strings.TrimSpace(parsed.Dimensions.BetaTesters.Data)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// fetchBetaTestersByIDs fetches beta testers matching the given IDs from
+// GET /v1/betaTesters using filter[id], following pagination and applying the
+// shared request timeout to every request.
+func fetchBetaTestersByIDs(ctx context.Context, client *asc.Client, ids []string) ([]asc.Resource[asc.BetaTesterAttributes], error) {
+	firstPage, err := func() (*asc.BetaTestersResponse, error) {
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		return client.GetBetaTesters(requestCtx, "", asc.WithBetaTestersIDs(ids), asc.WithBetaTestersLimit(200))
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		return client.GetBetaTesters(requestCtx, "", asc.WithBetaTestersNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	testers, ok := all.(*asc.BetaTestersResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected beta testers response type %T", all)
+	}
+	return testers.Data, nil
 }

--- a/internal/cli/testflight/testflight_sync.go
+++ b/internal/cli/testflight/testflight_sync.go
@@ -69,14 +69,6 @@ type TestFlightTesterConfig struct {
 	Groups []string `yaml:"groups,omitempty"`
 }
 
-type testFlightSyncSummary struct {
-	File    string `json:"file"`
-	App     string `json:"app"`
-	Groups  int    `json:"groups"`
-	Builds  int    `json:"builds"`
-	Testers int    `json:"testers"`
-}
-
 type testFlightPullOptions struct {
 	includeBuilds  bool
 	includeTesters bool
@@ -202,7 +194,7 @@ Examples:
 				return fmt.Errorf("testflight sync pull: %w", err)
 			}
 
-			summary := testFlightSyncSummary{
+			summary := asc.TestFlightSyncSummary{
 				File:    filepath.Clean(outputValue),
 				App:     config.App.Name,
 				Groups:  len(config.Groups),


### PR DESCRIPTION
## Why

Follow-up to #2051/#2052: a real automation session surfaced five ergonomics gaps that make the CLI easy to misuse from scripts and agents. This PR ships all five.

## 1. Truncation warning on unpaginated lists

Unpaginated `list` commands print one page with exit 0 and no signal that more pages exist — a script grepping `.data` silently acts on partial results (observed: `testers list` returning 50 of 198). `printOutput`/`printOutputWithRenderers` now emit a stderr warning whenever a printed response still carries `links.next`:

- `Warning: showing 50 of 198 results; pass --paginate for all (or --next for the next page)` (count+total when paging metadata is present; count-only and generic fallbacks otherwise)
- Correctness hinges on an existing invariant: `PaginateAll` erases `links.next` on aggregates, so `Next != ""` at print time is exactly "single page, unpaginated". No flag plumbing; covers all ~243 paginate-capable commands via the shared printer.
- Bonus fix: `beta-groups list --internal/--external` paginates fully then truncates client-side via `--limit` with no signal — now warns when it actually drops matches.
- Two cmdtest expectations updated: they asserted empty stderr on single-page fixtures specifically to prove no auto-pagination; the warning is now the expected signal there.

## 2. Tester name filters

`beta-testers list` gains `--first-name` / `--last-name` (exact-match `filter[firstName]`/`filter[lastName]`, OpenAPI-verified), following the existing `--email` plumbing exactly. "Find Lei Wang" is now one server-side call instead of fetch-all-and-grep.

## 3. Groups-per-tester discoverability

`testers groups list --id` already existed but appeared in no help example or doc — it now does (parent examples, view "See also", commands/testflight.mdx).

## 4. `--resolve-testers` on tester usage metrics

Metrics dimensions carry bare tester IDs. With `--resolve-testers`, the output gains an additive `testers` sidecar map (id → email/name/state/inviteType); `data[]` stays byte-identical. Resolution prefers the response's own `included` resources (previously discarded), then batch-fetches the rest via new `WithBetaTestersIDs` (`filter[id]`, chunks of 50, paginated, 500-ID cap with warning — never silent).

## 5. Output-shape contract

AGENTS.md now codifies the de-facto rule: reads print Apple's envelope unmodified; mutation receipts/computed results are exported camelCase structs in `internal/asc/output_*.go` with registered renderers. New `ListEnvelope[T]`/`ItemList[T]` generics provide an additive flattened form (`totalCount`/`hasMore` embed the envelope, existing `.data` consumers untouched) for future/experimental commands. Five outlier types normalized (dsyms, build wait, CSV export/import summaries, sync) — exported, renderer-registered, JSON byte-identical (fixture-tested).

## Tests

~30 new tests: query-builder + HTTP filter assertions, resolve-testers cmdtest (included-satisfied + batched fetch + flag-off byte-compat), warning unit tests (count+total/count-only/generic/aggregated/typed-nil/renderer-failure), `PageDataLen` edge cases, beta-groups truncation warning, ListEnvelope marshal shape + registry fallback, byte-compat fixtures for moved types.

## Notes for review

- Full gate green locally (docs check, website docs check, format, lint 0 issues, full short suite).
- `TestBuildsNextBuildNumberRefreshesDeadlinesAcrossHistoryPages` flaked once under full-suite load during a local gate run (context deadline on page 2), passed 3× in isolation; pre-existing sensitivity — its margins were already widened upstream in a7b4e549b. Not touched here.
- Implemented by three parallel agents with disjoint file ownership; integrated and gated as one change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exact first-name, last-name, and tester ID filters for TestFlight beta tester listings.
  * Added the `testers groups list` command and expanded related documentation.
  * Added optional `--resolve-testers` support for beta tester usage metrics.
  * Added structured output for TestFlight sync, beta tester imports/exports, dSYM downloads, and build-wait results.
* **Bug Fixes**
  * Added warnings for truncated results caused by additional pages or limits.
  * Improved pagination metadata and list counts in JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->