### PR TITLE
Register devices from validated TSV files

### DIFF
--- a/internal/asc/devices_output.go
+++ b/internal/asc/devices_output.go
@@ -1,14 +1,77 @@
 package asc
 
+import (
+	"fmt"
+)
+
 // DeviceLocalUDIDResult represents CLI output for local device UDID lookup.
 type DeviceLocalUDIDResult struct {
 	UDID     string `json:"udid"`
 	Platform string `json:"platform"`
 }
 
+// DeviceBatchRegistrationItem describes one row processed by a batch registration.
+type DeviceBatchRegistrationItem struct {
+	Row      int    `json:"row"`
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name"`
+	UDID     string `json:"udid"`
+	Platform string `json:"platform"`
+	Status   string `json:"status"`
+	Reason   string `json:"reason,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+// DeviceBatchRegistrationSummary represents CLI output for batch device registration.
+type DeviceBatchRegistrationSummary struct {
+	InputFile       string                        `json:"inputFile"`
+	DryRun          bool                          `json:"dryRun"`
+	ContinueOnError bool                          `json:"continueOnError"`
+	Total           int                           `json:"total"`
+	Processed       int                           `json:"processed"`
+	Registered      int                           `json:"registered"`
+	Planned         int                           `json:"planned"`
+	Skipped         int                           `json:"skipped"`
+	Failed          int                           `json:"failed"`
+	Results         []DeviceBatchRegistrationItem `json:"results"`
+}
+
 func deviceLocalUDIDRows(result *DeviceLocalUDIDResult) ([]string, [][]string) {
 	headers := []string{"UDID", "Platform"}
 	rows := [][]string{{result.UDID, result.Platform}}
+	return headers, rows
+}
+
+func deviceBatchRegistrationSummaryRows(summary *DeviceBatchRegistrationSummary) ([]string, [][]string) {
+	headers := []string{"Input File", "Dry Run", "Total", "Processed", "Registered", "Planned", "Skipped", "Failed"}
+	rows := [][]string{{
+		compactWhitespace(summary.InputFile),
+		fmt.Sprintf("%t", summary.DryRun),
+		fmt.Sprintf("%d", summary.Total),
+		fmt.Sprintf("%d", summary.Processed),
+		fmt.Sprintf("%d", summary.Registered),
+		fmt.Sprintf("%d", summary.Planned),
+		fmt.Sprintf("%d", summary.Skipped),
+		fmt.Sprintf("%d", summary.Failed),
+	}}
+	return headers, rows
+}
+
+func deviceBatchRegistrationItemRows(items []DeviceBatchRegistrationItem) ([]string, [][]string) {
+	headers := []string{"Line", "ID", "Name", "UDID", "Platform", "Status", "Reason", "Error"}
+	rows := make([][]string, 0, len(items))
+	for _, item := range items {
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", item.Row),
+			compactWhitespace(item.ID),
+			compactWhitespace(item.Name),
+			compactWhitespace(item.UDID),
+			compactWhitespace(item.Platform),
+			compactWhitespace(item.Status),
+			compactWhitespace(item.Reason),
+			compactWhitespace(item.Error),
+		})
+	}
 	return headers, rows
 }
 

--- a/internal/asc/devices_output_test.go
+++ b/internal/asc/devices_output_test.go
@@ -1,0 +1,36 @@
+package asc
+
+import (
+	"testing"
+)
+
+func TestDeviceBatchRegistrationSummaryRendererIncludesSummaryAndItems(t *testing.T) {
+	summary := &DeviceBatchRegistrationSummary{
+		InputFile:  "devices.txt",
+		Total:      1,
+		Processed:  1,
+		Registered: 1,
+		Results: []DeviceBatchRegistrationItem{{
+			Row:      2,
+			ID:       "device-1",
+			Name:     "Test Device",
+			UDID:     "UDID-1",
+			Platform: "IOS",
+			Status:   "registered",
+		}},
+	}
+
+	renderCalls := 0
+	err := renderByRegistry(summary, func(headers []string, rows [][]string) {
+		renderCalls++
+		if len(headers) == 0 || len(rows) != 1 {
+			t.Fatalf("unexpected rendered section: headers=%v rows=%v", headers, rows)
+		}
+	})
+	if err != nil {
+		t.Fatalf("renderByRegistry() error: %v", err)
+	}
+	if renderCalls != 2 {
+		t.Fatalf("expected summary and item tables, got %d sections", renderCalls)
+	}
+}

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -170,6 +170,15 @@ func registerAllOutputRenderers() {
 	registerRowsWithSingleResourceAdapter(actorsRows)
 	registerRowsWithSingleResourceAdapter(devicesRows)
 	registerRows(deviceLocalUDIDRows)
+	registerDirect(func(v *DeviceBatchRegistrationSummary, render func([]string, [][]string)) error {
+		h, r := deviceBatchRegistrationSummaryRows(v)
+		render(h, r)
+		if len(v.Results) > 0 {
+			ih, ir := deviceBatchRegistrationItemRows(v.Results)
+			render(ih, ir)
+		}
+		return nil
+	})
 	registerRowsWithSingleResourceAdapter(userInvitationsRows)
 	registerRows(userDeleteResultRows)
 	registerRows(userInvitationRevokeResultRows)

--- a/internal/cli/cmdtest/devices_register_batch_test.go
+++ b/internal/cli/cmdtest/devices_register_batch_test.go
@@ -217,3 +217,51 @@ func TestDevicesRegisterBatchReportsPartialAPIFailuresAndContinues(t *testing.T)
 		t.Fatalf("expected machine-readable partial result, got %q", stdout)
 	}
 }
+
+func TestDevicesRegisterBatchContinuesAfterIsolatedRequestTimeout(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := filepath.Join(t.TempDir(), "devices.txt")
+	if err := os.WriteFile(inputPath, []byte("UDID-1\tDevice One\tIOS\nUDID-2\tDevice Two\tIOS\n"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	createCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/devices":
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/devices":
+			createCount++
+			if createCount == 1 {
+				return nil, context.DeadlineExceeded
+			}
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"devices","id":"device-2","attributes":{"name":"Device Two","udid":"UDID-2","platform":"IOS"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected reported partial failure")
+	}
+	if createCount != 2 {
+		t.Fatalf("expected processing to continue after one request timeout, got %d creates", createCount)
+	}
+	if !strings.Contains(stdout, `"registered":1`) || !strings.Contains(stdout, `"failed":1`) {
+		t.Fatalf("expected machine-readable partial result, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/devices_register_batch_test.go
+++ b/internal/cli/cmdtest/devices_register_batch_test.go
@@ -1,0 +1,219 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDevicesRegisterBatchPaginatesAndSkipsNormalizedDuplicates(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := filepath.Join(t.TempDir(), "devices.txt")
+	contents := strings.Join([]string{
+		"# device registration",
+		"Device ID\tDevice Name\tDevice Platform",
+		"AA-BB-CC\tPhone One\tIOS",
+		"aabbcc\tRepeated Phone\tios",
+		"DD:EE:FF\tBuild Mac\tMAC_OS",
+		"EXISTING-1\tExisting Phone\tIOS",
+	}, "\n")
+	if err := os.WriteFile(inputPath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	created := make([]map[string]any, 0, 2)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/devices" && req.URL.Query().Get("cursor") == "page-2":
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"devices","id":"device-existing","attributes":{"name":"Existing Phone","udid":"EXISTING1","platform":"IOS","status":"ENABLED"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/devices":
+			if req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("expected 200-device page size, got %s", req.URL.RawQuery)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/devices?cursor=page-2"}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/devices":
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode create request: %v", err)
+			}
+			attrs := payload["data"].(map[string]any)["attributes"].(map[string]any)
+			created = append(created, attrs)
+			id := "device-" + strings.ReplaceAll(strings.ReplaceAll(attrs["udid"].(string), "-", ""), ":", "")
+			response, err := json.Marshal(map[string]any{
+				"data": map[string]any{"type": "devices", "id": id, "attributes": attrs},
+			})
+			if err != nil {
+				t.Fatalf("marshal create response: %v", err)
+			}
+			return jsonResponse(http.StatusCreated, string(response))
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if len(created) != 2 {
+		t.Fatalf("expected 2 registrations, got %d: %+v", len(created), created)
+	}
+	if created[0]["udid"] != "AA-BB-CC" || created[0]["platform"] != "IOS" {
+		t.Fatalf("unexpected first create: %+v", created[0])
+	}
+	if created[1]["udid"] != "DD:EE:FF" || created[1]["platform"] != "MAC_OS" {
+		t.Fatalf("unexpected second create: %+v", created[1])
+	}
+
+	var summary struct {
+		Total      int `json:"total"`
+		Registered int `json:"registered"`
+		Skipped    int `json:"skipped"`
+		Failed     int `json:"failed"`
+		Results    []struct {
+			Row    int    `json:"row"`
+			Status string `json:"status"`
+			Reason string `json:"reason"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("decode summary %q: %v", stdout, err)
+	}
+	if summary.Total != 4 || summary.Registered != 2 || summary.Skipped != 2 || summary.Failed != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if len(summary.Results) != 4 || summary.Results[1].Status != "skipped" || !strings.Contains(summary.Results[1].Reason, "duplicate") {
+		t.Fatalf("expected duplicate input result, got %+v", summary.Results)
+	}
+	if summary.Results[3].Status != "skipped" || !strings.Contains(summary.Results[3].Reason, "already registered") {
+		t.Fatalf("expected existing device result, got %+v", summary.Results[3])
+	}
+}
+
+func TestDevicesRegisterBatchValidatesEveryRowBeforeNetwork(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := filepath.Join(t.TempDir(), "devices.txt")
+	if err := os.WriteFile(inputPath, []byte("UDID-1\tValid\tIOS\nUDID-2\tInvalid\tTV_OS\n"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request before full input validation: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "line 2") || !strings.Contains(err.Error(), "--platform") {
+		t.Fatalf("expected line-specific validation error, got %v", err)
+	}
+}
+
+func TestDevicesRegisterBatchDryRunPlansWithoutCreating(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := filepath.Join(t.TempDir(), "devices.txt")
+	if err := os.WriteFile(inputPath, []byte("UDID-1\tDevice One\n"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/devices" {
+			t.Fatalf("unexpected dry-run request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonResponse(http.StatusOK, `{"data":[]}`)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--platform", "ios", "--dry-run"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `"planned":1`) || !strings.Contains(stdout, `"status":"planned"`) {
+		t.Fatalf("expected planned dry-run output, got %q", stdout)
+	}
+}
+
+func TestDevicesRegisterBatchReportsPartialAPIFailuresAndContinues(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := filepath.Join(t.TempDir(), "devices.txt")
+	if err := os.WriteFile(inputPath, []byte("UDID-1\tDevice One\tIOS\nUDID-2\tDevice Two\tIOS\n"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	createCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/devices":
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/devices":
+			createCount++
+			if createCount == 1 {
+				return jsonResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"invalid device"}]}`)
+			}
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"devices","id":"device-2","attributes":{"name":"Device Two","udid":"UDID-2","platform":"IOS"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected reported partial failure")
+	}
+	if createCount != 2 {
+		t.Fatalf("expected processing to continue after one API failure, got %d creates", createCount)
+	}
+	if !strings.Contains(stdout, `"registered":1`) || !strings.Contains(stdout, `"failed":1`) || !strings.Contains(stdout, `"status":"failed"`) {
+		t.Fatalf("expected machine-readable partial result, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/devices_register_batch_test.go
+++ b/internal/cli/cmdtest/devices_register_batch_test.go
@@ -265,3 +265,56 @@ func TestDevicesRegisterBatchContinuesAfterIsolatedRequestTimeout(t *testing.T) 
 		t.Fatalf("expected machine-readable partial result, got %q", stdout)
 	}
 }
+
+func TestDevicesRegisterBatchStopsAfterAPIFailureWhenRequested(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	inputPath := filepath.Join(t.TempDir(), "devices.txt")
+	if err := os.WriteFile(inputPath, []byte("UDID-1\tDevice One\tIOS\nUDID-2\tDevice Two\tIOS\n"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	createCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/devices":
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/devices":
+			createCount++
+			return jsonResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR","detail":"invalid device"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--continue-on-error=false"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected reported registration failure")
+	}
+	if createCount != 1 {
+		t.Fatalf("create requests = %d, want 1", createCount)
+	}
+	var summary struct {
+		Total     int `json:"total"`
+		Processed int `json:"processed"`
+		Failed    int `json:"failed"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("decode summary %q: %v", stdout, err)
+	}
+	if summary.Total != 2 || summary.Processed != 1 || summary.Failed != 1 {
+		t.Fatalf("unexpected stop-on-error summary: %+v", summary)
+	}
+}

--- a/internal/cli/cmdtest/devices_register_batch_test.go
+++ b/internal/cli/cmdtest/devices_register_batch_test.go
@@ -3,6 +3,8 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"os"
@@ -64,7 +66,7 @@ func TestDevicesRegisterBatchPaginatesAndSkipsNormalizedDuplicates(t *testing.T)
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--output", "json"}); err != nil {
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--output", "json", "--confirm"}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 
@@ -128,7 +130,7 @@ func TestDevicesRegisterBatchValidatesEveryRowBeforeNetwork(t *testing.T) {
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath}); err != nil {
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--confirm"}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 	err := root.Run(context.Background())
@@ -200,7 +202,7 @@ func TestDevicesRegisterBatchReportsPartialAPIFailuresAndContinues(t *testing.T)
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath}); err != nil {
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--confirm"}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 	var runErr error
@@ -248,7 +250,7 @@ func TestDevicesRegisterBatchContinuesAfterIsolatedRequestTimeout(t *testing.T) 
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath}); err != nil {
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--confirm"}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 	var runErr error
@@ -293,7 +295,7 @@ func TestDevicesRegisterBatchStopsAfterAPIFailureWhenRequested(t *testing.T) {
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--continue-on-error=false"}); err != nil {
+	if err := root.Parse([]string{"devices", "register-batch", "--file", inputPath, "--continue-on-error=false", "--confirm"}); err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
 	var runErr error
@@ -316,5 +318,36 @@ func TestDevicesRegisterBatchStopsAfterAPIFailureWhenRequested(t *testing.T) {
 	}
 	if summary.Total != 2 || summary.Processed != 1 || summary.Failed != 1 {
 		t.Fatalf("unexpected stop-on-error summary: %+v", summary)
+	}
+}
+
+func TestDevicesRegisterBatchRequiresConfirmBeforeReadingFileOrNetwork(t *testing.T) {
+	setupAuth(t)
+	missingPath := filepath.Join(t.TempDir(), "missing.txt")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request before confirmation: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"devices", "register-batch", "--file", missingPath}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || runErr.Error() != "--confirm is required unless --dry-run is set" {
+		t.Fatalf("run error = %v, want exact confirmation usage error", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "--confirm is required unless --dry-run is set") {
+		t.Fatalf("stderr = %q, want confirmation error", stderr)
 	}
 }

--- a/internal/cli/devices/devices.go
+++ b/internal/cli/devices/devices.go
@@ -45,6 +45,7 @@ Examples:
   asc devices view --id "DEVICE_ID"
   asc devices local-udid
   asc devices register --name "iPhone 15" --udid "UDID" --platform IOS
+  asc devices register-batch --file "./devices.txt"
   asc devices update --id "DEVICE_ID" --status DISABLED`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -53,6 +54,7 @@ Examples:
 			DevicesGetCommand(),
 			DevicesLocalUDIDCommand(),
 			DevicesRegisterCommand(),
+			DevicesRegisterBatchCommand(),
 			DevicesUpdateCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/devices/devices.go
+++ b/internal/cli/devices/devices.go
@@ -45,7 +45,7 @@ Examples:
   asc devices view --id "DEVICE_ID"
   asc devices local-udid
   asc devices register --name "iPhone 15" --udid "UDID" --platform IOS
-  asc devices register-batch --file "./devices.txt"
+  asc devices register-batch --file "./devices.txt" --confirm
   asc devices update --id "DEVICE_ID" --status DISABLED`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,

--- a/internal/cli/devices/devices_batch.go
+++ b/internal/cli/devices/devices_batch.go
@@ -34,6 +34,7 @@ func DevicesRegisterBatchCommand() *ffcli.Command {
 	filePath := fs.String("file", "", "Tab-separated device file (UDID, name, optional platform)")
 	platform := fs.String("platform", "", "Default platform when a row omits it: "+strings.Join(devicePlatformList(), ", "))
 	dryRun := fs.Bool("dry-run", false, "Validate and show the registration plan without creating devices")
+	confirm := fs.Bool("confirm", false, "Confirm device registration mutations")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue registering after an API failure (default true)")
 	output := shared.BindOutputFlags(fs)
 
@@ -52,10 +53,10 @@ The entire file is validated before network access. Existing devices and
 repeated UDIDs are skipped after removing hyphens and colons for comparison.
 
 Examples:
-  asc devices register-batch --file "./devices.txt"
-  asc devices register-batch --file "./devices.txt" --platform IOS
+  asc devices register-batch --file "./devices.txt" --confirm
+  asc devices register-batch --file "./devices.txt" --platform IOS --confirm
   asc devices register-batch --file "./devices.txt" --dry-run
-  asc devices register-batch --file "./devices.txt" --continue-on-error=false`,
+  asc devices register-batch --file "./devices.txt" --continue-on-error=false --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -72,6 +73,9 @@ Examples:
 			defaultPlatform, err := normalizeDevicePlatform(*platform)
 			if err != nil {
 				return fmt.Errorf("devices register-batch: %w", shared.UsageError(err.Error()))
+			}
+			if err := shared.RequireConfirmUnlessDryRun(*dryRun, *confirm); err != nil {
+				return err
 			}
 
 			records, err := readDeviceBatchTSV(fileValue, defaultPlatform)

--- a/internal/cli/devices/devices_batch.go
+++ b/internal/cli/devices/devices_batch.go
@@ -148,7 +148,7 @@ Examples:
 					result.Error = createErr.Error()
 					summary.Failed++
 					summary.Results = append(summary.Results, result)
-					if !*continueOnError || errors.Is(createErr, context.Canceled) || errors.Is(createErr, context.DeadlineExceeded) {
+					if !*continueOnError || ctx.Err() != nil {
 						break
 					}
 					continue
@@ -191,8 +191,12 @@ func readDeviceBatchTSV(path, defaultPlatform string) ([]deviceBatchRecord, erro
 	if info.Size() > maxDeviceBatchFileSize {
 		return nil, fmt.Errorf("device file exceeds %d-byte limit", maxDeviceBatchFileSize)
 	}
+	return readDeviceBatchTSVFromReader(file, defaultPlatform)
+}
 
-	reader := csv.NewReader(io.LimitReader(file, maxDeviceBatchFileSize+1))
+func readDeviceBatchTSVFromReader(input io.Reader, defaultPlatform string) ([]deviceBatchRecord, error) {
+	limited := &io.LimitedReader{R: input, N: maxDeviceBatchFileSize + 1}
+	reader := csv.NewReader(limited)
 	reader.Comma = '\t'
 	reader.FieldsPerRecord = -1
 
@@ -233,6 +237,9 @@ func readDeviceBatchTSV(path, defaultPlatform string) ([]deviceBatchRecord, erro
 		records = append(records, record)
 	}
 
+	if limited.N == 0 {
+		return nil, fmt.Errorf("device file exceeds %d-byte limit", maxDeviceBatchFileSize)
+	}
 	if len(records) == 0 {
 		return nil, fmt.Errorf("device file contains no records")
 	}

--- a/internal/cli/devices/devices_batch.go
+++ b/internal/cli/devices/devices_batch.go
@@ -35,7 +35,7 @@ func DevicesRegisterBatchCommand() *ffcli.Command {
 	platform := fs.String("platform", "", "Default platform when a row omits it: "+strings.Join(devicePlatformList(), ", "))
 	dryRun := fs.Bool("dry-run", false, "Validate and show the registration plan without creating devices")
 	confirm := fs.Bool("confirm", false, "Confirm device registration mutations")
-	continueOnError := fs.Bool("continue-on-error", true, "Continue registering after an API failure (default true)")
+	continueOnError := fs.Bool("continue-on-error", true, "Continue registering after an API failure")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{

--- a/internal/cli/devices/devices_batch.go
+++ b/internal/cli/devices/devices_batch.go
@@ -1,0 +1,346 @@
+package devices
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+)
+
+const maxDeviceBatchFileSize = 2 * 1024 * 1024
+
+type deviceBatchRecord struct {
+	Row      int
+	UDID     string
+	Name     string
+	Platform string
+}
+
+// DevicesRegisterBatchCommand returns the devices register-batch subcommand.
+func DevicesRegisterBatchCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("register-batch", flag.ExitOnError)
+
+	filePath := fs.String("file", "", "Tab-separated device file (UDID, name, optional platform)")
+	platform := fs.String("platform", "", "Default platform when a row omits it: "+strings.Join(devicePlatformList(), ", "))
+	dryRun := fs.Bool("dry-run", false, "Validate and show the registration plan without creating devices")
+	continueOnError := fs.Bool("continue-on-error", true, "Continue registering after an API failure (default true)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "register-batch",
+		ShortUsage: "asc devices register-batch --file FILE [--platform PLATFORM] [flags]",
+		ShortHelp:  "Register devices from a tab-separated file.",
+		LongHelp: `Register devices from a tab-separated file.
+
+Accepted rows contain a UDID, device name, and optional platform, separated by
+tabs. A header using Device ID, Device Name, and Device Platform is optional.
+Blank rows and rows whose first field begins with # are ignored. Use --platform
+as the default for rows without a platform.
+
+The entire file is validated before network access. Existing devices and
+repeated UDIDs are skipped after removing hyphens and colons for comparison.
+
+Examples:
+  asc devices register-batch --file "./devices.txt"
+  asc devices register-batch --file "./devices.txt" --platform IOS
+  asc devices register-batch --file "./devices.txt" --dry-run
+  asc devices register-batch --file "./devices.txt" --continue-on-error=false`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("devices register-batch does not accept positional arguments")
+			}
+
+			fileValue := strings.TrimSpace(*filePath)
+			if fileValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --file is required")
+				return shared.MissingRequiredUsageError("--file")
+			}
+
+			defaultPlatform, err := normalizeDevicePlatform(*platform)
+			if err != nil {
+				return fmt.Errorf("devices register-batch: %w", shared.UsageError(err.Error()))
+			}
+
+			records, err := readDeviceBatchTSV(fileValue, defaultPlatform)
+			if err != nil {
+				return fmt.Errorf("devices register-batch: %w", err)
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("devices register-batch: %w", err)
+			}
+
+			existing, err := fetchDevicesByNormalizedUDID(ctx, client)
+			if err != nil {
+				return fmt.Errorf("devices register-batch: failed to check existing devices: %w", err)
+			}
+
+			summary := &asc.DeviceBatchRegistrationSummary{
+				InputFile:       filepath.Clean(fileValue),
+				DryRun:          *dryRun,
+				ContinueOnError: *continueOnError,
+				Total:           len(records),
+				Results:         make([]asc.DeviceBatchRegistrationItem, 0, len(records)),
+			}
+			seenInput := make(map[string]int, len(records))
+
+			for _, record := range records {
+				normalizedUDID := normalizeDeviceUDIDForComparison(record.UDID)
+				result := asc.DeviceBatchRegistrationItem{
+					Row:      record.Row,
+					Name:     record.Name,
+					UDID:     record.UDID,
+					Platform: record.Platform,
+				}
+				summary.Processed++
+
+				if firstRow, duplicate := seenInput[normalizedUDID]; duplicate {
+					result.Status = "skipped"
+					result.Reason = fmt.Sprintf("duplicate UDID from line %d", firstRow)
+					summary.Skipped++
+					summary.Results = append(summary.Results, result)
+					continue
+				}
+				seenInput[normalizedUDID] = record.Row
+
+				if device, found := existing[normalizedUDID]; found {
+					result.ID = device.ID
+					result.Status = "skipped"
+					result.Reason = "already registered"
+					summary.Skipped++
+					summary.Results = append(summary.Results, result)
+					continue
+				}
+
+				if *dryRun {
+					result.Status = "planned"
+					summary.Planned++
+					summary.Results = append(summary.Results, result)
+					continue
+				}
+
+				requestCtx, cancel := shared.ContextWithTimeout(ctx)
+				created, createErr := client.CreateDevice(requestCtx, asc.DeviceCreateAttributes{
+					Name:     record.Name,
+					UDID:     record.UDID,
+					Platform: asc.DevicePlatform(record.Platform),
+				})
+				cancel()
+				if createErr == nil && (created == nil || strings.TrimSpace(created.Data.ID) == "") {
+					createErr = fmt.Errorf("registration returned an empty device ID")
+				}
+				if createErr != nil {
+					result.Status = "failed"
+					result.Error = createErr.Error()
+					summary.Failed++
+					summary.Results = append(summary.Results, result)
+					if !*continueOnError || errors.Is(createErr, context.Canceled) || errors.Is(createErr, context.DeadlineExceeded) {
+						break
+					}
+					continue
+				}
+
+				result.ID = created.Data.ID
+				result.Status = "registered"
+				summary.Registered++
+				summary.Results = append(summary.Results, result)
+				existing[normalizedUDID] = created.Data
+			}
+
+			if err := shared.PrintOutput(summary, *output.Output, *output.Pretty); err != nil {
+				return err
+			}
+			if summary.Failed > 0 {
+				return shared.NewReportedError(fmt.Errorf("devices register-batch: %d registration(s) failed", summary.Failed))
+			}
+			return nil
+		},
+	}
+}
+
+func readDeviceBatchTSV(path, defaultPlatform string) ([]deviceBatchRecord, error) {
+	defaultPlatform, err := normalizeDevicePlatform(defaultPlatform)
+	if err != nil {
+		return nil, shared.UsageError(err.Error())
+	}
+
+	file, err := rootfs.OpenFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("open --file: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat --file: %w", err)
+	}
+	if info.Size() > maxDeviceBatchFileSize {
+		return nil, fmt.Errorf("device file exceeds %d-byte limit", maxDeviceBatchFileSize)
+	}
+
+	reader := csv.NewReader(io.LimitReader(file, maxDeviceBatchFileSize+1))
+	reader.Comma = '\t'
+	reader.FieldsPerRecord = -1
+
+	records := make([]deviceBatchRecord, 0)
+	firstRecord := true
+	for {
+		row, readErr := reader.Read()
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return nil, fmt.Errorf("read tab-separated device file: %w", readErr)
+		}
+		line := 1
+		if len(row) > 0 {
+			line, _ = reader.FieldPos(0)
+			row[0] = strings.TrimPrefix(row[0], "\ufeff")
+		}
+		if isIgnoredDeviceBatchRow(row) {
+			continue
+		}
+
+		if firstRecord {
+			isHeader, headerErr := parseDeviceBatchHeader(row, line)
+			if headerErr != nil {
+				return nil, headerErr
+			}
+			firstRecord = false
+			if isHeader {
+				continue
+			}
+		}
+
+		record, err := parseDeviceBatchRow(row, line, defaultPlatform)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("device file contains no records")
+	}
+	return records, nil
+}
+
+func isIgnoredDeviceBatchRow(row []string) bool {
+	allEmpty := true
+	for _, value := range row {
+		if strings.TrimSpace(value) != "" {
+			allEmpty = false
+			break
+		}
+	}
+	if allEmpty {
+		return true
+	}
+	return len(row) > 0 && strings.HasPrefix(strings.TrimSpace(row[0]), "#")
+}
+
+func parseDeviceBatchHeader(row []string, line int) (bool, error) {
+	if len(row) == 0 {
+		return false, nil
+	}
+	first := normalizeDeviceBatchHeader(row[0])
+	if first != "deviceid" && first != "udid" {
+		return false, nil
+	}
+	if len(row) < 2 || (normalizeDeviceBatchHeader(row[1]) != "devicename" && normalizeDeviceBatchHeader(row[1]) != "name") {
+		return false, fmt.Errorf("line %d: device header must start with Device ID and Device Name", line)
+	}
+	if len(row) > 3 {
+		return false, fmt.Errorf("line %d: device header must contain 2 or 3 tab-separated columns", line)
+	}
+	if len(row) == 3 {
+		third := normalizeDeviceBatchHeader(row[2])
+		if third != "deviceplatform" && third != "platform" {
+			return false, fmt.Errorf("line %d: third header column must be Device Platform", line)
+		}
+	}
+	return true, nil
+}
+
+func normalizeDeviceBatchHeader(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	replacer := strings.NewReplacer(" ", "", "-", "", "_", "")
+	return replacer.Replace(value)
+}
+
+func parseDeviceBatchRow(row []string, line int, defaultPlatform string) (deviceBatchRecord, error) {
+	if len(row) < 2 || len(row) > 3 {
+		return deviceBatchRecord{}, fmt.Errorf("line %d: expected 2 or 3 tab-separated columns", line)
+	}
+	udid := strings.TrimSpace(row[0])
+	if udid == "" || normalizeDeviceUDIDForComparison(udid) == "" {
+		return deviceBatchRecord{}, fmt.Errorf("line %d: device UDID is required", line)
+	}
+	name := strings.TrimSpace(row[1])
+	if name == "" {
+		return deviceBatchRecord{}, fmt.Errorf("line %d: device name is required", line)
+	}
+
+	platform := defaultPlatform
+	if len(row) == 3 && strings.TrimSpace(row[2]) != "" {
+		platform = strings.TrimSpace(row[2])
+	}
+	if platform == "" {
+		return deviceBatchRecord{}, fmt.Errorf("line %d: device platform is required (provide a third column or --platform)", line)
+	}
+	platform, err := normalizeDevicePlatform(platform)
+	if err != nil {
+		return deviceBatchRecord{}, fmt.Errorf("line %d: %w", line, shared.UsageError(err.Error()))
+	}
+
+	return deviceBatchRecord{Row: line, UDID: udid, Name: name, Platform: platform}, nil
+}
+
+func fetchDevicesByNormalizedUDID(ctx context.Context, client *asc.Client) (map[string]asc.Resource[asc.DeviceAttributes], error) {
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	firstPage, err := client.GetDevices(
+		requestCtx,
+		asc.WithDevicesFields([]string{"name", "udid", "platform", "status"}),
+		asc.WithDevicesLimit(200),
+	)
+	cancel()
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := asc.PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		requestCtx, cancel := shared.ContextWithTimeout(ctx)
+		defer cancel()
+		return client.GetDevices(requestCtx, asc.WithDevicesNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+	devices, ok := all.(*asc.DevicesResponse)
+	if !ok || devices == nil {
+		return nil, fmt.Errorf("unexpected devices response type")
+	}
+
+	byUDID := make(map[string]asc.Resource[asc.DeviceAttributes], len(devices.Data))
+	for _, device := range devices.Data {
+		normalized := normalizeDeviceUDIDForComparison(device.Attributes.UDID)
+		if normalized != "" {
+			byUDID[normalized] = device
+		}
+	}
+	return byUDID, nil
+}

--- a/internal/cli/devices/devices_batch_test.go
+++ b/internal/cli/devices/devices_batch_test.go
@@ -1,0 +1,80 @@
+package devices
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadDeviceBatchTSVAcceptsHeaderCommentsBlankRowsAndDefaultPlatform(t *testing.T) {
+	path := writeDeviceBatchTestFile(t, strings.Join([]string{
+		"# exported device list",
+		"",
+		"Device ID\tDevice Name\tDevice Platform",
+		"00008110-001234567890001E\tPersonal iPhone\tios",
+		"  # disabled device",
+		"A1:B2:C3\tBuild Mac\t",
+		"",
+	}, "\n"))
+
+	records, err := readDeviceBatchTSV(path, "MAC_OS")
+	if err != nil {
+		t.Fatalf("readDeviceBatchTSV() error: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d: %+v", len(records), records)
+	}
+	if records[0].Row != 4 || records[0].UDID != "00008110-001234567890001E" || records[0].Name != "Personal iPhone" || records[0].Platform != "IOS" {
+		t.Fatalf("unexpected first record: %+v", records[0])
+	}
+	if records[1].Row != 6 || records[1].UDID != "A1:B2:C3" || records[1].Name != "Build Mac" || records[1].Platform != "MAC_OS" {
+		t.Fatalf("unexpected second record: %+v", records[1])
+	}
+}
+
+func TestReadDeviceBatchTSVAcceptsHeaderlessRows(t *testing.T) {
+	path := writeDeviceBatchTestFile(t, "UDID-1\tDevice One\nUDID-2\tDevice Two\tmac_os\n")
+
+	records, err := readDeviceBatchTSV(path, "IOS")
+	if err != nil {
+		t.Fatalf("readDeviceBatchTSV() error: %v", err)
+	}
+	if len(records) != 2 || records[0].Platform != "IOS" || records[1].Platform != "MAC_OS" {
+		t.Fatalf("unexpected records: %+v", records)
+	}
+}
+
+func TestReadDeviceBatchTSVRejectsInvalidRowsBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name            string
+		contents        string
+		defaultPlatform string
+		want            string
+	}{
+		{name: "missing name", contents: "Device ID\tDevice Name\nUDID-1\t\n", defaultPlatform: "IOS", want: "line 2: device name is required"},
+		{name: "missing platform", contents: "Device ID\tDevice Name\nUDID-1\tDevice\n", want: "line 2: device platform is required"},
+		{name: "invalid platform", contents: "UDID-1\tDevice\tTV_OS\n", want: "line 1: --platform must be one of"},
+		{name: "extra columns", contents: "UDID-1\tDevice\tIOS\textra\n", want: "line 1: expected 2 or 3 tab-separated columns"},
+		{name: "empty file", contents: "\n# comment\n", defaultPlatform: "IOS", want: "device file contains no records"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeDeviceBatchTestFile(t, test.contents)
+			_, err := readDeviceBatchTSV(path, test.defaultPlatform)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("expected error containing %q, got %v", test.want, err)
+			}
+		})
+	}
+}
+
+func writeDeviceBatchTestFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "devices.txt")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write device batch test file: %v", err)
+	}
+	return path
+}

--- a/internal/cli/devices/devices_batch_test.go
+++ b/internal/cli/devices/devices_batch_test.go
@@ -56,6 +56,9 @@ func TestReadDeviceBatchTSVRejectsInvalidRowsBeforeMutation(t *testing.T) {
 		{name: "missing platform", contents: "Device ID\tDevice Name\nUDID-1\tDevice\n", want: "line 2: device platform is required"},
 		{name: "invalid platform", contents: "UDID-1\tDevice\tTV_OS\n", want: "line 1: --platform must be one of"},
 		{name: "extra columns", contents: "UDID-1\tDevice\tIOS\textra\n", want: "line 1: expected 2 or 3 tab-separated columns"},
+		{name: "bad header name", contents: "Device ID\tSerial\nUDID-1\tDevice\tIOS\n", want: "line 1: device header must start with Device ID and Device Name"},
+		{name: "header with extra column", contents: "Device ID\tDevice Name\tDevice Platform\tExtra\n", want: "line 1: device header must contain 2 or 3 tab-separated columns"},
+		{name: "bad platform header", contents: "Device ID\tDevice Name\tOS\n", want: "line 1: third header column must be Device Platform"},
 		{name: "empty file", contents: "\n# comment\n", defaultPlatform: "IOS", want: "device file contains no records"},
 	}
 

--- a/internal/cli/devices/devices_batch_test.go
+++ b/internal/cli/devices/devices_batch_test.go
@@ -70,6 +70,15 @@ func TestReadDeviceBatchTSVRejectsInvalidRowsBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestReadDeviceBatchTSVFromReaderRejectsInputBeyondLimit(t *testing.T) {
+	contents := "UDID-1\tDevice One\tIOS\n#" + strings.Repeat("x", maxDeviceBatchFileSize)
+
+	_, err := readDeviceBatchTSVFromReader(strings.NewReader(contents), "IOS")
+	if err == nil || !strings.Contains(err.Error(), "device file exceeds") {
+		t.Fatalf("expected size-limit error, got %v", err)
+	}
+}
+
 func writeDeviceBatchTestFile(t *testing.T, contents string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "devices.txt")

--- a/internal/cli/devices/devices_test.go
+++ b/internal/cli/devices/devices_test.go
@@ -29,6 +29,14 @@ func TestDevicesCommand_BatchExampleConfirmsMutation(t *testing.T) {
 	}
 }
 
+func TestDevicesRegisterBatchHelpDoesNotDuplicateContinueDefault(t *testing.T) {
+	cmd := DevicesRegisterBatchCommand()
+	usage := cmd.FlagSet.Lookup("continue-on-error").Usage
+	if strings.Contains(usage, "default true") {
+		t.Fatalf("continue-on-error usage must leave default rendering to the shared formatter, got %q", usage)
+	}
+}
+
 func TestDevicesRegisterCommand_MissingUDID(t *testing.T) {
 	cmd := DevicesRegisterCommand()
 

--- a/internal/cli/devices/devices_test.go
+++ b/internal/cli/devices/devices_test.go
@@ -21,6 +21,14 @@ func TestDevicesRegisterCommand_MissingName(t *testing.T) {
 	}
 }
 
+func TestDevicesCommand_BatchExampleConfirmsMutation(t *testing.T) {
+	cmd := DevicesCommand()
+
+	if !strings.Contains(cmd.LongHelp, `asc devices register-batch --file "./devices.txt" --confirm`) {
+		t.Fatalf("devices help must show a runnable confirmed batch example, got:\n%s", cmd.LongHelp)
+	}
+}
+
 func TestDevicesRegisterCommand_MissingUDID(t *testing.T) {
 	cmd := DevicesRegisterCommand()
 


### PR DESCRIPTION
## What changed

- Add `asc devices register-batch --file FILE`.
- Accept portal-style TSV headers or headerless UDID/name/platform rows.
- Ignore blank rows and whole-row comments.
- Support a `--platform` default for two-column files.
- Validate the complete file before authentication or mutation.
- Page through every registered device and skip normalized existing or repeated UDIDs.
- Add `--dry-run` and configurable runtime failure continuation.
- Emit deterministic JSON, table, and Markdown summaries with a result for every processed row.

## Why

Registering a fleet one device at a time is slow and brittle in CI. Real exported device files also contain harmless formatting such as blank/comment rows and UDIDs with separators, so a useful batch workflow needs parsing, global deduplication, and explicit partial-result behavior rather than a thin loop around the single-device command.

## Failure behavior

Local format errors stop before any network request. Runtime API failures are recorded per row, the command continues by default, the summary is still written to stdout, and the process exits nonzero. Per-request timeouts prevent one registration from consuming the whole batch window.

## Validation

- Captured the missing command as RED parser and CLI tests.
- Added parser coverage for headers, headerless rows, comments, blanks, default platforms, invalid fields, and line-numbered errors.
- Added HTTP coverage for pagination, normalized duplicates, existing devices, payloads, dry-run, and partial failures.
- Added structured-output renderer coverage.
- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built the CLI and manually checked `asc devices register-batch --help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `devices register-batch` for registering multiple devices from a tab-separated file.
  * Supports optional headers, comments, blank rows, default platforms, duplicate detection, and already-registered device checks.
  * Validates the complete input before making changes and enforces input-size limits.
  * Added dry-run planning, confirmation safeguards, and an option to continue after individual failures.
  * Displays registration summaries and per-device results, including successes, skips, and errors.

* **Documentation**
  * Updated device command help to include batch registration and its options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->