### PR TITLE
fix(bundle-ids): reject positional mutation arguments

### DIFF
--- a/internal/cli/bundleids/bundle_ids.go
+++ b/internal/cli/bundleids/bundle_ids.go
@@ -180,6 +180,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.RejectPositionalArgs(args); err != nil {
+				return err
+			}
 			identifierValue := strings.TrimSpace(*identifier)
 			if identifierValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --identifier is required")
@@ -237,6 +240,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.RejectPositionalArgs(args); err != nil {
+				return err
+			}
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -286,6 +292,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.RejectPositionalArgs(args); err != nil {
+				return err
+			}
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")

--- a/internal/cli/bundleids/bundle_ids_capabilities.go
+++ b/internal/cli/bundleids/bundle_ids_capabilities.go
@@ -141,6 +141,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.RejectPositionalArgs(args); err != nil {
+				return err
+			}
 			bundleValue := strings.TrimSpace(*bundleID)
 			if bundleValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --bundle is required")
@@ -204,6 +207,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.RejectPositionalArgs(args); err != nil {
+				return err
+			}
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")
@@ -263,6 +269,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.RejectPositionalArgs(args); err != nil {
+				return err
+			}
 			idValue := strings.TrimSpace(*id)
 			if idValue == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestBundleIDsGetCommand_MissingID(t *testing.T) {
@@ -106,6 +110,55 @@ func TestBundleIDsDeleteCommand_MissingConfirm(t *testing.T) {
 
 	if err := cmd.Exec(context.Background(), []string{}); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp when --confirm is missing, got %v", err)
+	}
+}
+
+func TestBundleIDMutationsRejectPositionalArgsBeforeAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  func() *ffcli.Command
+		args []string
+	}{
+		{
+			name: "create",
+			cmd:  BundleIDsCreateCommand,
+			args: []string{"--identifier", "com.example.app", "--name", "Example", "stray", "extra"},
+		},
+		{
+			name: "update",
+			cmd:  BundleIDsUpdateCommand,
+			args: []string{"--id", "bundle-1", "--name", "Example", "stray", "extra"},
+		},
+		{
+			name: "delete",
+			cmd:  BundleIDsDeleteCommand,
+			args: []string{"--id", "bundle-1", "--confirm", "stray", "extra"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalls := 0
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalls++
+				return nil, fmt.Errorf("client should not be created")
+			}))
+
+			cmd := test.cmd()
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), cmd.FlagSet.Args())
+			if err == nil || err.Error() != "unexpected argument(s): stray extra" {
+				t.Fatalf("Exec() error = %v, want exact unexpected-arguments error", err)
+			}
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("Exec() error = %v, want usage error", err)
+			}
+			if clientFactoryCalls != 0 {
+				t.Fatalf("client factory calls = %d, want 0", clientFactoryCalls)
+			}
+		})
 	}
 }
 

--- a/internal/cli/bundleids/bundle_ids_test.go
+++ b/internal/cli/bundleids/bundle_ids_test.go
@@ -134,6 +134,21 @@ func TestBundleIDMutationsRejectPositionalArgsBeforeAuth(t *testing.T) {
 			cmd:  BundleIDsDeleteCommand,
 			args: []string{"--id", "bundle-1", "--confirm", "stray", "extra"},
 		},
+		{
+			name: "capabilities add",
+			cmd:  BundleIDsCapabilitiesAddCommand,
+			args: []string{"--bundle", "bundle-1", "--capability", "ICLOUD", "stray", "extra"},
+		},
+		{
+			name: "capabilities update",
+			cmd:  BundleIDsCapabilitiesUpdateCommand,
+			args: []string{"--id", "capability-1", "--capability", "ICLOUD", "stray", "extra"},
+		},
+		{
+			name: "capabilities remove",
+			cmd:  BundleIDsCapabilitiesRemoveCommand,
+			args: []string{"--id", "capability-1", "--confirm=true", "stray", "extra"},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/shared/positional_args.go
+++ b/internal/cli/shared/positional_args.go
@@ -1,0 +1,16 @@
+package shared
+
+import "strings"
+
+// RejectPositionalArgs rejects operands for commands whose inputs are flags only.
+func RejectPositionalArgs(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+
+	sanitized := make([]string, len(args))
+	for i, arg := range args {
+		sanitized[i] = SanitizeTerminal(arg)
+	}
+	return UsageErrorf("unexpected argument(s): %s", strings.Join(sanitized, " "))
+}

--- a/internal/cli/shared/positional_args_test.go
+++ b/internal/cli/shared/positional_args_test.go
@@ -1,0 +1,21 @@
+package shared
+
+import (
+	"errors"
+	"flag"
+	"testing"
+)
+
+func TestRejectPositionalArgs(t *testing.T) {
+	if err := RejectPositionalArgs(nil); err != nil {
+		t.Fatalf("RejectPositionalArgs(nil) error = %v", err)
+	}
+
+	err := RejectPositionalArgs([]string{"stray\x1b[31m", "extra\nline"})
+	if err == nil || err.Error() != "unexpected argument(s): stray[31m extra line" {
+		t.Fatalf("RejectPositionalArgs() error = %v", err)
+	}
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("RejectPositionalArgs() error = %v, want usage error", err)
+	}
+}


### PR DESCRIPTION
## Summary

- reject trailing positional arguments for bundle ID create, update, and delete before authentication or HTTP work
- add a terminal-safe shared guard for other flag-only commands to adopt
- verify the exact diagnostic, usage exit semantics, and zero client creation across all three mutations

## Why

These commands previously ignored operands left after flag parsing. With valid credentials, a typo could still perform the mutation even though part of the invocation was silently discarded.

## Verification

- focused shared, bundle ID, and CLI contract tests
- manual built-command smoke for create and delete
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./...`

The first full-suite pass exceeded an unrelated telemetry timing threshold by 2.1 ms; that test passed immediately in isolation, and the complete suite then passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundle ID create, update, delete, and capability commands now reject unexpected positional arguments.
  * Invalid command usage is reported clearly before authentication or API operations begin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->