### PR TITLE
feat(metadata): catch push-time metadata rejections offline

### DIFF
--- a/internal/cli/cmdtest/metadata_validate_test.go
+++ b/internal/cli/cmdtest/metadata_validate_test.go
@@ -380,6 +380,70 @@ func TestMetadataValidateWarnsForInvalidURLSyntax(t *testing.T) {
 	}
 }
 
+func TestMetadataValidateWarnsForOverlongURLs(t *testing.T) {
+	dir := t.TempDir()
+	versionDir := filepath.Join(dir, "version", "1.2.3")
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	supportURL := "https://example.com/" + strings.Repeat("a", 236)
+	if len(supportURL) != 256 {
+		t.Fatalf("expected 256-character support URL, got %d", len(supportURL))
+	}
+	body := `{"description":"English description","supportUrl":"` + supportURL + `"}`
+	if err := os.WriteFile(filepath.Join(versionDir, "en-US.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"metadata", "validate", "--dir", dir}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("expected warning-only validation, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Valid        bool `json:"valid"`
+		ErrorCount   int  `json:"errorCount"`
+		WarningCount int  `json:"warningCount"`
+		Issues       []struct {
+			Field    string `json:"field"`
+			Severity string `json:"severity"`
+			Message  string `json:"message"`
+			Length   int    `json:"length"`
+			Limit    int    `json:"limit"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%q", err, stdout)
+	}
+	if !payload.Valid || payload.ErrorCount != 0 {
+		t.Fatalf("expected valid warning-only report, got %+v", payload)
+	}
+	if payload.WarningCount != 1 {
+		t.Fatalf("expected exactly one URL length warning, got %+v", payload)
+	}
+
+	issue := payload.Issues[0]
+	if issue.Field != "supportUrl" || issue.Severity != "warning" {
+		t.Fatalf("expected supportUrl warning, got %+v", issue)
+	}
+	if issue.Length != 256 || issue.Limit != 255 {
+		t.Fatalf("expected length 256 and limit 255, got %+v", issue)
+	}
+	if !strings.Contains(issue.Message, "support URL exceeds 255 characters") {
+		t.Fatalf("expected URL length message, got %+v", issue)
+	}
+}
+
 func TestMetadataValidateAcceptsDefaultLocaleFiles(t *testing.T) {
 	dir := t.TempDir()
 	appInfoDir := filepath.Join(dir, "app-info")

--- a/internal/cli/cmdtest/metadata_validate_test.go
+++ b/internal/cli/cmdtest/metadata_validate_test.go
@@ -380,6 +380,64 @@ func TestMetadataValidateWarnsForInvalidURLSyntax(t *testing.T) {
 	}
 }
 
+func TestMetadataValidateWarnsForImplausiblyShortMetadata(t *testing.T) {
+	dir := t.TempDir()
+	appInfoDir := filepath.Join(dir, "app-info")
+	versionDir := filepath.Join(dir, "version", "1.2.3")
+	if err := os.MkdirAll(appInfoDir, 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appInfoDir, "en-US.json"), []byte(`{"name":"X"}`), 0o644); err != nil {
+		t.Fatalf("write app-info file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "en-US.json"), []byte(`{"description":"TBD"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"metadata", "validate", "--dir", dir}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("expected warning-only validation, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Valid        bool `json:"valid"`
+		ErrorCount   int  `json:"errorCount"`
+		WarningCount int  `json:"warningCount"`
+		Issues       []struct {
+			Field    string `json:"field"`
+			Severity string `json:"severity"`
+			Message  string `json:"message"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%q", err, stdout)
+	}
+	if !payload.Valid || payload.ErrorCount != 0 {
+		t.Fatalf("expected valid warning-only report, got %+v", payload)
+	}
+	if payload.WarningCount != 2 {
+		t.Fatalf("expected two minimum-length warnings, got %+v", payload)
+	}
+	for _, issue := range payload.Issues {
+		if issue.Severity != "warning" || !strings.Contains(issue.Message, "shorter than") {
+			t.Fatalf("expected minimum-length warning, got %+v", issue)
+		}
+	}
+}
+
 func TestMetadataValidateWarnsForOverlongURLs(t *testing.T) {
 	dir := t.TempDir()
 	versionDir := filepath.Join(dir, "version", "1.2.3")

--- a/internal/cli/cmdtest/metadata_validate_test.go
+++ b/internal/cli/cmdtest/metadata_validate_test.go
@@ -311,6 +311,75 @@ func TestMetadataValidatePassesForValidFiles(t *testing.T) {
 	}
 }
 
+func TestMetadataValidateWarnsForInvalidURLSyntax(t *testing.T) {
+	dir := t.TempDir()
+	appInfoDir := filepath.Join(dir, "app-info")
+	versionDir := filepath.Join(dir, "version", "1.2.3")
+	if err := os.MkdirAll(appInfoDir, 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appInfoDir, "en-US.json"), []byte(`{"name":"App Name","privacyPolicyUrl":"example.com/privacy"}`), 0o644); err != nil {
+		t.Fatalf("write app-info file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "en-US.json"), []byte(`{"description":"English description","supportUrl":"example.com"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"metadata", "validate", "--dir", dir}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("expected warning-only validation, got %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Valid        bool `json:"valid"`
+		ErrorCount   int  `json:"errorCount"`
+		WarningCount int  `json:"warningCount"`
+		Issues       []struct {
+			Field    string `json:"field"`
+			Severity string `json:"severity"`
+			Message  string `json:"message"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout=%q", err, stdout)
+	}
+	if !payload.Valid || payload.ErrorCount != 0 {
+		t.Fatalf("expected valid warning-only report, got %+v", payload)
+	}
+	if payload.WarningCount != 2 {
+		t.Fatalf("expected two URL syntax warnings, got %+v", payload)
+	}
+
+	wantFields := map[string]bool{"supportUrl": false, "privacyPolicyUrl": false}
+	for _, issue := range payload.Issues {
+		if _, ok := wantFields[issue.Field]; !ok {
+			continue
+		}
+		if issue.Severity != "warning" || !strings.Contains(issue.Message, "not a valid HTTP/HTTPS URL") {
+			t.Fatalf("expected URL syntax warning for %s, got %+v", issue.Field, issue)
+		}
+		wantFields[issue.Field] = true
+	}
+	for field, found := range wantFields {
+		if !found {
+			t.Fatalf("expected URL syntax warning for %s, got %+v", field, payload.Issues)
+		}
+	}
+}
+
 func TestMetadataValidateAcceptsDefaultLocaleFiles(t *testing.T) {
 	dir := t.TempDir()
 	appInfoDir := filepath.Join(dir, "app-info")

--- a/internal/cli/cmdtest/validate_test.go
+++ b/internal/cli/cmdtest/validate_test.go
@@ -268,7 +268,7 @@ func validValidateFixture() validateFixture {
 		appInfos:           `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}]}`,
 		appInfoLocs:        `{"data":[{"type":"appInfoLocalizations","id":"info-loc-1","attributes":{"locale":"en-US","name":"My App","subtitle":"Subtitle","privacyPolicyUrl":"https://example.com/privacy"}}]}`,
 		versionLocs:        fmt.Sprintf(`{"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1","attributes":{"locale":"en-US","description":"Description. Terms of Use: %s","keywords":"keyword","whatsNew":"Notes","promotionalText":"Promo","supportUrl":"https://support.example.com","marketingUrl":"https://marketing.example.com"}}]}`, validation.AppleStandardEULAURL),
-		reviewDetails:      `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"a@example.com","contactPhone":"123","demoAccountName":"","demoAccountPassword":"","demoAccountRequired":false,"notes":"Review notes"}}}`,
+		reviewDetails:      `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"a@example.com","contactPhone":"+1 555 010 1234","demoAccountName":"","demoAccountPassword":"","demoAccountRequired":false,"notes":"Review notes"}}}`,
 		primaryCategory:    `{"data":{"type":"appCategories","id":"cat-1"}}`,
 		build:              `{"data":{"type":"builds","id":"build-1","attributes":{"version":"1.0","processingState":"VALID","expired":false,"usesNonExemptEncryption":false}}}`,
 		priceSchedule:      `{"data":{"type":"appPriceSchedules","id":"sched-1","attributes":{}}}`,
@@ -1558,7 +1558,7 @@ func TestValidateFailsWhenReviewDetailsMissing(t *testing.T) {
 
 func TestValidateFailsWhenReviewDetailsMissingContactEmail(t *testing.T) {
 	fixture := validValidateFixture()
-	fixture.reviewDetails = `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"","contactPhone":"123","demoAccountRequired":false}}}`
+	fixture.reviewDetails = `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"","contactPhone":"+1 555 010 1234","demoAccountRequired":false}}}`
 
 	client := newValidateTestClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {
@@ -1599,9 +1599,65 @@ func TestValidateFailsWhenReviewDetailsMissingContactEmail(t *testing.T) {
 	}
 }
 
+func TestValidateFlagsMalformedReviewContactDetails(t *testing.T) {
+	fixture := validValidateFixture()
+	fixture.reviewDetails = `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"reviewer.example.com","contactPhone":"123","demoAccountRequired":false}}}`
+
+	client := newValidateTestClient(t, fixture)
+	restore := validate.SetClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	})
+	defer restore()
+
+	root := RootCommand("1.2.3")
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"validate", "--app", "app-1", "--version-id", "ver-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatalf("expected error for malformed review contact email")
+	}
+	if _, ok := errors.AsType[ReportedError](runErr); !ok {
+		t.Fatalf("expected ReportedError, got %v", runErr)
+	}
+
+	var report validation.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("failed to parse JSON output: %v", err)
+	}
+
+	foundEmail := false
+	foundPhone := false
+	for _, check := range report.Checks {
+		switch check.ID {
+		case "review_details.format.contact_email":
+			foundEmail = true
+			if check.Severity != validation.SeverityError {
+				t.Fatalf("expected contact email format error, got %+v", check)
+			}
+		case "review_details.format.contact_phone":
+			foundPhone = true
+			if check.Severity != validation.SeverityWarning {
+				t.Fatalf("expected contact phone format warning, got %+v", check)
+			}
+		}
+	}
+	if !foundEmail {
+		t.Fatalf("expected review_details.format.contact_email, got %+v", report.Checks)
+	}
+	if !foundPhone {
+		t.Fatalf("expected review_details.format.contact_phone, got %+v", report.Checks)
+	}
+}
+
 func TestValidateFailsWhenDemoCredentialsMissingAfterOptIn(t *testing.T) {
 	fixture := validValidateFixture()
-	fixture.reviewDetails = `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"a@example.com","contactPhone":"123","demoAccountName":"","demoAccountPassword":"","demoAccountRequired":true,"notes":"Reviewer signs in with the seeded account below."}}}`
+	fixture.reviewDetails = `{"data":{"type":"appStoreReviewDetails","id":"review-detail-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"a@example.com","contactPhone":"+1 555 010 1234","demoAccountName":"","demoAccountPassword":"","demoAccountRequired":true,"notes":"Reviewer signs in with the seeded account below."}}}`
 
 	client := newValidateTestClient(t, fixture)
 	restore := validate.SetClientFactory(func() (*asc.Client, error) {

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -65,6 +65,7 @@ Checks:
   - required fields
   - metadata character limits
   - URL syntax and length for marketing, support, privacy policy, and privacy choices URLs
+  - implausibly short app name and description values
   - optional subscription-app Terms of Use / EULA description link heuristic
 
 Examples:
@@ -161,6 +162,7 @@ func validateDir(dir string, subscriptionApp bool) (ValidateResult, error) {
 			}
 			result.Issues = append(result.Issues, appInfoLengthIssues(filePath, resolvedLocale, loc)...)
 			result.Issues = append(result.Issues, appInfoURLIssues(filePath, resolvedLocale, loc)...)
+			result.Issues = append(result.Issues, appInfoMinimumLengthIssues(filePath, resolvedLocale, loc)...)
 		}
 	}
 
@@ -226,6 +228,7 @@ func validateDir(dir string, subscriptionApp bool) (ValidateResult, error) {
 				}
 				result.Issues = append(result.Issues, versionLengthIssues(filePath, version, resolvedLocale, loc)...)
 				result.Issues = append(result.Issues, versionURLIssues(filePath, version, resolvedLocale, loc)...)
+				result.Issues = append(result.Issues, versionMinimumLengthIssues(filePath, version, resolvedLocale, loc)...)
 				if subscriptionApp {
 					result.Issues = append(result.Issues, versionTermsIssues(filePath, version, resolvedLocale, loc)...)
 				}
@@ -354,6 +357,48 @@ func appInfoLengthIssues(filePath, locale string, loc AppInfoLocalization) []Val
 		issues = append(issues, metadataLengthValidateIssue(appInfoDirName, filePath, locale, "", issue))
 	}
 	return issues
+}
+
+// versionMinimumLengthIssues reports version localization values that are too
+// short to be real content, such as a placeholder description.
+func versionMinimumLengthIssues(filePath, version, locale string, loc VersionLocalization) []ValidateIssue {
+	issues := make([]ValidateIssue, 0, 1)
+	for _, issue := range validation.VersionLocalizationMinimumLengthIssues(validation.VersionLocalization{
+		Description: loc.Description,
+	}) {
+		issues = append(issues, metadataMinimumLengthValidateIssue(versionDirName, filePath, locale, version, issue))
+	}
+	return issues
+}
+
+// appInfoMinimumLengthIssues reports app-info localization values that are too
+// short to be real content, such as a single-character app name.
+func appInfoMinimumLengthIssues(filePath, locale string, loc AppInfoLocalization) []ValidateIssue {
+	issues := make([]ValidateIssue, 0, 1)
+	for _, issue := range validation.AppInfoLocalizationMinimumLengthIssues(validation.AppInfoLocalization{
+		Name: loc.Name,
+	}) {
+		issues = append(issues, metadataMinimumLengthValidateIssue(appInfoDirName, filePath, locale, "", issue))
+	}
+	return issues
+}
+
+func metadataMinimumLengthValidateIssue(scope, filePath, locale, version string, issue validation.MetadataMinimumLengthIssue) ValidateIssue {
+	return ValidateIssue{
+		Scope:   scope,
+		File:    filePath,
+		Locale:  locale,
+		Version: version,
+		Field:   issue.Field,
+		// Apple publishes no exact minimum, so short values are advisory.
+		Severity: issueSeverityWarning,
+		Message: fmt.Sprintf(
+			"%s is shorter than %d characters",
+			validation.MetadataFieldLabel(issue.Field),
+			issue.Minimum,
+		),
+		Length: issue.Length,
+	}
 }
 
 func metadataLengthValidateIssue(scope, filePath, locale, version string, issue validation.MetadataLengthIssue) ValidateIssue {

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -64,7 +64,7 @@ Checks:
   - strict JSON schema decode (unknown keys rejected)
   - required fields
   - metadata character limits
-  - URL syntax for marketing, support, privacy policy, and privacy choices URLs
+  - URL syntax and length for marketing, support, privacy policy, and privacy choices URLs
   - optional subscription-app Terms of Use / EULA description link heuristic
 
 Examples:
@@ -329,50 +329,54 @@ func metadataIntentValidateIssues(scope, filePath, locale, version string, issue
 }
 
 func versionLengthIssues(filePath, version, locale string, loc VersionLocalization) []ValidateIssue {
-	issues := make([]ValidateIssue, 0, 4)
+	issues := make([]ValidateIssue, 0, 6)
 	for _, issue := range validation.VersionLocalizationLengthIssues(validation.VersionLocalization{
 		Description:     loc.Description,
 		Keywords:        loc.Keywords,
 		WhatsNew:        loc.WhatsNew,
 		PromotionalText: loc.PromotionalText,
+		MarketingURL:    loc.MarketingURL,
+		SupportURL:      loc.SupportURL,
 	}) {
-		message := fmt.Sprintf("%s exceeds %d %s", issue.Field, issue.Limit, issue.Unit)
-		if issue.Field == "keywords" {
-			message = fmt.Sprintf("keywords exceed %d %s", issue.Limit, issue.Unit)
-		}
-		issues = append(issues, ValidateIssue{
-			Scope:    versionDirName,
-			File:     filePath,
-			Locale:   locale,
-			Version:  version,
-			Field:    issue.Field,
-			Severity: issueSeverityError,
-			Message:  message,
-			Length:   issue.Length,
-			Limit:    issue.Limit,
-		})
+		issues = append(issues, metadataLengthValidateIssue(versionDirName, filePath, locale, version, issue))
 	}
 	return issues
 }
 
 func appInfoLengthIssues(filePath, locale string, loc AppInfoLocalization) []ValidateIssue {
-	issues := make([]ValidateIssue, 0, 2)
+	issues := make([]ValidateIssue, 0, 4)
 	for _, issue := range validation.AppInfoLocalizationLengthIssues(validation.AppInfoLocalization{
-		Name:     loc.Name,
-		Subtitle: loc.Subtitle,
+		Name:              loc.Name,
+		Subtitle:          loc.Subtitle,
+		PrivacyPolicyURL:  loc.PrivacyPolicyURL,
+		PrivacyChoicesURL: loc.PrivacyChoicesURL,
 	}) {
-		issues = append(issues, ValidateIssue{
-			Scope:    appInfoDirName,
-			File:     filePath,
-			Locale:   locale,
-			Field:    issue.Field,
-			Severity: issueSeverityError,
-			Message:  fmt.Sprintf("%s exceeds %d characters", issue.Field, issue.Limit),
-			Length:   issue.Length,
-			Limit:    issue.Limit,
-		})
+		issues = append(issues, metadataLengthValidateIssue(appInfoDirName, filePath, locale, "", issue))
 	}
 	return issues
+}
+
+func metadataLengthValidateIssue(scope, filePath, locale, version string, issue validation.MetadataLengthIssue) ValidateIssue {
+	verb := "exceeds"
+	if issue.Field == "keywords" {
+		verb = "exceed"
+	}
+	severity := issueSeverityError
+	if validation.MetadataLengthSeverity(issue.Field) == validation.SeverityWarning {
+		severity = issueSeverityWarning
+	}
+
+	return ValidateIssue{
+		Scope:    scope,
+		File:     filePath,
+		Locale:   locale,
+		Version:  version,
+		Field:    issue.Field,
+		Severity: severity,
+		Message:  fmt.Sprintf("%s %s %d %s", validation.MetadataFieldLabel(issue.Field), verb, issue.Limit, issue.Unit),
+		Length:   issue.Length,
+		Limit:    issue.Limit,
+	}
 }
 
 type metadataURLField struct {

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -64,6 +64,7 @@ Checks:
   - strict JSON schema decode (unknown keys rejected)
   - required fields
   - metadata character limits
+  - URL syntax for marketing, support, privacy policy, and privacy choices URLs
   - optional subscription-app Terms of Use / EULA description link heuristic
 
 Examples:
@@ -159,6 +160,7 @@ func validateDir(dir string, subscriptionApp bool) (ValidateResult, error) {
 				})
 			}
 			result.Issues = append(result.Issues, appInfoLengthIssues(filePath, resolvedLocale, loc)...)
+			result.Issues = append(result.Issues, appInfoURLIssues(filePath, resolvedLocale, loc)...)
 		}
 	}
 
@@ -223,6 +225,7 @@ func validateDir(dir string, subscriptionApp bool) (ValidateResult, error) {
 					})
 				}
 				result.Issues = append(result.Issues, versionLengthIssues(filePath, version, resolvedLocale, loc)...)
+				result.Issues = append(result.Issues, versionURLIssues(filePath, version, resolvedLocale, loc)...)
 				if subscriptionApp {
 					result.Issues = append(result.Issues, versionTermsIssues(filePath, version, resolvedLocale, loc)...)
 				}
@@ -367,6 +370,50 @@ func appInfoLengthIssues(filePath, locale string, loc AppInfoLocalization) []Val
 			Message:  fmt.Sprintf("%s exceeds %d characters", issue.Field, issue.Limit),
 			Length:   issue.Length,
 			Limit:    issue.Limit,
+		})
+	}
+	return issues
+}
+
+type metadataURLField struct {
+	field string
+	label string
+	value string
+}
+
+// versionURLIssues reports version localization URL fields App Store Connect
+// rejects at push time because they are not absolute HTTP/HTTPS URLs.
+func versionURLIssues(filePath, version, locale string, loc VersionLocalization) []ValidateIssue {
+	return metadataURLIssues(versionDirName, filePath, locale, version, []metadataURLField{
+		{field: "marketingUrl", label: "marketing URL", value: loc.MarketingURL},
+		{field: "supportUrl", label: "support URL", value: loc.SupportURL},
+	})
+}
+
+// appInfoURLIssues reports app-info localization URL fields App Store Connect
+// rejects at push time because they are not absolute HTTP/HTTPS URLs.
+func appInfoURLIssues(filePath, locale string, loc AppInfoLocalization) []ValidateIssue {
+	return metadataURLIssues(appInfoDirName, filePath, locale, "", []metadataURLField{
+		{field: "privacyChoicesUrl", label: "privacy choices URL", value: loc.PrivacyChoicesURL},
+		{field: "privacyPolicyUrl", label: "privacy policy URL", value: loc.PrivacyPolicyURL},
+	})
+}
+
+func metadataURLIssues(scope, filePath, locale, version string, fields []metadataURLField) []ValidateIssue {
+	issues := make([]ValidateIssue, 0, len(fields))
+	for _, field := range fields {
+		value := strings.TrimSpace(field.value)
+		if value == "" || validation.IsValidHTTPURL(value) {
+			continue
+		}
+		issues = append(issues, ValidateIssue{
+			Scope:    scope,
+			File:     filePath,
+			Locale:   locale,
+			Version:  version,
+			Field:    field.field,
+			Severity: issueSeverityWarning,
+			Message:  fmt.Sprintf("%s is not a valid HTTP/HTTPS URL", field.label),
 		})
 	}
 	return issues

--- a/internal/cli/metadata/validate_test.go
+++ b/internal/cli/metadata/validate_test.go
@@ -90,6 +90,58 @@ func TestValidateDirAcceptsArabicKeywordsWithinCharacterLimit(t *testing.T) {
 	}
 }
 
+func longHTTPSURL(length int) string {
+	const prefix = "https://example.com/"
+	return prefix + strings.Repeat("a", length-len(prefix))
+}
+
+func TestURLLengthIssuesBoundaries(t *testing.T) {
+	noVersionIssues := versionLengthIssues("file", "1.2.3", "en-US", VersionLocalization{
+		MarketingURL: longHTTPSURL(validation.LimitMarketingURL),
+		SupportURL:   longHTTPSURL(validation.LimitSupportURL),
+	})
+	if len(noVersionIssues) != 0 {
+		t.Fatalf("expected no issues at URL limits, got %+v", noVersionIssues)
+	}
+
+	versionIssues := versionLengthIssues("file", "1.2.3", "en-US", VersionLocalization{
+		MarketingURL: longHTTPSURL(validation.LimitMarketingURL + 1),
+		SupportURL:   longHTTPSURL(validation.LimitSupportURL + 1),
+	})
+	if len(versionIssues) != 2 {
+		t.Fatalf("expected 2 version URL issues, got %+v", versionIssues)
+	}
+	for _, issue := range versionIssues {
+		if issue.Severity != issueSeverityWarning {
+			t.Fatalf("expected warning severity for URL length, got %+v", issue)
+		}
+		if issue.Limit != 255 {
+			t.Fatalf("expected limit 255, got %+v", issue)
+		}
+	}
+
+	noAppInfoIssues := appInfoLengthIssues("file", "en-US", AppInfoLocalization{
+		PrivacyPolicyURL:  longHTTPSURL(validation.LimitPrivacyPolicyURL),
+		PrivacyChoicesURL: longHTTPSURL(validation.LimitPrivacyChoicesURL),
+	})
+	if len(noAppInfoIssues) != 0 {
+		t.Fatalf("expected no issues at app-info URL limits, got %+v", noAppInfoIssues)
+	}
+
+	appInfoIssues := appInfoLengthIssues("file", "en-US", AppInfoLocalization{
+		PrivacyPolicyURL:  longHTTPSURL(validation.LimitPrivacyPolicyURL + 1),
+		PrivacyChoicesURL: longHTTPSURL(validation.LimitPrivacyChoicesURL + 1),
+	})
+	if len(appInfoIssues) != 2 {
+		t.Fatalf("expected 2 app-info URL issues, got %+v", appInfoIssues)
+	}
+	for _, issue := range appInfoIssues {
+		if issue.Severity != issueSeverityWarning {
+			t.Fatalf("expected warning severity for URL length, got %+v", issue)
+		}
+	}
+}
+
 func TestValidateDirWarnsForInvalidURLSyntax(t *testing.T) {
 	dir := t.TempDir()
 	version := "1.2.3"

--- a/internal/cli/metadata/validate_test.go
+++ b/internal/cli/metadata/validate_test.go
@@ -90,6 +90,89 @@ func TestValidateDirAcceptsArabicKeywordsWithinCharacterLimit(t *testing.T) {
 	}
 }
 
+func TestValidateDirWarnsForInvalidURLSyntax(t *testing.T) {
+	dir := t.TempDir()
+	version := "1.2.3"
+
+	if err := os.MkdirAll(filepath.Join(dir, appInfoDirName), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, versionDirName, version), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	appInfoBody := `{"name":"App Name","privacyPolicyUrl":"example.com/privacy","privacyChoicesUrl":"example.com/choices"}`
+	if err := os.WriteFile(filepath.Join(dir, appInfoDirName, "en-US.json"), []byte(appInfoBody), 0o644); err != nil {
+		t.Fatalf("write app-info file: %v", err)
+	}
+	versionBody := `{"description":"English description","supportUrl":"example.com","marketingUrl":"www.example.com/app"}`
+	if err := os.WriteFile(filepath.Join(dir, versionDirName, version, "en-US.json"), []byte(versionBody), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	result, err := validateDir(dir, false)
+	if err != nil {
+		t.Fatalf("validateDir() error: %v", err)
+	}
+	if result.ErrorCount != 0 {
+		t.Fatalf("expected URL syntax issues to stay warnings, got %+v", result.Issues)
+	}
+	if !result.Valid {
+		t.Fatalf("expected valid=true for warning-only report, got %+v", result)
+	}
+
+	wantFields := map[string]bool{
+		"supportUrl":        false,
+		"marketingUrl":      false,
+		"privacyPolicyUrl":  false,
+		"privacyChoicesUrl": false,
+	}
+	for _, issue := range result.Issues {
+		if _, ok := wantFields[issue.Field]; !ok {
+			continue
+		}
+		if issue.Severity != issueSeverityWarning {
+			t.Fatalf("expected warning severity for %s, got %+v", issue.Field, issue)
+		}
+		if !strings.Contains(issue.Message, "not a valid HTTP/HTTPS URL") {
+			t.Fatalf("expected URL syntax message for %s, got %+v", issue.Field, issue)
+		}
+		wantFields[issue.Field] = true
+	}
+	for field, found := range wantFields {
+		if !found {
+			t.Fatalf("expected URL syntax warning for %s, got %+v", field, result.Issues)
+		}
+	}
+}
+
+func TestValidateDirAcceptsValidURLSyntax(t *testing.T) {
+	dir := t.TempDir()
+	version := "1.2.3"
+
+	if err := os.MkdirAll(filepath.Join(dir, appInfoDirName), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, versionDirName, version), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	appInfoBody := `{"name":"App Name","privacyPolicyUrl":"https://example.com/privacy","privacyChoicesUrl":"http://example.com/choices"}`
+	if err := os.WriteFile(filepath.Join(dir, appInfoDirName, "en-US.json"), []byte(appInfoBody), 0o644); err != nil {
+		t.Fatalf("write app-info file: %v", err)
+	}
+	versionBody := `{"description":"English description","supportUrl":"https://example.com","marketingUrl":"https://example.com/app"}`
+	if err := os.WriteFile(filepath.Join(dir, versionDirName, version, "en-US.json"), []byte(versionBody), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	result, err := validateDir(dir, false)
+	if err != nil {
+		t.Fatalf("validateDir() error: %v", err)
+	}
+	if len(result.Issues) != 0 {
+		t.Fatalf("expected no issues for valid URLs, got %+v", result.Issues)
+	}
+}
+
 func TestValidateDirTreatsDefaultLocaleCaseInsensitively(t *testing.T) {
 	dir := t.TempDir()
 	version := "1.2.3"

--- a/internal/cli/metadata/validate_test.go
+++ b/internal/cli/metadata/validate_test.go
@@ -73,7 +73,7 @@ func TestValidateDirAcceptsArabicKeywordsWithinCharacterLimit(t *testing.T) {
 		t.Fatalf("mkdir version dir: %v", err)
 	}
 
-	body := `{"description":"وصف عربي","keywords":"تغريدات,ردود,اعجابات,فلترة,بحث,ارشفة,ازالة,سجل,ريتويت,لايكات,منشن,خصوصية,منشورات,قديمة,حساب"}`
+	body := `{"description":"وصف تطبيق عربي كامل","keywords":"تغريدات,ردود,اعجابات,فلترة,بحث,ارشفة,ازالة,سجل,ريتويت,لايكات,منشن,خصوصية,منشورات,قديمة,حساب"}`
 	if err := os.WriteFile(filepath.Join(dir, versionDirName, version, "ar-SA.json"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write Arabic localization: %v", err)
 	}
@@ -193,6 +193,54 @@ func TestValidateDirWarnsForInvalidURLSyntax(t *testing.T) {
 	for field, found := range wantFields {
 		if !found {
 			t.Fatalf("expected URL syntax warning for %s, got %+v", field, result.Issues)
+		}
+	}
+}
+
+func TestValidateDirWarnsForImplausiblyShortMetadata(t *testing.T) {
+	dir := t.TempDir()
+	version := "1.2.3"
+
+	if err := os.MkdirAll(filepath.Join(dir, appInfoDirName), 0o755); err != nil {
+		t.Fatalf("mkdir app-info: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, versionDirName, version), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, appInfoDirName, "en-US.json"), []byte(`{"name":"X"}`), 0o644); err != nil {
+		t.Fatalf("write app-info file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, versionDirName, version, "en-US.json"), []byte(`{"description":"TBD"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	result, err := validateDir(dir, false)
+	if err != nil {
+		t.Fatalf("validateDir() error: %v", err)
+	}
+	if result.ErrorCount != 0 || !result.Valid {
+		t.Fatalf("expected short values to stay warnings, got %+v", result)
+	}
+	if len(result.Issues) != 2 {
+		t.Fatalf("expected 2 issues, got %+v", result.Issues)
+	}
+
+	wantFields := map[string]bool{"name": false, "description": false}
+	for _, issue := range result.Issues {
+		if _, ok := wantFields[issue.Field]; !ok {
+			t.Fatalf("unexpected issue: %+v", issue)
+		}
+		if issue.Severity != issueSeverityWarning {
+			t.Fatalf("expected warning severity, got %+v", issue)
+		}
+		if !strings.Contains(issue.Message, "shorter than") {
+			t.Fatalf("expected minimum-length message, got %+v", issue)
+		}
+		wantFields[issue.Field] = true
+	}
+	for field, found := range wantFields {
+		if !found {
+			t.Fatalf("expected minimum-length warning for %s, got %+v", field, result.Issues)
 		}
 	}
 }

--- a/internal/validation/legal.go
+++ b/internal/validation/legal.go
@@ -48,7 +48,7 @@ func legalChecks(copyright string, hasActiveMonetization bool, hasReviewRelevant
 	// URL format checks on version localizations.
 	for _, loc := range versionLocs {
 		if u := strings.TrimSpace(loc.SupportURL); u != "" {
-			if !isValidHTTPURL(u) {
+			if !IsValidHTTPURL(u) {
 				checks = append(checks, CheckResult{
 					ID:           "legal.format.support_url",
 					Severity:     SeverityWarning,
@@ -62,7 +62,7 @@ func legalChecks(copyright string, hasActiveMonetization bool, hasReviewRelevant
 			}
 		}
 		if u := strings.TrimSpace(loc.MarketingURL); u != "" {
-			if !isValidHTTPURL(u) {
+			if !IsValidHTTPURL(u) {
 				checks = append(checks, CheckResult{
 					ID:           "legal.format.marketing_url",
 					Severity:     SeverityWarning,
@@ -108,7 +108,7 @@ func legalChecks(copyright string, hasActiveMonetization bool, hasReviewRelevant
 			})
 		}
 
-		if privacyURL != "" && !isValidHTTPURL(privacyURL) {
+		if privacyURL != "" && !IsValidHTTPURL(privacyURL) {
 			checks = append(checks, CheckResult{
 				ID:           "legal.format.privacy_policy_url",
 				Severity:     SeverityWarning,
@@ -122,7 +122,7 @@ func legalChecks(copyright string, hasActiveMonetization bool, hasReviewRelevant
 		}
 
 		if u := strings.TrimSpace(loc.PrivacyChoicesURL); u != "" {
-			if !isValidHTTPURL(u) {
+			if !IsValidHTTPURL(u) {
 				checks = append(checks, CheckResult{
 					ID:           "legal.format.privacy_choices_url",
 					Severity:     SeverityWarning,
@@ -164,7 +164,7 @@ func HasTermsOfUseLink(description string) bool {
 	for _, match := range descriptionURLPattern.FindAllStringIndex(description, -1) {
 		rawURL := description[match[0]:match[1]]
 		normalizedURL := normalizeDescriptionURL(rawURL)
-		if !isValidHTTPURL(normalizedURL) {
+		if !IsValidHTTPURL(normalizedURL) {
 			continue
 		}
 		if isAppleStandardEULAURL(normalizedURL) || urlLooksLikeTermsLink(normalizedURL) {
@@ -197,8 +197,11 @@ func urlLooksLikeTermsLink(raw string) bool {
 	return termsURLPattern.MatchString(lower)
 }
 
-// isValidHTTPURL returns true for absolute HTTP/HTTPS URLs with a hostname and no raw whitespace.
-func isValidHTTPURL(s string) bool {
+// IsValidHTTPURL reports whether a value is an absolute HTTP/HTTPS URL with a
+// hostname and no raw whitespace, matching the URL syntax App Store Connect
+// accepts for metadata URL fields. It is exported so offline metadata checks
+// apply the same rule as the online validation report.
+func IsValidHTTPURL(s string) bool {
 	s = strings.TrimSpace(s)
 	if s == "" || strings.ContainsAny(s, " \t\r\n") {
 		return false

--- a/internal/validation/legal_test.go
+++ b/internal/validation/legal_test.go
@@ -401,6 +401,29 @@ func TestLegalChecks_AllValid_NoChecks(t *testing.T) {
 	}
 }
 
+func TestIsValidHTTPURL(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{value: "https://example.com", want: true},
+		{value: "http://example.com/support", want: true},
+		{value: "  https://example.com/support  ", want: true},
+		{value: "example.com", want: false},
+		{value: "www.example.com/support", want: false},
+		{value: "ftp://example.com", want: false},
+		{value: "https://", want: false},
+		{value: "https://exa mple.com", want: false},
+		{value: "", want: false},
+	}
+
+	for _, test := range tests {
+		if got := IsValidHTTPURL(test.value); got != test.want {
+			t.Fatalf("IsValidHTTPURL(%q) = %v, want %v", test.value, got, test.want)
+		}
+	}
+}
+
 func TestValidate_IncludesLegalChecks(t *testing.T) {
 	report := Validate(Input{
 		AppID:         "app-1",

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -9,3 +9,17 @@ const (
 	LimitName            = 30
 	LimitSubtitle        = 30
 )
+
+// App Store metadata URL length limits.
+//
+// Apple's App Store Connect OpenAPI specification carries no maxLength for
+// these attributes, so the values below track Apple's documented App Store
+// Connect field constraints instead of a machine-readable schema. Checks built
+// on them are advisory (warning severity) so a longer value Apple happens to
+// accept never hard-fails a local run.
+const (
+	LimitMarketingURL      = 255
+	LimitSupportURL        = 255
+	LimitPrivacyPolicyURL  = 255
+	LimitPrivacyChoicesURL = 255
+)

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -23,3 +23,11 @@ const (
 	LimitPrivacyPolicyURL  = 255
 	LimitPrivacyChoicesURL = 255
 )
+
+// Minimum lengths that separate real metadata from placeholders such as "X"
+// or "TBD". Apple states no exact minimum in a machine-readable form, so these
+// only ever produce warnings.
+const (
+	MinLengthName        = 2
+	MinLengthDescription = 10
+)

--- a/internal/validation/metadata.go
+++ b/internal/validation/metadata.go
@@ -20,6 +20,8 @@ func VersionLocalizationLengthIssues(loc VersionLocalization) []MetadataLengthIs
 		{field: "keywords", value: loc.Keywords, limit: LimitKeywords, length: KeywordFieldLength, unit: keywordLengthUnit},
 		{field: "whatsNew", value: loc.WhatsNew, limit: LimitWhatsNew},
 		{field: "promotionalText", value: loc.PromotionalText, limit: LimitPromotionalText},
+		{field: "marketingUrl", value: loc.MarketingURL, limit: LimitMarketingURL},
+		{field: "supportUrl", value: loc.SupportURL, limit: LimitSupportURL},
 	})
 }
 
@@ -28,7 +30,38 @@ func AppInfoLocalizationLengthIssues(loc AppInfoLocalization) []MetadataLengthIs
 	return metadataLengthIssues([]metadataLengthField{
 		{field: "name", value: loc.Name, limit: LimitName},
 		{field: "subtitle", value: loc.Subtitle, limit: LimitSubtitle},
+		{field: "privacyPolicyUrl", value: loc.PrivacyPolicyURL, limit: LimitPrivacyPolicyURL},
+		{field: "privacyChoicesUrl", value: loc.PrivacyChoicesURL, limit: LimitPrivacyChoicesURL},
 	})
+}
+
+// MetadataFieldLabel returns the operator-facing label for a metadata field.
+func MetadataFieldLabel(field string) string {
+	if label, ok := metadataFieldLabels[field]; ok {
+		return label
+	}
+	return field
+}
+
+var metadataFieldLabels = map[string]string{
+	"whatsNew":          "what's new",
+	"promotionalText":   "promotional text",
+	"marketingUrl":      "marketing URL",
+	"supportUrl":        "support URL",
+	"privacyPolicyUrl":  "privacy policy URL",
+	"privacyChoicesUrl": "privacy choices URL",
+}
+
+// MetadataLengthSeverity returns the severity for an over-limit metadata
+// field. URL limits are documented rather than schema-backed, so they stay
+// advisory while the text limits Apple publishes per field remain blocking.
+func MetadataLengthSeverity(field string) Severity {
+	switch field {
+	case "marketingUrl", "supportUrl", "privacyPolicyUrl", "privacyChoicesUrl":
+		return SeverityWarning
+	default:
+		return SeverityError
+	}
 }
 
 type metadataLengthField struct {
@@ -69,83 +102,58 @@ func metadataLengthChecks(versionLocs []VersionLocalization, appInfoLocs []AppIn
 
 	for _, loc := range versionLocs {
 		for _, issue := range VersionLocalizationLengthIssues(loc) {
-			switch issue.Field {
-			case "description":
-				checks = append(checks, CheckResult{
-					ID:           "metadata.length.description",
-					Severity:     SeverityError,
-					Locale:       loc.Locale,
-					Field:        "description",
-					ResourceType: "appStoreVersionLocalization",
-					ResourceID:   loc.ID,
-					Message:      fmt.Sprintf("description exceeds %d %s", issue.Limit, issue.Unit),
-					Remediation:  fmt.Sprintf("Shorten description to %d %s or fewer", issue.Limit, issue.Unit),
-				})
-			case "keywords":
-				checks = append(checks, CheckResult{
-					ID:           "metadata.length.keywords",
-					Severity:     SeverityError,
-					Locale:       loc.Locale,
-					Field:        "keywords",
-					ResourceType: "appStoreVersionLocalization",
-					ResourceID:   loc.ID,
-					Message:      fmt.Sprintf("keywords exceed %d %s", issue.Limit, issue.Unit),
-					Remediation:  fmt.Sprintf("Shorten keywords to %d %s or fewer", issue.Limit, issue.Unit),
-				})
-			case "whatsNew":
-				checks = append(checks, CheckResult{
-					ID:           "metadata.length.whats_new",
-					Severity:     SeverityError,
-					Locale:       loc.Locale,
-					Field:        "whatsNew",
-					ResourceType: "appStoreVersionLocalization",
-					ResourceID:   loc.ID,
-					Message:      fmt.Sprintf("what's new exceeds %d %s", issue.Limit, issue.Unit),
-					Remediation:  fmt.Sprintf("Shorten what's new to %d %s or fewer", issue.Limit, issue.Unit),
-				})
-			case "promotionalText":
-				checks = append(checks, CheckResult{
-					ID:           "metadata.length.promotional_text",
-					Severity:     SeverityError,
-					Locale:       loc.Locale,
-					Field:        "promotionalText",
-					ResourceType: "appStoreVersionLocalization",
-					ResourceID:   loc.ID,
-					Message:      fmt.Sprintf("promotional text exceeds %d %s", issue.Limit, issue.Unit),
-					Remediation:  fmt.Sprintf("Shorten promotional text to %d %s or fewer", issue.Limit, issue.Unit),
-				})
+			id, ok := versionLengthCheckIDs[issue.Field]
+			if !ok {
+				continue
 			}
+			checks = append(checks, metadataLengthCheck(id, issue, loc.Locale, "appStoreVersionLocalization", loc.ID))
 		}
 	}
 
 	for _, loc := range appInfoLocs {
 		for _, issue := range AppInfoLocalizationLengthIssues(loc) {
-			switch issue.Field {
-			case "name":
-				checks = append(checks, CheckResult{
-					ID:           "metadata.length.name",
-					Severity:     SeverityError,
-					Locale:       loc.Locale,
-					Field:        "name",
-					ResourceType: "appInfoLocalization",
-					ResourceID:   loc.ID,
-					Message:      fmt.Sprintf("name exceeds %d %s", issue.Limit, issue.Unit),
-					Remediation:  fmt.Sprintf("Shorten name to %d %s or fewer", issue.Limit, issue.Unit),
-				})
-			case "subtitle":
-				checks = append(checks, CheckResult{
-					ID:           "metadata.length.subtitle",
-					Severity:     SeverityError,
-					Locale:       loc.Locale,
-					Field:        "subtitle",
-					ResourceType: "appInfoLocalization",
-					ResourceID:   loc.ID,
-					Message:      fmt.Sprintf("subtitle exceeds %d %s", issue.Limit, issue.Unit),
-					Remediation:  fmt.Sprintf("Shorten subtitle to %d %s or fewer", issue.Limit, issue.Unit),
-				})
+			id, ok := appInfoLengthCheckIDs[issue.Field]
+			if !ok {
+				continue
 			}
+			checks = append(checks, metadataLengthCheck(id, issue, loc.Locale, "appInfoLocalization", loc.ID))
 		}
 	}
 
 	return checks
+}
+
+var versionLengthCheckIDs = map[string]string{
+	"description":     "metadata.length.description",
+	"keywords":        "metadata.length.keywords",
+	"whatsNew":        "metadata.length.whats_new",
+	"promotionalText": "metadata.length.promotional_text",
+	"marketingUrl":    "metadata.length.marketing_url",
+	"supportUrl":      "metadata.length.support_url",
+}
+
+var appInfoLengthCheckIDs = map[string]string{
+	"name":              "metadata.length.name",
+	"subtitle":          "metadata.length.subtitle",
+	"privacyPolicyUrl":  "metadata.length.privacy_policy_url",
+	"privacyChoicesUrl": "metadata.length.privacy_choices_url",
+}
+
+func metadataLengthCheck(id string, issue MetadataLengthIssue, locale, resourceType, resourceID string) CheckResult {
+	label := MetadataFieldLabel(issue.Field)
+	verb := "exceeds"
+	if issue.Field == "keywords" {
+		verb = "exceed"
+	}
+
+	return CheckResult{
+		ID:           id,
+		Severity:     MetadataLengthSeverity(issue.Field),
+		Locale:       locale,
+		Field:        issue.Field,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
+		Message:      fmt.Sprintf("%s %s %d %s", label, verb, issue.Limit, issue.Unit),
+		Remediation:  fmt.Sprintf("Shorten %s to %d %s or fewer", label, issue.Limit, issue.Unit),
+	}
 }

--- a/internal/validation/metadata.go
+++ b/internal/validation/metadata.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -33,6 +34,57 @@ func AppInfoLocalizationLengthIssues(loc AppInfoLocalization) []MetadataLengthIs
 		{field: "privacyPolicyUrl", value: loc.PrivacyPolicyURL, limit: LimitPrivacyPolicyURL},
 		{field: "privacyChoicesUrl", value: loc.PrivacyChoicesURL, limit: LimitPrivacyChoicesURL},
 	})
+}
+
+// MetadataMinimumLengthIssue describes one metadata field that is too short to
+// be real content.
+type MetadataMinimumLengthIssue struct {
+	Field   string
+	Length  int
+	Minimum int
+}
+
+// VersionLocalizationMinimumLengthIssues returns implausibly short fields for
+// one version localization. Empty values are left to the required-field
+// checks, which distinguish "unset" from "too short".
+func VersionLocalizationMinimumLengthIssues(loc VersionLocalization) []MetadataMinimumLengthIssue {
+	return metadataMinimumLengthIssues([]metadataMinimumLengthField{
+		{field: "description", value: loc.Description, minimum: MinLengthDescription},
+	})
+}
+
+// AppInfoLocalizationMinimumLengthIssues returns implausibly short fields for
+// one app-info localization.
+func AppInfoLocalizationMinimumLengthIssues(loc AppInfoLocalization) []MetadataMinimumLengthIssue {
+	return metadataMinimumLengthIssues([]metadataMinimumLengthField{
+		{field: "name", value: loc.Name, minimum: MinLengthName},
+	})
+}
+
+type metadataMinimumLengthField struct {
+	field   string
+	value   string
+	minimum int
+}
+
+func metadataMinimumLengthIssues(fields []metadataMinimumLengthField) []MetadataMinimumLengthIssue {
+	issues := make([]MetadataMinimumLengthIssue, 0, len(fields))
+	for _, field := range fields {
+		value := strings.TrimSpace(field.value)
+		if value == "" {
+			continue
+		}
+		length := utf8.RuneCountInString(value)
+		if length >= field.minimum {
+			continue
+		}
+		issues = append(issues, MetadataMinimumLengthIssue{
+			Field:   field.field,
+			Length:  length,
+			Minimum: field.minimum,
+		})
+	}
+	return issues
 }
 
 // MetadataFieldLabel returns the operator-facing label for a metadata field.

--- a/internal/validation/metadata_test.go
+++ b/internal/validation/metadata_test.go
@@ -68,6 +68,64 @@ func TestMetadataLengthChecks_ValidUnicode(t *testing.T) {
 	}
 }
 
+func longHTTPSURL(length int) string {
+	const prefix = "https://example.com/"
+	if length <= len(prefix) {
+		return prefix[:length]
+	}
+	return prefix + strings.Repeat("a", length-len(prefix))
+}
+
+func TestMetadataLengthChecks_URLsOverLimit(t *testing.T) {
+	loc := VersionLocalization{
+		Locale:       "en-US",
+		SupportURL:   longHTTPSURL(LimitSupportURL + 1),
+		MarketingURL: longHTTPSURL(LimitMarketingURL + 1),
+	}
+	appInfo := AppInfoLocalization{
+		Locale:            "en-US",
+		PrivacyPolicyURL:  longHTTPSURL(LimitPrivacyPolicyURL + 1),
+		PrivacyChoicesURL: longHTTPSURL(LimitPrivacyChoicesURL + 1),
+	}
+
+	checks := metadataLengthChecks([]VersionLocalization{loc}, []AppInfoLocalization{appInfo})
+
+	wantIDs := []string{
+		"metadata.length.support_url",
+		"metadata.length.marketing_url",
+		"metadata.length.privacy_policy_url",
+		"metadata.length.privacy_choices_url",
+	}
+	for _, id := range wantIDs {
+		if !hasCheckID(checks, id) {
+			t.Fatalf("expected %s check, got %+v", id, checks)
+		}
+	}
+	for _, check := range checks {
+		if check.Severity != SeverityWarning {
+			t.Fatalf("expected URL length checks to be warnings, got %+v", check)
+		}
+	}
+}
+
+func TestMetadataLengthChecks_URLsAtLimit(t *testing.T) {
+	loc := VersionLocalization{
+		Locale:       "en-US",
+		SupportURL:   longHTTPSURL(LimitSupportURL),
+		MarketingURL: longHTTPSURL(LimitMarketingURL),
+	}
+	appInfo := AppInfoLocalization{
+		Locale:            "en-US",
+		PrivacyPolicyURL:  longHTTPSURL(LimitPrivacyPolicyURL),
+		PrivacyChoicesURL: longHTTPSURL(LimitPrivacyChoicesURL),
+	}
+
+	checks := metadataLengthChecks([]VersionLocalization{loc}, []AppInfoLocalization{appInfo})
+	if len(checks) != 0 {
+		t.Fatalf("expected no checks at URL limits, got %+v", checks)
+	}
+}
+
 func TestVersionLocalizationLengthIssues_KeywordsUseCharacterLimit(t *testing.T) {
 	keywords := strings.Repeat("語", 101)
 

--- a/internal/validation/metadata_test.go
+++ b/internal/validation/metadata_test.go
@@ -68,6 +68,44 @@ func TestMetadataLengthChecks_ValidUnicode(t *testing.T) {
 	}
 }
 
+func TestVersionLocalizationMinimumLengthIssues(t *testing.T) {
+	issues := VersionLocalizationMinimumLengthIssues(VersionLocalization{
+		Locale:      "en-US",
+		Description: "TBD",
+	})
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %+v", issues)
+	}
+	if issues[0].Field != "description" || issues[0].Length != 3 || issues[0].Minimum != MinLengthDescription {
+		t.Fatalf("unexpected description issue: %+v", issues[0])
+	}
+
+	for _, description := range []string{"", strings.Repeat("d", MinLengthDescription), strings.Repeat("説", MinLengthDescription)} {
+		if issues := VersionLocalizationMinimumLengthIssues(VersionLocalization{Description: description}); len(issues) != 0 {
+			t.Fatalf("expected no issues for %q, got %+v", description, issues)
+		}
+	}
+}
+
+func TestAppInfoLocalizationMinimumLengthIssues(t *testing.T) {
+	issues := AppInfoLocalizationMinimumLengthIssues(AppInfoLocalization{
+		Locale: "en-US",
+		Name:   "X",
+	})
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %+v", issues)
+	}
+	if issues[0].Field != "name" || issues[0].Length != 1 || issues[0].Minimum != MinLengthName {
+		t.Fatalf("unexpected name issue: %+v", issues[0])
+	}
+
+	for _, name := range []string{"", "Ab", "名前"} {
+		if issues := AppInfoLocalizationMinimumLengthIssues(AppInfoLocalization{Name: name}); len(issues) != 0 {
+			t.Fatalf("expected no issues for %q, got %+v", name, issues)
+		}
+	}
+}
+
 func longHTTPSURL(length int) string {
 	const prefix = "https://example.com/"
 	if length <= len(prefix) {

--- a/internal/validation/review_details.go
+++ b/internal/validation/review_details.go
@@ -1,8 +1,20 @@
 package validation
 
-import "strings"
+import (
+	"net/mail"
+	"strings"
+	"unicode"
+)
 
 const reviewDetailsDemoCredentialsRemediation = "You set demoAccountRequired=true, so provide both demoAccountName and demoAccountPassword in App Store Connect. Use notes for supplemental reviewer guidance, not as a replacement for required credentials."
+
+// App Review has to be able to dial the contact number, so a value with too
+// few digits cannot be a reachable number. The upper bound stays well above
+// E.164's 15 digits so numbers written with an extension are not flagged.
+const (
+	minReviewContactPhoneDigits = 7
+	maxReviewContactPhoneDigits = 20
+)
 
 func reviewDetailsChecks(details *ReviewDetails) []CheckResult {
 	if details == nil {
@@ -26,11 +38,32 @@ func reviewDetailsChecks(details *ReviewDetails) []CheckResult {
 	if strings.TrimSpace(details.ContactLastName) == "" {
 		checks = append(checks, missingReviewDetailsField("contactLastName", resourceID))
 	}
-	if strings.TrimSpace(details.ContactEmail) == "" {
+	if email := strings.TrimSpace(details.ContactEmail); email == "" {
 		checks = append(checks, missingReviewDetailsField("contactEmail", resourceID))
+	} else if _, err := mail.ParseAddress(email); err != nil {
+		checks = append(checks, CheckResult{
+			ID:           "review_details.format.contact_email",
+			Severity:     SeverityError,
+			Field:        "contactEmail",
+			ResourceType: "appStoreReviewDetail",
+			ResourceID:   resourceID,
+			Message:      "review contact email is not a valid email address",
+			Remediation:  "Provide a deliverable email address App Review can reach, for example: reviewer@example.com",
+		})
 	}
-	if strings.TrimSpace(details.ContactPhone) == "" {
+
+	if phone := strings.TrimSpace(details.ContactPhone); phone == "" {
 		checks = append(checks, missingReviewDetailsField("contactPhone", resourceID))
+	} else if !hasPlausiblePhoneDigits(phone) {
+		checks = append(checks, CheckResult{
+			ID:           "review_details.format.contact_phone",
+			Severity:     SeverityWarning,
+			Field:        "contactPhone",
+			ResourceType: "appStoreReviewDetail",
+			ResourceID:   resourceID,
+			Message:      "review contact phone does not look like a reachable phone number",
+			Remediation:  "Provide a phone number App Review can dial, including country and area code, for example: +1 555 010 1234",
+		})
 	}
 
 	// Only require demo account credentials when the user explicitly marks them as required.
@@ -44,6 +77,19 @@ func reviewDetailsChecks(details *ReviewDetails) []CheckResult {
 	}
 
 	return checks
+}
+
+// hasPlausiblePhoneDigits reports whether a free-text phone value carries a
+// digit count a real phone number can have. App Store Connect stores the
+// contact phone as free text, so formatting characters are ignored.
+func hasPlausiblePhoneDigits(value string) bool {
+	digits := 0
+	for _, r := range value {
+		if unicode.IsDigit(r) {
+			digits++
+		}
+	}
+	return digits >= minReviewContactPhoneDigits && digits <= maxReviewContactPhoneDigits
 }
 
 func missingReviewDetailsField(field string, resourceID string) CheckResult {

--- a/internal/validation/review_details.go
+++ b/internal/validation/review_details.go
@@ -40,7 +40,7 @@ func reviewDetailsChecks(details *ReviewDetails) []CheckResult {
 	}
 	if email := strings.TrimSpace(details.ContactEmail); email == "" {
 		checks = append(checks, missingReviewDetailsField("contactEmail", resourceID))
-	} else if _, err := mail.ParseAddress(email); err != nil {
+	} else if !isBareEmailAddress(email) {
 		checks = append(checks, CheckResult{
 			ID:           "review_details.format.contact_email",
 			Severity:     SeverityError,
@@ -48,7 +48,7 @@ func reviewDetailsChecks(details *ReviewDetails) []CheckResult {
 			ResourceType: "appStoreReviewDetail",
 			ResourceID:   resourceID,
 			Message:      "review contact email is not a valid email address",
-			Remediation:  "Provide a deliverable email address App Review can reach, for example: reviewer@example.com",
+			Remediation:  "Provide a plain email address App Review can reach, with no display name, for example: reviewer@example.com",
 		})
 	}
 
@@ -77,6 +77,14 @@ func reviewDetailsChecks(details *ReviewDetails) []CheckResult {
 	}
 
 	return checks
+}
+
+// isBareEmailAddress reports whether a value is a single address with no RFC
+// display name, which is what App Store Connect stores in its contact email
+// fields. It matches the sandbox tester email rule used elsewhere in the CLI.
+func isBareEmailAddress(value string) bool {
+	parsed, err := mail.ParseAddress(value)
+	return err == nil && parsed != nil && strings.TrimSpace(parsed.Address) == value
 }
 
 // hasPlausiblePhoneDigits reports whether a free-text phone value carries a

--- a/internal/validation/review_details_remediation_test.go
+++ b/internal/validation/review_details_remediation_test.go
@@ -11,7 +11,7 @@ func TestReviewDetailsChecks_DemoCredentialRemediationExplainsOptIn(t *testing.T
 		ContactFirstName:    "A",
 		ContactLastName:     "B",
 		ContactEmail:        "a@example.com",
-		ContactPhone:        "123",
+		ContactPhone:        "+1 555 010 1234",
 		DemoAccountRequired: true,
 	})
 

--- a/internal/validation/review_details_test.go
+++ b/internal/validation/review_details_test.go
@@ -47,7 +47,7 @@ func TestReviewDetailsChecks_DemoAccountRequiredMissingCredentials(t *testing.T)
 		ContactFirstName:    "A",
 		ContactLastName:     "B",
 		ContactEmail:        "a@example.com",
-		ContactPhone:        "123",
+		ContactPhone:        "+1 555 010 1234",
 		DemoAccountRequired: true,
 		// Missing demo account name/password.
 	})
@@ -79,11 +79,81 @@ func TestReviewDetailsChecks_Pass(t *testing.T) {
 		ContactFirstName:    "A",
 		ContactLastName:     "B",
 		ContactEmail:        "a@example.com",
-		ContactPhone:        "123",
+		ContactPhone:        "+1 555 010 1234",
 		DemoAccountRequired: false,
 	})
 	if len(checks) != 0 {
 		t.Fatalf("expected no checks, got %d (%v)", len(checks), checks)
+	}
+}
+
+func TestReviewDetailsChecks_InvalidContactEmail(t *testing.T) {
+	for _, email := range []string{"reviewer", "reviewer@", "@example.com", "reviewer example.com"} {
+		checks := reviewDetailsChecks(&ReviewDetails{
+			ID:               "detail-1",
+			ContactFirstName: "A",
+			ContactLastName:  "B",
+			ContactEmail:     email,
+			ContactPhone:     "+1 555 010 1234",
+		})
+		if !hasCheckID(checks, "review_details.format.contact_email") {
+			t.Fatalf("expected contact email format check for %q, got %+v", email, checks)
+		}
+		for _, check := range checks {
+			if check.ID == "review_details.format.contact_email" && check.Severity != SeverityError {
+				t.Fatalf("expected error severity for %q, got %+v", email, check)
+			}
+		}
+	}
+}
+
+func TestReviewDetailsChecks_AcceptsValidContactEmails(t *testing.T) {
+	for _, email := range []string{"reviewer@example.com", "  reviewer@example.com  ", "Reviewer <reviewer@example.com>"} {
+		checks := reviewDetailsChecks(&ReviewDetails{
+			ID:               "detail-1",
+			ContactFirstName: "A",
+			ContactLastName:  "B",
+			ContactEmail:     email,
+			ContactPhone:     "+1 555 010 1234",
+		})
+		if len(checks) != 0 {
+			t.Fatalf("expected no checks for %q, got %+v", email, checks)
+		}
+	}
+}
+
+func TestReviewDetailsChecks_ImplausibleContactPhone(t *testing.T) {
+	for _, phone := range []string{"123", "call me", "+1-555"} {
+		checks := reviewDetailsChecks(&ReviewDetails{
+			ID:               "detail-1",
+			ContactFirstName: "A",
+			ContactLastName:  "B",
+			ContactEmail:     "a@example.com",
+			ContactPhone:     phone,
+		})
+		if !hasCheckID(checks, "review_details.format.contact_phone") {
+			t.Fatalf("expected contact phone format check for %q, got %+v", phone, checks)
+		}
+		for _, check := range checks {
+			if check.ID == "review_details.format.contact_phone" && check.Severity != SeverityWarning {
+				t.Fatalf("expected warning severity for %q, got %+v", phone, check)
+			}
+		}
+	}
+}
+
+func TestReviewDetailsChecks_AcceptsPlausibleContactPhones(t *testing.T) {
+	for _, phone := range []string{"5550101", "+1 (555) 010-1234", "+81 3-1234-5678", "+1 555 010 1234 ext. 42"} {
+		checks := reviewDetailsChecks(&ReviewDetails{
+			ID:               "detail-1",
+			ContactFirstName: "A",
+			ContactLastName:  "B",
+			ContactEmail:     "a@example.com",
+			ContactPhone:     phone,
+		})
+		if len(checks) != 0 {
+			t.Fatalf("expected no checks for %q, got %+v", phone, checks)
+		}
 	}
 }
 
@@ -93,7 +163,7 @@ func TestReviewDetailsChecks_PassWithDemoAccount(t *testing.T) {
 		ContactFirstName:    "A",
 		ContactLastName:     "B",
 		ContactEmail:        "a@example.com",
-		ContactPhone:        "123",
+		ContactPhone:        "+1 555 010 1234",
 		DemoAccountRequired: true,
 		DemoAccountName:     "demo",
 		DemoAccountPassword: "pass",
@@ -134,7 +204,7 @@ func TestReviewDetailsChecks_DemoCredentialPermutations(t *testing.T) {
 							ContactFirstName:    "A",
 							ContactLastName:     "B",
 							ContactEmail:        "a@example.com",
-							ContactPhone:        "123",
+							ContactPhone:        "+1 555 010 1234",
 							DemoAccountRequired: required,
 							DemoAccountName:     name,
 							DemoAccountPassword: password,

--- a/internal/validation/review_details_test.go
+++ b/internal/validation/review_details_test.go
@@ -88,7 +88,7 @@ func TestReviewDetailsChecks_Pass(t *testing.T) {
 }
 
 func TestReviewDetailsChecks_InvalidContactEmail(t *testing.T) {
-	for _, email := range []string{"reviewer", "reviewer@", "@example.com", "reviewer example.com"} {
+	for _, email := range []string{"reviewer", "reviewer@", "@example.com", "reviewer example.com", "Reviewer <reviewer@example.com>"} {
 		checks := reviewDetailsChecks(&ReviewDetails{
 			ID:               "detail-1",
 			ContactFirstName: "A",
@@ -108,7 +108,7 @@ func TestReviewDetailsChecks_InvalidContactEmail(t *testing.T) {
 }
 
 func TestReviewDetailsChecks_AcceptsValidContactEmails(t *testing.T) {
-	for _, email := range []string{"reviewer@example.com", "  reviewer@example.com  ", "Reviewer <reviewer@example.com>"} {
+	for _, email := range []string{"reviewer@example.com", "  reviewer@example.com  ", "reviewer+app-review@example.co.uk"} {
 		checks := reviewDetailsChecks(&ReviewDetails{
 			ID:               "detail-1",
 			ContactFirstName: "A",


### PR DESCRIPTION
## Problem

`asc metadata validate` runs offline, but it only checked schema decode, required fields, field intent, and character limits. Several classes of metadata problems slipped through the offline gate and only failed after a network round-trip at push or submission time:

- `"supportUrl": "example.com"` passed offline validation. App Store Connect requires an absolute HTTP/HTTPS URL, so the value was rejected later.
- No URL length checking existed anywhere, offline or online.
- App Store review detail contacts were only checked for presence, so `"contactEmail": "reviewer.example.com"` or a placeholder phone number validated cleanly and then App Review could not reach the developer.
- Authoring placeholders such as a one-character app name or `"TBD"` as the description validated cleanly.

## Behavior change

Four checks, added in one commit per check family.

**1. URL syntax (warning).** `internal/validation.isValidHTTPURL` was already used by the online `asc validate` report but was unreachable from the offline path. It is now exported as `IsValidHTTPURL` and applied to `marketingUrl`, `supportUrl`, `privacyPolicyUrl`, and `privacyChoicesUrl` in the offline directory scan, with the same message the online report emits.

**2. URL length, 255 characters (warning).** `LimitMarketingURL`, `LimitSupportURL`, `LimitPrivacyPolicyURL`, and `LimitPrivacyChoicesURL` join the existing limits and are wired through the shared length-issue helpers, so both `asc metadata validate` and `asc validate` report them.

Note on provenance: Apple's App Store Connect OpenAPI specification carries no `maxLength` for any attribute (`grep -c maxLength docs/openapi/latest.json` returns 0), so these values track Apple's documented App Store Connect field constraints rather than a machine-readable schema. That is why the resulting checks are warnings while the per-field text limits stay errors. `--strict` still promotes them to blocking.

Existing callers of the shared helpers (`asc localizations`, `asc apps rename`, `asc app-setup`, `asc migrate import`) construct the localization structs with text fields only, so their behavior is unchanged.

**3. Review contact format.** `contactEmail` is parsed with `net/mail.ParseAddress` and an unparseable address is an error, matching the existing primitive used for sandbox tester emails. `contactPhone` is free text with no canonical format, so an implausible digit count is a warning instead: the check counts digits and accepts 7 through 20, which covers international numbers written with or without country codes and extensions.

**4. Minimum lengths (warnings).** App name under 2 characters and description under 10 characters are flagged. Apple publishes no exact minimum in a machine-verifiable form, so these never block. Empty values still fall to the required-field checks, which separate "unset" from "too short".

Severity choice throughout: a false hard error on data App Store Connect actually accepts is worse than a warning, so anything not backed by a schema constraint is advisory.

## Example invocations

```console
$ cat metadata/version/1.2.3/en-US.json
{"description":"TBD","supportUrl":"example.com"}

$ asc metadata validate --dir ./metadata --output table
Dir: ./metadata
Files Scanned: 1
Errors: 0  Warnings: 2

scope    file                                    locale  version  field       severity  message                                      length  limit
version  metadata/version/1.2.3/en-US.json       en-US   1.2.3    description warning   description is shorter than 10 characters     3       -
version  metadata/version/1.2.3/en-US.json       en-US   1.2.3    supportUrl  warning   support URL is not a valid HTTP/HTTPS URL     -       -
```

Exit code stays 0 for a warning-only report and `valid` stays `true`; only errors flip `valid` to `false` and exit non-zero.

```console
$ asc validate --app APP_ID --version-id VERSION_ID
{"checks":[{"id":"review_details.format.contact_email","severity":"error","message":"review contact email is not a valid email address", ...}]}
```

## Compatibility

- Additive only. No existing check ID, message, or remediation changed, and no check changed severity.
- New JSON fields: none. New check IDs: `metadata.length.marketing_url`, `metadata.length.support_url`, `metadata.length.privacy_policy_url`, `metadata.length.privacy_choices_url`, `review_details.format.contact_email`, `review_details.format.contact_phone`.
- `asc metadata validate` messages for `whatsNew` and `promotionalText` now use the same operator-facing labels as the online report ("what's new", "promotional text") so both surfaces read identically. JSON `field` values are unchanged.
- Test fixtures that used `"123"` as a placeholder phone number now use a plausible number, and one Arabic fixture description was lengthened past the new minimum.
- Internal refactor: the per-field `CheckResult` switch in `metadataLengthChecks` became a table so the four URL fields reuse one construction path. Emitted output for existing fields is byte-identical.

## Tests

- `internal/validation`: exported URL syntax helper, URL length limits at and over the boundary, contact email valid/invalid forms, contact phone plausible/implausible forms, minimum-length helpers including multibyte input.
- `internal/cli/metadata`: `validateDir` fixtures for URL syntax, URL length boundaries, and short values.
- `internal/cli/cmdtest`: end-to-end fixtures through `asc metadata validate --dir` for URL syntax, over-long URLs, and short values, plus `asc validate` coverage for the malformed review contact.

Commands run: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all green, zero failures. No live API calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP/HTTPS URL validation for app metadata.
  * Added advisory warnings for very short app names and descriptions.
  * Added warning-level checks for overly long metadata URLs.
  * Added review-contact email and phone-number validation.

* **Bug Fixes**
  * Improved metadata validation messages, field identification, and warning reporting.

* **Tests**
  * Expanded coverage for invalid URLs, length limits, short metadata, and contact details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->