### PR TITLE
Add Apple Developer system status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ depending on a command in CI or scripts:
 
 ### Apple service health
 
-- Check Apple's developer services without credentials: `asc system-status`
+- `[experimental]` Check Apple's developer services without credentials: `asc system-status`
 - Narrow unexpected API or upload failures: `asc system-status --service "App Store Connect"`
 - Poll only when requested: `asc system-status --watch --poll-interval 30s`
 - Use `--issues-only` for a concise incident view; summary counts still cover all matched services

--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ depending on a command in CI or scripts:
 - If keychain access is blocked, retry with `ASC_BYPASS_KEYCHAIN=1` or re-run `asc auth login --bypass-keychain`
 - Use `asc auth login --local --bypass-keychain ...` when you want repo-local credentials in `./.asc/config.json`
 
+### Apple service health
+
+- Check Apple's developer services without credentials: `asc system-status`
+- Narrow unexpected API or upload failures: `asc system-status --service "App Store Connect"`
+- Poll only when requested: `asc system-status --watch --poll-interval 30s`
+- Use `--issues-only` for a concise incident view; summary counts still cover all matched services
+
 ### Output
 
 - `asc` defaults to `table` in an interactive terminal and `json` in pipes, files, and CI

--- a/cmd/root_usage.go
+++ b/cmd/root_usage.go
@@ -70,7 +70,7 @@ var rootUsageGroups = []rootCommandGroup{
 	},
 	{
 		title:    "UTILITY COMMANDS",
-		commands: []string{"diff", "capabilities", "search", "snitch", "version", "completion", "schema", "telemetry"},
+		commands: []string{"system-status", "diff", "capabilities", "search", "snitch", "version", "completion", "schema", "telemetry"},
 	},
 }
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -2663,6 +2663,9 @@ func TestRootCommand_UsageGroupsSubcommands(t *testing.T) {
 	if !strings.Contains(usage, "  screenshots:") || !strings.Contains(usage, "  video-previews:") {
 		t.Fatalf("expected screenshots and video-previews commands in root usage, got %q", usage)
 	}
+	if !strings.Contains(usage, "  system-status:") {
+		t.Fatalf("expected system-status command in root usage, got %q", usage)
+	}
 
 	if strings.Contains(usage, "  assets:") || strings.Contains(usage, "  shots:") {
 		t.Fatalf("expected old assets/shots commands to be removed from root usage, got %q", usage)

--- a/cmd/system_status_blackbox_test.go
+++ b/cmd/system_status_blackbox_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSystemStatusInvalidOutputWithBuiltBinary(t *testing.T) {
+	binaryPath := buildASCBlackboxBinary(t)
+	command := exec.Command(binaryPath, "system-status", "--output", "yaml")
+	command.Env = append(os.Environ(), "ASC_BYPASS_KEYCHAIN=1")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) || exitError.ExitCode() != ExitUsage {
+		t.Fatalf("exit error = %v, want exit %d", err, ExitUsage)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Error: unsupported format: yaml") {
+		t.Fatalf("stderr = %q, want invalid-output diagnostic", stderr.String())
+	}
+}

--- a/commands/overview.mdx
+++ b/commands/overview.mdx
@@ -143,7 +143,7 @@ Commands are organized into logical families based on functionality:
 
 ### Utility
 
-* `system-status` - Check Apple Developer service health without authentication
+* `system-status` - [experimental] Check Apple Developer service health without authentication
 * `version` - Print version information and exit
 * `completion` - Print shell completion scripts
 * `diff` - Generate deterministic non-mutating diff plans

--- a/commands/overview.mdx
+++ b/commands/overview.mdx
@@ -143,6 +143,7 @@ Commands are organized into logical families based on functionality:
 
 ### Utility
 
+* `system-status` - Check Apple Developer service health without authentication
 * `version` - Print version information and exit
 * `completion` - Print shell completion scripts
 * `diff` - Generate deterministic non-mutating diff plans

--- a/commands/system-status.mdx
+++ b/commands/system-status.mdx
@@ -50,7 +50,8 @@ names, for example `--service "App Store Connect,TestFlight"`.
 </ParamField>
 
 <ParamField path="--output" type="string">
-  Output format: `json`, `table`, or `markdown`; defaults are TTY-aware
+  Output format: `json`, `table`, or `markdown`; defaults to `table` in terminals
+  and minified `json` for pipes or CI, while an explicit value takes precedence
 </ParamField>
 
 ## Behavior

--- a/commands/system-status.mdx
+++ b/commands/system-status.mdx
@@ -1,0 +1,78 @@
+# system-status
+
+> Apple Developer service health without authentication
+
+The `system-status` command queries Apple's public Developer System Status feed.
+Use it when an App Store Connect request, build upload, TestFlight operation, or
+Xcode Cloud workflow behaves unexpectedly and you want to distinguish a local
+problem from an active Apple incident.
+
+## Usage
+
+```bash  theme={null}
+asc system-status [flags]
+```
+
+## Examples
+
+```bash  theme={null}
+asc system-status
+asc system-status --service "App Store Connect API"
+asc system-status --service "App Store Connect,TestFlight" --issues-only
+asc system-status --watch --poll-interval 30s
+asc system-status --output json
+```
+
+Service matching is case-insensitive and uses substrings, so
+`--service "App Store Connect"` selects the related API, upload, processing,
+analytics, sales, and TestFlight services. Separate multiple filters with
+commas.
+
+## Flags
+
+<ParamField path="--service" type="string">
+  Filter by service name substring(s), comma-separated
+</ParamField>
+
+<ParamField path="--issues-only" type="boolean" default="false">
+  Show only services with active incidents; summary counts still cover every matched service
+</ParamField>
+
+<ParamField path="--watch" type="boolean" default="false">
+  Poll and emit the initial snapshot, then emit only when selected status changes
+</ParamField>
+
+<ParamField path="--poll-interval" type="string" default="30s">
+  Polling interval for `--watch`
+</ParamField>
+
+<ParamField path="--max-polls" type="integer" default="0">
+  Maximum polls for `--watch` (`0` = unlimited)
+</ParamField>
+
+<ParamField path="--output" type="string">
+  Output format: `json`, `table`, or `markdown`; defaults are TTY-aware
+</ParamField>
+
+## Behavior
+
+A successfully fetched report exits zero even when Apple reports an incident;
+the incident is returned as data in `summary.status`, service status, and event
+details. Network, HTTP, or response-format failures exit non-zero. The command
+does not require App Store Connect credentials.
+
+Apple exposes this information through a public web feed rather than the App
+Store Connect OpenAPI. If Apple changes the feed shape, `asc` fails explicitly
+instead of silently reporting that services are healthy.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Release status" icon="activity" href="/commands/status">
+    Inspect the authenticated release pipeline for one app
+  </Card>
+
+  <Card title="Authentication" icon="key" href="/commands/auth">
+    Diagnose local credentials with `asc auth doctor`
+  </Card>
+</CardGroup>

--- a/commands/system-status.mdx
+++ b/commands/system-status.mdx
@@ -1,8 +1,8 @@
 # system-status
 
-> Apple Developer service health without authentication
+> [experimental] Apple Developer service health without authentication
 
-The `system-status` command queries Apple's public Developer System Status feed.
+The experimental `system-status` command queries Apple's public Developer System Status feed.
 Use it when an App Store Connect request, build upload, TestFlight operation, or
 Xcode Cloud workflow behaves unexpectedly and you want to distinguish a local
 problem from an active Apple incident.

--- a/commands/system-status.mdx
+++ b/commands/system-status.mdx
@@ -61,7 +61,8 @@ details. Network, HTTP, or response-format failures exit non-zero. The command
 does not require App Store Connect credentials.
 
 Watch mode retries a failed poll twice and exits after three consecutive
-failures. A successful poll resets the failure count.
+failures. A successful poll resets the failure count. JSON snapshots are
+newline-delimited, so `--pretty` is not supported with `--watch --output json`.
 
 Apple exposes this information through a public web feed rather than the App
 Store Connect OpenAPI. If Apple changes the feed shape, `asc` fails explicitly

--- a/commands/system-status.mdx
+++ b/commands/system-status.mdx
@@ -23,10 +23,9 @@ asc system-status --watch --poll-interval 30s
 asc system-status --output json
 ```
 
-Service matching is case-insensitive and uses substrings, so
-`--service "App Store Connect"` selects the related API, upload, processing,
-analytics, sales, and TestFlight services. Separate multiple filters with
-commas.
+Service matching is case-insensitive and applies each substring to individual
+service names. Use separate comma-delimited filters when you need multiple
+names, for example `--service "App Store Connect,TestFlight"`.
 
 ## Flags
 
@@ -39,7 +38,7 @@ commas.
 </ParamField>
 
 <ParamField path="--watch" type="boolean" default="false">
-  Poll and emit the initial snapshot, then emit only when selected status changes
+  Poll and emit the initial snapshot, then emit only when the selected report changes
 </ParamField>
 
 <ParamField path="--poll-interval" type="string" default="30s">
@@ -60,6 +59,9 @@ A successfully fetched report exits zero even when Apple reports an incident;
 the incident is returned as data in `summary.status`, service status, and event
 details. Network, HTTP, or response-format failures exit non-zero. The command
 does not require App Store Connect credentials.
+
+Watch mode retries a failed poll twice and exits after three consecutive
+failures. A successful poll resets the failure count.
 
 Apple exposes this information through a public web feed rather than the App
 Store Connect OpenAPI. If Apple changes the feed shape, `asc` fails explicitly

--- a/docs.json
+++ b/docs.json
@@ -154,6 +154,7 @@
               "commands/xcode-cloud",
               "commands/notify",
               "commands/migrate",
+              "commands/system-status",
               "commands/completion",
               "commands/telemetry"
             ]

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -138,7 +138,7 @@ asc <subcommand> [flags]
 
 ### Utility
 
-- `system-status` - Check Apple Developer service health.
+- `system-status` - [experimental] Check Apple Developer service health.
 - `diff` - Generate deterministic non-mutating diff plans.
 - `capabilities` - Show CLI, API, web-only, and public-API-limited capability coverage.
 - `search` - Search asc commands and examples for agent-oriented command discovery.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -138,6 +138,7 @@ asc <subcommand> [flags]
 
 ### Utility
 
+- `system-status` - Check Apple Developer service health.
 - `diff` - Generate deterministic non-mutating diff plans.
 - `capabilities` - Show CLI, API, web-only, and public-API-limited capability coverage.
 - `search` - Search asc commands and examples for agent-oriented command discovery.

--- a/docs/architecture/apple-developer-system-status.md
+++ b/docs/architecture/apple-developer-system-status.md
@@ -19,7 +19,7 @@ asc system-status --watch --poll-interval 30s
 The command accepts no positional arguments. `--service` is a comma-separated,
 case-insensitive substring filter. `--issues-only` limits the service list while
 retaining summary counts for all matched services. `--watch` emits the initial
-snapshot and later snapshots only when the selected status changes.
+snapshot and later snapshots only when the selected report changes.
 `--max-polls` provides a bounded watch for automation and tests.
 
 ## Data source and response
@@ -58,6 +58,9 @@ Markdown. A successfully fetched report exits zero even when Apple reports an
 incident; the incident is data, not a command failure. Invalid flags and flag
 combinations exit 2. Transport, HTTP, and parse failures exit 1. Standard data
 goes to stdout and diagnostics go to stderr.
+
+Watch mode reports failed polls to stderr and retries twice. It exits on the
+third consecutive failure, while any successful poll resets the failure count.
 
 ## Compatibility and agent discovery
 

--- a/docs/architecture/apple-developer-system-status.md
+++ b/docs/architecture/apple-developer-system-status.md
@@ -41,9 +41,10 @@ The feed currently wraps JSON in `jsonCallback(...)`. Its top-level payload has
 
 The parser also accepts plain JSON so a harmless transport-format change does
 not break the command. It rejects unknown wrappers, non-2xx responses, empty
-service lists, and bodies larger than 2 MiB. The source is a public web feed,
-not a documented API contract, so explicit parse failures are preferable to
-silently reporting a healthy state when Apple changes the schema.
+service lists, unknown non-empty event statuses, and bodies larger than 2 MiB.
+The source is a public web feed, not a documented API contract, so explicit
+parse failures are preferable to silently reporting a healthy state when Apple
+changes the schema.
 
 ## Output and exit behavior
 

--- a/docs/architecture/apple-developer-system-status.md
+++ b/docs/architecture/apple-developer-system-status.md
@@ -1,0 +1,95 @@
+# Apple Developer system status
+
+## Placement and command shape
+
+`asc system-status` is a top-level utility command. It is separate from
+`asc status`, which is an authenticated, app-scoped release dashboard, and
+from `asc doctor`, which is an established alias for authentication
+diagnostics.
+
+Expected invocations:
+
+```bash
+asc system-status
+asc system-status --service "App Store Connect API"
+asc system-status --service "App Store Connect,TestFlight" --issues-only
+asc system-status --watch --poll-interval 30s
+```
+
+The command accepts no positional arguments. `--service` is a comma-separated,
+case-insensitive substring filter. `--issues-only` limits the service list while
+retaining summary counts for all matched services. `--watch` emits the initial
+snapshot and later snapshots only when the selected status changes.
+`--max-polls` provides a bounded watch for automation and tests.
+
+## Data source and response
+
+This is not an App Store Connect OpenAPI operation. The command performs an
+unauthenticated `GET` of Apple's public Developer System Status data feed:
+
+```text
+https://www.apple.com/support/systemstatus/data/developer/system_status_en_US.js
+```
+
+The feed currently wraps JSON in `jsonCallback(...)`. Its top-level payload has
+`drMessage` and `services`; each service has `serviceName`, `redirectUrl`, and
+`events`. Event fields include `messageId`, `statusType`, `message`,
+`datePosted`, `startDate`, `endDate`, epoch timestamps, `usersAffected`, and
+`eventStatus`.
+
+The parser also accepts plain JSON so a harmless transport-format change does
+not break the command. It rejects unknown wrappers, non-2xx responses, empty
+service lists, and bodies larger than 2 MiB. The source is a public web feed,
+not a documented API contract, so explicit parse failures are preferable to
+silently reporting a healthy state when Apple changes the schema.
+
+## Output and exit behavior
+
+The computed camelCase report contains:
+
+- `source`, pointing to Apple's human-readable status page;
+- a summary with overall status and service/incident counts;
+- an optional global disaster-recovery message;
+- selected services with computed `operational` or `issues` status and Apple's
+  event details.
+
+Output follows the CLI's TTY-aware default and supports JSON, table, and
+Markdown. A successfully fetched report exits zero even when Apple reports an
+incident; the incident is data, not a command failure. Invalid flags and flag
+combinations exit 2. Transport, HTTP, and parse failures exit 1. Standard data
+goes to stdout and diagnostics go to stderr.
+
+## Compatibility and agent discovery
+
+This is an additive stable command with no authentication requirement and no
+changes to existing command behavior. The generated `ASC.md` agent reference
+will instruct agents to query it after unexpected Apple API failures. Timeout
+and server-error hints will reference the related App Store Connect services.
+No request automatically performs a hidden second network call.
+
+## Tests and verification
+
+RED-GREEN coverage includes:
+
+- command registration and help;
+- JSONP and plain-JSON decoding with a realistic incident;
+- service filtering, issues-only summaries, and no-match errors;
+- HTTP and malformed/oversized response failures;
+- positional arguments and invalid watch flag combinations;
+- changed-only bounded polling;
+- JSON, table, and Markdown rendering;
+- timeout and 5xx diagnostic hints;
+- a built-binary one-shot check against Apple's live feed.
+
+The repository gate is `make format`, `make check-docs`, `make lint`, and
+`ASC_BYPASS_KEYCHAIN=1 make test`. Because root help changes, generated command
+documentation must also be refreshed before the gate.
+
+## Alternatives considered
+
+Adding flags to `asc doctor` would mix unauthenticated service health with a
+stable authentication report and its JSON contract. Adding this to `asc status`
+would require an app and credentials precisely when Apple may be unavailable.
+Automatically querying Apple on every timeout or 5xx would add latency, noise,
+and a second failure mode. A dedicated command plus contextual hints remains
+explicit, scriptable, and reusable by both people and agents.

--- a/docs/architecture/apple-developer-system-status.md
+++ b/docs/architecture/apple-developer-system-status.md
@@ -63,14 +63,16 @@ goes to stdout and diagnostics go to stderr.
 
 Watch mode reports failed polls to stderr and retries twice. It exits on the
 third consecutive failure, while any successful poll resets the failure count.
+JSON watch output is newline-delimited; `--pretty` is rejected in that mode so
+each snapshot remains one complete JSON record.
 
 ## Compatibility and agent discovery
 
-This is an additive stable command with no authentication requirement and no
-changes to existing command behavior. The generated `ASC.md` agent reference
-will instruct agents to query it after unexpected Apple API failures. Timeout
-and server-error hints will reference the related App Store Connect services.
-No request automatically performs a hidden second network call.
+This is an additive experimental command with no authentication requirement
+and no changes to existing command behavior. The generated `ASC.md` agent
+reference will instruct agents to query it after unexpected Apple API failures.
+Timeout and server-error hints will reference the related App Store Connect
+services. No request automatically performs a hidden second network call.
 
 ## Tests and verification
 

--- a/docs/architecture/apple-developer-system-status.md
+++ b/docs/architecture/apple-developer-system-status.md
@@ -1,5 +1,7 @@
 # Apple Developer system status
 
+Status: Experimental
+
 ## Placement and command shape
 
 `asc system-status` is a top-level utility command. It is separate from

--- a/docs/architecture/apple-developer-system-status.md
+++ b/docs/architecture/apple-developer-system-status.md
@@ -73,8 +73,9 @@ each snapshot remains one complete JSON record.
 This is an additive experimental command with no authentication requirement
 and no changes to existing command behavior. The generated `ASC.md` agent
 reference will instruct agents to query it after unexpected Apple API failures.
-Timeout and server-error hints will reference the related App Store Connect
-services. No request automatically performs a hidden second network call.
+App Store Connect API 5xx errors reference the related system-status services;
+generic timeout hints remain service-neutral. No request automatically performs
+a hidden second network call.
 
 ## Tests and verification
 
@@ -87,7 +88,7 @@ RED-GREEN coverage includes:
 - positional arguments and invalid watch flag combinations;
 - changed-only bounded polling;
 - JSON, table, and Markdown rendering;
-- timeout and 5xx diagnostic hints;
+- service-neutral timeout hints and App Store Connect API-only 5xx hints;
 - a built-binary one-shot check against Apple's live feed.
 
 The repository gate is `make format`, `make check-docs`, `make lint`, and
@@ -107,5 +108,6 @@ Adding flags to `asc doctor` would mix unauthenticated service health with a
 stable authentication report and its JSON contract. Adding this to `asc status`
 would require an app and credentials precisely when Apple may be unavailable.
 Automatically querying Apple on every timeout or 5xx would add latency, noise,
-and a second failure mode. A dedicated command plus contextual hints remains
-explicit, scriptable, and reusable by both people and agents.
+and a second failure mode. A dedicated command plus a scoped App Store Connect
+API 5xx hint remains explicit, scriptable, and reusable by both people and
+agents.

--- a/docs/architecture/apple-developer-system-status.md
+++ b/docs/architecture/apple-developer-system-status.md
@@ -55,8 +55,9 @@ The computed camelCase report contains:
 - selected services with computed `operational` or `issues` status and Apple's
   event details.
 
-Output follows the CLI's TTY-aware default and supports JSON, table, and
-Markdown. A successfully fetched report exits zero even when Apple reports an
+Output defaults to table in terminals and minified JSON for pipes or CI; an
+explicit `--output` value takes precedence. JSON, table, and Markdown are
+supported. A successfully fetched report exits zero even when Apple reports an
 incident; the incident is data, not a command failure. Invalid flags and flag
 combinations exit 2. Transport, HTTP, and parse failures exit 1. Standard data
 goes to stdout and diagnostics go to stderr.
@@ -91,6 +92,13 @@ RED-GREEN coverage includes:
 The repository gate is `make format`, `make check-docs`, `make lint`, and
 `ASC_BYPASS_KEYCHAIN=1 make test`. Because root help changes, generated command
 documentation must also be refreshed before the gate.
+
+## Handoff and residual risk
+
+Implementation, validation, and review history are tracked in
+[pull request #2062](https://github.com/rorkai/App-Store-Connect-CLI/pull/2062).
+The remaining external risk is that the undocumented public feed can change
+without notice; bounded parsing and explicit failures keep that visible.
 
 ## Alternatives considered
 

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -6,6 +6,13 @@ package asc
 // commands that never render registry output (for example `asc --version`)
 // do not pay the ~450-type registration cost at process start.
 func registerAllOutputRenderers() {
+	registerDirect(func(v *DeveloperSystemStatusReport, render func([]string, [][]string)) error {
+		h, r := developerSystemStatusSummaryRows(v)
+		render(h, r)
+		sh, sr := developerSystemStatusServiceRows(v)
+		render(sh, sr)
+		return nil
+	})
 	registerRows(feedbackRows)
 	registerRows(crashesRows)
 	registerRowsWithSingleResourceAdapter(reviewsRows)

--- a/internal/asc/output_system_status.go
+++ b/internal/asc/output_system_status.go
@@ -1,0 +1,101 @@
+package asc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DeveloperSystemStatusReport is a computed snapshot of Apple's public
+// Developer System Status feed.
+type DeveloperSystemStatusReport struct {
+	Source   string                         `json:"source"`
+	Summary  DeveloperSystemStatusSummary   `json:"summary"`
+	Message  string                         `json:"message,omitempty"`
+	Services []DeveloperSystemStatusService `json:"services"`
+}
+
+// DeveloperSystemStatusSummary describes the selected services in a system
+// status report. Counts describe all services matched by --service even when
+// --issues-only omits healthy services from Services.
+type DeveloperSystemStatusSummary struct {
+	Status              string `json:"status"`
+	TotalServices       int    `json:"totalServices"`
+	OperationalServices int    `json:"operationalServices"`
+	AffectedServices    int    `json:"affectedServices"`
+	ActiveIncidents     int    `json:"activeIncidents"`
+}
+
+// DeveloperSystemStatusService is one Apple developer service and its recent
+// status events.
+type DeveloperSystemStatusService struct {
+	Name   string                       `json:"name"`
+	Status string                       `json:"status"`
+	URL    string                       `json:"url,omitempty"`
+	Events []DeveloperSystemStatusEvent `json:"events"`
+}
+
+// DeveloperSystemStatusEvent preserves the useful fields exposed by Apple's
+// public status feed and adds Active for deterministic filtering.
+type DeveloperSystemStatusEvent struct {
+	MessageID        string `json:"messageId"`
+	StatusType       string `json:"statusType,omitempty"`
+	EventStatus      string `json:"eventStatus,omitempty"`
+	Message          string `json:"message,omitempty"`
+	DatePosted       string `json:"datePosted,omitempty"`
+	StartDate        string `json:"startDate,omitempty"`
+	EndDate          string `json:"endDate,omitempty"`
+	EpochStartDate   int64  `json:"epochStartDate,omitempty"`
+	EpochEndDate     *int64 `json:"epochEndDate,omitempty"`
+	UsersAffected    string `json:"usersAffected,omitempty"`
+	AffectedServices string `json:"affectedServices,omitempty"`
+	Active           bool   `json:"active"`
+}
+
+func developerSystemStatusSummaryRows(report *DeveloperSystemStatusReport) ([]string, [][]string) {
+	if report == nil {
+		report = &DeveloperSystemStatusReport{}
+	}
+	return []string{"Status", "Services", "Operational", "Affected", "Active Incidents", "Message", "Source"}, [][]string{{
+		report.Summary.Status,
+		fmt.Sprintf("%d", report.Summary.TotalServices),
+		fmt.Sprintf("%d", report.Summary.OperationalServices),
+		fmt.Sprintf("%d", report.Summary.AffectedServices),
+		fmt.Sprintf("%d", report.Summary.ActiveIncidents),
+		report.Message,
+		report.Source,
+	}}
+}
+
+func developerSystemStatusServiceRows(report *DeveloperSystemStatusReport) ([]string, [][]string) {
+	headers := []string{"Service", "Status", "Active Incidents", "Details", "Updated", "Link"}
+	if report == nil {
+		return headers, nil
+	}
+
+	rows := make([][]string, 0, len(report.Services))
+	for _, service := range report.Services {
+		activeCount := 0
+		details := ""
+		updated := ""
+		for _, event := range service.Events {
+			if !event.Active {
+				continue
+			}
+			activeCount++
+			if details == "" {
+				details = strings.TrimSpace(strings.Join([]string{event.StatusType, event.Message}, ": "))
+				details = strings.Trim(details, ": ")
+				updated = event.DatePosted
+			}
+		}
+		rows = append(rows, []string{
+			service.Name,
+			service.Status,
+			fmt.Sprintf("%d", activeCount),
+			details,
+			updated,
+			service.URL,
+		})
+	}
+	return headers, rows
+}

--- a/internal/asc/output_system_status_test.go
+++ b/internal/asc/output_system_status_test.go
@@ -1,0 +1,81 @@
+package asc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDeveloperSystemStatusReportJSONContract(t *testing.T) {
+	epochEnd := int64(1787086740000)
+	report := &DeveloperSystemStatusReport{
+		Source:  "https://developer.apple.com/system-status/",
+		Message: "Developer services are operating in disaster recovery mode.",
+		Summary: DeveloperSystemStatusSummary{
+			Status:              "issues",
+			TotalServices:       2,
+			OperationalServices: 1,
+			AffectedServices:    1,
+			ActiveIncidents:     1,
+		},
+		Services: []DeveloperSystemStatusService{{
+			Name:   "App Store Connect API",
+			Status: "issues",
+			Events: []DeveloperSystemStatusEvent{{
+				MessageID:    "event-1",
+				EventStatus:  "ongoing",
+				EpochEndDate: &epochEnd,
+				Active:       true,
+			}},
+		}},
+	}
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	output := string(data)
+	for _, field := range []string{`"message":"Developer services are operating in disaster recovery mode."`, `"totalServices":2`, `"operationalServices":1`, `"affectedServices":1`, `"activeIncidents":1`, `"messageId":"event-1"`, `"epochEndDate":1787086740000`, `"active":true`} {
+		if !strings.Contains(output, field) {
+			t.Fatalf("JSON output missing %s: %s", field, output)
+		}
+	}
+}
+
+func TestDeveloperSystemStatusReportRendersTableAndMarkdown(t *testing.T) {
+	report := &DeveloperSystemStatusReport{
+		Source:  "https://developer.apple.com/system-status/",
+		Message: "Developer services are operating in disaster recovery mode.",
+		Summary: DeveloperSystemStatusSummary{
+			Status:           "issues",
+			TotalServices:    1,
+			AffectedServices: 1,
+			ActiveIncidents:  1,
+		},
+		Services: []DeveloperSystemStatusService{{
+			Name:   "Xcode Cloud",
+			Status: "issues",
+			Events: []DeveloperSystemStatusEvent{{
+				StatusType:  "Outage",
+				Message:     "Users are experiencing a problem.",
+				DatePosted:  "08/18/2026 13:01 PDT",
+				EventStatus: "ongoing",
+				Active:      true,
+			}},
+		}},
+	}
+
+	for _, renderer := range []struct {
+		name string
+		fn   func(any) error
+	}{
+		{name: "table", fn: PrintTable},
+		{name: "markdown", fn: PrintMarkdown},
+	} {
+		t.Run(renderer.name, func(t *testing.T) {
+			assertRenderedNonJSONContains(t, renderer.fn, report,
+				"Active Incidents", "Developer services are operating in disaster recovery mode.",
+				"Xcode Cloud", "Outage", "Users are experiencing a problem.")
+		})
+	}
+}

--- a/internal/cli/cmdtest/stability_tiers_test.go
+++ b/internal/cli/cmdtest/stability_tiers_test.go
@@ -17,6 +17,7 @@ func TestExperimentalCommandsHaveStabilityLabel(t *testing.T) {
 	cases := []struct {
 		path []string // subcommand path from root
 	}{
+		{[]string{"system-status"}},
 		{[]string{"screenshots", "run"}},
 		{[]string{"screenshots", "capture"}},
 		{[]string{"screenshots", "frame"}},

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -131,7 +131,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `init` - Initialize asc helper docs in the current repo.
 - `docs` - Generate asc cli reference docs for a repo.
 - `diff` - Generate deterministic non-mutating diff plans.
-- `system-status` - Check Apple Developer service health without authentication.
+- `system-status` - [experimental] Check Apple Developer service health without authentication.
 - `capabilities` - Show CLI, API, web-only, and public-API-limited capability coverage.
 - `search` - Search asc commands and examples for agent-oriented command discovery.
 - `status` - Show a release pipeline dashboard for an app.

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -39,6 +39,7 @@ Do not memorize flags. Always use `--help` for the current interface.
 |------|---------|
 | Check auth status | `asc auth status` |
 | Run auth doctor | `asc doctor --output json` |
+| Check Apple service health | `asc system-status --service "App Store Connect"` |
 | Check account health | `asc account status` |
 | Generate ASC.md | `asc init` |
 | Create an app (web flow) | `asc web apps create --name "My App" --bundle-id "com.example.app" --sku "SKU123"` |
@@ -130,6 +131,7 @@ Use `asc <command> --help` for subcommands and flags.
 - `init` - Initialize asc helper docs in the current repo.
 - `docs` - Generate asc cli reference docs for a repo.
 - `diff` - Generate deterministic non-mutating diff plans.
+- `system-status` - Check Apple Developer service health without authentication.
 - `capabilities` - Show CLI, API, web-only, and public-API-limited capability coverage.
 - `search` - Search asc commands and examples for agent-oriented command discovery.
 - `status` - Show a release pipeline dashboard for an app.

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -123,7 +123,7 @@ func NewCatalog(version string) *Catalog {
 		commandFactory("init", "Initialize asc helper docs in the current repo.", initcmd.InitCommand),
 		commandFactory("docs", "Access embedded documentation guides and reference helpers.", docs.DocsCommand),
 		commandFactory("diff", "Generate deterministic non-mutating diff plans.", diffcmd.DiffCommand),
-		commandFactory("system-status", "Check Apple Developer service health.", systemstatus.Command),
+		commandFactory("system-status", "[experimental] Check Apple Developer service health.", systemstatus.Command),
 		commandFactory("status", "Show a release pipeline dashboard for an app.", status.StatusCommand),
 		commandFactory("insights", "Generate weekly and daily insights from App Store data sources.", insights.InsightsCommand),
 		commandFactory("release-notes", "Generate and manage App Store release notes.", releasenotes.ReleaseNotesCommand),

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -72,6 +72,7 @@ import (
 	storekitcmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/storekit"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/submit"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/subscriptions"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/systemstatus"
 	telemetrycmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/telemetry"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/testflight"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/users"
@@ -122,6 +123,7 @@ func NewCatalog(version string) *Catalog {
 		commandFactory("init", "Initialize asc helper docs in the current repo.", initcmd.InitCommand),
 		commandFactory("docs", "Access embedded documentation guides and reference helpers.", docs.DocsCommand),
 		commandFactory("diff", "Generate deterministic non-mutating diff plans.", diffcmd.DiffCommand),
+		commandFactory("system-status", "Check Apple Developer service health.", systemstatus.Command),
 		commandFactory("status", "Show a release pipeline dashboard for an app.", status.StatusCommand),
 		commandFactory("insights", "Generate weekly and daily insights from App Store data sources.", insights.InsightsCommand),
 		commandFactory("release-notes", "Generate and manage App Store release notes.", releasenotes.ReleaseNotesCommand),

--- a/internal/cli/registry/registry_test.go
+++ b/internal/cli/registry/registry_test.go
@@ -39,7 +39,7 @@ func TestSubcommandsIncludesCoreEntries(t *testing.T) {
 		names[name] = struct{}{}
 	}
 
-	required := []string{"auth", "doctor", "account", "ads", "optimize", "insights", "builds", "reviews", "version", "completion"}
+	required := []string{"auth", "doctor", "account", "ads", "optimize", "insights", "builds", "reviews", "system-status", "version", "completion"}
 	for _, name := range required {
 		if _, ok := names[name]; !ok {
 			t.Fatalf("expected root subcommands to include %q", name)

--- a/internal/cli/shared/errfmt/errfmt.go
+++ b/internal/cli/shared/errfmt/errfmt.go
@@ -18,6 +18,7 @@ type ClassifiedError struct {
 const (
 	requestTimeoutHint = "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`)."
 	uploadTimeoutHint  = "Increase the upload timeout (e.g. set `ASC_UPLOAD_TIMEOUT=600s`)."
+	systemStatusHint   = "Check Apple's service health with `asc system-status --service \"App Store Connect\"`."
 )
 
 func Classify(err error) ClassifiedError {
@@ -39,7 +40,15 @@ func Classify(err error) ClassifiedError {
 		}
 		return ClassifiedError{
 			Message: err.Error(),
-			Hint:    hint,
+			Hint:    hint + " " + systemStatusHint,
+		}
+	}
+
+	var statusErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &statusErr) && statusErr.HTTPStatusCode() >= 500 {
+		return ClassifiedError{
+			Message: err.Error(),
+			Hint:    systemStatusHint,
 		}
 	}
 

--- a/internal/cli/shared/errfmt/errfmt.go
+++ b/internal/cli/shared/errfmt/errfmt.go
@@ -40,12 +40,12 @@ func Classify(err error) ClassifiedError {
 		}
 		return ClassifiedError{
 			Message: err.Error(),
-			Hint:    hint + " " + systemStatusHint,
+			Hint:    hint,
 		}
 	}
 
-	var statusErr interface{ HTTPStatusCode() int }
-	if errors.As(err, &statusErr) && statusErr.HTTPStatusCode() >= 500 {
+	var apiErr *asc.APIError
+	if errors.As(err, &apiErr) && apiErr.HTTPStatusCode() >= 500 {
 		return ClassifiedError{
 			Message: err.Error(),
 			Hint:    systemStatusHint,

--- a/internal/cli/shared/errfmt/errfmt_test.go
+++ b/internal/cli/shared/errfmt/errfmt_test.go
@@ -30,7 +30,7 @@ func TestClassify_Forbidden(t *testing.T) {
 
 func TestClassify_Timeout(t *testing.T) {
 	ce := Classify(context.DeadlineExceeded)
-	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`)." {
+	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`). Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
 		t.Fatalf("expected request timeout hint, got %q", ce.Hint)
 	}
 }
@@ -39,7 +39,7 @@ func TestClassify_TimeoutUploadOperation(t *testing.T) {
 	err := fmt.Errorf("builds upload: upload failed: upload operation 3: %w", context.DeadlineExceeded)
 
 	ce := Classify(err)
-	if ce.Hint != "Increase the upload timeout (e.g. set `ASC_UPLOAD_TIMEOUT=600s`)." {
+	if ce.Hint != "Increase the upload timeout (e.g. set `ASC_UPLOAD_TIMEOUT=600s`). Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
 		t.Fatalf("expected upload timeout hint, got %q", ce.Hint)
 	}
 }
@@ -48,8 +48,17 @@ func TestClassify_TimeoutBuildsUploadsListKeepsRequestHint(t *testing.T) {
 	err := fmt.Errorf("builds uploads list: failed to fetch: %w", context.DeadlineExceeded)
 
 	ce := Classify(err)
-	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`)." {
+	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`). Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
 		t.Fatalf("expected request timeout hint, got %q", ce.Hint)
+	}
+}
+
+func TestClassify_ServerErrorSuggestsSystemStatus(t *testing.T) {
+	err := &asc.APIError{Code: "INTERNAL_ERROR", Title: "Unavailable", StatusCode: 503}
+
+	ce := Classify(err)
+	if ce.Hint != "Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
+		t.Fatalf("expected system-status hint, got %q", ce.Hint)
 	}
 }
 

--- a/internal/cli/shared/errfmt/errfmt_test.go
+++ b/internal/cli/shared/errfmt/errfmt_test.go
@@ -7,8 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/appleads"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/storekit"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
 func TestClassify_MissingAuth(t *testing.T) {
@@ -30,7 +33,7 @@ func TestClassify_Forbidden(t *testing.T) {
 
 func TestClassify_Timeout(t *testing.T) {
 	ce := Classify(context.DeadlineExceeded)
-	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`). Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
+	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`)." {
 		t.Fatalf("expected request timeout hint, got %q", ce.Hint)
 	}
 }
@@ -39,7 +42,7 @@ func TestClassify_TimeoutUploadOperation(t *testing.T) {
 	err := fmt.Errorf("builds upload: upload failed: upload operation 3: %w", context.DeadlineExceeded)
 
 	ce := Classify(err)
-	if ce.Hint != "Increase the upload timeout (e.g. set `ASC_UPLOAD_TIMEOUT=600s`). Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
+	if ce.Hint != "Increase the upload timeout (e.g. set `ASC_UPLOAD_TIMEOUT=600s`)." {
 		t.Fatalf("expected upload timeout hint, got %q", ce.Hint)
 	}
 }
@@ -48,17 +51,36 @@ func TestClassify_TimeoutBuildsUploadsListKeepsRequestHint(t *testing.T) {
 	err := fmt.Errorf("builds uploads list: failed to fetch: %w", context.DeadlineExceeded)
 
 	ce := Classify(err)
-	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`). Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
+	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`)." {
 		t.Fatalf("expected request timeout hint, got %q", ce.Hint)
 	}
 }
 
 func TestClassify_ServerErrorSuggestsSystemStatus(t *testing.T) {
-	err := &asc.APIError{Code: "INTERNAL_ERROR", Title: "Unavailable", StatusCode: 503}
+	err := fmt.Errorf("apps list: %w", &asc.APIError{Code: "INTERNAL_ERROR", Title: "Unavailable", StatusCode: 503})
 
 	ce := Classify(err)
 	if ce.Hint != "Check Apple's service health with `asc system-status --service \"App Store Connect\"`." {
 		t.Fatalf("expected system-status hint, got %q", ce.Hint)
+	}
+}
+
+func TestClassify_NonASCServerErrorsDoNotSuggestSystemStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "Apple Ads", err: &appleads.APIError{StatusCode: 503}},
+		{name: "StoreKit", err: &storekit.APIError{StatusCode: 503}},
+		{name: "web session", err: &web.APIError{Status: 503}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if hint := Classify(test.err).Hint; hint != "" {
+				t.Fatalf("unexpected cross-service hint: %q", hint)
+			}
+		})
 	}
 }
 

--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -68,8 +68,8 @@ func commandWithClient(client *http.Client, endpoint string) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "system-status",
 		ShortUsage: "asc system-status [flags]",
-		ShortHelp:  "Check Apple Developer service health.",
-		LongHelp: `Check Apple's public Developer System Status feed without authentication.
+		ShortHelp:  "[experimental] Check Apple Developer service health.",
+		LongHelp: `[experimental] Check Apple's public Developer System Status feed without authentication.
 
 Use --service to match one or more service-name substrings. Watch mode emits
 the initial snapshot, then emits again only when the selected report changes.

--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -1,0 +1,421 @@
+package systemstatus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const (
+	statusDataURL          = "https://www.apple.com/support/systemstatus/data/developer/system_status_en_US.js"
+	statusPageURL          = "https://developer.apple.com/system-status/"
+	maxStatusResponseBytes = 2 << 20
+)
+
+type statusFeed struct {
+	DRMessage string              `json:"drMessage"`
+	Services  []statusFeedService `json:"services"`
+}
+
+type statusFeedService struct {
+	ServiceName string            `json:"serviceName"`
+	RedirectURL string            `json:"redirectUrl"`
+	Events      []statusFeedEvent `json:"events"`
+}
+
+type statusFeedEvent struct {
+	MessageID        string          `json:"messageId"`
+	StatusType       string          `json:"statusType"`
+	EventStatus      string          `json:"eventStatus"`
+	Message          string          `json:"message"`
+	DatePosted       string          `json:"datePosted"`
+	StartDate        string          `json:"startDate"`
+	EndDate          string          `json:"endDate"`
+	EpochStartDate   int64           `json:"epochStartDate"`
+	EpochEndDate     *int64          `json:"epochEndDate"`
+	UsersAffected    string          `json:"usersAffected"`
+	AffectedServices json.RawMessage `json:"affectedServices"`
+}
+
+// Command returns the unauthenticated Apple Developer system status command.
+func Command() *ffcli.Command {
+	return commandWithClient(http.DefaultClient, statusDataURL)
+}
+
+func commandWithClient(client *http.Client, endpoint string) *ffcli.Command {
+	fs := flag.NewFlagSet("system-status", flag.ExitOnError)
+	services := shared.BindOnceCSVFlag(fs, "service", "Filter by service name substring(s), comma-separated")
+	issuesOnly := fs.Bool("issues-only", false, "Show only services with active incidents")
+	watch := fs.Bool("watch", false, "Poll and emit snapshots when selected status changes")
+	pollInterval := fs.Duration("poll-interval", 30*time.Second, "Polling interval for --watch")
+	maxPolls := fs.Int("max-polls", 0, "Maximum polls for --watch (0 = unlimited)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "system-status",
+		ShortUsage: "asc system-status [flags]",
+		ShortHelp:  "Check Apple Developer service health.",
+		LongHelp: `Check Apple's public Developer System Status feed without authentication.
+
+Use --service to match one or more service-name substrings. Watch mode emits
+the initial snapshot, then emits again only when the selected status changes.
+
+Examples:
+  asc system-status
+  asc system-status --service "App Store Connect API"
+  asc system-status --service "App Store Connect,TestFlight" --issues-only
+  asc system-status --watch --poll-interval 30s
+  asc system-status --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				fmt.Fprintln(os.Stderr, "Error: system-status does not accept positional arguments")
+				return flag.ErrHelp
+			}
+			if *pollInterval <= 0 {
+				return shared.UsageError("--poll-interval must be greater than 0")
+			}
+			if *maxPolls < 0 {
+				return shared.UsageError("--max-polls must be greater than or equal to 0")
+			}
+			if *maxPolls > 0 && !*watch {
+				return shared.UsageError("--max-polls requires --watch")
+			}
+			pollIntervalSet := false
+			fs.Visit(func(current *flag.Flag) {
+				if current.Name == "poll-interval" {
+					pollIntervalSet = true
+				}
+			})
+			if pollIntervalSet && !*watch {
+				return shared.UsageError("--poll-interval requires --watch")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			filters := shared.SplitCSV(services.String())
+			if strings.TrimSpace(services.String()) != "" && len(filters) == 0 {
+				return shared.UsageError("--service must contain at least one non-empty service name")
+			}
+
+			if *watch {
+				return watchDeveloperSystemStatus(ctx, client, endpoint, filters, *issuesOnly, *output.Output, *output.Pretty, *pollInterval, *maxPolls)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			report, err := fetchDeveloperSystemStatus(requestCtx, client, endpoint)
+			cancel()
+			if err != nil {
+				return fmt.Errorf("system-status: %w", err)
+			}
+			report, err = selectDeveloperSystemStatus(report, filters, *issuesOnly)
+			if err != nil {
+				return fmt.Errorf("system-status: %w", err)
+			}
+			return shared.PrintOutput(report, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func fetchDeveloperSystemStatus(ctx context.Context, client *http.Client, endpoint string) (*asc.DeveloperSystemStatusReport, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json, application/javascript;q=0.9")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch Apple Developer System Status: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64<<10))
+		return nil, fmt.Errorf("developer system status feed returned HTTP %d", response.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxStatusResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if len(body) > maxStatusResponseBytes {
+		return nil, fmt.Errorf("response exceeds %d bytes", maxStatusResponseBytes)
+	}
+	return decodeDeveloperSystemStatus(body)
+}
+
+func decodeDeveloperSystemStatus(body []byte) (*asc.DeveloperSystemStatusReport, error) {
+	payload, err := unwrapStatusPayload(body)
+	if err != nil {
+		return nil, err
+	}
+
+	var feed statusFeed
+	if err := json.Unmarshal(payload, &feed); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if len(feed.Services) == 0 {
+		return nil, errors.New("response contained no services")
+	}
+
+	report := &asc.DeveloperSystemStatusReport{
+		Source:   statusPageURL,
+		Message:  strings.TrimSpace(feed.DRMessage),
+		Services: make([]asc.DeveloperSystemStatusService, 0, len(feed.Services)),
+	}
+	for index, rawService := range feed.Services {
+		name := strings.TrimSpace(rawService.ServiceName)
+		if name == "" {
+			return nil, fmt.Errorf("service %d has no name", index+1)
+		}
+
+		service := asc.DeveloperSystemStatusService{
+			Name:   name,
+			Status: "operational",
+			URL:    strings.TrimSpace(rawService.RedirectURL),
+			Events: make([]asc.DeveloperSystemStatusEvent, 0, len(rawService.Events)),
+		}
+		for _, rawEvent := range rawService.Events {
+			active := statusEventActive(rawEvent)
+			if active {
+				service.Status = "issues"
+			}
+			service.Events = append(service.Events, asc.DeveloperSystemStatusEvent{
+				MessageID:        strings.TrimSpace(rawEvent.MessageID),
+				StatusType:       strings.TrimSpace(rawEvent.StatusType),
+				EventStatus:      strings.TrimSpace(rawEvent.EventStatus),
+				Message:          strings.TrimSpace(rawEvent.Message),
+				DatePosted:       strings.TrimSpace(rawEvent.DatePosted),
+				StartDate:        strings.TrimSpace(rawEvent.StartDate),
+				EndDate:          strings.TrimSpace(rawEvent.EndDate),
+				EpochStartDate:   rawEvent.EpochStartDate,
+				EpochEndDate:     rawEvent.EpochEndDate,
+				UsersAffected:    strings.TrimSpace(rawEvent.UsersAffected),
+				AffectedServices: normalizeAffectedServices(rawEvent.AffectedServices),
+				Active:           active,
+			})
+		}
+		report.Services = append(report.Services, service)
+	}
+	report.Summary = summarizeDeveloperSystemStatus(report.Services, report.Message)
+	return report, nil
+}
+
+func unwrapStatusPayload(body []byte) ([]byte, error) {
+	trimmed := bytes.TrimSpace(bytes.TrimPrefix(body, []byte{0xef, 0xbb, 0xbf}))
+	if len(trimmed) == 0 {
+		return nil, errors.New("empty response")
+	}
+	if trimmed[0] == '{' {
+		return trimmed, nil
+	}
+
+	const callback = "jsonCallback"
+	if !bytes.HasPrefix(trimmed, []byte(callback)) {
+		return nil, errors.New("unsupported response wrapper")
+	}
+	wrapped := bytes.TrimSpace(trimmed[len(callback):])
+	if len(wrapped) < 2 || wrapped[0] != '(' {
+		return nil, errors.New("unsupported response wrapper")
+	}
+	wrapped = bytes.TrimSpace(wrapped[1:])
+	wrapped = bytes.TrimSpace(bytes.TrimSuffix(wrapped, []byte(";")))
+	if len(wrapped) == 0 || wrapped[len(wrapped)-1] != ')' {
+		return nil, errors.New("unsupported response wrapper")
+	}
+	return bytes.TrimSpace(wrapped[:len(wrapped)-1]), nil
+}
+
+func statusEventActive(event statusFeedEvent) bool {
+	status := strings.TrimSpace(event.EventStatus)
+	if strings.EqualFold(status, "ongoing") {
+		return true
+	}
+	return status == "" && strings.TrimSpace(event.EndDate) == "" && event.EpochEndDate == nil
+}
+
+func normalizeAffectedServices(raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return ""
+	}
+	var value string
+	if json.Unmarshal(raw, &value) == nil {
+		return strings.TrimSpace(value)
+	}
+	var values []string
+	if json.Unmarshal(raw, &values) == nil {
+		return strings.Join(values, ", ")
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func selectDeveloperSystemStatus(report *asc.DeveloperSystemStatusReport, filters []string, issuesOnly bool) (*asc.DeveloperSystemStatusReport, error) {
+	matched := make([]asc.DeveloperSystemStatusService, 0, len(report.Services))
+	for _, service := range report.Services {
+		if matchesServiceFilters(service.Name, filters) {
+			matched = append(matched, service)
+		}
+	}
+	if len(matched) == 0 && len(filters) > 0 {
+		return nil, shared.UsageErrorf("no services matched --service %q", strings.Join(filters, ","))
+	}
+
+	selected := matched
+	if issuesOnly {
+		selected = make([]asc.DeveloperSystemStatusService, 0, len(matched))
+		for _, service := range matched {
+			if service.Status == "issues" {
+				selected = append(selected, service)
+			}
+		}
+	}
+	result := &asc.DeveloperSystemStatusReport{
+		Source:   report.Source,
+		Message:  report.Message,
+		Summary:  summarizeDeveloperSystemStatus(matched, report.Message),
+		Services: selected,
+	}
+	return result, nil
+}
+
+func matchesServiceFilters(name string, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	name = strings.ToLower(name)
+	for _, filter := range filters {
+		if strings.Contains(name, strings.ToLower(strings.TrimSpace(filter))) {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeDeveloperSystemStatus(services []asc.DeveloperSystemStatusService, message string) asc.DeveloperSystemStatusSummary {
+	summary := asc.DeveloperSystemStatusSummary{
+		Status:        "operational",
+		TotalServices: len(services),
+	}
+	for _, service := range services {
+		if service.Status == "issues" {
+			summary.Status = "issues"
+			summary.AffectedServices++
+		} else {
+			summary.OperationalServices++
+		}
+		for _, event := range service.Events {
+			if event.Active {
+				summary.ActiveIncidents++
+			}
+		}
+	}
+	if strings.TrimSpace(message) != "" {
+		summary.Status = "issues"
+	}
+	return summary
+}
+
+func watchDeveloperSystemStatus(ctx context.Context, client *http.Client, endpoint string, filters []string, issuesOnly bool, output string, pretty bool, pollInterval time.Duration, maxPolls int) error {
+	previous := ""
+	for poll := 1; maxPolls == 0 || poll <= maxPolls; poll++ {
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		report, err := fetchDeveloperSystemStatus(requestCtx, client, endpoint)
+		cancel()
+		if err != nil {
+			if contextDone(ctx) {
+				return nil
+			}
+			return fmt.Errorf("system-status: %w", err)
+		}
+		report, err = selectDeveloperSystemStatus(report, filters, issuesOnly)
+		if err != nil {
+			return fmt.Errorf("system-status: %w", err)
+		}
+
+		snapshot, err := json.Marshal(report)
+		if err != nil {
+			return fmt.Errorf("system-status: encode watch snapshot: %w", err)
+		}
+		if poll == 1 || string(snapshot) != previous {
+			if err := printWatchSnapshot(report, output, pretty, poll > 1); err != nil {
+				return err
+			}
+			previous = string(snapshot)
+		}
+		if maxPolls > 0 && poll >= maxPolls {
+			return nil
+		}
+		if err := waitForPoll(ctx, pollInterval); err != nil {
+			if contextDone(ctx) {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func printWatchSnapshot(report *asc.DeveloperSystemStatusReport, output string, pretty bool, separator bool) error {
+	format := strings.ToLower(strings.TrimSpace(output))
+	if format == "" {
+		format = shared.DefaultOutputFormat()
+	}
+	if format == "json" {
+		var (
+			data []byte
+			err  error
+		)
+		if pretty {
+			data, err = json.MarshalIndent(report, "", "  ")
+		} else {
+			data, err = json.Marshal(report)
+		}
+		if err != nil {
+			return fmt.Errorf("system-status: encode watch snapshot: %w", err)
+		}
+		_, err = fmt.Fprintln(os.Stdout, string(data))
+		return err
+	}
+	if separator {
+		if format == "markdown" || format == "md" {
+			fmt.Fprintln(os.Stdout, "\n---")
+		} else {
+			fmt.Fprintln(os.Stdout)
+		}
+	}
+	return shared.PrintOutput(report, output, pretty)
+}
+
+func waitForPoll(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func contextDone(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	return errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)
+}

--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -23,6 +23,7 @@ const (
 	statusDataURL          = "https://www.apple.com/support/systemstatus/data/developer/system_status_en_US.js"
 	statusPageURL          = "https://developer.apple.com/system-status/"
 	maxStatusResponseBytes = 2 << 20
+	maxWatchFailures       = 3
 )
 
 type statusFeed struct {
@@ -59,7 +60,7 @@ func commandWithClient(client *http.Client, endpoint string) *ffcli.Command {
 	fs := flag.NewFlagSet("system-status", flag.ExitOnError)
 	services := shared.BindOnceCSVFlag(fs, "service", "Filter by service name substring(s), comma-separated")
 	issuesOnly := fs.Bool("issues-only", false, "Show only services with active incidents")
-	watch := fs.Bool("watch", false, "Poll and emit snapshots when selected status changes")
+	watch := fs.Bool("watch", false, "Poll and emit snapshots when the selected report changes")
 	pollInterval := fs.Duration("poll-interval", 30*time.Second, "Polling interval for --watch")
 	maxPolls := fs.Int("max-polls", 0, "Maximum polls for --watch (0 = unlimited)")
 	output := shared.BindOutputFlags(fs)
@@ -71,7 +72,7 @@ func commandWithClient(client *http.Client, endpoint string) *ffcli.Command {
 		LongHelp: `Check Apple's public Developer System Status feed without authentication.
 
 Use --service to match one or more service-name substrings. Watch mode emits
-the initial snapshot, then emits again only when the selected status changes.
+the initial snapshot, then emits again only when the selected report changes.
 
 Examples:
   asc system-status
@@ -108,10 +109,20 @@ Examples:
 				return shared.UsageError(err.Error())
 			}
 
-			filters := shared.SplitCSV(services.String())
-			if strings.TrimSpace(services.String()) != "" && len(filters) == 0 {
-				return shared.UsageError("--service must contain at least one non-empty service name")
+			serviceFilterSet := false
+			fs.Visit(func(current *flag.Flag) {
+				if current.Name == "service" {
+					serviceFilterSet = true
+				}
+			})
+			if serviceFilterSet {
+				for _, service := range strings.Split(services.String(), ",") {
+					if strings.TrimSpace(service) == "" {
+						return shared.UsageError("--service must not contain empty service names")
+					}
+				}
 			}
+			filters := shared.SplitCSV(services.String())
 
 			if *watch {
 				return watchDeveloperSystemStatus(ctx, client, endpoint, filters, *issuesOnly, *output.Output, *output.Pretty, *pollInterval, *maxPolls)
@@ -333,6 +344,7 @@ func summarizeDeveloperSystemStatus(services []asc.DeveloperSystemStatusService,
 
 func watchDeveloperSystemStatus(ctx context.Context, client *http.Client, endpoint string, filters []string, issuesOnly bool, output string, pretty bool, pollInterval time.Duration, maxPolls int) error {
 	previous := ""
+	consecutiveFailures := 0
 	for poll := 1; maxPolls == 0 || poll <= maxPolls; poll++ {
 		requestCtx, cancel := shared.ContextWithTimeout(ctx)
 		report, err := fetchDeveloperSystemStatus(requestCtx, client, endpoint)
@@ -341,8 +353,20 @@ func watchDeveloperSystemStatus(ctx context.Context, client *http.Client, endpoi
 			if contextDone(ctx) {
 				return nil
 			}
-			return fmt.Errorf("system-status: %w", err)
+			consecutiveFailures++
+			if consecutiveFailures >= maxWatchFailures || (maxPolls > 0 && poll >= maxPolls) {
+				return fmt.Errorf("system-status: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Warning: system-status poll %d failed (%v); retrying in %s\n", poll, err, pollInterval)
+			if err := waitForPoll(ctx, pollInterval); err != nil {
+				if contextDone(ctx) {
+					return nil
+				}
+				return err
+			}
+			continue
 		}
+		consecutiveFailures = 0
 		report, err = selectDeveloperSystemStatus(report, filters, issuesOnly)
 		if err != nil {
 			return fmt.Errorf("system-status: %w", err)
@@ -352,8 +376,8 @@ func watchDeveloperSystemStatus(ctx context.Context, client *http.Client, endpoi
 		if err != nil {
 			return fmt.Errorf("system-status: encode watch snapshot: %w", err)
 		}
-		if poll == 1 || string(snapshot) != previous {
-			if err := printWatchSnapshot(report, output, pretty, poll > 1); err != nil {
+		if string(snapshot) != previous {
+			if err := printWatchSnapshot(report, output, pretty, previous != ""); err != nil {
 				return err
 			}
 			previous = string(snapshot)
@@ -377,20 +401,7 @@ func printWatchSnapshot(report *asc.DeveloperSystemStatusReport, output string, 
 		format = shared.DefaultOutputFormat()
 	}
 	if format == "json" {
-		var (
-			data []byte
-			err  error
-		)
-		if pretty {
-			data, err = json.MarshalIndent(report, "", "  ")
-		} else {
-			data, err = json.Marshal(report)
-		}
-		if err != nil {
-			return fmt.Errorf("system-status: encode watch snapshot: %w", err)
-		}
-		_, err = fmt.Fprintln(os.Stdout, string(data))
-		return err
+		return shared.PrintOutput(report, format, pretty)
 	}
 	if separator {
 		if format == "markdown" || format == "md" {

--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -209,8 +209,11 @@ func decodeDeveloperSystemStatus(body []byte) (*asc.DeveloperSystemStatusReport,
 			URL:    strings.TrimSpace(rawService.RedirectURL),
 			Events: make([]asc.DeveloperSystemStatusEvent, 0, len(*rawService.Events)),
 		}
-		for _, rawEvent := range *rawService.Events {
-			active := statusEventActive(rawEvent)
+		for eventIndex, rawEvent := range *rawService.Events {
+			active, err := statusEventActive(rawEvent)
+			if err != nil {
+				return nil, fmt.Errorf("service %q event %d has %w", name, eventIndex+1, err)
+			}
 			if active {
 				service.Status = "issues"
 			}
@@ -260,12 +263,18 @@ func unwrapStatusPayload(body []byte) ([]byte, error) {
 	return bytes.TrimSpace(wrapped[:len(wrapped)-1]), nil
 }
 
-func statusEventActive(event statusFeedEvent) bool {
+func statusEventActive(event statusFeedEvent) (bool, error) {
 	status := strings.TrimSpace(event.EventStatus)
-	if strings.EqualFold(status, "ongoing") {
-		return true
+	switch {
+	case status == "":
+		return strings.TrimSpace(event.EndDate) == "" && event.EpochEndDate == nil, nil
+	case strings.EqualFold(status, "ongoing"):
+		return true, nil
+	case strings.EqualFold(status, "resolved"):
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown eventStatus %q", status)
 	}
-	return status == "" && strings.TrimSpace(event.EndDate) == "" && event.EpochEndDate == nil
 }
 
 func normalizeAffectedServices(raw json.RawMessage) string {

--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -85,8 +85,7 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) > 0 {
-				fmt.Fprintln(os.Stderr, "Error: system-status does not accept positional arguments")
-				return flag.ErrHelp
+				return shared.UsageError("system-status does not accept positional arguments")
 			}
 			if *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")
@@ -282,6 +281,19 @@ func normalizeAffectedServices(raw json.RawMessage) string {
 }
 
 func selectDeveloperSystemStatus(report *asc.DeveloperSystemStatusReport, filters []string, issuesOnly bool) (*asc.DeveloperSystemStatusReport, error) {
+	for _, filter := range filters {
+		filterMatched := false
+		for _, service := range report.Services {
+			if matchesServiceFilters(service.Name, []string{filter}) {
+				filterMatched = true
+				break
+			}
+		}
+		if !filterMatched {
+			return nil, shared.UsageErrorf("no services matched --service %q", filter)
+		}
+	}
+
 	matched := make([]asc.DeveloperSystemStatusService, 0, len(report.Services))
 	for _, service := range report.Services {
 		if matchesServiceFilters(service.Name, filters) {

--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -73,6 +73,7 @@ func commandWithClient(client *http.Client, endpoint string) *ffcli.Command {
 
 Use --service to match one or more service-name substrings. Watch mode emits
 the initial snapshot, then emits again only when the selected report changes.
+JSON watch output is newline-delimited and does not support --pretty.
 
 Examples:
   asc system-status
@@ -105,8 +106,12 @@ Examples:
 			if pollIntervalSet && !*watch {
 				return shared.UsageError("--poll-interval requires --watch")
 			}
-			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+			normalizedOutput, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty)
+			if err != nil {
 				return shared.UsageError(err.Error())
+			}
+			if *watch && *output.Pretty && normalizedOutput == "json" {
+				return shared.UsageError("--pretty is not supported with --watch JSON output")
 			}
 
 			serviceFilterSet := false

--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -32,9 +32,9 @@ type statusFeed struct {
 }
 
 type statusFeedService struct {
-	ServiceName string            `json:"serviceName"`
-	RedirectURL string            `json:"redirectUrl"`
-	Events      []statusFeedEvent `json:"events"`
+	ServiceName string             `json:"serviceName"`
+	RedirectURL string             `json:"redirectUrl"`
+	Events      *[]statusFeedEvent `json:"events"`
 }
 
 type statusFeedEvent struct {
@@ -199,14 +199,17 @@ func decodeDeveloperSystemStatus(body []byte) (*asc.DeveloperSystemStatusReport,
 		if name == "" {
 			return nil, fmt.Errorf("service %d has no name", index+1)
 		}
+		if rawService.Events == nil {
+			return nil, fmt.Errorf("service %q is missing events", name)
+		}
 
 		service := asc.DeveloperSystemStatusService{
 			Name:   name,
 			Status: "operational",
 			URL:    strings.TrimSpace(rawService.RedirectURL),
-			Events: make([]asc.DeveloperSystemStatusEvent, 0, len(rawService.Events)),
+			Events: make([]asc.DeveloperSystemStatusEvent, 0, len(*rawService.Events)),
 		}
-		for _, rawEvent := range rawService.Events {
+		for _, rawEvent := range *rawService.Events {
 			active := statusEventActive(rawEvent)
 			if active {
 				service.Status = "issues"

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -464,3 +464,10 @@ func TestDecodeDeveloperSystemStatusRejectsMissingOrNullEvents(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeDeveloperSystemStatusRejectsUnknownEventStatus(t *testing.T) {
+	_, err := decodeDeveloperSystemStatus([]byte(`{"services":[{"serviceName":"TestFlight","events":[{"eventStatus":"investigating"}]}]}`))
+	if err == nil || !strings.Contains(err.Error(), `service "TestFlight" event 1 has unknown eventStatus "investigating"`) {
+		t.Fatalf("decode error = %v, want unknown-event-status failure", err)
+	}
+}

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -12,8 +12,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 const healthyAndOutagePayload = `jsonCallback({
@@ -152,6 +155,8 @@ func TestSystemStatusCommandRejectsInvalidArguments(t *testing.T) {
 		{name: "max polls without watch", args: []string{"--max-polls", "2"}, want: "--max-polls requires --watch"},
 		{name: "poll interval without watch", args: []string{"--poll-interval", "1s"}, want: "--poll-interval requires --watch"},
 		{name: "invalid output before network", args: []string{"--output", "yaml"}, want: "unsupported format: yaml"},
+		{name: "empty service", args: []string{"--service", ""}, want: "--service must not contain empty service names"},
+		{name: "trailing empty service", args: []string{"--service", "TestFlight, "}, want: "--service must not contain empty service names"},
 	}
 
 	for _, test := range tests {
@@ -207,6 +212,59 @@ func TestSystemStatusCommandWatchPrintsOnlyChanges(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &report); err != nil {
 			t.Fatalf("line %d is not JSON: %v\n%s", index, err, line)
 		}
+	}
+}
+
+func TestSystemStatusCommandWatchRetriesTransientFailures(t *testing.T) {
+	var requests atomic.Int32
+	healthy := `{"drMessage":null,"services":[{"serviceName":"App Store Connect API","redirectUrl":null,"events":[]}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = io.WriteString(w, healthy)
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := runCommand(t, server.Client(), server.URL,
+		"--watch", "--poll-interval", "1ms", "--max-polls", "2", "--output", "json")
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+	if !strings.Contains(stderr, "poll 1 failed") || !strings.Contains(stderr, "retrying in 1ms") {
+		t.Fatalf("stderr = %q, want retry warning", stderr)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("watch output is not JSON: %v\n%s", err, stdout)
+	}
+}
+
+func TestSystemStatusCommandWatchStopsAfterRepeatedFailures(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := runCommand(t, server.Client(), server.URL,
+		"--watch", "--poll-interval", "1ms", "--output", "json")
+	if err == nil {
+		t.Fatal("run error = nil, want repeated failure")
+	}
+	if requests.Load() != maxWatchFailures {
+		t.Fatalf("requests = %d, want %d", requests.Load(), maxWatchFailures)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if warnings := strings.Count(stderr, "retrying in 1ms"); warnings != maxWatchFailures-1 {
+		t.Fatalf("retry warnings = %d, want %d; stderr=%q", warnings, maxWatchFailures-1, stderr)
 	}
 }
 
@@ -271,29 +329,89 @@ func runCommand(t *testing.T, client *http.Client, endpoint string, args ...stri
 		os.Stderr = originalStderr
 	}()
 
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+	copyErrors := make(chan error, 2)
+	var copies sync.WaitGroup
+	copies.Add(2)
+	go func() {
+		defer copies.Done()
+		_, err := io.Copy(&stdoutBuffer, stdoutReader)
+		copyErrors <- err
+	}()
+	go func() {
+		defer copies.Done()
+		_, err := io.Copy(&stderrBuffer, stderrReader)
+		copyErrors <- err
+	}()
+
 	runErr = command.Run(context.Background())
 	_ = stdoutWriter.Close()
 	_ = stderrWriter.Close()
-
-	var stdoutBuffer bytes.Buffer
-	var stderrBuffer bytes.Buffer
-	if _, err := io.Copy(&stdoutBuffer, stdoutReader); err != nil {
-		t.Fatalf("read stdout: %v", err)
-	}
-	if _, err := io.Copy(&stderrBuffer, stderrReader); err != nil {
-		t.Fatalf("read stderr: %v", err)
+	copies.Wait()
+	close(copyErrors)
+	for err := range copyErrors {
+		if err != nil {
+			t.Fatalf("capture command output: %v", err)
+		}
 	}
 	return stdoutBuffer.String(), stderrBuffer.String(), runErr
 }
 
-func TestDecodePlainJSON(t *testing.T) {
-	payload := []byte(`{"drMessage":"Maintenance window","services":[{"serviceName":"TestFlight","redirectUrl":null,"events":[]}]}`)
-	report, err := decodeDeveloperSystemStatus(payload)
-	if err != nil {
-		t.Fatalf("decode error: %v", err)
+func TestDecodeDeveloperSystemStatusFeedShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   []byte
+		assert func(*testing.T, *asc.DeveloperSystemStatusReport)
+	}{
+		{
+			name: "plain JSON",
+			body: []byte(`{"drMessage":"Maintenance window","services":[{"serviceName":"TestFlight","redirectUrl":null,"events":[]}]}`),
+			assert: func(t *testing.T, report *asc.DeveloperSystemStatusReport) {
+				if report.Message != "Maintenance window" || report.Summary.Status != "issues" {
+					t.Fatalf("unexpected report: %#v", report)
+				}
+			},
+		},
+		{
+			name: "UTF-8 BOM",
+			body: append([]byte{0xef, 0xbb, 0xbf}, []byte(`{"services":[{"serviceName":"TestFlight","events":[]}]}`)...),
+			assert: func(t *testing.T, report *asc.DeveloperSystemStatusReport) {
+				if len(report.Services) != 1 || report.Services[0].Name != "TestFlight" {
+					t.Fatalf("unexpected services: %#v", report.Services)
+				}
+			},
+		},
+		{
+			name: "affected services array",
+			body: []byte(`{"services":[{"serviceName":"Xcode Cloud","events":[{"eventStatus":"ongoing","affectedServices":["App Store","TestFlight"]}]}]}`),
+			assert: func(t *testing.T, report *asc.DeveloperSystemStatusReport) {
+				got := report.Services[0].Events[0].AffectedServices
+				if got != "App Store, TestFlight" {
+					t.Fatalf("affected services = %q, want %q", got, "App Store, TestFlight")
+				}
+			},
+		},
+		{
+			name: "resolved event",
+			body: []byte(`{"services":[{"serviceName":"TestFlight","events":[{"eventStatus":"resolved","epochEndDate":1787086740000}]}]}`),
+			assert: func(t *testing.T, report *asc.DeveloperSystemStatusReport) {
+				service := report.Services[0]
+				if service.Status != "operational" || service.Events[0].Active {
+					t.Fatalf("resolved service = %#v, want inactive operational event", service)
+				}
+			},
+		},
 	}
-	if report.Message != "Maintenance window" || report.Summary.Status != "issues" {
-		t.Fatalf("unexpected report: %#v", report)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			report, err := decodeDeveloperSystemStatus(test.body)
+			if err != nil {
+				t.Fatalf("decode error: %v", err)
+			}
+			test.assert(t, report)
+		})
 	}
 }
 

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -452,3 +452,15 @@ func TestFetchDeveloperSystemStatusRejectsOversizedBody(t *testing.T) {
 		t.Fatalf("error = %v, want oversized response error", err)
 	}
 }
+
+func TestDecodeDeveloperSystemStatusRejectsMissingOrNullEvents(t *testing.T) {
+	for _, body := range []string{
+		`{"services":[{"serviceName":"TestFlight"}]}`,
+		`{"services":[{"serviceName":"TestFlight","events":null}]}`,
+	} {
+		_, err := decodeDeveloperSystemStatus([]byte(body))
+		if err == nil || !strings.Contains(err.Error(), `service "TestFlight" is missing events`) {
+			t.Fatalf("decode error = %v, want missing-events failure for %s", err, body)
+		}
+	}
+}

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -1,0 +1,310 @@
+package systemstatus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+const healthyAndOutagePayload = `jsonCallback({
+  "drMessage": null,
+  "services": [
+    {
+      "serviceName": "App Store Connect API",
+      "redirectUrl": "https://developer.apple.com/app-store-connect/api/",
+      "events": [{
+        "messageId": "2000005599",
+        "statusType": "Outage",
+        "message": "Users are experiencing a problem with this service.",
+        "datePosted": "08/18/2026 13:01 PDT",
+        "startDate": "08/18/2026 12:59 PDT",
+        "endDate": null,
+        "epochStartDate": 1787083140000,
+        "epochEndDate": null,
+        "usersAffected": "Some users are affected",
+        "affectedServices": null,
+        "eventStatus": "ongoing"
+      }]
+    },
+    {
+      "serviceName": "TestFlight",
+      "redirectUrl": null,
+      "events": []
+    }
+  ]
+});`
+
+func TestSystemStatusCommandJSONFiltersServices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if got := r.Header.Get("Accept"); !strings.Contains(got, "application/json") {
+			t.Fatalf("Accept = %q, want JSON support", got)
+		}
+		_, _ = io.WriteString(w, healthyAndOutagePayload)
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := runCommand(t, server.Client(), server.URL,
+		"--service", "App Store Connect API", "--output", "json")
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var report struct {
+		Source  string `json:"source"`
+		Summary struct {
+			Status              string `json:"status"`
+			TotalServices       int    `json:"totalServices"`
+			OperationalServices int    `json:"operationalServices"`
+			AffectedServices    int    `json:"affectedServices"`
+			ActiveIncidents     int    `json:"activeIncidents"`
+		} `json:"summary"`
+		Services []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Events []struct {
+				Active bool `json:"active"`
+			} `json:"events"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, stdout)
+	}
+	if report.Source != statusPageURL {
+		t.Fatalf("source = %q, want %q", report.Source, statusPageURL)
+	}
+	if report.Summary.Status != "issues" || report.Summary.TotalServices != 1 ||
+		report.Summary.AffectedServices != 1 || report.Summary.OperationalServices != 0 ||
+		report.Summary.ActiveIncidents != 1 {
+		t.Fatalf("unexpected summary: %#v", report.Summary)
+	}
+	if len(report.Services) != 1 || report.Services[0].Name != "App Store Connect API" ||
+		report.Services[0].Status != "issues" || len(report.Services[0].Events) != 1 ||
+		!report.Services[0].Events[0].Active {
+		t.Fatalf("unexpected services: %#v", report.Services)
+	}
+}
+
+func TestSystemStatusCommandIssuesOnlyRetainsMatchedSummary(t *testing.T) {
+	server := statusServer(t, healthyAndOutagePayload)
+	defer server.Close()
+
+	stdout, _, err := runCommand(t, server.Client(), server.URL, "--issues-only", "--output", "json")
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	var report struct {
+		Summary struct {
+			TotalServices       int `json:"totalServices"`
+			OperationalServices int `json:"operationalServices"`
+			AffectedServices    int `json:"affectedServices"`
+		} `json:"summary"`
+		Services []struct {
+			Name string `json:"name"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if report.Summary.TotalServices != 2 || report.Summary.OperationalServices != 1 || report.Summary.AffectedServices != 1 {
+		t.Fatalf("unexpected summary: %#v", report.Summary)
+	}
+	if len(report.Services) != 1 || report.Services[0].Name != "App Store Connect API" {
+		t.Fatalf("unexpected services: %#v", report.Services)
+	}
+}
+
+func TestSystemStatusCommandRejectsUnknownService(t *testing.T) {
+	server := statusServer(t, healthyAndOutagePayload)
+	defer server.Close()
+
+	_, _, err := runCommand(t, server.Client(), server.URL, "--service", "No Such Service", "--output", "json")
+	if err == nil || !strings.Contains(err.Error(), `no services matched --service "No Such Service"`) {
+		t.Fatalf("error = %v, want no-match error", err)
+	}
+}
+
+func TestSystemStatusCommandRejectsInvalidArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "positional", args: []string{"App Store Connect"}, want: "does not accept positional arguments"},
+		{name: "non-positive interval", args: []string{"--watch", "--poll-interval", "0s"}, want: "--poll-interval must be greater than 0"},
+		{name: "negative max polls", args: []string{"--watch", "--max-polls", "-1"}, want: "--max-polls must be greater than or equal to 0"},
+		{name: "max polls without watch", args: []string{"--max-polls", "2"}, want: "--max-polls requires --watch"},
+		{name: "poll interval without watch", args: []string{"--poll-interval", "1s"}, want: "--poll-interval requires --watch"},
+		{name: "invalid output before network", args: []string{"--output", "yaml"}, want: "unsupported format: yaml"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, stderr, err := runCommand(t, http.DefaultClient, "http://127.0.0.1:1", test.args...)
+			if err == nil {
+				t.Fatalf("error = nil, want %q", test.want)
+			}
+			if test.name == "positional" {
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("positional error = %v, want flag.ErrHelp", err)
+				}
+				if !strings.Contains(stderr, test.want) {
+					t.Fatalf("stderr = %q, want %q", stderr, test.want)
+				}
+			} else if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSystemStatusCommandWatchPrintsOnlyChanges(t *testing.T) {
+	var requests atomic.Int32
+	healthy := `{"drMessage":null,"services":[{"serviceName":"App Store Connect API","redirectUrl":null,"events":[]}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		poll := requests.Add(1)
+		if poll < 3 {
+			_, _ = io.WriteString(w, healthy)
+			return
+		}
+		_, _ = io.WriteString(w, healthyAndOutagePayload)
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := runCommand(t, server.Client(), server.URL,
+		"--service", "App Store Connect API", "--watch", "--poll-interval", "1ms", "--max-polls", "3", "--output", "json")
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("watch lines = %d, want 2; output=%q", len(lines), stdout)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("requests = %d, want 3", requests.Load())
+	}
+	for index, line := range lines {
+		var report map[string]any
+		if err := json.Unmarshal([]byte(line), &report); err != nil {
+			t.Fatalf("line %d is not JSON: %v\n%s", index, err, line)
+		}
+	}
+}
+
+func TestFetchDeveloperSystemStatusErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       string
+	}{
+		{name: "http", statusCode: http.StatusServiceUnavailable, body: "unavailable", want: "HTTP 503"},
+		{name: "unknown wrapper", statusCode: http.StatusOK, body: `otherCallback({"services":[]})`, want: "unsupported response wrapper"},
+		{name: "invalid JSON", statusCode: http.StatusOK, body: `jsonCallback({)`, want: "decode response"},
+		{name: "empty services", statusCode: http.StatusOK, body: `{"services":[]}`, want: "contained no services"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.statusCode)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+
+			_, err := fetchDeveloperSystemStatus(context.Background(), server.Client(), server.URL)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func statusServer(t *testing.T, payload string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, payload)
+	}))
+}
+
+func runCommand(t *testing.T, client *http.Client, endpoint string, args ...string) (stdout string, stderr string, runErr error) {
+	t.Helper()
+	command := commandWithClient(client, endpoint)
+	command.FlagSet.SetOutput(io.Discard)
+	if err := command.Parse(args); err != nil {
+		return "", "", err
+	}
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	}()
+
+	runErr = command.Run(context.Background())
+	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
+
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+	if _, err := io.Copy(&stdoutBuffer, stdoutReader); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if _, err := io.Copy(&stderrBuffer, stderrReader); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return stdoutBuffer.String(), stderrBuffer.String(), runErr
+}
+
+func TestDecodePlainJSON(t *testing.T) {
+	payload := []byte(`{"drMessage":"Maintenance window","services":[{"serviceName":"TestFlight","redirectUrl":null,"events":[]}]}`)
+	report, err := decodeDeveloperSystemStatus(payload)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if report.Message != "Maintenance window" || report.Summary.Status != "issues" {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+}
+
+func TestFetchDeveloperSystemStatusRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, strings.Repeat("x", maxStatusResponseBytes+1))
+	}))
+	defer server.Close()
+
+	_, err := fetchDeveloperSystemStatus(context.Background(), server.Client(), server.URL)
+	if err == nil || !strings.Contains(err.Error(), "response exceeds") {
+		t.Fatalf("error = %v, want oversized response error", err)
+	}
+}

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -47,6 +47,15 @@ const healthyAndOutagePayload = `jsonCallback({
   ]
 });`
 
+type countingTransport struct {
+	requests atomic.Int32
+}
+
+func (transport *countingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	transport.requests.Add(1)
+	return nil, errors.New("unexpected HTTP request")
+}
+
 func TestSystemStatusCommandJSONFiltersServices(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -161,7 +170,9 @@ func TestSystemStatusCommandRejectsInvalidArguments(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, stderr, err := runCommand(t, http.DefaultClient, "http://127.0.0.1:1", test.args...)
+			transport := &countingTransport{}
+			client := &http.Client{Transport: transport}
+			_, stderr, err := runCommand(t, client, "https://example.invalid", test.args...)
 			if err == nil {
 				t.Fatalf("error = nil, want %q", test.want)
 			}
@@ -172,8 +183,19 @@ func TestSystemStatusCommandRejectsInvalidArguments(t *testing.T) {
 				if !strings.Contains(stderr, test.want) {
 					t.Fatalf("stderr = %q, want %q", stderr, test.want)
 				}
-			} else if !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("error = %v, want %q", err, test.want)
+			} else {
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want flag.ErrHelp classification", err)
+				}
+				if err.Error() != test.want {
+					t.Fatalf("error = %q, want %q", err.Error(), test.want)
+				}
+				if wantStderr := "Error: " + test.want + "\n"; stderr != wantStderr {
+					t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
+				}
+			}
+			if requests := transport.requests.Load(); requests != 0 {
+				t.Fatalf("HTTP requests = %d, want 0", requests)
 			}
 		})
 	}

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -146,9 +146,19 @@ func TestSystemStatusCommandRejectsUnknownService(t *testing.T) {
 	server := statusServer(t, healthyAndOutagePayload)
 	defer server.Close()
 
-	_, _, err := runCommand(t, server.Client(), server.URL, "--service", "No Such Service", "--output", "json")
-	if err == nil || !strings.Contains(err.Error(), `no services matched --service "No Such Service"`) {
-		t.Fatalf("error = %v, want no-match error", err)
+	for _, test := range []struct {
+		filter string
+		want   string
+	}{
+		{filter: "No Such Service", want: `no services matched --service "No Such Service"`},
+		{filter: "TestFlight,Unknown", want: `no services matched --service "Unknown"`},
+	} {
+		t.Run(test.filter, func(t *testing.T) {
+			_, _, err := runCommand(t, server.Client(), server.URL, "--service", test.filter, "--output", "json")
+			if err == nil || !errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want classified error containing %q", err, test.want)
+			}
+		})
 	}
 }
 
@@ -158,7 +168,7 @@ func TestSystemStatusCommandRejectsInvalidArguments(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "positional", args: []string{"App Store Connect"}, want: "does not accept positional arguments"},
+		{name: "positional", args: []string{"App Store Connect"}, want: "system-status does not accept positional arguments"},
 		{name: "non-positive interval", args: []string{"--watch", "--poll-interval", "0s"}, want: "--poll-interval must be greater than 0"},
 		{name: "negative max polls", args: []string{"--watch", "--max-polls", "-1"}, want: "--max-polls must be greater than or equal to 0"},
 		{name: "max polls without watch", args: []string{"--max-polls", "2"}, want: "--max-polls requires --watch"},
@@ -177,23 +187,14 @@ func TestSystemStatusCommandRejectsInvalidArguments(t *testing.T) {
 			if err == nil {
 				t.Fatalf("error = nil, want %q", test.want)
 			}
-			if test.name == "positional" {
-				if !errors.Is(err, flag.ErrHelp) {
-					t.Fatalf("positional error = %v, want flag.ErrHelp", err)
-				}
-				if !strings.Contains(stderr, test.want) {
-					t.Fatalf("stderr = %q, want %q", stderr, test.want)
-				}
-			} else {
-				if !errors.Is(err, flag.ErrHelp) {
-					t.Fatalf("error = %v, want flag.ErrHelp classification", err)
-				}
-				if err.Error() != test.want {
-					t.Fatalf("error = %q, want %q", err.Error(), test.want)
-				}
-				if wantStderr := "Error: " + test.want + "\n"; stderr != wantStderr {
-					t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
-				}
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("error = %v, want flag.ErrHelp classification", err)
+			}
+			if err.Error() != test.want {
+				t.Fatalf("error = %q, want %q", err.Error(), test.want)
+			}
+			if wantStderr := "Error: " + test.want + "\n"; stderr != wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
 			}
 			if requests := transport.requests.Load(); requests != 0 {
 				t.Fatalf("HTTP requests = %d, want 0", requests)
@@ -372,6 +373,8 @@ func runCommand(t *testing.T, client *http.Client, endpoint string, args ...stri
 	_ = stdoutWriter.Close()
 	_ = stderrWriter.Close()
 	copies.Wait()
+	_ = stdoutReader.Close()
+	_ = stderrReader.Close()
 	close(copyErrors)
 	for err := range copyErrors {
 		if err != nil {

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -164,6 +164,7 @@ func TestSystemStatusCommandRejectsInvalidArguments(t *testing.T) {
 		{name: "max polls without watch", args: []string{"--max-polls", "2"}, want: "--max-polls requires --watch"},
 		{name: "poll interval without watch", args: []string{"--poll-interval", "1s"}, want: "--poll-interval requires --watch"},
 		{name: "invalid output before network", args: []string{"--output", "yaml"}, want: "unsupported format: yaml"},
+		{name: "pretty JSON watch", args: []string{"--watch", "--output", "json", "--pretty"}, want: "--pretty is not supported with --watch JSON output"},
 		{name: "empty service", args: []string{"--service", ""}, want: "--service must not contain empty service names"},
 		{name: "trailing empty service", args: []string{"--service", "TestFlight, "}, want: "--service must not contain empty service names"},
 	}


### PR DESCRIPTION
## Summary

- add an auth-free `asc system-status` command backed by Apple's public Developer System Status feed
- support case-insensitive service filters, `--issues-only`, changed-only `--watch` polling, bounded `--max-polls`, and JSON/table/Markdown output
- make the capability agent-discoverable through generated `ASC.md` guidance and timeout/5xx diagnostics
- document the command, feed contract, compatibility decision, and alternatives

## Why this shape

`asc status` is already the authenticated app release dashboard, while root `asc doctor` is an established authentication diagnostic. A separate command remains usable during App Store Connect failures without changing either existing contract or making every failed request perform a hidden second network call.

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/cli/systemstatus`
- `make build`
- built-binary checks for help, JSON/table output, stdout/stderr and exit codes, service filtering, unchanged bounded watch output, and invalid/no-match usage
- live read-only verification against Apple's feed: App Store Connect API reported operational while the active Xcode Cloud outage was surfaced correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the experimental, unauthenticated `system-status` command for checking Apple Developer service health.
  - Supports service and issue filtering, watch/polling mode, multiple output formats, and detailed incident information.
  - Added outage guidance to relevant timeout and server-error messages.

- **Documentation**
  - Added command reference, usage examples, troubleshooting guidance, navigation entries, and architecture documentation.

- **Tests**
  - Added coverage for filtering, validation, watch mode, output formats, feed decoding, oversized responses, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->