### PR TITLE
fix(auth): backdate JWT issued-at to absorb client clock skew

### DIFF
--- a/internal/asc/client_core.go
+++ b/internal/asc/client_core.go
@@ -30,6 +30,9 @@ const (
 	tokenLifetime = 10 * time.Minute
 	// jwtRefreshSkew refreshes a token a bit early to avoid edge-of-expiry races.
 	jwtRefreshSkew = 30 * time.Second
+	// jwtIssuedAtSkew backdates the issued-at claim so a client clock running
+	// ahead of Apple's does not produce a token rejected as issued in the future.
+	jwtIssuedAtSkew = 60 * time.Second
 
 	// Retry defaults
 	DefaultMaxRetries = 3

--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -80,7 +80,7 @@ func GenerateJWT(keyID, issuerID string, privateKey *ecdsa.PrivateKey) (string, 
 	now := time.Now()
 	claims := jwt.RegisteredClaims{
 		Audience:  jwt.ClaimStrings{"appstoreconnect-v1"},
-		IssuedAt:  jwt.NewNumericDate(now),
+		IssuedAt:  jwt.NewNumericDate(now.Add(-jwtIssuedAtSkew)),
 		ExpiresAt: jwt.NewNumericDate(now.Add(tokenLifetime)),
 	}
 	if issuerID == "" {

--- a/internal/asc/client_http_jwt_test.go
+++ b/internal/asc/client_http_jwt_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -81,6 +82,44 @@ func TestGenerateJWT_WhitespaceIssuerUsesUserSubjectClaim(t *testing.T) {
 	}
 	if claims.Subject != "user" {
 		t.Fatalf("subject claim = %q, want user", claims.Subject)
+	}
+}
+
+func TestGenerateJWT_BackdatesIssuedAtForClockSkew(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	before := time.Now()
+	tokenString, err := GenerateJWT("KEY123", "ISS456", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateJWT() error: %v", err)
+	}
+	after := time.Now()
+
+	claims := parseJWTClaims(t, tokenString, privateKey)
+	assertJWTIssuedAtSkew(t, claims.IssuedAt, claims.ExpiresAt, before, after, tokenLifetime)
+}
+
+// assertJWTIssuedAtSkew checks that issued-at is backdated by jwtIssuedAtSkew
+// while expiry stays anchored to the signing time. Numeric dates are truncated
+// to whole seconds, so each bound allows a second of slack.
+func assertJWTIssuedAtSkew(t *testing.T, issuedAt, expiresAt *jwt.NumericDate, before, after time.Time, lifetime time.Duration) {
+	t.Helper()
+
+	if issuedAt == nil {
+		t.Fatal("issued-at claim is missing")
+	}
+	if expiresAt == nil {
+		t.Fatal("expires-at claim is missing")
+	}
+
+	if issuedAt.Before(before.Add(-jwtIssuedAtSkew-time.Second)) || issuedAt.After(after.Add(-jwtIssuedAtSkew)) {
+		t.Fatalf("issued-at = %s, want signing time minus %s (~%s)", issuedAt.Time, jwtIssuedAtSkew, before.Add(-jwtIssuedAtSkew))
+	}
+	if expiresAt.Before(before.Add(lifetime-time.Second)) || expiresAt.After(after.Add(lifetime)) {
+		t.Fatalf("expires-at = %s, want signing time plus %s (~%s)", expiresAt.Time, lifetime, before.Add(lifetime))
+	}
+	if got, want := expiresAt.Sub(issuedAt.Time), lifetime+jwtIssuedAtSkew; got != want {
+		t.Fatalf("expires-at minus issued-at = %s, want %s", got, want)
 	}
 }
 

--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -136,7 +136,7 @@ func GenerateNotaryJWT(keyID, issuerID string, privateKey any) (string, error) {
 	now := time.Now()
 	claims := jwt.MapClaims{
 		"aud":   "appstoreconnect-v1",
-		"iat":   jwt.NewNumericDate(now),
+		"iat":   jwt.NewNumericDate(now.Add(-jwtIssuedAtSkew)),
 		"exp":   jwt.NewNumericDate(now.Add(tokenLifetime)),
 		"scope": []string{"/notary/v2"},
 	}

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newTestNotaryClient(t *testing.T, serverURL string) *Client {
@@ -56,6 +57,20 @@ func TestGenerateNotaryJWT(t *testing.T) {
 	if len(parts) != 3 {
 		t.Fatalf("expected 3 token parts, got %d", len(parts))
 	}
+}
+
+func TestGenerateNotaryJWT_BackdatesIssuedAtForClockSkew(t *testing.T) {
+	privateKey := testJWTPrivateKey(t)
+
+	before := time.Now()
+	tokenString, err := GenerateNotaryJWT("KEY123", "ISS456", privateKey)
+	if err != nil {
+		t.Fatalf("GenerateNotaryJWT() error: %v", err)
+	}
+	after := time.Now()
+
+	claims := parseJWTClaims(t, tokenString, privateKey)
+	assertJWTIssuedAtSkew(t, claims.IssuedAt, claims.ExpiresAt, before, after, tokenLifetime)
 }
 
 func TestGenerateNotaryJWT_NormalizesIdentifiers(t *testing.T) {

--- a/internal/storekit/client.go
+++ b/internal/storekit/client.go
@@ -20,7 +20,12 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/auth"
 )
 
-const tokenLifetime = 20 * time.Minute
+const (
+	tokenLifetime = 20 * time.Minute
+	// jwtIssuedAtSkew backdates the issued-at claim so a client clock running
+	// ahead of Apple's does not produce a token rejected as issued in the future.
+	jwtIssuedAtSkew = 60 * time.Second
+)
 
 type ClientOption func(*Client)
 
@@ -121,7 +126,7 @@ func (c *Client) signedToken() (string, error) {
 	now := c.now().UTC()
 	claims := jwt.MapClaims{
 		"iss": c.credentials.IssuerID,
-		"iat": now.Unix(),
+		"iat": now.Add(-jwtIssuedAtSkew).Unix(),
 		"exp": now.Add(tokenLifetime).Unix(),
 		"aud": "appstoreconnect-v1",
 		"bid": c.credentials.BundleID,

--- a/internal/storekit/client_test.go
+++ b/internal/storekit/client_test.go
@@ -54,8 +54,10 @@ func TestClientSignsStoreKitJWT(t *testing.T) {
 	if got := claims["bid"]; got != "com.example.app" {
 		t.Fatalf("bid = %v, want com.example.app", got)
 	}
-	if got := int64(claims["iat"].(float64)); got != now.Unix() {
-		t.Fatalf("iat = %d, want %d", got, now.Unix())
+	// Issued-at is backdated so a client clock running ahead of Apple's does not
+	// produce a token that is rejected as issued in the future.
+	if got, want := int64(claims["iat"].(float64)), now.Add(-jwtIssuedAtSkew).Unix(); got != want {
+		t.Fatalf("iat = %d, want %d", got, want)
 	}
 	if got := int64(claims["exp"].(float64)); got != now.Add(20*time.Minute).Unix() {
 		t.Fatalf("exp = %d, want %d", got, now.Add(20*time.Minute).Unix())


### PR DESCRIPTION
## Problem

Every request signs a fresh ES256 token with `iat` set to the local clock. Apple validates that claim against *its* clock and rejects a token that claims to be issued in the future, so a machine running a few seconds fast signs tokens that fail authentication.

The failure is unforgiving because a 401 is not retryable. What an operator sees today:

```
$ asc apps list
Error: authentication failed (status 401): NOT_AUTHORIZED
```

Nothing in that output points at the clock, so the natural response is to regenerate the API key, re-run `asc auth login`, or re-check the issuer ID — none of which fix a clock that is ahead. It is intermittent and machine-specific: CI runners, VMs resumed from snapshots, and containers with drifting clocks hit it while a colleague on the same key never does.

## Behavior change

`iat` is now stamped 60 seconds in the past at all three signing sites:

- `internal/asc/client_http.go` (App Store Connect API)
- `internal/asc/notary.go` (Notary API)
- `internal/storekit/client.go` (StoreKit Retention Messaging API)

`exp` stays anchored to the signing time, so effective token lifetimes are unchanged: 10 minutes for App Store Connect and Notary, 20 minutes for StoreKit. The `iat`-to-`exp` span is 11 and 21 minutes respectively, well inside Apple's ceilings, and the in-memory token cache still refreshes on the same schedule.

The skew value lives in a named constant (`jwtIssuedAtSkew`) beside the existing `jwtRefreshSkew`, so the two clock allowances are readable together. A client whose clock is behind Apple's was never affected and stays unaffected.

## Tests

- `TestGenerateJWT_BackdatesIssuedAtForClockSkew` decodes a freshly signed App Store Connect token and asserts `iat` lands in a bounded window around signing time minus 60s, that `exp` is still signing time plus the token lifetime, and that `exp - iat` equals lifetime plus skew exactly.
- `TestGenerateNotaryJWT_BackdatesIssuedAtForClockSkew` asserts the same for the Notary token, which carries the extra `scope` claim.
- `TestClientSignsStoreKitJWT` pins the exact backdated `iat` and the unchanged `exp` using the injectable clock the StoreKit client already exposes.

Commands run: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all pass. No live API calls.

## Compatibility

- No user-facing surface changes: no flags, no output, no docs. `asc auth token` still prints a valid token.
- Signing is the only thing that changes; verification, caching, and refresh behavior are untouched.
- Independent of #2076 (rate-limited write retries), which touches a different region of `internal/asc/client_http.go`. The two branches merge cleanly and can land in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT authentication reliability by backdating issued-at timestamps to accommodate minor clock differences.
  * Preserved existing token expiration times and claims.

* **Tests**
  * Added coverage confirming timestamp handling across supported authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->