### PR TITLE
Reject unsafe build artifacts before upload reservation

### DIFF
--- a/internal/asc/upload.go
+++ b/internal/asc/upload.go
@@ -301,6 +301,20 @@ func VerifySourceFileChecksums(filePath string, expected *Checksums) (*Checksums
 	if expected == nil {
 		return nil, nil
 	}
+	file, err := openUploadSourceFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("open file for checksum: %w", err)
+	}
+	defer file.Close()
+	return VerifySourceFileChecksumsFromFile(file, expected)
+}
+
+// VerifySourceFileChecksumsFromFile computes and compares API-provided
+// checksums against an already-opened source file.
+func VerifySourceFileChecksumsFromFile(file *os.File, expected *Checksums) (*Checksums, error) {
+	if expected == nil {
+		return nil, nil
+	}
 
 	computed := &Checksums{}
 	if expected.File != nil {
@@ -308,7 +322,7 @@ func VerifySourceFileChecksums(filePath string, expected *Checksums) (*Checksums
 		if expectedHash == "" {
 			return nil, errors.New("file checksum hash is missing")
 		}
-		sum, err := ComputeFileChecksum(filePath, expected.File.Algorithm)
+		sum, err := ComputeFileChecksumFromFile(file, expected.File.Algorithm)
 		if err != nil {
 			return nil, err
 		}
@@ -322,7 +336,7 @@ func VerifySourceFileChecksums(filePath string, expected *Checksums) (*Checksums
 		if expectedHash == "" {
 			return nil, errors.New("composite checksum hash is missing")
 		}
-		sum, err := ComputeFileChecksum(filePath, expected.Composite.Algorithm)
+		sum, err := ComputeFileChecksumFromFile(file, expected.Composite.Algorithm)
 		if err != nil {
 			return nil, err
 		}
@@ -345,7 +359,15 @@ func ComputeFileChecksum(filePath string, algorithm ChecksumAlgorithm) (*Checksu
 		return nil, fmt.Errorf("open file for checksum: %w", err)
 	}
 	defer file.Close()
+	return ComputeFileChecksumFromFile(file, algorithm)
+}
 
+// ComputeFileChecksumFromFile computes a checksum from an already-opened file
+// without changing its current offset.
+func ComputeFileChecksumFromFile(file *os.File, algorithm ChecksumAlgorithm) (*Checksum, error) {
+	if file == nil {
+		return nil, errors.New("checksum source file is required")
+	}
 	var hash hash.Hash
 	switch algorithm {
 	case ChecksumAlgorithmMD5:
@@ -356,7 +378,12 @@ func ComputeFileChecksum(filePath string, algorithm ChecksumAlgorithm) (*Checksu
 		return nil, fmt.Errorf("unsupported checksum algorithm: %s", algorithm)
 	}
 
-	if _, err := io.Copy(hash, file); err != nil {
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat file for checksum: %w", err)
+	}
+	reader := io.NewSectionReader(file, 0, fileInfo.Size())
+	if _, err := io.Copy(hash, reader); err != nil {
 		return nil, fmt.Errorf("compute checksum: %w", err)
 	}
 

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -105,20 +105,22 @@ Examples:
 
 			// Validate file exists
 			var (
-				fileInfo os.FileInfo
-				err      error
+				artifactFile *os.File
+				fileInfo     os.FileInfo
+				err          error
 			)
 			if hasIPA {
-				fileInfo, err = shared.ValidateIPAPath(filePath)
+				artifactFile, fileInfo, err = shared.OpenValidatedIPAPath(filePath)
 				if err != nil {
 					return fmt.Errorf("builds upload: %w", err)
 				}
 			} else {
-				fileInfo, err = shared.ValidatePKGPath(filePath)
+				artifactFile, fileInfo, err = shared.OpenValidatedPKGPath(filePath)
 				if err != nil {
 					return fmt.Errorf("builds upload: %w", err)
 				}
 			}
+			defer artifactFile.Close()
 
 			// Determine platform
 			var platformValue asc.Platform
@@ -189,7 +191,7 @@ Examples:
 			buildNumberValue := strings.TrimSpace(*buildNumber)
 			var ipaBundleID string
 			if hasIPA {
-				ipaInfo, extractErr := shared.ExtractBundleInfoFromIPA(filePath)
+				ipaInfo, extractErr := shared.ExtractBundleInfoFromIPAFile(artifactFile)
 				if extractErr != nil {
 					return fmt.Errorf("builds upload: inspect IPA metadata: %w", extractErr)
 				}
@@ -297,7 +299,7 @@ Examples:
 				}
 				fmt.Fprintf(os.Stderr, "Uploading %s (%d bytes) to App Store Connect...\n", fileInfo.Name(), fileInfo.Size())
 				uploadCtx, uploadCancel := shared.ContextWithUploadTimeout(ctx)
-				err = asc.ExecuteUploadOperations(uploadCtx, filePath, fileResp.Data.Attributes.UploadOperations, uploadOpts...)
+				err = asc.ExecuteUploadOperationsFromFile(uploadCtx, artifactFile, fileResp.Data.Attributes.UploadOperations, uploadOpts...)
 				uploadCancel()
 				if err != nil {
 					return fmt.Errorf("builds upload: upload failed: %w", err)
@@ -310,7 +312,7 @@ Examples:
 					if src == nil || (src.File == nil && src.Composite == nil) {
 						fmt.Fprintln(os.Stderr, "Warning: --checksum requested but API provided no checksums to verify; skipping")
 					} else {
-						checksums, err := asc.VerifySourceFileChecksums(filePath, src)
+						checksums, err := asc.VerifySourceFileChecksumsFromFile(artifactFile, src)
 						if err != nil {
 							return fmt.Errorf("builds upload: checksum verification failed: %w", err)
 						}

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -114,12 +114,9 @@ Examples:
 					return fmt.Errorf("builds upload: %w", err)
 				}
 			} else {
-				fileInfo, err = os.Stat(filePath)
+				fileInfo, err = shared.ValidatePKGPath(filePath)
 				if err != nil {
-					return fmt.Errorf("builds upload: failed to stat PKG: %w", err)
-				}
-				if fileInfo.IsDir() {
-					return fmt.Errorf("builds upload: --pkg must be a file")
+					return fmt.Errorf("builds upload: %w", err)
 				}
 			}
 

--- a/internal/cli/cmdtest/builds_upload_artifact_validation_test.go
+++ b/internal/cli/cmdtest/builds_upload_artifact_validation_test.go
@@ -2,6 +2,8 @@ package cmdtest
 
 import (
 	"context"
+	"crypto/md5"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -25,7 +27,7 @@ func TestBuildsUploadRejectsUnsafePKGBeforeNetwork(t *testing.T) {
 	}
 	linkPath := filepath.Join(dir, "link.pkg")
 	if err := os.Symlink(targetPath, linkPath); err != nil {
-		t.Skipf("symlink not supported: %v", err)
+		t.Fatalf("create PKG symlink: %v", err)
 	}
 
 	originalTransport := http.DefaultTransport
@@ -41,7 +43,7 @@ func TestBuildsUploadRejectsUnsafePKGBeforeNetwork(t *testing.T) {
 		wantErr string
 	}{
 		{name: "empty", path: emptyPath, wantErr: "--pkg must not be empty"},
-		{name: "symlink", path: linkPath, wantErr: "refusing to read symlink"},
+		{name: "symlink", path: linkPath, wantErr: "from --pkg"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -62,5 +64,84 @@ func TestBuildsUploadRejectsUnsafePKGBeforeNetwork(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", test.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestBuildsUploadPinsValidatedPKGAcrossPathReplacement(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	dir := t.TempDir()
+	pkgPath := filepath.Join(dir, "app.pkg")
+	replacementPath := filepath.Join(dir, "replacement.pkg")
+	originalPayload := []byte("original")
+	replacementPayload := []byte("replaced")
+	if err := os.WriteFile(pkgPath, originalPayload, 0o600); err != nil {
+		t.Fatalf("write original PKG: %v", err)
+	}
+	if err := os.WriteFile(replacementPath, replacementPayload, 0o600); err != nil {
+		t.Fatalf("write replacement PKG: %v", err)
+	}
+	originalHash := fmt.Sprintf("%x", md5.Sum(originalPayload))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	var uploadedPayload string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"MAC_OS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			if err := os.Remove(pkgPath); err != nil {
+				t.Fatalf("remove original PKG path: %v", err)
+			}
+			if err := os.Rename(replacementPath, pkgPath); err != nil {
+				t.Fatalf("replace original PKG path: %v", err)
+			}
+			body := fmt.Sprintf(`{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.pkg","fileSize":%d,"uti":"com.apple.pkg","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":%d,"offset":0}],"sourceFileChecksums":{"file":{"hash":%q,"algorithm":"MD5"}}}}}`, len(originalPayload), len(originalPayload), originalHash)
+			return jsonResponse(http.StatusOK, body)
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			uploadedPayload = string(body)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			if !strings.Contains(string(body), originalHash) {
+				t.Fatalf("commit body does not contain original checksum %q: %s", originalHash, body)
+			}
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"uploaded":true}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"builds", "upload",
+		"--app", "123456789",
+		"--pkg", pkgPath,
+		"--version", "1.0.0",
+		"--build-number", "42",
+		"--checksum",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var runErr error
+	_, _ = captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if uploadedPayload != string(originalPayload) {
+		t.Fatalf("uploaded payload = %q, want original %q", uploadedPayload, originalPayload)
 	}
 }

--- a/internal/cli/cmdtest/builds_upload_artifact_validation_test.go
+++ b/internal/cli/cmdtest/builds_upload_artifact_validation_test.go
@@ -1,0 +1,66 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildsUploadRejectsUnsafePKGBeforeNetwork(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	dir := t.TempDir()
+	emptyPath := filepath.Join(dir, "empty.pkg")
+	if err := os.WriteFile(emptyPath, nil, 0o600); err != nil {
+		t.Fatalf("write empty PKG: %v", err)
+	}
+	targetPath := filepath.Join(dir, "target.pkg")
+	if err := os.WriteFile(targetPath, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write PKG target: %v", err)
+	}
+	linkPath := filepath.Join(dir, "link.pkg")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request for unsafe PKG: %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{name: "empty", path: emptyPath, wantErr: "--pkg must not be empty"},
+		{name: "symlink", path: linkPath, wantErr: "refusing to read symlink"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			if err := root.Parse([]string{
+				"builds", "upload",
+				"--app", "123456789",
+				"--pkg", test.path,
+				"--version", "1.0.0",
+				"--build-number", "42",
+				"--dry-run",
+			}); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			err := root.Run(context.Background())
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", test.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/cli/shared/ipa.go
+++ b/internal/cli/shared/ipa.go
@@ -22,33 +22,87 @@ type IPABundleInfo struct {
 // ValidateIPAPath ensures an IPA path points to a non-empty regular file and
 // rejects symlinks so upload commands don't dereference unexpected files.
 func ValidateIPAPath(ipaPath string) (os.FileInfo, error) {
-	return validateBuildArtifactPath(ipaPath, "IPA", "--ipa")
+	file, fileInfo, err := OpenValidatedIPAPath(ipaPath)
+	if err != nil {
+		return nil, err
+	}
+	_ = file.Close()
+	return fileInfo, nil
 }
 
 // ValidatePKGPath ensures a PKG path points to a non-empty regular file and
 // rejects symlinks before an upload reservation is created.
 func ValidatePKGPath(pkgPath string) (os.FileInfo, error) {
-	return validateBuildArtifactPath(pkgPath, "PKG", "--pkg")
+	file, fileInfo, err := OpenValidatedPKGPath(pkgPath)
+	if err != nil {
+		return nil, err
+	}
+	_ = file.Close()
+	return fileInfo, nil
 }
 
-func validateBuildArtifactPath(filePath, artifactName, flagName string) (os.FileInfo, error) {
-	fileInfo, err := os.Lstat(filePath)
+// OpenValidatedIPAPath opens and validates an IPA without following a symlink.
+// The returned handle pins the validated file across the upload lifecycle.
+func OpenValidatedIPAPath(ipaPath string) (*os.File, os.FileInfo, error) {
+	return openValidatedBuildArtifactPath(ipaPath, "IPA", "--ipa")
+}
+
+// OpenValidatedPKGPath opens and validates a PKG without following a symlink.
+// The returned handle pins the validated file across the upload lifecycle.
+func OpenValidatedPKGPath(pkgPath string) (*os.File, os.FileInfo, error) {
+	return openValidatedBuildArtifactPath(pkgPath, "PKG", "--pkg")
+}
+
+func openValidatedBuildArtifactPath(filePath, artifactName, flagName string) (*os.File, os.FileInfo, error) {
+	pathInfo, err := os.Lstat(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat %s: %w", artifactName, err)
+		return nil, nil, fmt.Errorf("failed to stat %s: %w", artifactName, err)
 	}
-	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("refusing to read symlink %q", filePath)
+	if pathInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, nil, buildArtifactSymlinkError(filePath, flagName)
 	}
+	if err := validateBuildArtifactInfo(pathInfo, flagName); err != nil {
+		return nil, nil, err
+	}
+
+	file, err := OpenExistingNoFollow(filePath)
+	if err != nil {
+		if latestInfo, statErr := os.Lstat(filePath); statErr == nil && latestInfo.Mode()&os.ModeSymlink != 0 {
+			return nil, nil, buildArtifactSymlinkError(filePath, flagName)
+		}
+		return nil, nil, fmt.Errorf("failed to open %s: %w", artifactName, err)
+	}
+	fileInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("failed to stat opened %s: %w", artifactName, err)
+	}
+	if !os.SameFile(pathInfo, fileInfo) {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("%s changed while being opened", flagName)
+	}
+	if err := validateBuildArtifactInfo(fileInfo, flagName); err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	return file, fileInfo, nil
+}
+
+func validateBuildArtifactInfo(fileInfo os.FileInfo, flagName string) error {
 	if fileInfo.IsDir() {
-		return nil, fmt.Errorf("%s must be a file", flagName)
+		return fmt.Errorf("%s must be a file", flagName)
 	}
 	if !fileInfo.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s must be a regular file", flagName)
+		return fmt.Errorf("%s must be a regular file", flagName)
 	}
 	if fileInfo.Size() == 0 {
-		return nil, fmt.Errorf("%s must not be empty", flagName)
+		return fmt.Errorf("%s must not be empty", flagName)
 	}
-	return fileInfo, nil
+	return nil
+}
+
+func buildArtifactSymlinkError(filePath, flagName string) error {
+	return fmt.Errorf("refusing to read symlink %q from %s", filePath, flagName)
 }
 
 // ExtractBundleInfoFromIPA reads the top-level app's bundle identifier and
@@ -59,8 +113,27 @@ func ExtractBundleInfoFromIPA(ipaPath string) (IPABundleInfo, error) {
 		return IPABundleInfo{}, fmt.Errorf("open IPA: %w", err)
 	}
 	defer reader.Close()
+	return extractBundleInfoFromIPAFiles(reader.File)
+}
 
-	for _, file := range reader.File {
+// ExtractBundleInfoFromIPAFile reads top-level app metadata from an opened IPA.
+func ExtractBundleInfoFromIPAFile(file *os.File) (IPABundleInfo, error) {
+	if file == nil {
+		return IPABundleInfo{}, fmt.Errorf("open IPA: file is required")
+	}
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return IPABundleInfo{}, fmt.Errorf("stat IPA: %w", err)
+	}
+	reader, err := zip.NewReader(file, fileInfo.Size())
+	if err != nil {
+		return IPABundleInfo{}, fmt.Errorf("open IPA: %w", err)
+	}
+	return extractBundleInfoFromIPAFiles(reader.File)
+}
+
+func extractBundleInfoFromIPAFiles(files []*zip.File) (IPABundleInfo, error) {
+	for _, file := range files {
 		if file.FileInfo().IsDir() {
 			continue
 		}

--- a/internal/cli/shared/ipa.go
+++ b/internal/cli/shared/ipa.go
@@ -19,18 +19,34 @@ type IPABundleInfo struct {
 	BuildNumber string
 }
 
-// ValidateIPAPath ensures an IPA path points to a regular file and rejects
-// symlinks so upload commands don't accidentally dereference unexpected files.
+// ValidateIPAPath ensures an IPA path points to a non-empty regular file and
+// rejects symlinks so upload commands don't dereference unexpected files.
 func ValidateIPAPath(ipaPath string) (os.FileInfo, error) {
-	fileInfo, err := os.Lstat(ipaPath)
+	return validateBuildArtifactPath(ipaPath, "IPA", "--ipa")
+}
+
+// ValidatePKGPath ensures a PKG path points to a non-empty regular file and
+// rejects symlinks before an upload reservation is created.
+func ValidatePKGPath(pkgPath string) (os.FileInfo, error) {
+	return validateBuildArtifactPath(pkgPath, "PKG", "--pkg")
+}
+
+func validateBuildArtifactPath(filePath, artifactName, flagName string) (os.FileInfo, error) {
+	fileInfo, err := os.Lstat(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat IPA: %w", err)
+		return nil, fmt.Errorf("failed to stat %s: %w", artifactName, err)
 	}
 	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("refusing to read symlink %q", ipaPath)
+		return nil, fmt.Errorf("refusing to read symlink %q", filePath)
 	}
 	if fileInfo.IsDir() {
-		return nil, fmt.Errorf("--ipa must be a file")
+		return nil, fmt.Errorf("%s must be a file", flagName)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file", flagName)
+	}
+	if fileInfo.Size() == 0 {
+		return nil, fmt.Errorf("%s must not be empty", flagName)
 	}
 	return fileInfo, nil
 }

--- a/internal/cli/shared/ipa_test.go
+++ b/internal/cli/shared/ipa_test.go
@@ -214,6 +214,41 @@ func TestValidateIPAPathAllowsRegularFile(t *testing.T) {
 	}
 }
 
+func TestValidateIPAPathRejectsEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.ipa")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("write empty IPA: %v", err)
+	}
+
+	_, err := ValidateIPAPath(path)
+	if err == nil || !strings.Contains(err.Error(), "--ipa must not be empty") {
+		t.Fatalf("expected empty IPA rejection, got %v", err)
+	}
+}
+
+func TestValidatePKGPathRejectsSymlinkAndEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	emptyPath := filepath.Join(dir, "empty.pkg")
+	if err := os.WriteFile(emptyPath, nil, 0o600); err != nil {
+		t.Fatalf("write empty PKG: %v", err)
+	}
+	if _, err := ValidatePKGPath(emptyPath); err == nil || !strings.Contains(err.Error(), "--pkg must not be empty") {
+		t.Fatalf("expected empty PKG rejection, got %v", err)
+	}
+
+	targetPath := filepath.Join(dir, "target.pkg")
+	if err := os.WriteFile(targetPath, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write PKG target: %v", err)
+	}
+	linkPath := filepath.Join(dir, "link.pkg")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := ValidatePKGPath(linkPath); err == nil || !strings.Contains(err.Error(), "refusing to read symlink") {
+		t.Fatalf("expected PKG symlink rejection, got %v", err)
+	}
+}
+
 func TestResolveBundleInfoForIPAUsesProvidedValues(t *testing.T) {
 	version, buildNumber, err := ResolveBundleInfoForIPA("ignored.ipa", "1.2.3", "42")
 	if err != nil {

--- a/internal/cli/shared/ipa_test.go
+++ b/internal/cli/shared/ipa_test.go
@@ -242,9 +242,9 @@ func TestValidatePKGPathRejectsSymlinkAndEmptyFile(t *testing.T) {
 	}
 	linkPath := filepath.Join(dir, "link.pkg")
 	if err := os.Symlink(targetPath, linkPath); err != nil {
-		t.Skipf("symlink not supported: %v", err)
+		t.Fatalf("create PKG symlink: %v", err)
 	}
-	if _, err := ValidatePKGPath(linkPath); err == nil || !strings.Contains(err.Error(), "refusing to read symlink") {
+	if _, err := ValidatePKGPath(linkPath); err == nil || !strings.Contains(err.Error(), "from --pkg") {
 		t.Fatalf("expected PKG symlink rejection, got %v", err)
 	}
 }


### PR DESCRIPTION
## What changed

- Require IPA and PKG upload inputs to be non-empty regular files.
- Reject PKG symlinks instead of following them.
- Apply the checks before authentication and build-upload reservation.

## Why

PKG uploads previously used a following `stat` call and accepted zero-byte or non-regular paths. That could dereference an unintended target or create remote upload resources for an artifact that cannot be uploaded successfully. IPA checks now use the same complete file contract for consistent behavior.

## Compatibility

Valid regular IPA and PKG files are unchanged. Empty files, symlinks, directories, and other non-regular inputs now fail locally with a flag-specific error.

## Validation

- Captured zero-byte and symlinked PKG reservations as RED CLI/HTTP tests.
- Added shared validator coverage for empty IPA/PKG files and PKG symlinks.
- Ran focused build, publish, shared, and CLI suites.
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PKG and IPA uploads now reject empty files, directories, non-regular files, and symlinked paths before network requests.
  * Uploads now use the validated artifact contents throughout transfer and checksum verification, even if the artifact path changes.
  * Upload validation errors remain clearly associated with the builds upload command.

* **Tests**
  * Added coverage confirming invalid PKG and IPA artifacts are detected during validation.
  * Added coverage confirming uploads remain tied to the originally validated artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->