### PR TITLE
docs(versions): add worked examples to versions group help

### DIFF
--- a/internal/cli/cmdtest/versions_group_help_test.go
+++ b/internal/cli/cmdtest/versions_group_help_test.go
@@ -1,0 +1,117 @@
+package cmdtest
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/kballard/go-shellquote"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func versionsGroupHelpText(t *testing.T) string {
+	t.Helper()
+
+	var help string
+	stdout, stderr := captureOutput(t, func() {
+		if code := cmd.Run([]string{"versions", "--help"}, "1.2.3"); code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	help = stdout + stderr
+	if !strings.Contains(help, "SUBCOMMANDS") {
+		t.Fatalf("expected group help, got %q", help)
+	}
+	return help
+}
+
+func TestVersionsGroupHelpDocumentsCoreWorkflows(t *testing.T) {
+	help := versionsGroupHelpText(t)
+
+	if !strings.Contains(help, "Examples:") {
+		t.Fatalf("expected an Examples block in `asc versions --help`, got %q", help)
+	}
+
+	wantSubcommands := []string{
+		"asc versions list ",
+		"asc versions create ",
+		"asc versions update ",
+		"asc versions attach-build ",
+		"asc versions release ",
+	}
+	for _, want := range wantSubcommands {
+		if !strings.Contains(help, want) {
+			t.Fatalf("expected example for %q in group help, got %q", strings.TrimSpace(want), help)
+		}
+	}
+
+	if strings.Contains(help, " -app ") || strings.Contains(help, " -version ") {
+		t.Fatalf("examples must use long-form flags, got %q", help)
+	}
+}
+
+func TestVersionsGroupHelpExamplesParseAgainstCurrentCLI(t *testing.T) {
+	help := versionsGroupHelpText(t)
+
+	examples := make([]string, 0, 8)
+	for _, line := range strings.Split(help, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "asc versions ") {
+			continue
+		}
+		// Skip the USAGE placeholder line rather than the concrete examples.
+		if strings.Contains(trimmed, "<") {
+			continue
+		}
+		examples = append(examples, trimmed)
+	}
+	if len(examples) < 5 {
+		t.Fatalf("expected example invocations in group help, got %d in %q", len(examples), help)
+	}
+
+	for _, example := range examples {
+		t.Run(example, func(t *testing.T) {
+			args, err := shellquote.Split(example)
+			if err != nil {
+				t.Fatalf("split %q: %v", example, err)
+			}
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			if err := root.Parse(args[1:]); err != nil {
+				t.Fatalf("parse %q: %v", example, err)
+			}
+		})
+	}
+}
+
+func TestVersionsGroupHelpListsEverySubcommand(t *testing.T) {
+	help := versionsGroupHelpText(t)
+
+	wantSubcommands := []string{
+		"list",
+		"view",
+		"links",
+		"experiments-v2",
+		"customer-reviews",
+		"app-clip-default-experience",
+		"create",
+		"update",
+		"delete",
+		"attach-build",
+		"release",
+		"phased-release",
+		"promotions",
+	}
+
+	subcommandsBlock := help
+	if index := strings.Index(help, "SUBCOMMANDS"); index >= 0 {
+		subcommandsBlock = help[index:]
+	}
+	for _, name := range wantSubcommands {
+		if !strings.Contains(subcommandsBlock, "\n  "+name+" ") {
+			t.Fatalf("expected subcommand %q listed in group help, got %q", name, subcommandsBlock)
+		}
+	}
+}

--- a/internal/cli/cmdtest/versions_group_help_test.go
+++ b/internal/cli/cmdtest/versions_group_help_test.go
@@ -35,19 +35,17 @@ func TestVersionsGroupHelpDocumentsCoreWorkflows(t *testing.T) {
 
 	wantSubcommands := []string{
 		"asc versions list ",
+		"asc versions view ",
 		"asc versions create ",
 		"asc versions update ",
 		"asc versions attach-build ",
 		"asc versions release ",
+		"asc versions phased-release ",
 	}
 	for _, want := range wantSubcommands {
 		if !strings.Contains(help, want) {
 			t.Fatalf("expected example for %q in group help, got %q", strings.TrimSpace(want), help)
 		}
-	}
-
-	if strings.Contains(help, " -app ") || strings.Contains(help, " -version ") {
-		t.Fatalf("examples must use long-form flags, got %q", help)
 	}
 }
 
@@ -75,6 +73,11 @@ func TestVersionsGroupHelpExamplesParseAgainstCurrentCLI(t *testing.T) {
 			args, err := shellquote.Split(example)
 			if err != nil {
 				t.Fatalf("split %q: %v", example, err)
+			}
+			for _, arg := range args {
+				if strings.HasPrefix(arg, "-") && arg != "-" && !strings.HasPrefix(arg, "--") {
+					t.Fatalf("example %q uses short-form flag %q", example, arg)
+				}
 			}
 
 			root := RootCommand("1.2.3")

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -21,8 +21,19 @@ func VersionsCommand() *ffcli.Command {
 		Name:       "versions",
 		ShortUsage: "asc versions <subcommand> [flags]",
 		ShortHelp:  "Manage App Store versions.",
-		LongHelp:   `Manage App Store versions.`,
-		UsageFunc:  shared.VisibleUsageFunc,
+		LongHelp: `Manage App Store versions.
+
+Examples:
+  asc versions list --app "123456789"
+  asc versions list --app "123456789" --platform IOS --state READY_FOR_REVIEW
+  asc versions view --version-id "VERSION_ID" --include-build --include-submission
+  asc versions create --app "123456789" --version "2.0.0" --platform IOS
+  asc versions create --app "123456789" --version "2.4.0" --copy-metadata-from "2.3.2"
+  asc versions update --version-id "VERSION_ID" --release-type MANUAL
+  asc versions attach-build --version-id "VERSION_ID" --build-id "BUILD_ID"
+  asc versions release --version-id "VERSION_ID" --confirm
+  asc versions phased-release view --version-id "VERSION_ID"`,
+		UsageFunc: shared.VisibleUsageFunc,
 		Subcommands: []*ffcli.Command{
 			VersionsListCommand(),
 			viewCmd,


### PR DESCRIPTION
## Problem

`asc versions --help` listed 13 subcommands and nothing else — no sample invocation anywhere in the group help. Every other core App Store domain group leads with worked examples (`asc apps --help` has 24, `asc builds --help` has 30), so a caller landing on `versions` had to open each subcommand's help to learn the shape of a basic release flow.

## Behavior change

Help text only — no command, flag, request, or output change.

`asc versions --help` now renders an Examples block between USAGE and SUBCOMMANDS, covering the common path end to end:

```
Examples:
  asc versions list --app "123456789"
  asc versions list --app "123456789" --platform IOS --state READY_FOR_REVIEW
  asc versions view --version-id "VERSION_ID" --include-build --include-submission
  asc versions create --app "123456789" --version "2.0.0" --platform IOS
  asc versions create --app "123456789" --version "2.4.0" --copy-metadata-from "2.3.2"
  asc versions update --version-id "VERSION_ID" --release-type MANUAL
  asc versions attach-build --version-id "VERSION_ID" --build-id "BUILD_ID"
  asc versions release --version-id "VERSION_ID" --confirm
  asc versions phased-release view --version-id "VERSION_ID"
```

All long-form flags, and every line is a real invocation of a current subcommand — enforced by a test rather than by review.

## Usage function: kept as-is, deliberately

The group renders with `shared.VisibleUsageFunc` rather than `shared.DefaultUsageFunc`, so I checked whether that is an accident.

It is not. `VisibleUsageFunc` (`internal/cli/shared/compat_aliases.go`) clones the command and drops direct subcommands whose `ShortHelp` starts with `DEPRECATED:` before delegating to `DefaultUsageFunc` — it exists to keep deprecated compatibility aliases out of group help. It is the convention for top-level domain groups that can host such aliases, including `apps`, `builds`, `submit`, `release`, `certificates`, `profiles`, and `publish`.

The versions group has no deprecated subcommand today, so both functions render byte-identical output (verified by diffing `asc versions --help` with each). Switching would therefore change nothing now, while removing the guard that keeps a future deprecated alias hidden and putting this group out of step with its peers. Keeping `VisibleUsageFunc`; the new subcommand-listing test locks the current rendering in either way.

## Tests

New `internal/cli/cmdtest/versions_group_help_test.go`:

- `TestVersionsGroupHelpDocumentsCoreWorkflows` — the Examples block exists and covers list, create, update, attach-build, and release, with long-form flags.
- `TestVersionsGroupHelpExamplesParseAgainstCurrentCLI` — every example line in the group help is shell-split and parsed against the live command tree, so an example cannot go stale when a flag is renamed.
- `TestVersionsGroupHelpListsEverySubcommand` — all 13 subcommands stay listed, pinning the rendering discussed above.

Ran `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all green (the full suite also runs via the pre-commit hook). Ran `make generate-command-docs`: `docs/COMMANDS.md` is generated from the root `asc --help` group listing, so a group LongHelp change leaves it byte-identical and there is nothing to commit.

## Compatibility

Help text only. No flag, output shape, or exit code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded `versions` command help with examples for listing, viewing, creating, updating, attaching builds, releasing, and viewing phased releases.
  * Improved command guidance by documenting required long-form flags and available subcommands.

* **Tests**
  * Added coverage to verify that all documented `versions` examples and subcommands are valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->