### PR TITLE
Detect the platform declared by IPA uploads

### DIFF
--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -28,7 +28,7 @@ func BuildsUploadCommand() *ffcli.Command {
 	pkgPath := fs.String("pkg", "", "Path to .pkg file (for macOS apps)")
 	version := fs.String("version", "", "CFBundleShortVersionString (e.g., 1.0.0, auto-extracted from IPA if not provided)")
 	buildNumber := fs.String("build-number", "", "CFBundleVersion (e.g., 123, auto-extracted from IPA if not provided)")
-	platform := fs.String("platform", "", "Platform: IOS, MAC_OS, TV_OS, VISION_OS (auto-detected for --pkg)")
+	platform := fs.String("platform", "", "Platform: IOS, MAC_OS, TV_OS, VISION_OS (auto-detected for --ipa and --pkg)")
 	dryRun := fs.Bool("dry-run", false, "Reserve upload operations without uploading the file")
 	concurrency := fs.Int("concurrency", asc.DefaultUploadConcurrency, "Upload concurrency")
 	verifyChecksum := fs.Bool("checksum", false, "Verify upload checksums if provided by API")
@@ -54,8 +54,10 @@ Use --dry-run to only reserve the upload operations.
 Presigned URLs and request-header values are redacted from output by default.
 Pass --include-sensitive only when another tool must consume those capabilities.
 
-Use --ipa for iOS, tvOS, and visionOS apps. Use --pkg for macOS apps.
-When using --pkg, the platform is automatically set to MAC_OS.
+Use --ipa for iOS, tvOS, and visionOS apps. Its platform is detected from the
+top-level app Info.plist when available, with IOS retained as the compatibility
+default for older archives without platform metadata. Use --pkg for macOS apps;
+its platform is automatically set to MAC_OS.
 
 Examples:
   asc builds upload --app "123456789" --ipa "path/to/app.ipa"
@@ -132,7 +134,8 @@ Examples:
 				}
 				platformValue = asc.PlatformMacOS
 			} else {
-				// For IPA files, default to IOS if not specified
+				// For IPA files, retain IOS as the compatibility default until
+				// metadata inspection can provide a more specific platform.
 				platformStr := strings.ToUpper(*platform)
 				if platformStr == "" {
 					platformStr = "IOS"
@@ -205,6 +208,12 @@ Examples:
 				}
 				if buildNumberValue == "" {
 					buildNumberValue = ipaInfo.BuildNumber
+				}
+				if ipaInfo.Platform != "" {
+					if strings.TrimSpace(*platform) != "" && platformValue != ipaInfo.Platform {
+						return fmt.Errorf("builds upload: --platform %s does not match IPA platform %s", platformValue, ipaInfo.Platform)
+					}
+					platformValue = ipaInfo.Platform
 				}
 			} else if versionValue == "" || buildNumberValue == "" {
 				// PKG files require explicit version and build number

--- a/internal/cli/cmdtest/builds_upload_identity_test.go
+++ b/internal/cli/cmdtest/builds_upload_identity_test.go
@@ -69,6 +69,82 @@ func TestBuildsUploadResolvesExactBundleIDAndChecksIPAIdentityBeforeReservation(
 	}
 }
 
+func TestBuildsUploadAutoDetectsIPAPlatformBeforeReservation(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	ipaPath := writeBuildUploadIPAWithPlatform(t, "com.example.demo", "appletvos", []string{"AppleTVOS"})
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read reservation request: %v", err)
+			}
+			if !strings.Contains(string(body), `"platform":"TV_OS"`) {
+				t.Fatalf("expected auto-detected TV_OS platform in reservation body: %s", body)
+			}
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"TV_OS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":1,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[]}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"builds", "upload",
+		"--app", "123456789",
+		"--ipa", ipaPath,
+		"--dry-run",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if err := root.Run(context.Background()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+}
+
+func TestBuildsUploadRejectsExplicitIPAPlatformMismatchBeforeNetwork(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	ipaPath := writeBuildUploadIPAWithPlatform(t, "com.example.demo", "xros", []string{"XROS"})
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"builds", "upload",
+		"--app", "123456789",
+		"--ipa", ipaPath,
+		"--platform", "IOS",
+		"--dry-run",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected platform mismatch error")
+	}
+	if !strings.Contains(err.Error(), "--platform IOS does not match IPA platform VISION_OS") {
+		t.Fatalf("unexpected mismatch error: %v", err)
+	}
+}
+
 func TestBuildsUploadRejectsMissingOrAmbiguousExactAppBeforeReservation(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -220,11 +296,18 @@ func TestBuildsUploadRequiresTopLevelIPABundleIDBeforeAppLookup(t *testing.T) {
 
 func writeBuildUploadIPA(t *testing.T, bundleID string) string {
 	t.Helper()
+	return writeBuildUploadIPAWithPlatform(t, bundleID, "", nil)
+}
+
+func writeBuildUploadIPAWithPlatform(t *testing.T, bundleID, platformName string, supportedPlatforms []string) string {
+	t.Helper()
 
 	plistData, err := plist.Marshal(map[string]any{
 		"CFBundleIdentifier":         bundleID,
 		"CFBundleShortVersionString": "1.0.0",
 		"CFBundleVersion":            "42",
+		"DTPlatformName":             platformName,
+		"CFBundleSupportedPlatforms": supportedPlatforms,
 	}, plist.XMLFormat)
 	if err != nil {
 		t.Fatalf("marshal Info.plist: %v", err)

--- a/internal/cli/shared/ipa.go
+++ b/internal/cli/shared/ipa.go
@@ -10,6 +10,7 @@ import (
 
 	"howett.net/plist"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
 )
 
@@ -17,6 +18,7 @@ type IPABundleInfo struct {
 	BundleID    string
 	Version     string
 	BuildNumber string
+	Platform    asc.Platform
 }
 
 // ValidateIPAPath ensures an IPA path points to a regular file and rejects
@@ -95,11 +97,79 @@ func readBundleInfoFromInfoPlist(file *zip.File) (IPABundleInfo, error) {
 		return IPABundleInfo{}, fmt.Errorf("decode Info.plist: %w", err)
 	}
 
+	platform, err := detectIPAPlatform(info)
+	if err != nil {
+		return IPABundleInfo{}, err
+	}
+
 	return IPABundleInfo{
 		BundleID:    coercePlistValueToString(info["CFBundleIdentifier"]),
 		Version:     coercePlistValueToString(info["CFBundleShortVersionString"]),
 		BuildNumber: coercePlistValueToString(info["CFBundleVersion"]),
+		Platform:    platform,
 	}, nil
+}
+
+func detectIPAPlatform(info map[string]any) (asc.Platform, error) {
+	type platformMarker struct {
+		key   string
+		value string
+	}
+
+	markers := make([]platformMarker, 0, 3)
+	if value := coercePlistValueToString(info["DTPlatformName"]); value != "" {
+		markers = append(markers, platformMarker{key: "DTPlatformName", value: value})
+	}
+	for _, value := range plistStringValues(info["CFBundleSupportedPlatforms"]) {
+		markers = append(markers, platformMarker{key: "CFBundleSupportedPlatforms", value: value})
+	}
+
+	var detected asc.Platform
+	for _, marker := range markers {
+		platform, ok := appStorePlatformForIPA(marker.value)
+		if !ok {
+			return "", fmt.Errorf("unsupported IPA platform metadata %s=%q", marker.key, marker.value)
+		}
+		if detected != "" && detected != platform {
+			return "", fmt.Errorf("conflicting IPA platform metadata: %s and %s", detected, platform)
+		}
+		detected = platform
+	}
+	return detected, nil
+}
+
+func plistStringValues(value any) []string {
+	values := make([]string, 0, 1)
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if text := coercePlistValueToString(item); text != "" {
+				values = append(values, text)
+			}
+		}
+	case []string:
+		for _, item := range typed {
+			if text := strings.TrimSpace(item); text != "" {
+				values = append(values, text)
+			}
+		}
+	}
+	return values
+}
+
+func appStorePlatformForIPA(value string) (asc.Platform, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "iphoneos", "watchos":
+		return asc.PlatformIOS, true
+	case "appletvos":
+		return asc.PlatformTVOS, true
+	case "xros":
+		return asc.PlatformVisionOS, true
+	case "macosx":
+		return asc.PlatformMacOS, true
+	default:
+		return "", false
+	}
 }
 
 // ResolveBundleInfoForIPA fills missing version/build-number values from the IPA

--- a/internal/cli/shared/ipa_test.go
+++ b/internal/cli/shared/ipa_test.go
@@ -116,6 +116,71 @@ func TestExtractBundleInfoFromIPA_BinaryPlist(t *testing.T) {
 	}
 }
 
+func TestExtractBundleInfoFromIPA_DetectsPlatform(t *testing.T) {
+	tests := []struct {
+		name               string
+		platformName       string
+		supportedPlatforms []string
+		format             int
+		want               string
+	}{
+		{name: "iOS", platformName: "iphoneos", supportedPlatforms: []string{"iPhoneOS"}, format: plist.XMLFormat, want: "IOS"},
+		{name: "tvOS binary plist", platformName: "appletvos", supportedPlatforms: []string{"AppleTVOS"}, format: plist.BinaryFormat, want: "TV_OS"},
+		{name: "visionOS", platformName: "xros", supportedPlatforms: []string{"XROS"}, format: plist.XMLFormat, want: "VISION_OS"},
+		{name: "supported platform fallback", supportedPlatforms: []string{"AppleTVOS"}, format: plist.XMLFormat, want: "TV_OS"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plistData, err := plist.Marshal(map[string]any{
+				"CFBundleIdentifier":         "com.example.demo",
+				"CFBundleShortVersionString": "1.2.3",
+				"CFBundleVersion":            "45",
+				"DTPlatformName":             test.platformName,
+				"CFBundleSupportedPlatforms": test.supportedPlatforms,
+			}, test.format)
+			if err != nil {
+				t.Fatalf("marshal Info.plist: %v", err)
+			}
+			ipaPath := writeTestIPA(t, map[string][]byte{
+				"Payload/Demo.app/Info.plist": plistData,
+			})
+
+			info, err := ExtractBundleInfoFromIPA(ipaPath)
+			if err != nil {
+				t.Fatalf("ExtractBundleInfoFromIPA() error: %v", err)
+			}
+			if string(info.Platform) != test.want {
+				t.Fatalf("expected platform %s, got %q", test.want, info.Platform)
+			}
+		})
+	}
+}
+
+func TestExtractBundleInfoFromIPA_RejectsConflictingPlatformMetadata(t *testing.T) {
+	plistData, err := plist.Marshal(map[string]any{
+		"CFBundleIdentifier":         "com.example.demo",
+		"CFBundleShortVersionString": "1.2.3",
+		"CFBundleVersion":            "45",
+		"DTPlatformName":             "iphoneos",
+		"CFBundleSupportedPlatforms": []string{"AppleTVOS"},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatalf("marshal Info.plist: %v", err)
+	}
+	ipaPath := writeTestIPA(t, map[string][]byte{
+		"Payload/Demo.app/Info.plist": plistData,
+	})
+
+	_, err = ExtractBundleInfoFromIPA(ipaPath)
+	if err == nil {
+		t.Fatal("expected conflicting platform metadata error")
+	}
+	if !strings.Contains(err.Error(), "conflicting IPA platform metadata") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestExtractBundleInfoFromIPA_InfoPlistAtSizeLimit(t *testing.T) {
 	plistData := buildInfoPlistOfSize(t, infoplist.MaxBytes)
 	ipaPath := writeTestIPA(t, map[string][]byte{

--- a/internal/cli/shared/ipa_test.go
+++ b/internal/cli/shared/ipa_test.go
@@ -127,6 +127,7 @@ func TestExtractBundleInfoFromIPA_DetectsPlatform(t *testing.T) {
 		{name: "iOS", platformName: "iphoneos", supportedPlatforms: []string{"iPhoneOS"}, format: plist.XMLFormat, want: "IOS"},
 		{name: "tvOS binary plist", platformName: "appletvos", supportedPlatforms: []string{"AppleTVOS"}, format: plist.BinaryFormat, want: "TV_OS"},
 		{name: "visionOS", platformName: "xros", supportedPlatforms: []string{"XROS"}, format: plist.XMLFormat, want: "VISION_OS"},
+		{name: "macOS", platformName: "macosx", supportedPlatforms: []string{"MacOSX"}, format: plist.XMLFormat, want: "MAC_OS"},
 		{name: "supported platform fallback", supportedPlatforms: []string{"AppleTVOS"}, format: plist.XMLFormat, want: "TV_OS"},
 	}
 


### PR DESCRIPTION
## What changed

- Detect the upload platform from the top-level app's `DTPlatformName` and `CFBundleSupportedPlatforms` metadata.
- Send the detected iOS, tvOS, visionOS, or macOS platform in the build-upload reservation.
- Reject contradictory archive metadata and explicit `--platform` mismatches before authentication or network requests.
- Keep `IOS` as the compatibility fallback when older archives contain no platform markers.
- Clarify `asc builds upload --help`.

## Why

IPA uploads previously defaulted to `IOS` even when the archive declared another Apple platform. That could reserve the build under the wrong platform and defer a locally detectable mistake to remote processing.

## Compatibility

Explicit matching platforms continue to work. Archives without platform metadata retain the existing iOS default. A supplied platform that contradicts the archive now fails early instead of creating an invalid reservation.

## Validation

- Captured the incorrect `IOS` request in a RED CLI/HTTP regression test.
- Added XML and binary plist coverage for iOS, tvOS, and visionOS.
- Added conflicting-metadata and explicit-mismatch coverage.
- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built the CLI and manually checked `asc builds upload --help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IPA uploads now automatically detect the app platform from embedded metadata, including iOS, tvOS, visionOS, and macOS.
  * When platform metadata is unavailable, uploads default to iOS.
* **Bug Fixes**
  * Uploads now reject explicitly selected platforms that conflict with the IPA’s detected platform.
  * Unsupported or conflicting platform metadata is reported before upload processing begins, avoiding unnecessary network requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->