### PR TITLE
fix(build-localizations): validate release notes before the API call

### DIFF
--- a/internal/cli/buildlocalizations/build_localizations.go
+++ b/internal/cli/buildlocalizations/build_localizations.go
@@ -180,7 +180,7 @@ func BuildLocalizationsCreateCommand() *ffcli.Command {
 
 	buildID := fs.String("build", "", "Build ID")
 	locale := fs.String("locale", "", "Locale (e.g., en-US)")
-	whatsNew := fs.String("whats-new", "", "Release notes (whats new)")
+	whatsNew := fs.String("whats-new", "", "Release notes (whats new), up to 4000 characters")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -188,6 +188,9 @@ func BuildLocalizationsCreateCommand() *ffcli.Command {
 		ShortUsage: "asc build-localizations create [flags]",
 		ShortHelp:  "Create a localization for a build.",
 		LongHelp: `Create a localization for a build.
+
+Release notes are limited to 4000 characters and are checked before the
+request is sent.
 
 Examples:
   asc build-localizations create --build "BUILD_ID" --locale "en-US"
@@ -212,6 +215,16 @@ Examples:
 
 			whatsNewValue := strings.TrimSpace(*whatsNew)
 
+			attrs := asc.AppStoreVersionLocalizationAttributes{
+				Locale: localeValue,
+			}
+			if whatsNewValue != "" {
+				attrs.WhatsNew = whatsNewValue
+			}
+			if err := shared.ValidateVersionLocalizationAttributes(attrs); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("build-localizations create: %w", err)
@@ -223,13 +236,6 @@ Examples:
 			versionID, err := resolveBuildAppStoreVersion(requestCtx, client, build)
 			if err != nil {
 				return fmt.Errorf("build-localizations create: %w", err)
-			}
-
-			attrs := asc.AppStoreVersionLocalizationAttributes{
-				Locale: localeValue,
-			}
-			if whatsNewValue != "" {
-				attrs.WhatsNew = whatsNewValue
 			}
 
 			resp, err := client.CreateAppStoreVersionLocalization(requestCtx, versionID, attrs)
@@ -259,7 +265,7 @@ func BuildLocalizationsUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 
 	localizationID := fs.String("id", "", "Localization ID")
-	whatsNew := fs.String("whats-new", "", "Release notes (whats new)")
+	whatsNew := fs.String("whats-new", "", "Release notes (whats new), up to 4000 characters")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -267,6 +273,9 @@ func BuildLocalizationsUpdateCommand() *ffcli.Command {
 		ShortUsage: "asc build-localizations update [flags]",
 		ShortHelp:  "Update a localization by ID.",
 		LongHelp: `Update a localization by ID.
+
+Release notes are limited to 4000 characters and are checked before the
+request is sent.
 
 Examples:
   asc build-localizations update --id "LOCALIZATION_ID" --whats-new "New features"`,
@@ -285,6 +294,13 @@ Examples:
 				return shared.MissingRequiredUsageError("--whats-new")
 			}
 
+			attrs := asc.AppStoreVersionLocalizationAttributes{
+				WhatsNew: whatsNewValue,
+			}
+			if err := shared.ValidateVersionLocalizationAttributes(attrs); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("build-localizations update: %w", err)
@@ -292,10 +308,6 @@ Examples:
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
-
-			attrs := asc.AppStoreVersionLocalizationAttributes{
-				WhatsNew: whatsNewValue,
-			}
 
 			resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, id, attrs)
 			if err != nil {

--- a/internal/cli/cmdtest/build_localizations_validation_test.go
+++ b/internal/cli/cmdtest/build_localizations_validation_test.go
@@ -1,0 +1,123 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+// App Store Connect rejects release notes longer than the documented limit, so
+// the CLI has to refuse them before spending a request on the resolution and
+// mutation round-trip.
+func TestBuildLocalizationsRejectsOverlongWhatsNewBeforeAnyRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "create",
+			args: []string{"build-localizations", "create", "--build", "build-1", "--locale", "en-US"},
+		},
+		{
+			name: "update",
+			args: []string{"build-localizations", "update", "--id", "loc-1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientCalls++
+				return nil, errors.New("client should not be created")
+			}))
+
+			args := append(append([]string(nil), test.args...), "--whats-new", strings.Repeat("w", validation.LimitWhatsNew+1))
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(args, "1.2.3"); code != cmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "whatsNew exceeds 4000 characters") {
+				t.Fatalf("expected length error on stderr, got %q", stderr)
+			}
+			if clientCalls != 0 {
+				t.Fatalf("expected no client creation, got %d", clientCalls)
+			}
+		})
+	}
+}
+
+// Release notes are limited by character count, so multibyte text at the limit
+// stays valid even though it is several times that many bytes.
+func TestBuildLocalizationsAcceptsMultibyteWhatsNewAtLimit(t *testing.T) {
+	setupAuth(t)
+
+	whatsNew := strings.Repeat("あ", validation.LimitWhatsNew)
+	if len(whatsNew) <= validation.LimitWhatsNew {
+		t.Fatalf("expected multibyte payload larger than the character limit, got %d bytes", len(whatsNew))
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	var sentWhatsNew string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/build-1/appStoreVersion":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"version-1"}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/appStoreVersionLocalizations":
+			var payload struct {
+				Data struct {
+					Attributes struct {
+						WhatsNew string `json:"whatsNew"`
+					} `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			sentWhatsNew = payload.Data.Attributes.WhatsNew
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"ja"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"build-localizations", "create",
+			"--build", "build-1",
+			"--locale", "ja",
+			"--whats-new", whatsNew,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(t.Context()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if sentWhatsNew != whatsNew {
+		t.Fatalf("expected operator input to reach the API unchanged, got %d characters", len([]rune(sentWhatsNew)))
+	}
+}


### PR DESCRIPTION
## Problem

`asc build-localizations create` and `asc build-localizations update` write the `whatsNew` attribute of an `appStoreVersionLocalization` — the same field on the same resource that `asc localizations create/update`, `asc metadata push`, `asc metadata keywords push`, `asc app-setup info set`, and `asc migrate import` write. Every one of those paths runs `shared.ValidateVersionLocalizationAttributes` before touching the network. `build-localizations` did not.

The result: an over-limit `--whats-new` cost a build lookup (`GET /v1/builds/{id}/appStoreVersion`) plus the mutation request before App Store Connect rejected it, and the failure surfaced as a generic API error instead of a usage error.

## Behavior change

`create` and `update` now validate the attributes they are about to send, before the ASC client is created:

- over-limit `--whats-new` fails with usage exit code 2, naming the field and the limit, and no HTTP request is made;
- the attributes struct is validated as a whole, so any field these commands gain later is covered by the same gate;
- operator input is never trimmed, stripped, or truncated — the command refuses and exits, or sends exactly what was passed.

The limit is counted in characters, not bytes, matching `internal/validation.LimitWhatsNew` as already applied by `asc validate` and `asc metadata validate`. A byte-based limit would reject Japanese or Arabic release notes at 4000 characters (12000 and 8000 bytes) that the other two surfaces accept, which would be a false hard error on valid input.

The error text is identical to the message `asc localizations` emits for the same field, so an agent sees one failure mode regardless of which command it used.

## Example invocations

```console
$ asc build-localizations update --id "LOCALIZATION_ID" --whats-new "$(python3 -c 'print("w"*4001)')"
Error: whatsNew exceeds 4000 characters
...usage...
$ echo $?
2
```

No request is issued. Within the limit, behavior is unchanged:

```console
$ asc build-localizations create --build "BUILD_ID" --locale "ja" --whats-new "バグ修正"
{"data":{"type":"appStoreVersionLocalizations","id":"...","attributes":{"locale":"ja","whatsNew":"バグ修正"}}}
```

Help now states the limit on both subcommands and on the `--whats-new` flag.

## Tests

`internal/cli/cmdtest/build_localizations_validation_test.go`:

- `TestBuildLocalizationsRejectsOverlongWhatsNewBeforeAnyRequest` — table over `create` and `update`: exit code 2, the length error on stderr, empty stdout, and the ASC client factory asserted never to be called.
- `TestBuildLocalizationsAcceptsMultibyteWhatsNewAtLimit` — 4000 multibyte characters (12000 bytes) reach the API unchanged, guarding against a byte-counted regression and against any silent truncation of operator input.

Existing `TestBuildLocalizationsCreateWarnsForIncompleteCreate` and the rest of the `build-localizations` coverage still pass.

## Compatibility

- Additive. Values within the limit behave exactly as before; only input App Store Connect would have rejected now fails earlier and with usage semantics.
- No output shape change. No new flags, no new constants.
- Help text changed; `docs/COMMANDS.md` regenerated and unchanged (it does not embed long help).

Commands run: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all green, zero failures. Manual check with `ASC_BYPASS_KEYCHAIN=1 ./asc build-localizations update --id loc-1 --whats-new <4001 chars>` confirmed exit 2 with no request. No live API calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documented 4,000-character limit for release notes in localization create and update commands.
  * Added validation for localization attributes before requests are submitted.
  * Supports multibyte text up to the character limit without altering its content.

* **Bug Fixes**
  * Invalid or overlong release notes now return a clear usage error without making an API request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->