### PR TITLE
apps wall: add Wander: Markdown Editor

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1801,6 +1801,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/df/80/ae/df80aeb3-38cc-afe1-e15c-e0b27e957f66/AppIcon-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Wander: Markdown Editor",
+    "link": "https://apps.apple.com/us/app/wander-markdown-editor/id6791206855?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/86/fc/6f/86fc6f47-00d7-4465-b567-fe4246d47945/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Wat Kham",
     "link": "https://apps.apple.com/us/app/wat-kham/id6760705576?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/86/4a/45/864a4587-87e9-4a25-e53e-2e9e025800e0/AppIcon-1x_U007emarketing-0-8-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Wander: Markdown Editor` to the Wall of Apps

## Entry

- App ID: 6791206855
- App: Wander: Markdown Editor
- App Store: https://apps.apple.com/us/app/wander-markdown-editor/id6791206855?uo=4
- Website: https://wander.md

## Notes

- Submitted via `asc apps wall submit`
- The website is listed here for context only: entries in `docs/wall-of-apps.json`
  carry `app` / `link` / `icon`, so the diff adds no field to the schema.