### PR TITLE
fix(ads): bound optimization body pagination

### DIFF
--- a/internal/appleads/pagination.go
+++ b/internal/appleads/pagination.go
@@ -31,7 +31,10 @@ type platformPaginatedEnvelope struct {
 	Pagination platformPageDetail `json:"pagination"`
 }
 
-const maxPlatformPaginationPages = 1000
+// MaxPlatformPaginationPages bounds how many pages any Apple Ads paginator
+// fetches for a single logical query. Servers that keep returning full pages
+// without a total count would otherwise loop forever.
+const MaxPlatformPaginationPages = 1000
 
 // PaginateAll fetches all pages for an offset-paginated endpoint.
 func (c *Client) PaginateAll(ctx context.Context, spec EndpointSpec, pathParams map[string]string, query url.Values, startOffset, pageSize int, body json.RawMessage) (RawResponse, error) {
@@ -113,8 +116,8 @@ func (c *Client) paginatePlatformChangeHistoryDetail(ctx context.Context, spec E
 	var aggregated []json.RawMessage
 	var total *int
 	for pages := 0; ; pages++ {
-		if pages >= maxPlatformPaginationPages {
-			return nil, fmt.Errorf("platform API v1 pagination exceeded the %d-page safety limit; narrow your query or use --offset to continue from a smaller result set", maxPlatformPaginationPages)
+		if pages >= MaxPlatformPaginationPages {
+			return nil, fmt.Errorf("platform API v1 pagination exceeded the %d-page safety limit; narrow your query or use --offset to continue from a smaller result set", MaxPlatformPaginationPages)
 		}
 		pageQuery := cloneValues(query)
 		pageQuery.Set("limit", strconv.Itoa(pageSize))
@@ -318,8 +321,8 @@ func (c *Client) paginatePlatformGET(ctx context.Context, spec EndpointSpec, pat
 	var total *int
 	pages := 0
 	for {
-		if pages >= maxPlatformPaginationPages {
-			return nil, fmt.Errorf("platform API v1 pagination exceeded the %d-page safety limit; narrow your query or use --offset to continue from a smaller result set", maxPlatformPaginationPages)
+		if pages >= MaxPlatformPaginationPages {
+			return nil, fmt.Errorf("platform API v1 pagination exceeded the %d-page safety limit; narrow your query or use --offset to continue from a smaller result set", MaxPlatformPaginationPages)
 		}
 		pages++
 		pageQuery := cloneValues(query)

--- a/internal/appleads/pagination_test.go
+++ b/internal/appleads/pagination_test.go
@@ -133,7 +133,7 @@ func TestPaginateAllPlatformGETCapsUnboundedPages(t *testing.T) {
 	if err == nil {
 		t.Fatal("PaginateAll() unexpectedly succeeded for an unbounded result")
 	}
-	if got, want := requests, maxPlatformPaginationPages; got != want {
+	if got, want := requests, MaxPlatformPaginationPages; got != want {
 		t.Fatalf("request count = %d, want %d", got, want)
 	}
 	for _, want := range []string{"1000-page safety limit", "narrow your query", "--offset"} {

--- a/internal/cli/ads/search_optimization.go
+++ b/internal/cli/ads/search_optimization.go
@@ -483,7 +483,7 @@ func fetchOptimizationSearchTerms(ctx context.Context, client *appleads.Client, 
 func queryOptimizationList[T any](ctx context.Context, client *appleads.Client, spec appleads.EndpointSpec, body map[string]any, pageSize int) ([]T, error) {
 	items := make([]T, 0)
 	offset := 0
-	for {
+	for pages := 0; pages < appleads.MaxPlatformPaginationPages; pages++ {
 		pageBody := cloneOptimizationBody(body)
 		pageBody["pagination"] = optimizationRequestPagination(spec, offset, pageSize)
 		raw, err := executeOptimizationQuery(ctx, client, spec, pageBody)
@@ -503,12 +503,13 @@ func queryOptimizationList[T any](ctx context.Context, client *appleads.Client, 
 		}
 		offset += len(envelope.Result)
 	}
+	return items, optimizationPageLimitError(spec)
 }
 
 func queryOptimizationRows[T any](ctx context.Context, client *appleads.Client, spec appleads.EndpointSpec, body map[string]any, pageSize int) ([]T, error) {
 	items := make([]T, 0)
 	offset := 0
-	for {
+	for pages := 0; pages < appleads.MaxPlatformPaginationPages; pages++ {
 		pageBody := cloneOptimizationBody(body)
 		pageBody["pagination"] = optimizationRequestPagination(spec, offset, pageSize)
 		raw, err := executeOptimizationQuery(ctx, client, spec, pageBody)
@@ -530,6 +531,14 @@ func queryOptimizationRows[T any](ctx context.Context, client *appleads.Client, 
 		}
 		offset += len(envelope.Result.Rows)
 	}
+	return items, optimizationPageLimitError(spec)
+}
+
+// optimizationPageLimitError reports that a body-paginated Apple Ads query kept
+// returning full pages past the shared safety bound. The pages already fetched
+// are returned with it so callers can still record partial evidence.
+func optimizationPageLimitError(spec appleads.EndpointSpec) error {
+	return fmt.Errorf("platform API v1 pagination for %s exceeded the %d-page safety limit; narrow the request filters or time range", strings.Join(spec.CommandPath, " "), appleads.MaxPlatformPaginationPages)
 }
 
 func executeOptimizationQuery(ctx context.Context, client *appleads.Client, spec appleads.EndpointSpec, body map[string]any) (appleads.RawResponse, error) {

--- a/internal/cli/ads/search_optimization_test.go
+++ b/internal/cli/ads/search_optimization_test.go
@@ -198,6 +198,72 @@ func TestQueryOptimizationListPaginatesRequestBody(t *testing.T) {
 	}
 }
 
+func TestQueryOptimizationListCapsUnboundedPages(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		writeJSON(t, w, `{"result":[{"text":"one","popularity":1}],"pagination":{"offset":0,"pageSize":1}}`)
+	}))
+	defer server.Close()
+	client, err := appleads.NewClient(appleads.Credentials{AccessToken: "token", AdAccountID: "account-1"}, appleads.WithPlatformBaseURL(server.URL+"/v1/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec, ok := appleads.PlatformEndpointByCommandPath("suggestions", "keywords", "find")
+	if !ok {
+		t.Fatal("missing endpoint spec")
+	}
+
+	items, err := queryOptimizationList[SearchSuggestion](context.Background(), client, spec, map[string]any{}, 1)
+	if err == nil {
+		t.Fatal("queryOptimizationList() unexpectedly succeeded for an unbounded result")
+	}
+	if got, want := requests, appleads.MaxPlatformPaginationPages; got != want {
+		t.Fatalf("request count = %d, want %d", got, want)
+	}
+	if got, want := len(items), appleads.MaxPlatformPaginationPages; got != want {
+		t.Fatalf("accumulated items = %d, want the %d fetched pages returned alongside the error", got, want)
+	}
+	for _, want := range []string{"1000-page safety limit", "suggestions keywords find", "narrow"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want it to contain %q", err, want)
+		}
+	}
+}
+
+func TestQueryOptimizationRowsCapsUnboundedPages(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		writeJSON(t, w, `{"result":{"rows":[{"searchTerm":"habit tracker"}]},"pagination":{"offset":0,"pageSize":1}}`)
+	}))
+	defer server.Close()
+	client, err := appleads.NewClient(appleads.Credentials{AccessToken: "token", AdAccountID: "account-1"}, appleads.WithPlatformBaseURL(server.URL+"/v1/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec, ok := appleads.PlatformEndpointByCommandPath("insights", "search-term-popularity", "find")
+	if !ok {
+		t.Fatal("missing endpoint spec")
+	}
+
+	items, err := queryOptimizationRows[popularityResponse](context.Background(), client, spec, map[string]any{}, 1)
+	if err == nil {
+		t.Fatal("queryOptimizationRows() unexpectedly succeeded for an unbounded result")
+	}
+	if got, want := requests, appleads.MaxPlatformPaginationPages; got != want {
+		t.Fatalf("request count = %d, want %d", got, want)
+	}
+	if got, want := len(items), appleads.MaxPlatformPaginationPages; got != want {
+		t.Fatalf("accumulated rows = %d, want the %d fetched pages returned alongside the error", got, want)
+	}
+	for _, want := range []string{"1000-page safety limit", "insights search-term-popularity find", "narrow"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want it to contain %q", err, want)
+		}
+	}
+}
+
 func TestFetchOptimizationPhraseSuggestionsReadsPhraseField(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any


### PR DESCRIPTION
## Problem

`internal/cli/ads/search_optimization.go` paginates the Apple Ads Platform API v1 body queries with two `for { ... }` loops (`queryOptimizationList`, `queryOptimizationRows`). Both rely entirely on `optimizationPageComplete` to break:

```go
func optimizationPageComplete(offset, pageSize, count, total int) bool {
	if count == 0 {
		return true
	}
	if total > 0 {
		return offset + count >= total
	}
	return count < pageSize
}
```

A server that keeps returning `count == pageSize` and omits `totalCount` never satisfies any branch, so the loop runs forever. There is no wall-clock ceiling either: `executeOptimizationQuery` derives a fresh `shared.ContextWithTimeout` per request, so the per-request deadline is renewed on every iteration and never bounds the loop as a whole. `asc optimize search plan` would hang instead of failing.

The platform paginator in `internal/appleads/pagination.go` already guards the same failure mode with a 1000-page cap; the body paginators were left as a follow-up when this code landed.

## Change

- Export `maxPlatformPaginationPages` as `appleads.MaxPlatformPaginationPages` so both paginators share one value (the platform paginator's behavior is unchanged).
- Bound both optimization helpers by that page count. When the bound is hit, the pages fetched so far are returned alongside an error:

  ```
  platform API v1 pagination for insights search-term-popularity find exceeded the 1000-page safety limit; narrow the request filters or time range
  ```

  The guidance intentionally differs from the platform paginator's `--offset` hint, since `asc optimize search plan` has no `--offset` flag; `--window`, `--country`, and `--genre` are what actually narrow these queries.

Returning partial items matches how the rest of this file behaves on failure: `fetchSearchOptimizationData` records each source's status, so a capped query surfaces as an `unavailable` source with the page-limit reason rather than taking down the whole plan.

## Failure mode fixed

Before: a full page with no `totalCount`, repeated, hangs the command indefinitely (confirmed — the new tests time out against the pre-fix code).
After: at most 1000 requests per query, then a clear error naming the query and the limit.

## Tests

New in `internal/cli/ads/search_optimization_test.go`, mirroring `TestPaginateAllPlatformGETCapsUnboundedPages`:

- `TestQueryOptimizationListCapsUnboundedPages`
- `TestQueryOptimizationRowsCapsUnboundedPages`

Each drives a test server that always returns a full page without `totalCount` and asserts the request count equals `appleads.MaxPlatformPaginationPages`, that the accumulated items come back with the error, and that the message names the limit and the query. Both run in ~0.05s, so no injectable bound was needed — the tests exercise the production constant directly, like the existing platform paginator test.

Commands run: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` (all pass; no live API calls).

## Compatibility

No CLI surface change: no new or changed flags, help text, or JSON shapes. Successful pagination behavior is identical below 1000 pages, which no real Apple Ads response reaches for these queries at the page sizes used (1000 and 5000). The only new outcome is an error where the command previously hung. The constant rename is internal to `internal/appleads`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a safety limit to Apple Ads optimization list and row pagination.
  - Prevented searches from continuing indefinitely when result totals are unavailable.
  - Searches now return accumulated results with a clear error when the pagination limit is reached.
  - Error messages identify the affected endpoint and suggest narrowing the query.

- **Tests**
  - Added coverage for pagination-limit behavior and partial results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->