### PR TITLE
fix(cli): identify misplaced global flags

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -139,9 +139,17 @@ func printConciseUnknownCommand(analysis invocationAnalysis, commandName string)
 	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
 }
 
-func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
+func printConciseUnknownFlag(root *ffcli.Command, analysis invocationAnalysis, commandName string) {
 	flagName := unknownFlagName(analysis)
 	fmt.Fprintf(os.Stderr, "Error: %s\n", unknownFlagError(analysis, commandName))
+	if name, ok := flagLookupName(flagName); ok && root != nil && root.FlagSet != nil && root.FlagSet.Lookup(name) != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"`%s` is a global flag; the flag and any required valid value must appear before the command name.\nFor help:\n  asc --help\n",
+			shared.SanitizeTerminal(flagName),
+		)
+		return
+	}
 
 	visibleFlags := shared.VisibleHelpFlags(analysis.command.FlagSet)
 	candidates := make([]string, 0, len(visibleFlags))
@@ -163,6 +171,14 @@ func printConciseUnknownFlag(analysis invocationAnalysis, commandName string) {
 	}
 	fmt.Fprintln(os.Stderr, "For help:")
 	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
+}
+
+func flagLookupName(token string) (string, bool) {
+	if !hasValidFlagPrefix(token) {
+		return "", false
+	}
+	name := strings.TrimLeft(token, "-")
+	return name, name != ""
 }
 
 func unknownCommandError(analysis invocationAnalysis, commandName string) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -66,7 +66,7 @@ func Run(args []string, versionInfo string) int {
 			badFlagSyntax = firstLine
 		}
 		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
-			printConciseUnknownFlag(analysis, getCommandName(root, args))
+			printConciseUnknownFlag(root, analysis, getCommandName(root, args))
 		} else if strings.HasPrefix(badFlagSyntax, "bad flag syntax:") {
 			fmt.Fprintf(os.Stderr, "Error: %s\nFor help:\n  asc --help\n", shared.SanitizeTerminal(badFlagSyntax))
 		} else {

--- a/internal/cli/cmdtest/global_flag_position_test.go
+++ b/internal/cli/cmdtest/global_flag_position_test.go
@@ -1,0 +1,111 @@
+package cmdtest
+
+import (
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func TestMisplacedGlobalFlagExplainsRootPlacement(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		commandName string
+		flagName    string
+	}{
+		{
+			name:        "boolean flag",
+			args:        []string{"apps", "list", "--debug"},
+			commandName: "asc apps list",
+			flagName:    "--debug",
+		},
+		{
+			name:        "separate value",
+			args:        []string{"apps", "list", "--profile", "work"},
+			commandName: "asc apps list",
+			flagName:    "--profile",
+		},
+		{
+			name:        "inline value",
+			args:        []string{"apps", "list", "--profile=work"},
+			commandName: "asc apps list",
+			flagName:    "--profile",
+		},
+		{
+			name:        "nested command",
+			args:        []string{"testflight", "groups", "list", "--api-debug"},
+			commandName: "asc testflight groups list",
+			flagName:    "--api-debug",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				code = rootcmd.Run(test.args, "1.2.3")
+			})
+
+			if code != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			want := "Error: unknown flag `" + test.flagName + "` for `" + test.commandName + "`\n" +
+				"`" + test.flagName + "` is a global flag; the flag and any required valid value must appear before the command name.\n" +
+				"For help:\n  asc --help\n"
+			if stderr != want {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
+			}
+		})
+	}
+}
+
+func TestNonGlobalFlagSuggestionIsUnchanged(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"apps", "list", "--bundle-idd", "com.example.app"}, "1.2.3")
+	})
+
+	if code != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "Try:\n  --bundle-id\n") {
+		t.Fatalf("stderr = %q, want command flag suggestion", stderr)
+	}
+	if strings.Contains(stderr, "global flag") {
+		t.Fatalf("stderr = %q, want no global classification", stderr)
+	}
+}
+
+func TestMalformedGlobalFlagGuidanceDoesNotPromiseValueCorrection(t *testing.T) {
+	for _, args := range [][]string{
+		{"apps", "list", "--profile"},
+		{"apps", "list", "--debug=maybe"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				code = rootcmd.Run(args, "1.2.3")
+			})
+
+			if code != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, "is a global flag; the flag and any required valid value must appear before the command name.\n") {
+				t.Fatalf("stderr = %q, want value-qualified placement guidance", stderr)
+			}
+			if !strings.Contains(stderr, "For help:\n  asc --help\n") {
+				t.Fatalf("stderr = %q, want root help", stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -465,6 +465,28 @@ func TestSearchSupportsMixedFlagOrder(t *testing.T) {
 	}
 }
 
+func TestSearchPreservesRootShapedQueryTerms(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "logging", "--debug"}, "1.2.3")
+	})
+
+	if code != rootcmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d with stderr %q", code, rootcmd.ExitSuccess, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if response.Query != "logging --debug" {
+		t.Fatalf("query = %q, want %q", response.Query, "logging --debug")
+	}
+}
+
 func TestSearchRequiresQuery(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)


### PR DESCRIPTION
## Problem

A root-level flag placed after a command is rejected as unknown, but the diagnostic points to the command help page even though global flags are documented by `asc --help`.

## Change

When the existing unknown-flag parse-error path sees that the rejected flag also exists in the root flag set, it now adds one narrow explanation:

```console
$ asc apps list --debug
Error: unknown flag `--debug` for `asc apps list`
`--debug` is a global flag; the flag and any required valid value must appear before the command name.
For help:
  asc --help
```

The implementation does not rewrite or execute a corrected invocation, scan positional payloads, validate values, or model command-specific validation. It only classifies the exact flag that parsing already rejected. Boolean flags, value-taking flags, inline values, and nested commands use the same root flag-set lookup. The value-qualified wording remains accurate for incomplete or malformed values without promising a runnable correction.

Non-global typos keep their existing closest-flag suggestions and command-specific help. Valid invocations are untouched; for example, root-shaped tokens after a search query remain search terms. Exit code 2 and the stdout/stderr contract are unchanged for the usage failure.

## Tests

Coverage includes boolean, separate-value, inline-value, and nested misplaced global flags; missing and malformed root values; unchanged non-global typo suggestions; and a successful search whose query contains `--debug`.

Validated on current main with `make format`, `make check-docs`, `make lint`, focused and adjacent tests, and `ASC_BYPASS_KEYCHAIN=1 make test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved errors for global flags placed after a command, including guidance to move them before the command name.
  * Displays root-level help when misplaced global flags are detected.
  * Preserved helpful suggestions for non-global unknown flags.
  * Correctly preserves flag-like text as search query content when applicable.

* **Tests**
  * Added coverage for misplaced, malformed, and value-based global flags and search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->