### PR TITLE
Set TestFlight notes as soon as builds appear

### DIFF
--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -32,7 +32,7 @@ func BuildsUploadCommand() *ffcli.Command {
 	dryRun := fs.Bool("dry-run", false, "Reserve upload operations without uploading the file")
 	concurrency := fs.Int("concurrency", asc.DefaultUploadConcurrency, "Upload concurrency")
 	verifyChecksum := fs.Bool("checksum", false, "Verify upload checksums if provided by API")
-	testNotes := fs.String("test-notes", "", "What to Test notes (requires build processing)")
+	testNotes := fs.String("test-notes", "", "What to Test notes (waits for build discovery)")
 	locale := fs.String("locale", "", "Locale for --test-notes (e.g., en-US)")
 	wait := fs.Bool("wait", false, "Wait for build processing to complete")
 	pollInterval := fs.Duration("poll-interval", shared.PublishDefaultPollInterval, "Polling interval for --wait and --test-notes")
@@ -50,6 +50,9 @@ By default, this command uploads the IPA/PKG to the presigned URLs and commits
 the file immediately. Use --verify-timeout to briefly watch for immediate
 post-commit processing failures, or --wait for full build discovery and
 processing.
+When --test-notes is set, the command waits only until the build appears, then
+creates or updates the requested localization. Add --wait when the invocation
+must also wait for processing to complete.
 Use --dry-run to only reserve the upload operations.
 Presigned URLs and request-header values are redacted from output by default.
 Pass --include-sensitive only when another tool must consume those capabilities.
@@ -62,7 +65,7 @@ Examples:
   asc builds upload --ipa "app.ipa" --version "1.0.0" --build-number "123"
   asc builds upload --app "123456789" --ipa "app.ipa" --dry-run
   asc builds upload --app "123456789" --ipa "app.ipa" --dry-run --include-sensitive
-  asc builds upload --app "123456789" --ipa "app.ipa" --test-notes "Test flow" --locale "en-US" --wait
+  asc builds upload --app "123456789" --ipa "app.ipa" --test-notes "Test flow" --locale "en-US"
   asc builds upload --app "123456789" --pkg "path/to/app.pkg" --version "1.0.0" --build-number "123"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -351,14 +354,16 @@ Examples:
 						return fmt.Errorf("builds upload: failed to resolve build for version %q build %q", versionValue, buildNumberValue)
 					}
 
-					fmt.Fprintf(os.Stderr, "Build %s discovered; waiting for processing...\n", buildResp.Data.ID)
-					buildResp, err = client.WaitForBuildProcessing(requestCtx, buildResp.Data.ID, *pollInterval)
-					if err != nil {
-						return fmt.Errorf("builds upload: %w", err)
+					if testNotesValue != "" {
+						fmt.Fprintf(os.Stderr, "Build %s discovered; setting What to Test notes...\n", buildResp.Data.ID)
+						if _, err := shared.UpsertBetaBuildLocalization(requestCtx, client, buildResp.Data.ID, localeValue, testNotesValue); err != nil {
+							return fmt.Errorf("builds upload: %w", err)
+						}
 					}
 
-					if testNotesValue != "" {
-						if _, err := shared.UpsertBetaBuildLocalization(requestCtx, client, buildResp.Data.ID, localeValue, testNotesValue); err != nil {
+					if *wait {
+						fmt.Fprintf(os.Stderr, "Build %s discovered; waiting for processing...\n", buildResp.Data.ID)
+						if _, err := client.WaitForBuildProcessing(requestCtx, buildResp.Data.ID, *pollInterval); err != nil {
 							return fmt.Errorf("builds upload: %w", err)
 						}
 					}

--- a/internal/cli/builds/builds_commands_test.go
+++ b/internal/cli/builds/builds_commands_test.go
@@ -89,6 +89,20 @@ func TestBuildsUploadCommandAppHelpDescribesExactIPAIdentityLookup(t *testing.T)
 	}
 }
 
+func TestBuildsUploadCommandTestNotesHelpDescribesDiscoveryOnlyWait(t *testing.T) {
+	cmd := BuildsUploadCommand()
+	testNotesFlag := cmd.FlagSet.Lookup("test-notes")
+	if testNotesFlag == nil {
+		t.Fatal("expected --test-notes flag to be registered")
+	}
+	if !strings.Contains(testNotesFlag.Usage, "build discovery") {
+		t.Fatalf("expected --test-notes usage to describe discovery wait, got %q", testNotesFlag.Usage)
+	}
+	if !strings.Contains(cmd.LongHelp, "Add --wait") {
+		t.Fatalf("expected long help to explain the optional processing wait, got %q", cmd.LongHelp)
+	}
+}
+
 func TestBuildsListCommand_ProcessingStateFlagDescription(t *testing.T) {
 	cmd := BuildsListCommand()
 

--- a/internal/cli/cmdtest/builds_upload_wait_test.go
+++ b/internal/cli/cmdtest/builds_upload_wait_test.go
@@ -249,6 +249,87 @@ func TestBuildsUploadWithoutWaitSkipsPostCommitVerificationByDefault(t *testing.
 	}
 }
 
+func TestBuildsUploadTestNotesWritesBeforeProcessingCompletes(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	buildReads := 0
+	localizationCreated := false
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":4,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":4,"offset":0,"requestHeaders":[{"name":"Content-Type","value":"application/octet-stream"}]}]}}}`)
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"uploaded":true}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-1":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","relationships":{"build":{"data":{"type":"builds","id":"build-1"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/build-1":
+			buildReads++
+			if buildReads > 1 {
+				return nil, http.ErrUseLastResponse
+			}
+			return jsonResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"PROCESSING"}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/build-1/betaBuildLocalizations":
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/betaBuildLocalizations":
+			localizationCreated = true
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"betaBuildLocalizations","id":"loc-1","attributes":{"locale":"en-US","whatsNew":"Test the new flow"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "upload",
+			"--app", "123456789",
+			"--ipa", ipaPath,
+			"--version", "1.0.0",
+			"--build-number", "42",
+			"--test-notes", "Test the new flow",
+			"--locale", "en-US",
+			"--poll-interval", "1ms",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr != nil {
+		t.Fatalf("expected test notes to be written after discovery, got %v", runErr)
+	}
+	if buildReads != 1 {
+		t.Fatalf("expected one build read for discovery, got %d", buildReads)
+	}
+	if !localizationCreated {
+		t.Fatal("expected beta build localization to be created")
+	}
+	if !strings.Contains(stderr, "Build build-1 discovered; setting What to Test notes...") {
+		t.Fatalf("expected note progress on stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"uploadId":"upload-1"`) {
+		t.Fatalf("expected JSON output with upload ID, got %q", stdout)
+	}
+}
+
 func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))


### PR DESCRIPTION
## What changed

- Write `--test-notes` immediately after the uploaded build is discovered.
- Wait for full processing only when `--wait` is explicitly set.
- Clarify the command help and example.

## Why

App Store Connect exposes the build record before full processing finishes, and beta build localizations can be created or updated at that point. The upload command unnecessarily waited for processing whenever notes were supplied, increasing CI time.

## Compatibility

No flags or output schemas changed. Existing commands with `--test-notes` finish earlier unless they explicitly pass `--wait`.

## Validation

- Added a CLI/HTTP regression test that fails if the command polls processing before writing notes.
- Added command-help coverage.
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built the CLI and manually checked `asc builds upload --help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated build upload behavior so `--test-notes` waits for build discovery before updating localization notes.
  * Added optional processing completion waiting through the separate `--wait` option.
  * Improved command help text and examples to clarify these options.

* **Bug Fixes**
  * Preserved the existing build response when processing wait errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->