### PR TITLE
feat(localizations): update directly by resource ID

### DIFF
--- a/internal/cli/cmdtest/localizations_update_test.go
+++ b/internal/cli/cmdtest/localizations_update_test.go
@@ -120,6 +120,119 @@ func TestLocalizationsUpdateVersionRequiresVersion(t *testing.T) {
 	}
 }
 
+func TestLocalizationsUpdateVersionByResourceIDSkipsDiscovery(t *testing.T) {
+	setupLocUpdateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = locUpdateRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersionLocalizations/loc-1" {
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		body, _ := io.ReadAll(req.Body)
+		if !strings.Contains(string(body), `"description":"Updated"`) {
+			t.Fatalf("unexpected patch body: %s", body)
+		}
+		return locUpdateJSONResponse(`{"data":{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US","description":"Updated"}}}`)
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"localizations", "update",
+			"--id", "loc-1",
+			"--description", "Updated",
+		}, "1.2.3")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitSuccess, code)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want one direct PATCH", requestCount)
+	}
+	if !strings.Contains(stdout, `"id":"loc-1"`) {
+		t.Fatalf("expected updated localization output, got %q", stdout)
+	}
+}
+
+func TestLocalizationsUpdateAppInfoByResourceIDSkipsDiscovery(t *testing.T) {
+	setupLocUpdateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = locUpdateRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/appInfoLocalizations/loc-1" {
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		return locUpdateJSONResponse(`{"data":{"type":"appInfoLocalizations","id":"loc-1","attributes":{"locale":"en-US","name":"Updated"}}}`)
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		code := cmd.Run([]string{
+			"localizations", "update",
+			"--type", "app-info",
+			"--id", "loc-1",
+			"--name", "Updated",
+		}, "1.2.3")
+		if code != cmd.ExitSuccess {
+			t.Fatalf("expected exit code %d, got %d", cmd.ExitSuccess, code)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want one direct PATCH", requestCount)
+	}
+	if !strings.Contains(stdout, `"id":"loc-1"`) {
+		t.Fatalf("expected updated localization output, got %q", stdout)
+	}
+}
+
+func TestLocalizationsUpdateResourceIDRejectsDiscoverySelectorsBeforeAuth(t *testing.T) {
+	clientCalls := 0
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientCalls++
+		return nil, errors.New("client should not be created")
+	}))
+
+	tests := [][]string{
+		{"--id", "loc-1", "--version", "ver-1", "--description", "Updated"},
+		{"--id", "loc-1", "--locale", "en-US", "--description", "Updated"},
+		{"--type", "app-info", "--id", "loc-1", "--app", "123456789", "--name", "Updated"},
+		{"--type", "app-info", "--id", "loc-1", "--app-info", "info-1", "--name", "Updated"},
+	}
+
+	for _, args := range tests {
+		stdout, stderr := captureOutput(t, func() {
+			code := cmd.Run(append([]string{"localizations", "update"}, args...), "1.2.3")
+			if code != cmd.ExitUsage {
+				t.Fatalf("args %v: expected exit code %d, got %d", args, cmd.ExitUsage, code)
+			}
+		})
+		if stdout != "" {
+			t.Fatalf("args %v: expected empty stdout, got %q", args, stdout)
+		}
+		if !strings.Contains(stderr, "--id cannot be combined") {
+			t.Fatalf("args %v: expected selector conflict, got %q", args, stderr)
+		}
+	}
+
+	if clientCalls != 0 {
+		t.Fatalf("expected no client creation, got %d", clientCalls)
+	}
+}
+
 func TestLocalizationsUpdate_RejectsUnsupportedLocaleWithSuggestion(t *testing.T) {
 	setupLocUpdateAuth(t)
 

--- a/internal/cli/localizations/update.go
+++ b/internal/cli/localizations/update.go
@@ -18,12 +18,13 @@ import (
 func LocalizationsUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 
+	localizationID := fs.String("id", "", "Localization resource ID (skips parent and locale lookup)")
 	versionID := fs.String("version", "", "App Store version ID (for version localizations)")
 	legacyVersionID := shared.BindDeprecatedStringFlagAlias(fs, "version-id", "version")
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID, for app-info localizations)")
 	appInfoID := fs.String("app-info", "", "App Info ID (optional override)")
 	locType := fs.String("type", shared.LocalizationTypeVersion, "Localization type: version (default) or app-info")
-	locale := fs.String("locale", "", "Locale to update (required; reuse exact ASC locale like en-US, ar-SA, zh-Hans)")
+	locale := fs.String("locale", "", "Locale to update when resolving by parent (reuse exact ASC locale like en-US, ar-SA, zh-Hans)")
 
 	// App-info fields
 	name := fs.String("name", "", "App name (app-info)")
@@ -48,6 +49,10 @@ func LocalizationsUpdateCommand() *ffcli.Command {
 		ShortHelp:  "Update localization fields directly.",
 		LongHelp: `Update localization fields directly without file preparation.
 
+Use --id to update a known localization resource directly. Otherwise, identify
+the parent version or app and pass the exact locale already stored in App Store
+Connect.
+
 Pass the exact locale value already stored in App Store Connect. Common accepted
 forms include en-US, de-DE, ja, ar-SA, zh-Hans, and zh-Hant.
 
@@ -64,9 +69,11 @@ For app-info localizations, inspect configured locales with:
   asc localizations list --app "APP_ID" --type app-info
 
 For app-info localizations (name, subtitle, privacy URLs):
+  asc localizations update --type app-info --id "LOCALIZATION_ID" --subtitle "Arabic subtitle"
   asc localizations update --app "APP_ID" --type app-info --locale "ar-SA" --subtitle "Arabic subtitle"
 
 For version localizations (description, keywords, whatsNew):
+  asc localizations update --id "LOCALIZATION_ID" --description "Simplified Chinese description"
   asc localizations update --version "VERSION_ID" --locale "zh-Hans" --description "Simplified Chinese description"
 
 At least one field flag must be provided.`,
@@ -76,24 +83,33 @@ At least one field flag must be provided.`,
 			if err := legacyVersionID.Apply(versionID); err != nil {
 				return err
 			}
+			localizationIDValue := strings.TrimSpace(*localizationID)
+			if localizationIDValue != "" && (strings.TrimSpace(*versionID) != "" || strings.TrimSpace(*appID) != "" || strings.TrimSpace(*appInfoID) != "" || strings.TrimSpace(*locale) != "") {
+				fmt.Fprintln(os.Stderr, "Error: --id cannot be combined with --version, --app, --app-info, or --locale")
+				return flag.ErrHelp
+			}
 			normalizedType, err := shared.NormalizeLocalizationType(*locType)
 			if err != nil {
 				return fmt.Errorf("localizations update: %w", err)
 			}
 
-			localeValue := strings.TrimSpace(*locale)
-			if localeValue == "" {
-				fmt.Fprintln(os.Stderr, "Error: --locale is required")
-				return shared.MissingRequiredUsageError("--locale")
-			}
-			localeValue, err = shared.CanonicalizeAppStoreLocalizationLocale(localeValue)
-			if err != nil {
-				return shared.UsageError(err.Error())
+			localeValue := ""
+			if localizationIDValue == "" {
+				localeValue = strings.TrimSpace(*locale)
+				if localeValue == "" {
+					fmt.Fprintln(os.Stderr, "Error: --locale is required when --id is not provided")
+					return shared.MissingRequiredUsageError("--locale")
+				}
+				localeValue, err = shared.CanonicalizeAppStoreLocalizationLocale(localeValue)
+				if err != nil {
+					return shared.UsageError(err.Error())
+				}
 			}
 
 			switch normalizedType {
 			case shared.LocalizationTypeAppInfo:
 				return updateAppInfoLocalization(ctx, updateAppInfoParams{
+					localizationID:    localizationIDValue,
 					appID:             *appID,
 					appInfoID:         *appInfoID,
 					locale:            localeValue,
@@ -106,6 +122,7 @@ At least one field flag must be provided.`,
 				})
 			case shared.LocalizationTypeVersion:
 				return updateVersionLocalization(ctx, updateVersionParams{
+					localizationID:  localizationIDValue,
 					versionID:       *versionID,
 					locale:          localeValue,
 					description:     *description,
@@ -124,6 +141,7 @@ At least one field flag must be provided.`,
 }
 
 type updateAppInfoParams struct {
+	localizationID                                                         string
 	appID, appInfoID, locale                                               string
 	name, subtitle, privacyPolicyURL, privacyChoicesURL, privacyPolicyText string
 	output                                                                 shared.OutputFlags
@@ -135,10 +153,14 @@ func updateAppInfoLocalization(ctx context.Context, p updateAppInfoParams) error
 		return shared.MissingRequiredUsageError("")
 	}
 
-	resolvedAppID := shared.ResolveAppID(p.appID)
-	if resolvedAppID == "" {
-		fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations (or set ASC_APP_ID)")
-		return shared.MissingRequiredUsageError("--app")
+	localizationID := strings.TrimSpace(p.localizationID)
+	resolvedAppID := ""
+	if localizationID == "" {
+		resolvedAppID = shared.ResolveAppID(p.appID)
+		if resolvedAppID == "" {
+			fmt.Fprintln(os.Stderr, "Error: --app is required for app-info localizations (or set ASC_APP_ID)")
+			return shared.MissingRequiredUsageError("--app")
+		}
 	}
 
 	client, err := shared.GetASCClient()
@@ -149,26 +171,27 @@ func updateAppInfoLocalization(ctx context.Context, p updateAppInfoParams) error
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
-	appInfo, err := shared.ResolveAppInfoID(requestCtx, client, resolvedAppID, strings.TrimSpace(p.appInfoID))
-	if err != nil {
-		return fmt.Errorf("localizations update: %w", err)
-	}
-
-	// Find existing localization ID for the locale
-	existing, err := client.GetAppInfoLocalizations(requestCtx, appInfo, asc.WithAppInfoLocalizationsLimit(200))
-	if err != nil {
-		return fmt.Errorf("localizations update: failed to fetch localizations: %w", err)
-	}
-
-	var localizationID string
-	for _, item := range existing.Data {
-		if strings.EqualFold(strings.TrimSpace(item.Attributes.Locale), p.locale) {
-			localizationID = item.ID
-			break
-		}
-	}
 	if localizationID == "" {
-		return fmt.Errorf("localizations update: no existing localization found for locale %q", p.locale)
+		appInfo, err := shared.ResolveAppInfoID(requestCtx, client, resolvedAppID, strings.TrimSpace(p.appInfoID))
+		if err != nil {
+			return fmt.Errorf("localizations update: %w", err)
+		}
+
+		// Find existing localization ID for the locale
+		existing, err := client.GetAppInfoLocalizations(requestCtx, appInfo, asc.WithAppInfoLocalizationsLimit(200))
+		if err != nil {
+			return fmt.Errorf("localizations update: failed to fetch localizations: %w", err)
+		}
+
+		for _, item := range existing.Data {
+			if strings.EqualFold(strings.TrimSpace(item.Attributes.Locale), p.locale) {
+				localizationID = item.ID
+				break
+			}
+		}
+		if localizationID == "" {
+			return fmt.Errorf("localizations update: no existing localization found for locale %q", p.locale)
+		}
 	}
 
 	attrs := asc.AppInfoLocalizationAttributes{
@@ -181,9 +204,13 @@ func updateAppInfoLocalization(ctx context.Context, p updateAppInfoParams) error
 
 	resp, err := client.UpdateAppInfoLocalization(requestCtx, localizationID, attrs)
 	if err != nil {
+		selector := p.locale
+		if selector == "" {
+			selector = localizationID
+		}
 		return fmt.Errorf(
 			"localizations update: update app-info localization %q via PATCH /v1/appInfoLocalizations/%s (fields: %s): %w",
-			p.locale,
+			selector,
 			localizationID,
 			formatAttemptedFields(appInfoAttemptedFields(p)),
 			err,
@@ -198,6 +225,7 @@ func hasAnyAppInfoField(p updateAppInfoParams) bool {
 }
 
 type updateVersionParams struct {
+	localizationID                                                             string
 	versionID, locale                                                          string
 	description, keywords, whatsNew, promotionalText, supportURL, marketingURL string
 	output                                                                     shared.OutputFlags
@@ -209,8 +237,9 @@ func updateVersionLocalization(ctx context.Context, p updateVersionParams) error
 		return shared.MissingRequiredUsageError("")
 	}
 
+	localizationID := strings.TrimSpace(p.localizationID)
 	vid := strings.TrimSpace(p.versionID)
-	if vid == "" {
+	if localizationID == "" && vid == "" {
 		fmt.Fprintln(os.Stderr, "Error: --version is required for version localizations")
 		return shared.MissingRequiredUsageError("--version")
 	}
@@ -234,28 +263,33 @@ func updateVersionLocalization(ctx context.Context, p updateVersionParams) error
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
-	// Find existing localization ID for the locale
-	existing, err := client.GetAppStoreVersionLocalizations(requestCtx, vid, asc.WithAppStoreVersionLocalizationsLimit(200))
-	if err != nil {
-		return fmt.Errorf("localizations update: failed to fetch localizations: %w", err)
-	}
-
-	var localizationID string
-	for _, item := range existing.Data {
-		if strings.EqualFold(strings.TrimSpace(item.Attributes.Locale), p.locale) {
-			localizationID = item.ID
-			break
-		}
-	}
 	if localizationID == "" {
-		return fmt.Errorf("localizations update: no existing localization found for locale %q", p.locale)
+		// Find existing localization ID for the locale
+		existing, err := client.GetAppStoreVersionLocalizations(requestCtx, vid, asc.WithAppStoreVersionLocalizationsLimit(200))
+		if err != nil {
+			return fmt.Errorf("localizations update: failed to fetch localizations: %w", err)
+		}
+
+		for _, item := range existing.Data {
+			if strings.EqualFold(strings.TrimSpace(item.Attributes.Locale), p.locale) {
+				localizationID = item.ID
+				break
+			}
+		}
+		if localizationID == "" {
+			return fmt.Errorf("localizations update: no existing localization found for locale %q", p.locale)
+		}
 	}
 
 	resp, err := client.UpdateAppStoreVersionLocalization(requestCtx, localizationID, attrs)
 	if err != nil {
+		selector := p.locale
+		if selector == "" {
+			selector = localizationID
+		}
 		return fmt.Errorf(
 			"localizations update: update version localization %q via PATCH /v1/appStoreVersionLocalizations/%s (fields: %s): %w",
-			p.locale,
+			selector,
 			localizationID,
 			formatAttemptedFields(versionAttemptedFields(p)),
 			err,


### PR DESCRIPTION
## Summary

- add `--id` to update known version-localization resources directly
- support the same direct path for app-info localizations with `--type app-info`
- skip parent and locale discovery requests in direct mode
- reject mixed direct/discovery selectors before authentication

## Why

Callers often already have the localization resource ID from list output. Requiring the parent resource and locale forced an unnecessary lookup and made the update command inconsistent with other localization mutation commands. Direct selection is also less sensitive to locale spelling and parent lookup failures.

## Compatibility

This is additive. Existing app/version plus locale workflows are unchanged, including locale canonicalization and payload validation. Direct app-info updates remain explicit through `--type app-info` because localization IDs do not encode their resource type.

## Verification

- direct version and app-info tests assert one PATCH and zero discovery GETs
- selector-conflict tests assert failure before client creation
- `go test ./internal/cli/localizations ./internal/cli/cmdtest -run "LocalizationsUpdate|Localization.*Update|AnalyticsRanked" -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating app-info and version localizations directly by resource ID.
  * Direct resource ID updates skip unnecessary parent and locale discovery.
  * Locale values are normalized for lookup-based updates, while conflicting selectors are rejected with clear usage errors.

* **Bug Fixes**
  * Improved update error messages to identify the relevant locale or resource ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->