### PR TITLE
fix(versions): reject repeated copy field flags on versions create

### DIFF
--- a/internal/cli/cmdtest/versions_create_copy_metadata_test.go
+++ b/internal/cli/cmdtest/versions_create_copy_metadata_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestVersionsCreateCopyMetadataAppliesSelectedFields(t *testing.T) {
@@ -339,5 +341,73 @@ func TestVersionsCreateCopyMetadataRejectsInvalidExcludeField(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "--exclude-fields must be one of:") {
 		t.Fatalf("expected exclude-fields usage error, got %q", stderr)
+	}
+}
+
+func TestVersionsCreateRejectsRepeatedCopyFieldFlags(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request to %s", req.URL.String())
+		return nil, nil
+	})
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "copy-fields",
+			args: []string{
+				"versions", "create",
+				"--app", "app-1",
+				"--version", "2.4.0",
+				"--copy-metadata-from", "2.3.2",
+				"--copy-fields", "description",
+				"--copy-fields", "keywords",
+			},
+			wantErr: `--copy-fields specified multiple times; pass one comma-separated list, for example --copy-fields "description,keywords"`,
+		},
+		{
+			name: "exclude-fields",
+			args: []string{
+				"versions", "create",
+				"--app", "app-1",
+				"--version", "2.4.0",
+				"--copy-metadata-from", "2.3.2",
+				"--exclude-fields", "whatsNew",
+				"--exclude-fields", "keywords",
+			},
+			wantErr: `--exclude-fields specified multiple times; pass one comma-separated list, for example --exclude-fields "whatsNew,keywords"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				code := cmd.Run(test.args, "1.2.3")
+				if code != cmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+
+			if strings.TrimSpace(stdout) != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("stderr = %q, want it to contain %q", stderr, test.wantErr)
+			}
+			if strings.Contains(stderr, "SUBCOMMANDS") {
+				t.Fatalf("expected a usage error instead of a help dump, got %q", stderr)
+			}
+		})
 	}
 }

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -269,8 +269,8 @@ func VersionsCreateCommand() *ffcli.Command {
 	copyright := fs.String("copyright", "", "Copyright text (e.g., '2026 My Company')")
 	releaseType := fs.String("release-type", "", "Release type: MANUAL, AFTER_APPROVAL, SCHEDULED")
 	copyMetadataFrom := fs.String("copy-metadata-from", "", "Copy localization metadata from this source version string")
-	copyFields := fs.String("copy-fields", "", "Comma-separated metadata fields to copy: description, keywords, marketingUrl, promotionalText, supportUrl, whatsNew")
-	excludeFields := fs.String("exclude-fields", "", "Comma-separated metadata fields to exclude from copy")
+	copyFields := shared.BindOnceCSVFlag(fs, "copy-fields", "Comma-separated metadata fields to copy: description, keywords, marketingUrl, promotionalText, supportUrl, whatsNew")
+	excludeFields := shared.BindOnceCSVFlag(fs, "exclude-fields", "Comma-separated metadata fields to exclude from copy")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -305,12 +305,12 @@ Examples:
 			}
 
 			copyMetadataFromValue := strings.TrimSpace(*copyMetadataFrom)
-			copyFieldsValue, err := normalizeVersionMetadataCopyFields(*copyFields, "--copy-fields")
+			copyFieldsValue, err := normalizeVersionMetadataCopyFields(copyFields.String(), "--copy-fields")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				return flag.ErrHelp
 			}
-			excludeFieldsValue, err := normalizeVersionMetadataCopyFields(*excludeFields, "--exclude-fields")
+			excludeFieldsValue, err := normalizeVersionMetadataCopyFields(excludeFields.String(), "--exclude-fields")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				return flag.ErrHelp


### PR DESCRIPTION
## Problem

On `asc versions create`, `--copy-fields` and `--exclude-fields` were bound with plain `fs.String`. Passing either flag more than once was accepted, and the standard flag parser kept only the last occurrence. The command then created the version and copied metadata according to a list the caller never asked for — silent data loss on a mutating command, with no warning and a success exit code.

The identical flags on `asc release stage` already guard against this with `shared.BindOnceCSVFlag`; `versions create` was simply never converted.

Before this change, the RED test showed the command going all the way to `POST /v1/appStoreVersions` with only the last list applied.

## Behavior change

Both flags now bind through `shared.BindOnceCSVFlag`, so a repeated flag fails at parse time with a usage error (exit 2) that names the flag and shows the merged list to pass instead. Nothing else about the command changes: a single flag occurrence, the field validation messages, and the help text are all identical.

## Example invocations

```
$ asc versions create --app "APP_ID" --version "2.4.0" --copy-metadata-from "2.3.2" --copy-fields "description" --copy-fields "keywords"
--copy-fields specified multiple times; pass one comma-separated list, for example --copy-fields "description,keywords"
$ echo $?
2
```

```
$ asc versions create --app "APP_ID" --version "2.4.0" --copy-metadata-from "2.3.2" --exclude-fields "whatsNew" --exclude-fields "keywords"
--exclude-fields specified multiple times; pass one comma-separated list, for example --exclude-fields "whatsNew,keywords"
$ echo $?
2
```

The supported form is unchanged:

```
asc versions create --app "APP_ID" --version "2.4.0" --copy-metadata-from "2.3.2" --copy-fields "description,keywords,supportUrl"
```

## Tests

Added `TestVersionsCreateRejectsRepeatedCopyFieldFlags` to `internal/cli/cmdtest/versions_create_copy_metadata_test.go`, covering both flags: exit 2, the once-CSV message on stderr, no help dump, and no HTTP request issued. The test fails on `main` by reaching the create request.

Ran `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all green (the full suite also runs via the pre-commit hook). No live API calls.

## Compatibility

No flag is removed or renamed and no valid invocation changes behavior. The only newly rejected input is a repeat of a flag whose previous handling discarded data, so nothing that worked as documented breaks. Help text is byte-identical, so `docs/COMMANDS.md` is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repeated `--copy-fields` and `--exclude-fields` options in the `versions create` command.
  * Added clearer validation errors for invalid or conflicting field selections.
  * Prevented unnecessary help output when command-line validation fails.
* **Tests**
  * Added coverage for repeated options, validation failures, exit codes, and ensuring no network requests are made for invalid commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->