### PR TITLE
feat(analytics): allow missing sales reports

### DIFF
--- a/commands/analytics.mdx
+++ b/commands/analytics.mdx
@@ -52,6 +52,7 @@ The CLI validates the complete type, subtype, frequency, and version combination
 * `--version` - Report format version allowed for the selected type, subtype, and frequency
 * `--output` - Custom output path (default: `sales_report_{date|latest}_{type}.tsv.gz`)
 * `--decompress` - Decompress to `.tsv` format
+* `--allow-missing` - **[experimental]** Return successful metadata with `available: false` instead of creating a file when no report exists for the requested date. Without this flag, the API error remains unchanged.
 
 **Examples:**
 
@@ -63,6 +64,16 @@ asc analytics sales \
   --subtype SUMMARY \
   --frequency DAILY \
   --date "2024-01-20"
+
+# Poll a date without treating an unavailable report as a failed job
+asc analytics sales \
+  --vendor "12345678" \
+  --type SALES \
+  --subtype SUMMARY \
+  --frequency DAILY \
+  --date "2024-01-20" \
+  --allow-missing \
+  --output-format json
 
 # Latest subscriber report with decompression
 asc analytics sales \

--- a/internal/asc/analytics_output.go
+++ b/internal/asc/analytics_output.go
@@ -10,6 +10,7 @@ type SalesReportResult struct {
 	Frequency        string `json:"frequency"`
 	ReportDate       string `json:"reportDate"`
 	Version          string `json:"version,omitempty"`
+	Available        *bool  `json:"available,omitempty"`
 	FilePath         string `json:"filePath"`
 	FileSize         int64  `json:"fileSize"`
 	Decompressed     bool   `json:"decompressed"`
@@ -89,6 +90,19 @@ type AnalyticsReportGetSegment struct {
 }
 
 func salesReportResultRows(result *SalesReportResult) ([]string, [][]string) {
+	if result.Available != nil {
+		headers := []string{"Vendor", "Type", "Subtype", "Frequency", "Date", "Version", "Available"}
+		rows := [][]string{{
+			result.VendorNumber,
+			result.ReportType,
+			result.ReportSubType,
+			result.Frequency,
+			result.ReportDate,
+			result.Version,
+			fmt.Sprintf("%t", *result.Available),
+		}}
+		return headers, rows
+	}
 	headers := []string{"Vendor", "Type", "Subtype", "Frequency", "Date", "Version", "Compressed File", "Compressed Size", "Decompressed File", "Decompressed Size"}
 	rows := [][]string{{
 		result.VendorNumber,

--- a/internal/asc/analytics_output_test.go
+++ b/internal/asc/analytics_output_test.go
@@ -101,3 +101,32 @@ func TestAnalyticsReportRequestOutputUsesCurrentSchema(t *testing.T) {
 		})
 	}
 }
+
+func TestSalesReportResultRowsShowsMissingAvailabilityWithoutFileColumns(t *testing.T) {
+	available := false
+	headers, rows := salesReportResultRows(&SalesReportResult{
+		VendorNumber:  "12345678",
+		ReportType:    "SALES",
+		ReportSubType: "SUMMARY",
+		Frequency:     "DAILY",
+		ReportDate:    "2026-08-18",
+		Version:       "1_0",
+		Available:     &available,
+	})
+	if len(headers) != 7 || headers[6] != "Available" {
+		t.Fatalf("headers = %v, want availability metadata without file columns", headers)
+	}
+	if len(rows) != 1 || len(rows[0]) != 7 || rows[0][6] != "false" {
+		t.Fatalf("rows = %v, want available=false", rows)
+	}
+}
+
+func TestSalesReportResultRowsPreservesDownloadedFileColumns(t *testing.T) {
+	headers, rows := salesReportResultRows(&SalesReportResult{FilePath: "report.tsv.gz"})
+	if len(headers) != 10 || headers[6] != "Compressed File" {
+		t.Fatalf("headers = %v, want existing download columns", headers)
+	}
+	if len(rows) != 1 || len(rows[0]) != 10 || rows[0][6] != "report.tsv.gz" {
+		t.Fatalf("rows = %v, want existing download row", rows)
+	}
+}

--- a/internal/cli/analytics/analytics_sales.go
+++ b/internal/cli/analytics/analytics_sales.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -25,6 +26,7 @@ func AnalyticsSalesCommand() *ffcli.Command {
 	version := fs.String("version", "", "Report format version allowed for the selected type, subtype, and frequency")
 	output := fs.String("output", "", "Output file path (default: sales_report_{date|latest}_{type}.tsv.gz)")
 	decompress := fs.Bool("decompress", false, "Decompress gzip output to .tsv")
+	allowMissing := fs.Bool("allow-missing", false, "[experimental] Return available=false instead of failing when no report exists for the requested date")
 	outputFlags := shared.BindMetadataOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -38,6 +40,7 @@ Examples:
   asc analytics sales --vendor "12345678" --type SALES --subtype SUMMARY --frequency DAILY
   asc analytics sales --vendor "12345678" --type SALES --subtype SUMMARY --frequency WEEKLY --date "2024-01-15" # Monday start accepted
   asc analytics sales --vendor "12345678" --type SUBSCRIBER --subtype DETAILED --frequency DAILY
+  asc analytics sales --vendor "12345678" --type SALES --subtype SUMMARY --frequency DAILY --date "2024-01-20" --allow-missing
   asc analytics sales --vendor "12345678" --type SALES --subtype SUMMARY --frequency DAILY --date "2024-01-20" --decompress
   asc analytics sales --vendor "12345678" --type SALES --subtype SUMMARY --frequency DAILY --date "2024-01-20" --output "reports/daily_sales.tsv.gz"`,
 		FlagSet:   fs,
@@ -105,6 +108,18 @@ Examples:
 				Version:       reportVersion,
 			})
 			if err != nil {
+				if *allowMissing && errors.Is(err, asc.ErrNotFound) {
+					available := false
+					return shared.PrintOutput(&asc.SalesReportResult{
+						VendorNumber:  vendorNumber,
+						ReportType:    string(salesType),
+						ReportSubType: string(subType),
+						Frequency:     string(freq),
+						ReportDate:    reportDate,
+						Version:       string(reportVersion),
+						Available:     &available,
+					}, *outputFlags.OutputFormat, *outputFlags.Pretty)
+				}
 				return fmt.Errorf("analytics sales: failed to download report: %w", err)
 			}
 			defer download.Body.Close()

--- a/internal/cli/analytics/analytics_sales.go
+++ b/internal/cli/analytics/analytics_sales.go
@@ -108,7 +108,7 @@ Examples:
 				Version:       reportVersion,
 			})
 			if err != nil {
-				if *allowMissing && errors.Is(err, asc.ErrNotFound) {
+				if *allowMissing && isMissingSalesReportError(err) {
 					available := false
 					return shared.PrintOutput(&asc.SalesReportResult{
 						VendorNumber:  vendorNumber,
@@ -154,4 +154,17 @@ Examples:
 			return shared.PrintOutput(result, *outputFlags.OutputFormat, *outputFlags.Pretty)
 		},
 	}
+}
+
+func isMissingSalesReportError(err error) bool {
+	if !errors.Is(err, asc.ErrNotFound) {
+		return false
+	}
+
+	var apiErr *asc.APIError
+	if !errors.As(err, &apiErr) || apiErr == nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(apiErr.Detail), "no sales for the date specified")
 }

--- a/internal/cli/analytics/analytics_test.go
+++ b/internal/cli/analytics/analytics_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+func TestAnalyticsSalesAllowMissingFlagIsExperimental(t *testing.T) {
+	flag := AnalyticsSalesCommand().FlagSet.Lookup("allow-missing")
+	if flag == nil {
+		t.Fatal("--allow-missing flag not found")
+	}
+	if !strings.HasPrefix(flag.Usage, "[experimental] ") {
+		t.Fatalf("--allow-missing usage = %q, want [experimental] prefix", flag.Usage)
+	}
+}
+
 func TestAnalyticsViewProcessingDateFlagLifecycle(t *testing.T) {
 	root := AnalyticsCommand()
 	viewIndex := -1

--- a/internal/cli/cmdtest/analytics_sales_missing_test.go
+++ b/internal/cli/cmdtest/analytics_sales_missing_test.go
@@ -1,0 +1,154 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestAnalyticsSalesAllowMissingReturnsStructuredResultWithoutFile(t *testing.T) {
+	requestCount := setMissingSalesReportTestClient(t)
+
+	outputPath := filepath.Join(t.TempDir(), "missing.tsv.gz")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"analytics", "sales",
+		"--vendor", "12345678",
+		"--type", "SALES",
+		"--subtype", "SUMMARY",
+		"--frequency", "DAILY",
+		"--date", "2026-08-18",
+		"--output", outputPath,
+		"--output-format", "json",
+		"--allow-missing",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if *requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", *requestCount)
+	}
+	if _, err := os.Stat(outputPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("output file stat error = %v, want not-exist", err)
+	}
+
+	var result struct {
+		VendorNumber  string `json:"vendorNumber"`
+		ReportType    string `json:"reportType"`
+		ReportSubType string `json:"reportSubType"`
+		Frequency     string `json:"frequency"`
+		ReportDate    string `json:"reportDate"`
+		Version       string `json:"version"`
+		Available     *bool  `json:"available"`
+		FilePath      string `json:"filePath"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse JSON output: %v; stdout=%q", err, stdout)
+	}
+	if result.Available == nil || *result.Available {
+		t.Fatalf("available = %v, want false", result.Available)
+	}
+	if result.VendorNumber != "12345678" || result.ReportType != "SALES" || result.ReportSubType != "SUMMARY" || result.Frequency != "DAILY" || result.ReportDate != "2026-08-18" || result.Version != "1_0" {
+		t.Fatalf("unexpected result metadata: %+v", result)
+	}
+	if result.FilePath != "" {
+		t.Fatalf("filePath = %q, want empty", result.FilePath)
+	}
+}
+
+func TestAnalyticsSalesMissingReportFailsByDefault(t *testing.T) {
+	setMissingSalesReportTestClient(t)
+
+	outputPath := filepath.Join(t.TempDir(), "missing.tsv.gz")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"analytics", "sales",
+		"--vendor", "12345678",
+		"--type", "SALES",
+		"--subtype", "SUMMARY",
+		"--frequency", "DAILY",
+		"--date", "2026-08-18",
+		"--output", outputPath,
+		"--output-format", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "There were no sales for the date specified") {
+		t.Fatalf("run error = %v, want missing-report API error", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if _, err := os.Stat(outputPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("output file stat error = %v, want not-exist", err)
+	}
+}
+
+func setMissingSalesReportTestClient(t *testing.T) *int {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/salesReports" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found","detail":"There were no sales for the date specified."}]}`)
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create analytics sales test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
+	return &requestCount
+}

--- a/internal/cli/cmdtest/analytics_sales_missing_test.go
+++ b/internal/cli/cmdtest/analytics_sales_missing_test.go
@@ -112,7 +112,41 @@ func TestAnalyticsSalesMissingReportFailsByDefault(t *testing.T) {
 	}
 }
 
+func TestAnalyticsSalesAllowMissingDoesNotSwallowUnrelatedNotFound(t *testing.T) {
+	setSalesReportNotFoundTestClient(t, "The requested vendor account was not found.")
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"analytics", "sales",
+		"--vendor", "12345678",
+		"--type", "SALES",
+		"--subtype", "SUMMARY",
+		"--frequency", "DAILY",
+		"--date", "2026-08-18",
+		"--output-format", "json",
+		"--allow-missing",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "requested vendor account was not found") {
+		t.Fatalf("run error = %v, want unrelated not-found error", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+}
+
 func setMissingSalesReportTestClient(t *testing.T) *int {
+	return setSalesReportNotFoundTestClient(t, "There were no sales for the date specified.")
+}
+
+func setSalesReportNotFoundTestClient(t *testing.T, detail string) *int {
 	t.Helper()
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -125,7 +159,7 @@ func setMissingSalesReportTestClient(t *testing.T) *int {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		_, _ = io.WriteString(w, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found","detail":"There were no sales for the date specified."}]}`)
+		_, _ = io.WriteString(w, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found","detail":"`+detail+`"}]}`)
 	}))
 	t.Cleanup(server.Close)
 	serverURL, err := url.Parse(server.URL)


### PR DESCRIPTION
## Summary

- add an experimental `--allow-missing` mode to `analytics sales`
- return structured `available: false` metadata for an unavailable dated report without creating an output file
- preserve the existing error path by default and preserve successful download output columns

## Why

Date-driven automation commonly needs to poll for a report before it becomes available. Treating the expected unavailable state as an opt-in successful result removes brittle error-text parsing while keeping the default contract unchanged.

## Verification

- established RED CLI coverage for the missing flag
- focused unit and command integration tests
- manual `analytics sales --help` smoke test with isolated authentication
- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 go test ./...`

Two unrelated deadline-sensitive tests failed in the first concurrent full-suite run; both passed in isolation and the complete suite passed on its clean rerun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental `--allow-missing` option for sales reports.
  * Missing reports can return successful availability metadata without creating an output file.
  * JSON output now indicates whether a report is available.

* **Documentation**
  * Added usage guidance and an example for polling daily reports.

* **Bug Fixes**
  * Preserved existing file and decompression details when report files are available.
  * Unrelated report errors continue to be reported normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->