### PR TITLE
fix(ads): backdate client secret issued-at to absorb clock skew

### DIFF
--- a/internal/appleads/auth.go
+++ b/internal/appleads/auth.go
@@ -21,8 +21,14 @@ const (
 	tokenScope       = "searchadsorg"
 	clientSecretTTL  = 10 * time.Minute
 	tokenRefreshSkew = 30 * time.Second
-	clientSecretAud  = "https://appleid.apple.com"
-	grantClientCreds = "client_credentials"
+	// jwtIssuedAtSkew backdates the issued-at claim so a client clock running
+	// ahead of Apple's does not produce a secret rejected as issued in the future.
+	jwtIssuedAtSkew = 60 * time.Second
+	// maxClientSecretSpan is Apple's cap on how far a client secret may expire
+	// past its issued-at claim.
+	maxClientSecretSpan = 180 * 24 * time.Hour
+	clientSecretAud     = "https://appleid.apple.com"
+	grantClientCreds    = "client_credentials"
 )
 
 // Credentials contains resolved Apple Ads authentication inputs.
@@ -157,12 +163,14 @@ func GenerateClientSecret(keyID, teamID, clientID string, privateKey *ecdsa.Priv
 	if lifetime <= 0 {
 		lifetime = clientSecretTTL
 	}
-	if lifetime > 180*24*time.Hour {
-		return "", fmt.Errorf("client secret lifetime must be <= 180 days")
+	// The secret is signed with a backdated issued-at claim, so Apple's cap
+	// applies to the lifetime plus that skew.
+	if lifetime+jwtIssuedAtSkew > maxClientSecretSpan {
+		return "", fmt.Errorf("client secret lifetime must be <= 180 days including the %s issued-at skew", jwtIssuedAtSkew)
 	}
 	claims := jwt.MapClaims{
 		"iss": teamID,
-		"iat": jwt.NewNumericDate(now),
+		"iat": jwt.NewNumericDate(now.Add(-jwtIssuedAtSkew)),
 		"exp": jwt.NewNumericDate(now.Add(lifetime)),
 		"aud": clientSecretAud,
 		"sub": clientID,

--- a/internal/appleads/auth.go
+++ b/internal/appleads/auth.go
@@ -164,8 +164,10 @@ func GenerateClientSecret(keyID, teamID, clientID string, privateKey *ecdsa.Priv
 		lifetime = clientSecretTTL
 	}
 	// The secret is signed with a backdated issued-at claim, so Apple's cap
-	// applies to the lifetime plus that skew.
-	if lifetime+jwtIssuedAtSkew > maxClientSecretSpan {
+	// applies to the lifetime plus that skew. Subtract instead of adding: the
+	// sum overflows for a lifetime near the maximum duration and would wrap
+	// past the guard.
+	if lifetime > maxClientSecretSpan-jwtIssuedAtSkew {
 		return "", fmt.Errorf("client secret lifetime must be <= 180 days including the %s issued-at skew", jwtIssuedAtSkew)
 	}
 	claims := jwt.MapClaims{

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -74,8 +74,38 @@ func TestGenerateClientSecretClaims(t *testing.T) {
 	assertClaim(t, claims, "iss", "TEAM123")
 	assertClaim(t, claims, "aud", "https://appleid.apple.com")
 	assertClaim(t, claims, "sub", "CLIENT123")
-	if got, want := int64(claims["exp"].(float64)-claims["iat"].(float64)), int64((10 * time.Minute).Seconds()); got != want {
-		t.Fatalf("exp-iat = %d, want %d", got, want)
+	// Issued-at is backdated so a client clock running ahead of Apple's does not
+	// sign a secret that is rejected as issued in the future. Expiry stays
+	// anchored to the signing time, so the requested lifetime is unchanged.
+	if got, want := int64(claims["iat"].(float64)), now.Add(-jwtIssuedAtSkew).Unix(); got != want {
+		t.Fatalf("iat = %d, want %d", got, want)
+	}
+	if got, want := int64(claims["exp"].(float64)), now.Add(10*time.Minute).Unix(); got != want {
+		t.Fatalf("exp = %d, want %d", got, want)
+	}
+}
+
+// Apple caps a client secret at 180 days. The signed token spans the backdated
+// issued-at through expiry, so the guard has to measure that whole span.
+func TestGenerateClientSecretRejectsLifetimeExceedingAppleMaximum(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+
+	if _, err := GenerateClientSecret("KEY123", "TEAM123", "CLIENT123", testPrivateKey(t), now, maxClientSecretSpan); err == nil {
+		t.Fatal("expected error for a lifetime that pushes the signed span past 180 days, got nil")
+	}
+
+	tokenString, err := GenerateClientSecret("KEY123", "TEAM123", "CLIENT123", testPrivateKey(t), now, maxClientSecretSpan-jwtIssuedAtSkew)
+	if err != nil {
+		t.Fatalf("GenerateClientSecret() error: %v", err)
+	}
+
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(tokenString, claims); err != nil {
+		t.Fatalf("ParseUnverified() error: %v", err)
+	}
+	span := time.Duration(int64(claims["exp"].(float64)-claims["iat"].(float64))) * time.Second
+	if span != maxClientSecretSpan {
+		t.Fatalf("exp-iat = %s, want %s", span, maxClientSecretSpan)
 	}
 }
 

--- a/internal/appleads/client_test.go
+++ b/internal/appleads/client_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -90,8 +91,21 @@ func TestGenerateClientSecretClaims(t *testing.T) {
 func TestGenerateClientSecretRejectsLifetimeExceedingAppleMaximum(t *testing.T) {
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 
-	if _, err := GenerateClientSecret("KEY123", "TEAM123", "CLIENT123", testPrivateKey(t), now, maxClientSecretSpan); err == nil {
-		t.Fatal("expected error for a lifetime that pushes the signed span past 180 days, got nil")
+	rejected := []struct {
+		name     string
+		lifetime time.Duration
+	}{
+		{name: "span exceeds the cap once the skew is counted", lifetime: maxClientSecretSpan},
+		// Measuring the span must not overflow: a wrapped sum would slip past the
+		// guard and sign a secret with a nonsense expiry.
+		{name: "maximum representable duration", lifetime: time.Duration(math.MaxInt64)},
+	}
+	for _, tt := range rejected {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := GenerateClientSecret("KEY123", "TEAM123", "CLIENT123", testPrivateKey(t), now, tt.lifetime); err == nil {
+				t.Fatalf("expected error for lifetime %s, got nil", tt.lifetime)
+			}
+		})
 	}
 
 	tokenString, err := GenerateClientSecret("KEY123", "TEAM123", "CLIENT123", testPrivateKey(t), now, maxClientSecretSpan-jwtIssuedAtSkew)


### PR DESCRIPTION
## Problem

The Apple Ads OAuth client secret is an ES256 JWT signed on every token refresh, with `iat` taken straight from the local clock. Apple validates that claim against *its* clock and rejects a secret that claims to be issued in the future, so a machine running a few seconds fast fails the `client_credentials` exchange at `appleid.apple.com` before any Ads request is made.

The failure is unforgiving because the OAuth error is not retryable. What an operator sees today:

```
$ asc ads campaigns list --org 1234567
Error: invalid_client
```

Nothing points at the clock, so the natural response is to re-check the client ID, team ID, or key — none of which fix a clock that is ahead. It is intermittent and machine-specific: CI runners, VMs resumed from snapshots, and containers with drifting clocks hit it while a colleague on the same key never does.

This is the same class of failure fixed for the App Store Connect, Notary, and StoreKit signers in #2083; the Apple Ads signer is the remaining one.

## Behavior change

`iat` is stamped 60 seconds in the past in `GenerateClientSecret`, using a local `jwtIssuedAtSkew` constant consistent with that package's existing `tokenRefreshSkew`. `exp` stays anchored to the signing time, so the requested lifetime is unchanged: the runtime path still asks for 10 minutes, and the token cache and its 30-second refresh skew are untouched.

One documented Apple constraint interacts with this and is handled rather than ignored. Apple caps a client secret at 180 days past its issued-at claim, which the code already guarded. Because the signed token now spans the backdated claim through expiry, the guard measures that whole span (`lifetime + jwtIssuedAtSkew`) instead of the requested lifetime alone, so every secret this code emits stays inside Apple's cap. The 180-day boundary is only reachable through the exported `GenerateClientSecret` function — no command or flag lets a caller choose a lifetime, and the single production caller asks for 10 minutes — so the effective change for CLI users is nil. The error message names the skew so a direct Go caller at the boundary knows why.

No documented Apple Ads requirement ties `iat` to the exact current instant; the repository's own Apple Ads OAuth notes list `iat`/`exp` without such a constraint.

## Tests

- `TestGenerateClientSecretClaims` now asserts the relationship explicitly instead of the old `exp - iat == 10m` delta: `iat` equals signing time minus 60s and `exp` equals signing time plus the requested 10 minutes, both exact because the function takes an injected `now`.
- `TestGenerateClientSecretRejectsLifetimeExceedingAppleMaximum` covers the guard from both sides: a request for the full 180 days is rejected once the skew is counted, and 180 days minus the skew signs a token whose `exp - iat` span is exactly 180 days.

Commands run: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all pass. No live API calls.

## Compatibility

- No user-facing surface changes: no flags, no output, no docs. `asc ads auth token` still returns a working bearer token.
- Only signing changes; the token exchange, cache, and refresh behavior are untouched.
- Independent of #2083 and #2076 — different package, no shared files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple Ads authentication token timing by accounting for clock differences.
  * Enforced Apple’s maximum 180-day token lifetime, including timing adjustments.
  * Requests exceeding the allowed lifetime now return a clearer validation error.
  * Improved validation for unusually large token lifetimes, preventing invalid values from being accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->