### PR TITLE
apps wall: add Secure Storage: Private Vault

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1371,6 +1371,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/cf/8e/88/cf8e88b7-50bc-e82f-f37b-734549d82fcd/AppIcon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Secure Storage: Private Vault",
+    "link": "https://apps.apple.com/us/app/secure-storage-private-vault/id6794763277?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/02/4e/89/024e8960-34e7-b77b-3da3-d293b7da39b5/SecureStorage-0-0-1x_U007ephone-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Set - Strength Log",
     "link": "https://apps.apple.com/us/app/set-strength-log/id6759079224?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4d/80/3d/4d803d98-3f09-a0f4-d5d7-65c6f0f08066/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Secure Storage: Private Vault` to the Wall of Apps

## Entry

- App ID: 6794763277
- App: Secure Storage: Private Vault
- App Store: https://apps.apple.com/in/app/secure-storage-private-vault/id6794763277
- Website: https://securestorage.app

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Secure Storage: Private Vault” app to the application directory.
  * Included its App Store link and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->