### PR TITLE
feat(versions): resolve view by app and version

### DIFF
--- a/commands/versions.mdx
+++ b/commands/versions.mdx
@@ -77,8 +77,23 @@ View details for an app store version.
 In 1.0, the deprecated `asc versions get` alias was removed. Use
 `asc versions view` as the canonical command.
 
-<ParamField path="--version-id" type="string" required>
-  App Store version ID
+Provide either `--version-id`, or the experimental `--app` and `--version`
+selectors. `--platform` defaults to `IOS` for selector-based lookup.
+
+<ParamField path="--version-id" type="string">
+  App Store version ID. Cannot be combined with the alternate selectors.
+</ParamField>
+
+<ParamField path="--app" type="string">
+  **[experimental]** App Store Connect app ID (or `ASC_APP_ID`)
+</ParamField>
+
+<ParamField path="--version" type="string">
+  **[experimental]** Version string used with `--app`
+</ParamField>
+
+<ParamField path="--platform" type="string" default="IOS">
+  **[experimental]** Platform used with `--app` and `--version`: `IOS`, `MAC_OS`, `TV_OS`, or `VISION_OS`
 </ParamField>
 
 <ParamField path="--include-build" type="boolean" default="false">
@@ -97,6 +112,8 @@ In 1.0, the deprecated `asc versions get` alias was removed. Use
 
 ```bash  theme={null}
 asc versions view --version-id "VERSION_ID"
+asc versions view --app "123456789" --version "1.2.3"
+asc versions view --app "123456789" --version "1.2.3" --platform MAC_OS
 asc versions view --version-id "VERSION_ID" --include-build --include-submission
 asc versions view --version-id "VERSION_ID" --include "ageRatingDeclaration,appStoreReviewDetail"
 ```

--- a/commands/versions.mdx
+++ b/commands/versions.mdx
@@ -79,6 +79,10 @@ In 1.0, the deprecated `asc versions get` alias was removed. Use
 
 Provide either `--version-id`, or the experimental `--app` and `--version`
 selectors. `--platform` defaults to `IOS` for selector-based lookup.
+Selector lookup first resolves the version ID, then fetches its details. Use
+`--version-id` to retain the single-request path for automation. Conflicting or
+incomplete selectors, and unsupported platform values, exit with a usage error
+before authentication or API requests.
 
 <ParamField path="--version-id" type="string">
   App Store version ID. Cannot be combined with the alternate selectors.

--- a/internal/cli/cmdtest/versions_contract_test.go
+++ b/internal/cli/cmdtest/versions_contract_test.go
@@ -168,7 +168,7 @@ func TestVersionsViewSelectorValidationBeforeClient(t *testing.T) {
 		{
 			name:       "invalid platform",
 			args:       []string{"versions", "view", "--app", "app-1", "--version", "1.2.3", "--platform", "ANDROID"},
-			wantStderr: "--platform must be one of: IOS, MAC_OS, TV_OS, VISION_OS",
+			wantStderr: "versions view: --platform must be one of: IOS, MAC_OS, TV_OS, VISION_OS",
 		},
 	}
 
@@ -190,13 +190,30 @@ func TestVersionsViewSelectorValidationBeforeClient(t *testing.T) {
 			if stdout != "" {
 				t.Errorf("stdout = %q, want empty", stdout)
 			}
-			if !strings.Contains(stderr, test.wantStderr) {
-				t.Errorf("stderr = %q, want substring %q", stderr, test.wantStderr)
+			errorLine, _, _ := strings.Cut(stderr, "\n")
+			if got := errorLine + "\n"; got != "Error: "+test.wantStderr+"\n" {
+				t.Errorf("stderr error line = %q, want %q; full stderr = %q", got, "Error: "+test.wantStderr+"\n", stderr)
 			}
 			if clientFactoryCalls != 0 {
 				t.Errorf("client factory calls = %d, want 0", clientFactoryCalls)
 			}
 		})
+	}
+}
+
+func TestVersionsViewSelectorFlagsAreExperimental(t *testing.T) {
+	cmd := findSubcommand(RootCommand("test"), "versions", "view")
+	if cmd == nil {
+		t.Fatal("versions view command not found")
+	}
+	for _, name := range []string{"app", "version", "platform"} {
+		flag := cmd.FlagSet.Lookup(name)
+		if flag == nil {
+			t.Fatalf("--%s flag not found", name)
+		}
+		if !strings.HasPrefix(flag.Usage, "[experimental] ") {
+			t.Fatalf("--%s usage = %q, want [experimental] prefix", name, flag.Usage)
+		}
 	}
 }
 

--- a/internal/cli/cmdtest/versions_contract_test.go
+++ b/internal/cli/cmdtest/versions_contract_test.go
@@ -23,6 +23,7 @@ const appStoreVersionIncludeValues = "ageRatingDeclaration, app, appStoreVersion
 
 func clearASCAuth(t *testing.T) {
 	t.Helper()
+	t.Setenv("ASC_APP_ID", "")
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	t.Setenv("ASC_PROFILE", "")

--- a/internal/cli/cmdtest/versions_contract_test.go
+++ b/internal/cli/cmdtest/versions_contract_test.go
@@ -157,6 +157,11 @@ func TestVersionsViewSelectorValidationBeforeClient(t *testing.T) {
 			wantStderr: "--version-id cannot be combined with --app, --version, or --platform",
 		},
 		{
+			name:       "explicit empty direct ID with lookup selectors",
+			args:       []string{"versions", "view", "--version-id", " ", "--app", "app-1", "--version", "1.2.3"},
+			wantStderr: "--version-id cannot be combined with --app, --version, or --platform",
+		},
+		{
 			name:       "app without version",
 			args:       []string{"versions", "view", "--app", "app-1"},
 			wantStderr: "--version is required when resolving by app",
@@ -164,6 +169,11 @@ func TestVersionsViewSelectorValidationBeforeClient(t *testing.T) {
 		{
 			name:       "version without app",
 			args:       []string{"versions", "view", "--version", "1.2.3"},
+			wantStderr: "--app is required (or set ASC_APP_ID)",
+		},
+		{
+			name:       "version with whitespace app",
+			args:       []string{"versions", "view", "--app", " ", "--version", "1.2.3"},
 			wantStderr: "--app is required (or set ASC_APP_ID)",
 		},
 		{

--- a/internal/cli/cmdtest/versions_contract_test.go
+++ b/internal/cli/cmdtest/versions_contract_test.go
@@ -81,6 +81,125 @@ func TestVersionsViewSendsExactSupportedIncludeQuery(t *testing.T) {
 	}
 }
 
+func TestVersionsViewResolvesVersionFromAppAndVersionString(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	requests := make([]string, 0, 2)
+	stubTransport(t, func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Method+" "+req.URL.Path)
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appStoreVersions":
+			query := req.URL.Query()
+			if got := query.Get("filter[versionString]"); got != "1.2.3" {
+				t.Fatalf("version filter = %q, want 1.2.3", got)
+			}
+			if got := query.Get("filter[platform]"); got != "IOS" {
+				t.Fatalf("platform filter = %q, want IOS", got)
+			}
+			if got := query.Get("limit"); got != "10" {
+				t.Fatalf("limit = %q, want 10", got)
+			}
+			return jsonResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS"}}]}`)
+		case "/v1/appStoreVersions/version-1":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"IOS","appVersionState":"PREPARE_FOR_SUBMISSION"}}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("test")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"versions", "view",
+			"--app", "app-1",
+			"--version", "1.2.3",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result asc.AppStoreVersionDetailResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal stdout: %v; stdout=%q", err, stdout)
+	}
+	if result.ID != "version-1" || result.VersionString != "1.2.3" || result.Platform != "IOS" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	wantRequests := []string{
+		"GET /v1/apps/app-1/appStoreVersions",
+		"GET /v1/appStoreVersions/version-1",
+	}
+	if fmt.Sprint(requests) != fmt.Sprint(wantRequests) {
+		t.Fatalf("requests = %v, want %v", requests, wantRequests)
+	}
+}
+
+func TestVersionsViewSelectorValidationBeforeClient(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name:       "direct ID with lookup selectors",
+			args:       []string{"versions", "view", "--version-id", "version-1", "--app", "app-1", "--version", "1.2.3"},
+			wantStderr: "--version-id cannot be combined with --app, --version, or --platform",
+		},
+		{
+			name:       "app without version",
+			args:       []string{"versions", "view", "--app", "app-1"},
+			wantStderr: "--version is required when resolving by app",
+		},
+		{
+			name:       "version without app",
+			args:       []string{"versions", "view", "--version", "1.2.3"},
+			wantStderr: "--app is required (or set ASC_APP_ID)",
+		},
+		{
+			name:       "invalid platform",
+			args:       []string{"versions", "view", "--app", "app-1", "--version", "1.2.3", "--platform", "ANDROID"},
+			wantStderr: "--platform must be one of: IOS, MAC_OS, TV_OS, VISION_OS",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearASCAuth(t)
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return nil, fmt.Errorf("client should not be created")
+			}))
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run(test.args, "test"); code != rootcmd.ExitUsage {
+					t.Errorf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Errorf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, test.wantStderr) {
+				t.Errorf("stderr = %q, want substring %q", stderr, test.wantStderr)
+			}
+			if clientFactoryCalls != 0 {
+				t.Errorf("client factory calls = %d, want 0", clientFactoryCalls)
+			}
+		})
+	}
+}
+
 func TestVersionsViewIncludeValidationBeforeClient(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -173,14 +173,17 @@ Examples:
 				return err
 			}
 			trimmedID := strings.TrimSpace(*versionID)
+			directIDRequested := false
 			lookupRequested := false
 			fs.Visit(func(parsed *flag.Flag) {
 				switch parsed.Name {
+				case "id", "version-id":
+					directIDRequested = true
 				case "app", "version", "platform":
 					lookupRequested = true
 				}
 			})
-			if trimmedID != "" && lookupRequested {
+			if directIDRequested && lookupRequested {
 				return shared.UsageError("--version-id cannot be combined with --app, --version, or --platform")
 			}
 			if trimmedID == "" && !lookupRequested {
@@ -196,7 +199,7 @@ Examples:
 					fmt.Fprintln(os.Stderr, "Error: --version is required when resolving by app")
 					return shared.MissingRequiredUsageError("--version")
 				}
-				resolvedAppID = shared.ResolveAppID(*appID)
+				resolvedAppID = strings.TrimSpace(shared.ResolveAppID(*appID))
 				if resolvedAppID == "" {
 					fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 					return shared.MissingRequiredUsageError("--app")

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -143,8 +143,11 @@ Examples:
 func VersionsViewCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("versions view", flag.ExitOnError)
 
-	versionID := fs.String("version-id", "", "App Store version ID (required)")
+	versionID := fs.String("version-id", "", "App Store version ID")
 	legacyID := shared.BindDeprecatedStringFlagAlias(fs, "id", "version-id")
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	versionString := fs.String("version", "", "Version string used with --app")
+	platform := fs.String("platform", "IOS", "Platform used with --app and --version: IOS, MAC_OS, TV_OS, VISION_OS")
 	includeBuild := fs.Bool("include-build", false, "Include attached build information")
 	includeSubmission := fs.Bool("include-submission", false, "Include submission information")
 	include := fs.String("include", "", "Include related resources: "+strings.Join(appStoreVersionIncludeList(), ", "))
@@ -153,12 +156,14 @@ func VersionsViewCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "view",
-		ShortUsage: "asc versions view [flags]",
+		ShortUsage: "asc versions view (--version-id \"VERSION_ID\" | --app \"APP_ID\" --version \"1.2.3\") [flags]",
 		ShortHelp:  "View details for an app store version.",
 		LongHelp: `View details for an app store version.
 
 Examples:
   asc versions view --version-id "VERSION_ID"
+  asc versions view --app "123456789" --version "1.2.3"
+  asc versions view --app "123456789" --version "1.2.3" --platform MAC_OS
   asc versions view --version-id "VERSION_ID" --include-build --include-submission
   asc versions view --version-id "VERSION_ID" --include "ageRatingDeclaration,appStoreReviewDetail"`,
 		FlagSet:   fs,
@@ -168,9 +173,39 @@ Examples:
 				return err
 			}
 			trimmedID := strings.TrimSpace(*versionID)
-			if trimmedID == "" {
+			lookupRequested := false
+			fs.Visit(func(parsed *flag.Flag) {
+				switch parsed.Name {
+				case "app", "version", "platform":
+					lookupRequested = true
+				}
+			})
+			if trimmedID != "" && lookupRequested {
+				return shared.UsageError("--version-id cannot be combined with --app, --version, or --platform")
+			}
+			if trimmedID == "" && !lookupRequested {
 				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
 				return shared.MissingRequiredUsageError("--version-id")
+			}
+
+			resolvedAppID := ""
+			resolvedPlatform := ""
+			trimmedVersion := strings.TrimSpace(*versionString)
+			if trimmedID == "" {
+				if trimmedVersion == "" {
+					fmt.Fprintln(os.Stderr, "Error: --version is required when resolving by app")
+					return shared.MissingRequiredUsageError("--version")
+				}
+				resolvedAppID = shared.ResolveAppID(*appID)
+				if resolvedAppID == "" {
+					fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+					return shared.MissingRequiredUsageError("--app")
+				}
+				var err error
+				resolvedPlatform, err = shared.NormalizeAppStoreVersionPlatform(*platform)
+				if err != nil {
+					return shared.UsageErrorf("versions view: %v", err)
+				}
 			}
 
 			includeValues, err := normalizeAppStoreVersionInclude(*include)
@@ -188,6 +223,12 @@ Examples:
 
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
+			if trimmedID == "" {
+				trimmedID, err = shared.ResolveAppStoreVersionID(requestCtx, client, resolvedAppID, trimmedVersion, resolvedPlatform)
+				if err != nil {
+					return fmt.Errorf("versions view: resolve version: %w", err)
+				}
+			}
 
 			if len(includeValues) > 0 {
 				apiIncludes, includeAgeRating := splitCompatAppStoreVersionIncludes(includeValues)

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -145,9 +145,9 @@ func VersionsViewCommand() *ffcli.Command {
 
 	versionID := fs.String("version-id", "", "App Store version ID")
 	legacyID := shared.BindDeprecatedStringFlagAlias(fs, "id", "version-id")
-	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
-	versionString := fs.String("version", "", "Version string used with --app")
-	platform := fs.String("platform", "IOS", "Platform used with --app and --version: IOS, MAC_OS, TV_OS, VISION_OS")
+	appID := fs.String("app", "", "[experimental] App Store Connect app ID (or ASC_APP_ID)")
+	versionString := fs.String("version", "", "[experimental] Version string used with --app")
+	platform := fs.String("platform", "IOS", "[experimental] Platform used with --app and --version: IOS, MAC_OS, TV_OS, VISION_OS")
 	includeBuild := fs.Bool("include-build", false, "Include attached build information")
 	includeSubmission := fs.Bool("include-submission", false, "Include submission information")
 	include := fs.String("include", "", "Include related resources: "+strings.Join(appStoreVersionIncludeList(), ", "))


### PR DESCRIPTION
## Summary

- let `asc versions view` resolve a version from `--app`, `--version`, and optional `--platform`
- preserve the direct `--version-id` path and reject ambiguous selector combinations before authentication
- cover exact lookup requests, validation, output, and the documented command shape

## Why

Real-world usage repeatedly attempts to view a version using the app and human-readable version string. Supporting that shape removes a manual list-and-copy step while retaining the single-request ID path for automation that already has the resource ID.

## Verification

- `go test ./internal/cli/versions ./internal/cli/cmdtest -run VersionsView`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./...`

One verbose full-suite run encountered an unrelated transient failure; the immediate non-verbose full-suite rerun passed every package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `versions view` now supports locating versions by app ID, version string, and platform, in addition to direct version ID lookup.
  - Added optional platform filtering, defaulting to `IOS`.
  - Added validation for incompatible or incomplete lookup options and clearer errors when no matching version is found.
  - Lookup selectors are marked experimental, with updated help text and usage examples.

- **Documentation**
  - Documented selector-based lookups and noted removal of the deprecated `asc versions get` alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->