### PR TITLE
Make build upload failures actionable

### DIFF
--- a/internal/cli/shared/build_wait.go
+++ b/internal/cli/shared/build_wait.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -273,10 +275,82 @@ func buildUploadFailureError(upload *asc.BuildUploadResponse) error {
 	}
 
 	details := buildUploadStateDetails(upload.Data.Attributes.State.Errors)
+	recovery := buildUploadRecoveryGuidance(upload.Data.Attributes.State.Errors)
 	if details == "" {
+		if recovery != "" {
+			return fmt.Errorf("build upload %q failed with state %s; recovery: %s", upload.Data.ID, state, recovery)
+		}
 		return fmt.Errorf("build upload %q failed with state %s", upload.Data.ID, state)
 	}
+	if recovery != "" {
+		return fmt.Errorf("build upload %q failed with state %s: %s; recovery: %s", upload.Data.ID, state, details, recovery)
+	}
 	return fmt.Errorf("build upload %q failed with state %s: %s", upload.Data.ID, state, details)
+}
+
+var usageDescriptionKeyPattern = regexp.MustCompile(`\b[A-Za-z0-9_]+UsageDescription\b`)
+
+func buildUploadRecoveryGuidance(details []asc.StateDetail) string {
+	switch {
+	case stateDetailCodesMatch(details, "90062", "90186", "90478"):
+		return "increase the marketing version (CFBundleShortVersionString), rebuild, and upload again"
+	case stateDetailCodesMatch(details, "90189"):
+		return "increase the build number (CFBundleVersion), rebuild, and upload again"
+	case stateDetailCodesMatch(details, "90054", "90055"):
+		return "verify that the artifact's bundle identifier matches the selected app; rebuild with the correct identifier or select the intended app"
+	case stateDetailCodesMatch(details, "90683"):
+		keys := missingUsageDescriptionKeys(details)
+		if len(keys) > 0 {
+			return fmt.Sprintf("add the missing privacy purpose strings to Info.plist (%s), rebuild, and upload again", strings.Join(keys, ", "))
+		}
+		return "add the missing privacy purpose strings to Info.plist, rebuild, and upload again"
+	case stateDetailCodesMatch(details, "90725"):
+		return "rebuild with a currently supported SDK and toolchain, then upload again"
+	case stateDetailCodesMatch(details, "90771"):
+		return "add BGTaskSchedulerPermittedIdentifiers to Info.plist with every scheduled background task identifier, rebuild, and upload again"
+	case stateDetailCodesMatch(details, "90391", "90713"):
+		return "add the required app icons and icon metadata (such as CFBundleIconName or CFBundleIconFiles) to every failing bundle, rebuild, and upload again"
+	default:
+		return ""
+	}
+}
+
+func stateDetailCodesMatch(details []asc.StateDetail, allowed ...string) bool {
+	if len(details) == 0 {
+		return false
+	}
+
+	allowedCodes := make(map[string]struct{}, len(allowed))
+	for _, code := range allowed {
+		allowedCodes[code] = struct{}{}
+	}
+	for _, detail := range details {
+		code := strings.TrimSpace(detail.Code)
+		if _, ok := allowedCodes[code]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func missingUsageDescriptionKeys(details []asc.StateDetail) []string {
+	keys := make(map[string]struct{})
+	for _, detail := range details {
+		message := strings.TrimSpace(detail.Message)
+		if message == "" {
+			message = strings.TrimSpace(detail.Description)
+		}
+		for _, key := range usageDescriptionKeyPattern.FindAllString(message, -1) {
+			keys[key] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func enrichBuildUploadFailure(ctx context.Context, client *asc.Client, appID string, upload *asc.BuildUploadResponse, baseErr error) error {

--- a/internal/cli/shared/build_wait.go
+++ b/internal/cli/shared/build_wait.go
@@ -292,30 +292,34 @@ var usageDescriptionKeyPattern = regexp.MustCompile(`\b[A-Za-z0-9_]+UsageDescrip
 
 func buildUploadRecoveryGuidance(details []asc.StateDetail) string {
 	switch {
-	case stateDetailCodesMatch(details, "90062", "90186", "90478"):
+	case allStateDetailCodesIn(details, "90062", "90186", "90478"):
 		return "increase the marketing version (CFBundleShortVersionString), rebuild, and upload again"
-	case stateDetailCodesMatch(details, "90189"):
+	case allStateDetailCodesIn(details, "90189"):
 		return "increase the build number (CFBundleVersion), rebuild, and upload again"
-	case stateDetailCodesMatch(details, "90054", "90055"):
+	case allStateDetailCodesIn(details, "90054") && stateDetailTextContains(details, "cfbundleversion"):
+		return "format CFBundleVersion as a period-separated list of at most three non-negative integers, rebuild, and upload again"
+	case allStateDetailCodesIn(details, "90054", "90055") && stateDetailTextContains(details, "bundle identifier"):
 		return "verify that the artifact's bundle identifier matches the selected app; rebuild with the correct identifier or select the intended app"
-	case stateDetailCodesMatch(details, "90683"):
+	case allStateDetailCodesIn(details, "90683"):
 		keys := missingUsageDescriptionKeys(details)
 		if len(keys) > 0 {
 			return fmt.Sprintf("add the missing privacy purpose strings to Info.plist (%s), rebuild, and upload again", strings.Join(keys, ", "))
 		}
 		return "add the missing privacy purpose strings to Info.plist, rebuild, and upload again"
-	case stateDetailCodesMatch(details, "90725"):
+	case allStateDetailCodesIn(details, "90725"):
 		return "rebuild with a currently supported SDK and toolchain, then upload again"
-	case stateDetailCodesMatch(details, "90771"):
+	case allStateDetailCodesIn(details, "90771"):
 		return "add BGTaskSchedulerPermittedIdentifiers to Info.plist with every scheduled background task identifier, rebuild, and upload again"
-	case stateDetailCodesMatch(details, "90391", "90713"):
+	case allStateDetailCodesIn(details, "90391", "90713"):
 		return "add the required app icons and icon metadata (such as CFBundleIconName or CFBundleIconFiles) to every failing bundle, rebuild, and upload again"
 	default:
 		return ""
 	}
 }
 
-func stateDetailCodesMatch(details []asc.StateDetail, allowed ...string) bool {
+// allStateDetailCodesIn reports whether every received error belongs to one
+// known code family. Codes in a family are alternatives and need not all occur.
+func allStateDetailCodesIn(details []asc.StateDetail, allowed ...string) bool {
 	if len(details) == 0 {
 		return false
 	}
@@ -333,15 +337,28 @@ func stateDetailCodesMatch(details []asc.StateDetail, allowed ...string) bool {
 	return true
 }
 
+func stateDetailTextContains(details []asc.StateDetail, fragment string) bool {
+	fragment = strings.ToLower(strings.TrimSpace(fragment))
+	if fragment == "" {
+		return false
+	}
+	for _, detail := range details {
+		for _, text := range []string{detail.Message, detail.Description} {
+			if strings.Contains(strings.ToLower(text), fragment) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func missingUsageDescriptionKeys(details []asc.StateDetail) []string {
 	keys := make(map[string]struct{})
 	for _, detail := range details {
-		message := strings.TrimSpace(detail.Message)
-		if message == "" {
-			message = strings.TrimSpace(detail.Description)
-		}
-		for _, key := range usageDescriptionKeyPattern.FindAllString(message, -1) {
-			keys[key] = struct{}{}
+		for _, text := range []string{detail.Message, detail.Description} {
+			for _, key := range usageDescriptionKeyPattern.FindAllString(strings.TrimSpace(text), -1) {
+				keys[key] = struct{}{}
+			}
 		}
 	}
 

--- a/internal/cli/shared/build_wait.go
+++ b/internal/cli/shared/build_wait.go
@@ -541,7 +541,10 @@ func buildUploadStateDetails(details []asc.StateDetail) string {
 	parts := make([]string, 0, len(details))
 	for _, detail := range details {
 		code := strings.TrimSpace(detail.Code)
-		message := strings.TrimSpace(detail.Message)
+		message := strings.TrimSpace(detail.Description)
+		if message == "" {
+			message = strings.TrimSpace(detail.Message)
+		}
 		switch {
 		case code != "" && message != "":
 			parts = append(parts, fmt.Sprintf("%s (%s)", code, message))

--- a/internal/cli/shared/build_wait.go
+++ b/internal/cli/shared/build_wait.go
@@ -291,15 +291,15 @@ func buildUploadFailureError(upload *asc.BuildUploadResponse) error {
 var usageDescriptionKeyPattern = regexp.MustCompile(`\b[A-Za-z0-9_]+UsageDescription\b`)
 
 func buildUploadRecoveryGuidance(details []asc.StateDetail) string {
+	if recovery, ok := buildUploadVersionRecoveryGuidance(details); ok {
+		return recovery
+	}
+
 	switch {
 	case allStateDetailCodesIn(details, "90062", "90186", "90478"):
 		return "increase the marketing version (CFBundleShortVersionString), rebuild, and upload again"
 	case allStateDetailCodesIn(details, "90189"):
 		return "increase the build number (CFBundleVersion), rebuild, and upload again"
-	case allStateDetailCodesIn(details, "90054") && stateDetailTextContains(details, "cfbundleversion"):
-		return "format CFBundleVersion as a period-separated list of at most three non-negative integers, rebuild, and upload again"
-	case allStateDetailCodesIn(details, "90054", "90055") && stateDetailTextContains(details, "bundle identifier"):
-		return "verify that the artifact's bundle identifier matches the selected app; rebuild with the correct identifier or select the intended app"
 	case allStateDetailCodesIn(details, "90683"):
 		keys := missingUsageDescriptionKeys(details)
 		if len(keys) > 0 {
@@ -315,6 +315,34 @@ func buildUploadRecoveryGuidance(details []asc.StateDetail) string {
 	default:
 		return ""
 	}
+}
+
+func buildUploadVersionRecoveryGuidance(details []asc.StateDetail) (string, bool) {
+	if !allStateDetailCodesIn(details, "90054", "90055") {
+		return "", false
+	}
+
+	invalidBuildNumber := false
+	bundleIdentifierMismatch := false
+	for _, detail := range details {
+		switch {
+		case strings.TrimSpace(detail.Code) == "90054" && stateDetailTextContains([]asc.StateDetail{detail}, "cfbundleversion"):
+			invalidBuildNumber = true
+		case stateDetailTextContains([]asc.StateDetail{detail}, "bundle identifier"):
+			bundleIdentifierMismatch = true
+		default:
+			return "", false
+		}
+	}
+
+	recoveries := make([]string, 0, 2)
+	if invalidBuildNumber {
+		recoveries = append(recoveries, "format CFBundleVersion as a period-separated list of at most three non-negative integers, rebuild, and upload again")
+	}
+	if bundleIdentifierMismatch {
+		recoveries = append(recoveries, "verify that the artifact's bundle identifier matches the selected app; rebuild with the correct identifier or select the intended app")
+	}
+	return strings.Join(recoveries, "; "), len(recoveries) > 0
 }
 
 // allStateDetailCodesIn reports whether every received error belongs to one

--- a/internal/cli/shared/build_wait_test.go
+++ b/internal/cli/shared/build_wait_test.go
@@ -393,6 +393,24 @@ func TestBuildUploadFailureErrorLeavesUnknownFailuresUnchanged(t *testing.T) {
 	}
 }
 
+func TestBuildUploadFailureErrorPreservesDescriptionWhenMessageIsEmpty(t *testing.T) {
+	state := "FAILED"
+	upload := &asc.BuildUploadResponse{}
+	upload.Data.ID = "upload-1"
+	upload.Data.Attributes.State = &asc.AppMediaAssetState{
+		State:  &state,
+		Errors: []asc.StateDetail{{Code: "90054", Description: "raw App Store Connect description"}},
+	}
+
+	err := buildUploadFailureError(upload)
+	if err == nil {
+		t.Fatal("expected failure error")
+	}
+	if !strings.Contains(err.Error(), "raw App Store Connect description") {
+		t.Fatalf("expected raw description in %q", err)
+	}
+}
+
 func TestBuildUploadFailureErrorDoesNotGuessForMixedCodes(t *testing.T) {
 	state := "FAILED"
 	upload := &asc.BuildUploadResponse{}

--- a/internal/cli/shared/build_wait_test.go
+++ b/internal/cli/shared/build_wait_test.go
@@ -243,6 +243,7 @@ func TestBuildUploadFailureErrorIncludesRecoveryGuidance(t *testing.T) {
 	tests := []struct {
 		name        string
 		codes       []string
+		message     string
 		description string
 		want        []string
 	}{
@@ -257,13 +258,21 @@ func TestBuildUploadFailureErrorIncludesRecoveryGuidance(t *testing.T) {
 			want:  []string{"increase the build number", "CFBundleVersion"},
 		},
 		{
-			name:  "bundle identifier mismatch",
-			codes: []string{"90054", "90055"},
-			want:  []string{"bundle identifier", "selected app"},
+			name:        "bundle identifier mismatch",
+			codes:       []string{"90054", "90055"},
+			description: "The bundle identifier does not match the selected app.",
+			want:        []string{"bundle identifier", "selected app"},
+		},
+		{
+			name:        "invalid build number format",
+			codes:       []string{"90054"},
+			description: "The value for CFBundleVersion must be a period-separated list of at most three non-negative integers.",
+			want:        []string{"CFBundleVersion", "period-separated list"},
 		},
 		{
 			name:        "missing privacy purpose string",
 			codes:       []string{"90683"},
+			message:     "Privacy validation failed.",
 			description: "Missing Info.plist value. A value for NSCameraUsageDescription must be present.",
 			want:        []string{"NSCameraUsageDescription", "Info.plist"},
 		},
@@ -289,7 +298,11 @@ func TestBuildUploadFailureErrorIncludesRecoveryGuidance(t *testing.T) {
 			state := "FAILED"
 			details := make([]asc.StateDetail, 0, len(tt.codes))
 			for _, code := range tt.codes {
-				details = append(details, asc.StateDetail{Code: code, Description: tt.description, Message: tt.description})
+				message := tt.message
+				if message == "" {
+					message = tt.description
+				}
+				details = append(details, asc.StateDetail{Code: code, Description: tt.description, Message: message})
 			}
 			upload := &asc.BuildUploadResponse{}
 			upload.Data.ID = "upload-1"
@@ -308,6 +321,25 @@ func TestBuildUploadFailureErrorIncludesRecoveryGuidance(t *testing.T) {
 				if !strings.Contains(err.Error(), code) {
 					t.Fatalf("expected original code %q in %q", code, err)
 				}
+			}
+		})
+	}
+}
+
+func TestBuildUploadFailureErrorRecognizesIndividualCodeFromFamily(t *testing.T) {
+	for _, code := range []string{"90062", "90186", "90478"} {
+		t.Run(code, func(t *testing.T) {
+			state := "FAILED"
+			upload := &asc.BuildUploadResponse{}
+			upload.Data.ID = "upload-1"
+			upload.Data.Attributes.State = &asc.AppMediaAssetState{
+				State:  &state,
+				Errors: []asc.StateDetail{{Code: code}},
+			}
+
+			err := buildUploadFailureError(upload)
+			if err == nil || !strings.Contains(err.Error(), "increase the marketing version") {
+				t.Fatalf("expected closed-version guidance for %s, got %v", code, err)
 			}
 		})
 	}

--- a/internal/cli/shared/build_wait_test.go
+++ b/internal/cli/shared/build_wait_test.go
@@ -298,11 +298,11 @@ func TestBuildUploadFailureErrorIncludesRecoveryGuidance(t *testing.T) {
 			state := "FAILED"
 			details := make([]asc.StateDetail, 0, len(tt.codes))
 			for _, code := range tt.codes {
-				message := tt.message
-				if message == "" {
-					message = tt.description
-				}
-				details = append(details, asc.StateDetail{Code: code, Description: tt.description, Message: message})
+				details = append(details, asc.StateDetail{
+					Code:        code,
+					Description: tt.description,
+					Message:     tt.message,
+				})
 			}
 			upload := &asc.BuildUploadResponse{}
 			upload.Data.ID = "upload-1"
@@ -323,6 +323,35 @@ func TestBuildUploadFailureErrorIncludesRecoveryGuidance(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildUploadFailureErrorCombinesIndependentVersionRecoveries(t *testing.T) {
+	state := "FAILED"
+	upload := &asc.BuildUploadResponse{}
+	upload.Data.ID = "upload-1"
+	upload.Data.Attributes.State = &asc.AppMediaAssetState{
+		State: &state,
+		Errors: []asc.StateDetail{
+			{
+				Code:        "90054",
+				Description: "The value for CFBundleVersion must be a period-separated list of at most three non-negative integers.",
+			},
+			{
+				Code:        "90055",
+				Description: "The bundle identifier does not match the selected app.",
+			},
+		},
+	}
+
+	err := buildUploadFailureError(upload)
+	if err == nil {
+		t.Fatal("expected failure error")
+	}
+	for _, want := range []string{"CFBundleVersion", "period-separated list", "bundle identifier", "selected app"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected %q in %q", want, err)
+		}
 	}
 }
 

--- a/internal/cli/shared/build_wait_test.go
+++ b/internal/cli/shared/build_wait_test.go
@@ -239,6 +239,120 @@ func TestWaitForBuildByNumberOrUploadFailureIncludesProcessingDiagnostics(t *tes
 	}
 }
 
+func TestBuildUploadFailureErrorIncludesRecoveryGuidance(t *testing.T) {
+	tests := []struct {
+		name        string
+		codes       []string
+		description string
+		want        []string
+	}{
+		{
+			name:  "closed version train",
+			codes: []string{"90062", "90186", "90478"},
+			want:  []string{"increase the marketing version", "CFBundleShortVersionString"},
+		},
+		{
+			name:  "duplicate build number",
+			codes: []string{"90189"},
+			want:  []string{"increase the build number", "CFBundleVersion"},
+		},
+		{
+			name:  "bundle identifier mismatch",
+			codes: []string{"90054", "90055"},
+			want:  []string{"bundle identifier", "selected app"},
+		},
+		{
+			name:        "missing privacy purpose string",
+			codes:       []string{"90683"},
+			description: "Missing Info.plist value. A value for NSCameraUsageDescription must be present.",
+			want:        []string{"NSCameraUsageDescription", "Info.plist"},
+		},
+		{
+			name:  "unsupported SDK",
+			codes: []string{"90725"},
+			want:  []string{"supported SDK", "toolchain"},
+		},
+		{
+			name:  "missing background task identifiers",
+			codes: []string{"90771"},
+			want:  []string{"BGTaskSchedulerPermittedIdentifiers", "Info.plist"},
+		},
+		{
+			name:  "missing app icons",
+			codes: []string{"90391", "90713"},
+			want:  []string{"required app icons", "CFBundleIconName"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := "FAILED"
+			details := make([]asc.StateDetail, 0, len(tt.codes))
+			for _, code := range tt.codes {
+				details = append(details, asc.StateDetail{Code: code, Description: tt.description, Message: tt.description})
+			}
+			upload := &asc.BuildUploadResponse{}
+			upload.Data.ID = "upload-1"
+			upload.Data.Attributes.State = &asc.AppMediaAssetState{State: &state, Errors: details}
+
+			err := buildUploadFailureError(upload)
+			if err == nil {
+				t.Fatal("expected failure error")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("expected %q in %q", want, err)
+				}
+			}
+			for _, code := range tt.codes {
+				if !strings.Contains(err.Error(), code) {
+					t.Fatalf("expected original code %q in %q", code, err)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildUploadFailureErrorLeavesUnknownFailuresUnchanged(t *testing.T) {
+	state := "FAILED"
+	upload := &asc.BuildUploadResponse{}
+	upload.Data.ID = "upload-1"
+	upload.Data.Attributes.State = &asc.AppMediaAssetState{
+		State:  &state,
+		Errors: []asc.StateDetail{{Code: "UNKNOWN", Description: "Server-provided detail", Message: "Server-provided detail"}},
+	}
+
+	err := buildUploadFailureError(upload)
+	if err == nil {
+		t.Fatal("expected failure error")
+	}
+	want := `build upload "upload-1" failed with state FAILED: UNKNOWN (Server-provided detail)`
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err, want)
+	}
+}
+
+func TestBuildUploadFailureErrorDoesNotGuessForMixedCodes(t *testing.T) {
+	state := "FAILED"
+	upload := &asc.BuildUploadResponse{}
+	upload.Data.ID = "upload-1"
+	upload.Data.Attributes.State = &asc.AppMediaAssetState{
+		State: &state,
+		Errors: []asc.StateDetail{
+			{Code: "90189"},
+			{Code: "UNKNOWN"},
+		},
+	}
+
+	err := buildUploadFailureError(upload)
+	if err == nil {
+		t.Fatal("expected failure error")
+	}
+	if strings.Contains(err.Error(), "recovery:") {
+		t.Fatalf("mixed errors must not receive speculative guidance: %v", err)
+	}
+}
+
 func TestWaitForBuildByNumberOrUploadFailureFallsBackWhenUploadLookupFails(t *testing.T) {
 	client := newBuildWaitTestClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet {


### PR DESCRIPTION
## Summary

- add targeted recovery guidance for recognized build-upload validation classes
- extract missing privacy-purpose keys when server descriptions identify them
- combine independent build-number and bundle-identifier recoveries without masking either failure
- preserve every raw code and description while leaving unknown or mixed failures unchanged

## Why

Failed uploads already surface server diagnostics, but raw numeric codes alone do not tell callers whether to bump a version, fix the bundle identifier, update privacy metadata, use a newer toolchain, or repair bundle resources. The new guidance stays conservative: every received error must belong to one known class, and ambiguous codes are gated by the server diagnostic text.

## Test plan

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved App Store submission failure messages with targeted recovery guidance for recognized validation errors.
  * Added guidance for common issues involving version numbers, build numbers, bundle identifiers, privacy descriptions, SDK requirements, background tasks, and app icons.
  * Improved detection of diagnostic details across error messages and descriptions, including clearer handling of privacy-related keys.
  * Combined recovery suggestions when independent version and bundle-identifier issues occur.
  * Preserved the original error format when failures are unknown or contain mixed recognized and unrecognized issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->