### PR TITLE
fix(cli): reject repeated comma-separated flags on nominations, profiles, and win-back offers

### DIFF
--- a/internal/cli/cmdtest/once_csv_repeated_flag_contract_test.go
+++ b/internal/cli/cmdtest/once_csv_repeated_flag_contract_test.go
@@ -1,0 +1,148 @@
+package cmdtest
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+// Comma-separated list flags bound with shared.BindOnceCSVFlag must reject a
+// repeated occurrence instead of silently keeping only the last one. These
+// tests pin that contract end to end through the real command tree so the
+// behavior cannot regress into silent data loss on a mutating command.
+
+func TestRepeatedCSVFlagRejectedEndToEnd(t *testing.T) {
+	isolateRepeatedCSVFlagEnv(t)
+
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{
+			"profiles", "create",
+			"--name", "Contract",
+			"--profile-type", "IOS_APP_DEVELOPMENT",
+			"--bundle", "BUNDLE_ID",
+			"--certificate", "CERT_A",
+			"--certificate", "CERT_B",
+		}, "1.2.3")
+		if code != rootcmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+
+	wantMessage := repeatedCSVFlagMessage("certificate", "CERT_A", "CERT_B")
+	if !strings.Contains(stderr, wantMessage) {
+		t.Fatalf("stderr = %q, want it to contain %q", stderr, wantMessage)
+	}
+
+	// The rejection is a flag parse failure, not a help request: `--help` exits
+	// 0 and starts with the usage banner, so the first stderr line has to be the
+	// flag error itself.
+	firstLine, _, _ := strings.Cut(stderr, "\n")
+	wantFirstLine := fmt.Sprintf("invalid value %q for flag -certificate: %s", "CERT_B", wantMessage)
+	if firstLine != wantFirstLine {
+		t.Fatalf("first stderr line = %q, want %q", firstLine, wantFirstLine)
+	}
+}
+
+func TestRepeatedCSVFlagRejectedAcrossConvertedCommands(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+		flag    string
+	}{
+		{name: "nominations create app", command: []string{"nominations", "create"}, flag: "app"},
+		{name: "nominations create device families", command: []string{"nominations", "create"}, flag: "device-families"},
+		{name: "nominations create locales", command: []string{"nominations", "create"}, flag: "locales"},
+		{name: "nominations create supplemental materials uris", command: []string{"nominations", "create"}, flag: "supplemental-materials-uris"},
+		{name: "nominations create in-app events", command: []string{"nominations", "create"}, flag: "in-app-events"},
+		{name: "nominations create supported territories", command: []string{"nominations", "create"}, flag: "supported-territories"},
+		{name: "nominations update app", command: []string{"nominations", "update"}, flag: "app"},
+		{name: "nominations update device families", command: []string{"nominations", "update"}, flag: "device-families"},
+		{name: "nominations update locales", command: []string{"nominations", "update"}, flag: "locales"},
+		{name: "nominations update supplemental materials uris", command: []string{"nominations", "update"}, flag: "supplemental-materials-uris"},
+		{name: "nominations update in-app events", command: []string{"nominations", "update"}, flag: "in-app-events"},
+		{name: "nominations update supported territories", command: []string{"nominations", "update"}, flag: "supported-territories"},
+		{name: "profiles create certificate", command: []string{"profiles", "create"}, flag: "certificate"},
+		{name: "profiles create device", command: []string{"profiles", "create"}, flag: "device"},
+		{name: "win-back offers create price", command: []string{"subscriptions", "offers", "win-back", "create"}, flag: "price"},
+		{name: "win-back offers create territory", command: []string{"subscriptions", "offers", "win-back", "create"}, flag: "territory"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isolateRepeatedCSVFlagEnv(t)
+
+			args := append([]string{}, test.command...)
+			args = append(args, "--"+test.flag, "ONE", "--"+test.flag, "TWO")
+
+			assertUsageExit(t, args, repeatedCSVFlagMessage(test.flag, "ONE", "TWO"))
+		})
+	}
+}
+
+// An explicitly empty value stays a single occurrence, so the existing
+// per-command validation still owns the outcome. This documents current
+// behavior; the once-only binding does not change it.
+func TestExplicitEmptyCSVFlagKeepsExistingValidation(t *testing.T) {
+	t.Run("required flag reports missing input", func(t *testing.T) {
+		isolateRepeatedCSVFlagEnv(t)
+
+		assertUsageExit(t, []string{
+			"profiles", "create",
+			"--name", "Contract",
+			"--profile-type", "IOS_APP_DEVELOPMENT",
+			"--bundle", "BUNDLE_ID",
+			"--certificate", "",
+		}, "Error: --certificate is required")
+	})
+
+	t.Run("empty update flag stays a visited flag", func(t *testing.T) {
+		isolateRepeatedCSVFlagEnv(t)
+
+		stdout, stderr := captureOutput(t, func() {
+			code := rootcmd.Run([]string{
+				"nominations", "update",
+				"--id", "NOMINATION_ID",
+				"--submitted=false",
+				"--locales", "",
+			}, "1.2.3")
+			if code != rootcmd.ExitError {
+				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitError)
+			}
+		})
+
+		if stdout != "" {
+			t.Fatalf("expected empty stdout, got %q", stdout)
+		}
+		if want := "Error: nominations update: --locales is required"; !strings.Contains(stderr, want) {
+			t.Fatalf("stderr = %q, want it to contain %q", stderr, want)
+		}
+	})
+}
+
+func repeatedCSVFlagMessage(name, first, second string) string {
+	return fmt.Sprintf(
+		"--%s specified multiple times; pass one comma-separated list, for example --%s %q",
+		name, name, first+","+second,
+	)
+}
+
+func isolateRepeatedCSVFlagEnv(t *testing.T) {
+	t.Helper()
+
+	setCmdtestHome(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+}

--- a/internal/cli/nominations/nominations.go
+++ b/internal/cli/nominations/nominations.go
@@ -295,22 +295,22 @@ Examples:
 func NominationsCreateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("nominations create", flag.ExitOnError)
 
-	appID := fs.String("app", "", "Related app ID(s), comma-separated (or ASC_APP_ID)")
+	appID := shared.BindOnceCSVFlag(fs, "app", "Related app ID(s), comma-separated (or ASC_APP_ID)")
 	name := fs.String("name", "", "Nomination name (required)")
 	nomType := fs.String("type", "", "Nomination type (required): "+strings.Join(nominationTypeList(), ", "))
 	description := fs.String("description", "", "Nomination description (required)")
 	submitted := fs.Bool("submitted", false, "Submit nomination now (true/false)")
 	publishStartDate := fs.String("publish-start-date", "", "Publish start date (RFC3339, required)")
 	publishEndDate := fs.String("publish-end-date", "", "Publish end date (RFC3339)")
-	deviceFamilies := fs.String("device-families", "", "Device families, comma-separated: "+strings.Join(nominationDeviceFamilyList(), ", "))
-	locales := fs.String("locales", "", "Locales, comma-separated")
-	supplementalMaterialsURIs := fs.String("supplemental-materials-uris", "", "Supplemental material URIs, comma-separated")
+	deviceFamilies := shared.BindOnceCSVFlag(fs, "device-families", "Device families, comma-separated: "+strings.Join(nominationDeviceFamilyList(), ", "))
+	locales := shared.BindOnceCSVFlag(fs, "locales", "Locales, comma-separated")
+	supplementalMaterialsURIs := shared.BindOnceCSVFlag(fs, "supplemental-materials-uris", "Supplemental material URIs, comma-separated")
 	hasInAppEvents := fs.Bool("has-in-app-events", false, "Indicate in-app events are included")
 	launchInSelectMarketsFirst := fs.Bool("launch-in-select-markets-first", false, "Launch in select markets first")
 	notes := fs.String("notes", "", "Internal notes")
 	preOrderEnabled := fs.Bool("pre-order-enabled", false, "Enable pre-order")
-	inAppEvents := fs.String("in-app-events", "", "In-app event IDs, comma-separated")
-	supportedTerritories := fs.String("supported-territories", "", "Supported territory IDs, comma-separated")
+	inAppEvents := shared.BindOnceCSVFlag(fs, "in-app-events", "In-app event IDs, comma-separated")
+	supportedTerritories := shared.BindOnceCSVFlag(fs, "supported-territories", "Supported territory IDs, comma-separated")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -330,7 +330,7 @@ Examples:
 				visited[f.Name] = true
 			})
 
-			relatedApps := shared.SplitCSV(shared.ResolveAppID(*appID))
+			relatedApps := shared.SplitCSV(shared.ResolveAppID(appID.String()))
 			if len(relatedApps) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError("--app")
@@ -370,7 +370,7 @@ Examples:
 				return flag.ErrHelp
 			}
 
-			deviceFamilyValues, err := normalizeNominationDeviceFamilies(shared.SplitCSVUpper(*deviceFamilies))
+			deviceFamilyValues, err := normalizeNominationDeviceFamilies(shared.SplitCSVUpper(deviceFamilies.String()))
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Error:", err)
 				return flag.ErrHelp
@@ -403,10 +403,10 @@ Examples:
 			if len(deviceFamilyValues) > 0 {
 				attrs.DeviceFamilies = normalizeNominationDeviceFamilyAttributes(deviceFamilyValues)
 			}
-			if localesValue := shared.SplitCSV(*locales); len(localesValue) > 0 {
+			if localesValue := shared.SplitCSV(locales.String()); len(localesValue) > 0 {
 				attrs.Locales = localesValue
 			}
-			if supplementalValue := shared.SplitCSV(*supplementalMaterialsURIs); len(supplementalValue) > 0 {
+			if supplementalValue := shared.SplitCSV(supplementalMaterialsURIs.String()); len(supplementalValue) > 0 {
 				attrs.SupplementalMaterialsURIs = supplementalValue
 			}
 			if visited["has-in-app-events"] {
@@ -429,10 +429,10 @@ Examples:
 			relationships := asc.NominationRelationships{
 				RelatedApps: buildNominationRelationshipList(asc.ResourceTypeApps, relatedApps),
 			}
-			if inAppEventIDs := shared.SplitCSV(*inAppEvents); len(inAppEventIDs) > 0 {
+			if inAppEventIDs := shared.SplitCSV(inAppEvents.String()); len(inAppEventIDs) > 0 {
 				relationships.InAppEvents = buildNominationRelationshipList(asc.ResourceTypeAppEvents, inAppEventIDs)
 			}
-			if territoryIDs := shared.SplitCSV(*supportedTerritories); len(territoryIDs) > 0 {
+			if territoryIDs := shared.SplitCSV(supportedTerritories.String()); len(territoryIDs) > 0 {
 				relationships.SupportedTerritories = buildNominationRelationshipList(asc.ResourceTypeTerritories, territoryIDs)
 			}
 
@@ -458,16 +458,16 @@ func NominationsUpdateCommand() *ffcli.Command {
 	archived := fs.Bool("archived", false, "Archive nomination (true/false)")
 	publishStartDate := fs.String("publish-start-date", "", "Publish start date (RFC3339)")
 	publishEndDate := fs.String("publish-end-date", "", "Publish end date (RFC3339)")
-	deviceFamilies := fs.String("device-families", "", "Device families, comma-separated: "+strings.Join(nominationDeviceFamilyList(), ", "))
-	locales := fs.String("locales", "", "Locales, comma-separated")
-	supplementalMaterialsURIs := fs.String("supplemental-materials-uris", "", "Supplemental material URIs, comma-separated")
+	deviceFamilies := shared.BindOnceCSVFlag(fs, "device-families", "Device families, comma-separated: "+strings.Join(nominationDeviceFamilyList(), ", "))
+	locales := shared.BindOnceCSVFlag(fs, "locales", "Locales, comma-separated")
+	supplementalMaterialsURIs := shared.BindOnceCSVFlag(fs, "supplemental-materials-uris", "Supplemental material URIs, comma-separated")
 	hasInAppEvents := fs.Bool("has-in-app-events", false, "Indicate in-app events are included")
 	launchInSelectMarketsFirst := fs.Bool("launch-in-select-markets-first", false, "Launch in select markets first")
 	notes := fs.String("notes", "", "Internal notes")
 	preOrderEnabled := fs.Bool("pre-order-enabled", false, "Enable pre-order")
-	appIDs := fs.String("app", "", "Replace related app ID(s), comma-separated")
-	inAppEvents := fs.String("in-app-events", "", "Replace in-app event IDs, comma-separated")
-	supportedTerritories := fs.String("supported-territories", "", "Replace supported territory IDs, comma-separated")
+	appIDs := shared.BindOnceCSVFlag(fs, "app", "Replace related app ID(s), comma-separated")
+	inAppEvents := shared.BindOnceCSVFlag(fs, "in-app-events", "Replace in-app event IDs, comma-separated")
+	supportedTerritories := shared.BindOnceCSVFlag(fs, "supported-territories", "Replace supported territory IDs, comma-separated")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -570,7 +570,7 @@ Examples:
 					attrsValue.PublishEndDate = &normalized
 				}
 				if visited["device-families"] {
-					deviceFamilyValues, err := normalizeNominationDeviceFamilies(shared.SplitCSVUpper(*deviceFamilies))
+					deviceFamilyValues, err := normalizeNominationDeviceFamilies(shared.SplitCSVUpper(deviceFamilies.String()))
 					if err != nil {
 						fmt.Fprintln(os.Stderr, "Error:", err)
 						return flag.ErrHelp
@@ -581,14 +581,14 @@ Examples:
 					attrsValue.DeviceFamilies = normalizeNominationDeviceFamilyAttributes(deviceFamilyValues)
 				}
 				if visited["locales"] {
-					localesValue := shared.SplitCSV(*locales)
+					localesValue := shared.SplitCSV(locales.String())
 					if len(localesValue) == 0 {
 						return fmt.Errorf("nominations update: --locales is required")
 					}
 					attrsValue.Locales = localesValue
 				}
 				if visited["supplemental-materials-uris"] {
-					supplementalValue := shared.SplitCSV(*supplementalMaterialsURIs)
+					supplementalValue := shared.SplitCSV(supplementalMaterialsURIs.String())
 					if len(supplementalValue) == 0 {
 						return fmt.Errorf("nominations update: --supplemental-materials-uris is required")
 					}
@@ -617,21 +617,21 @@ Examples:
 			if hasRelationshipUpdates {
 				relationshipValue := asc.NominationRelationships{}
 				if visited["app"] {
-					appValues := shared.SplitCSV(*appIDs)
+					appValues := shared.SplitCSV(appIDs.String())
 					if len(appValues) == 0 {
 						return fmt.Errorf("nominations update: --app is required")
 					}
 					relationshipValue.RelatedApps = buildNominationRelationshipList(asc.ResourceTypeApps, appValues)
 				}
 				if visited["in-app-events"] {
-					eventValues := shared.SplitCSV(*inAppEvents)
+					eventValues := shared.SplitCSV(inAppEvents.String())
 					if len(eventValues) == 0 {
 						return fmt.Errorf("nominations update: --in-app-events is required")
 					}
 					relationshipValue.InAppEvents = buildNominationRelationshipList(asc.ResourceTypeAppEvents, eventValues)
 				}
 				if visited["supported-territories"] {
-					territoryValues := shared.SplitCSV(*supportedTerritories)
+					territoryValues := shared.SplitCSV(supportedTerritories.String())
 					if len(territoryValues) == 0 {
 						return fmt.Errorf("nominations update: --supported-territories is required")
 					}

--- a/internal/cli/profiles/profiles.go
+++ b/internal/cli/profiles/profiles.go
@@ -198,8 +198,8 @@ func ProfilesCreateCommand() *ffcli.Command {
 	name := fs.String("name", "", "Profile name")
 	profileType := fs.String("profile-type", "", "Profile type (e.g., IOS_APP_DEVELOPMENT)")
 	bundleID := fs.String("bundle", "", "Bundle ID")
-	certificates := fs.String("certificate", "", "Certificate ID(s), comma-separated")
-	devices := fs.String("device", "", "Device ID(s), comma-separated (optional)")
+	certificates := shared.BindOnceCSVFlag(fs, "certificate", "Certificate ID(s), comma-separated")
+	devices := shared.BindOnceCSVFlag(fs, "device", "Device ID(s), comma-separated (optional)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -229,12 +229,12 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --bundle is required")
 				return shared.MissingRequiredUsageError("--bundle")
 			}
-			certificateIDs := shared.SplitCSV(*certificates)
+			certificateIDs := shared.SplitCSV(certificates.String())
 			if len(certificateIDs) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --certificate is required")
 				return shared.MissingRequiredUsageError("--certificate")
 			}
-			deviceIDs := shared.SplitCSV(*devices)
+			deviceIDs := shared.SplitCSV(devices.String())
 
 			client, err := shared.GetASCClient()
 			if err != nil {

--- a/internal/cli/winbackoffers/win_back_offers.go
+++ b/internal/cli/winbackoffers/win_back_offers.go
@@ -275,8 +275,8 @@ func WinBackOffersCreateCommand() *ffcli.Command {
 	endDate := fs.String("end-date", "", "End date (YYYY-MM-DD)")
 	priority := fs.String("priority", "", "Offer priority: "+strings.Join(winBackOfferPriorityValues, ", "))
 	promotionIntent := fs.String("promotion-intent", "", "Promotion intent: "+strings.Join(winBackOfferPromotionIntentValues, ", "))
-	priceIDs := fs.String("price", "", "Subscription price point ID(s), comma-separated (required for paid offer modes)")
-	territories := fs.String("territory", "", "Territories for FREE_TRIAL offers, comma-separated (accepts alpha-2, alpha-3, or exact English country names)")
+	priceIDs := shared.BindOnceCSVFlag(fs, "price", "Subscription price point ID(s), comma-separated (required for paid offer modes)")
+	territories := shared.BindOnceCSVFlag(fs, "territory", "Territories for FREE_TRIAL offers, comma-separated (accepts alpha-2, alpha-3, or exact English country names)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -390,14 +390,14 @@ Examples:
 			isFreeTrial := offerModeValue == asc.SubscriptionOfferModeFreeTrial
 			priceProvided := false
 			fs.Visit(func(f *flag.Flag) { priceProvided = priceProvided || f.Name == "price" })
-			prices := shared.SplitCSV(*priceIDs)
+			prices := shared.SplitCSV(priceIDs.String())
 			var freeTrialTerritories []string
 			if isFreeTrial {
 				if priceProvided {
 					fmt.Fprintln(os.Stderr, "Error: --price is not supported when --offer-mode is FREE_TRIAL; use --territory to choose territories")
 					return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "--price")
 				}
-				freeTrialTerritories, err = shared.NormalizeASCTerritoryCSV(*territories)
+				freeTrialTerritories, err = shared.NormalizeASCTerritoryCSV(territories.String())
 				if err != nil {
 					return shared.UsageError(fmt.Sprintf("win-back-offers create: %v", err))
 				}
@@ -406,7 +406,7 @@ Examples:
 					return shared.MissingRequiredUsageError("--territory")
 				}
 			} else {
-				if strings.TrimSpace(*territories) != "" {
+				if strings.TrimSpace(territories.String()) != "" {
 					fmt.Fprintln(os.Stderr, "Error: --territory is only supported when --offer-mode is FREE_TRIAL")
 					return shared.WithDiagnostic(flag.ErrHelp, shared.DiagnosticConflictingInput, "--territory")
 				}


### PR DESCRIPTION
## Problem

Mutating commands with comma-separated list flags bound via plain `fs.String` silently keep only the **last** occurrence when a flag is repeated. The earlier values are dropped, the command exits 0, and the caller sees a successful mutation that is missing data:

```console
$ asc profiles create --name "CI" --profile-type IOS_APP_DEVELOPMENT --bundle "BUNDLE_ID" \
    --certificate "CERT_A" --certificate "CERT_B"
# before: profile created with CERT_B only, exit 0
```

Repeating a flag is a natural shape for a generated invocation (loops, templated arg lists), so this is a quiet data-loss path on create/update commands.

`shared.BindOnceCSVFlag` (internal/cli/shared/once_csv_value.go) already exists for exactly this and 36 sites were converted previously; the remainder was left as follow-up work. This PR finishes three more packages.

## Change

Converted 16 comma-separated list flags on mutating paths:

| Command | Flags |
| --- | --- |
| `asc nominations create` | `--app`, `--device-families`, `--locales`, `--supplemental-materials-uris`, `--in-app-events`, `--supported-territories` |
| `asc nominations update` | same six |
| `asc profiles create` | `--certificate`, `--device` |
| `asc subscriptions offers win-back create` | `--price`, `--territory` |

A repeated flag now fails at parse time with the helper's established message:

```console
$ asc profiles create ... --certificate "CERT_A" --certificate "CERT_B"
invalid value "CERT_B" for flag -certificate: --certificate specified multiple times; pass one comma-separated list, for example --certificate "CERT_A,CERT_B"
# exit 2, nothing on stdout

$ asc profiles create ... --certificate "CERT_A,CERT_B"   # supported shape, unchanged
```

## Tests

New `internal/cli/cmdtest/once_csv_repeated_flag_contract_test.go` pins the user-facing contract end to end through the real command tree:

- repeated flag exits 2, writes nothing to stdout, and the first stderr line is the `specified multiple times` guidance, so the failure can never be mistaken for a help request (`--help` exits 0);
- a table asserts the message for every one of the 16 converted flags;
- two cases pin current explicit-empty behavior unchanged: `--certificate ""` still reports `Error: --certificate is required` (exit 2), and `nominations update --locales ""` still reports `--locales is required` (exit 1), which also proves `fs.Visit` still tracks flags bound through `flag.Value`.

RED was established against the unconverted commands before the conversions landed (17 assertions failing), GREEN after.

## Compatibility

- Single-occurrence and comma-separated usage is unchanged; help text is byte-identical (verified by diffing `--help` for all four commands before/after), so `docs/COMMANDS.md` needs no regeneration.
- Repeated flags now fail loudly instead of silently dropping values. That is the point of the change and matches the contract already shipped for the previously converted 36 sites.

## Scope notes

- Read/filter flags left alone on purpose: `nominations list --app`, `win-back-offers prices --territory`.
- The rest of the sweep (`appclips`, `subscriptions`, `encryption`, and others) stays follow-up work; `internal/cli/versions` is covered by a sibling PR.

## Validation

`make build`, `make format`, `make check-docs`, `make lint` (0 issues), `ASC_BYPASS_KEYCHAIN=1 make test` — all green. No live API calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for repeated comma-separated command-line flags across profile, nomination, and win-back offer commands.
  * Repeated flags now return clear usage errors without producing output.
  * Existing validation for explicitly empty flag values remains unchanged.
  * Preserved existing checks for required certificates, free-trial conflicts, and territory values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->