### PR TITLE
feat(categories): paginate categories list with --next and --paginate

### DIFF
--- a/commands/categories.mdx
+++ b/commands/categories.mdx
@@ -13,7 +13,15 @@ Category commands manage App Store categories for your app, including primary an
 List available App Store categories.
 
 <ParamField path="--limit" type="integer" default="200">
-  Maximum results to fetch (1-200)
+  Maximum results per page (1-200)
+</ParamField>
+
+<ParamField path="--next" type="string">
+  Fetch the next page using a `links.next` URL
+</ParamField>
+
+<ParamField path="--paginate" type="boolean" default="false">
+  Automatically fetch all pages (aggregate results)
 </ParamField>
 
 <ParamField path="--output" type="string" default="json">
@@ -25,7 +33,12 @@ List available App Store categories.
 ```bash  theme={null}
 asc categories list
 asc categories list --output table
+asc categories list --paginate
 ```
+
+Use `--next` with the `links.next` URL from a previous response to resume from
+that page. Do not combine `--next` with `--limit`; the cursor already carries
+the page size.
 
 **Response:**
 

--- a/commands/categories.mdx
+++ b/commands/categories.mdx
@@ -34,6 +34,8 @@ List available App Store categories.
 asc categories list
 asc categories list --output table
 asc categories list --paginate
+asc categories list --next "<links.next>"
+asc categories list --paginate --next "<links.next>"
 ```
 
 Use `--next` with the `links.next` URL from a previous response to resume from
@@ -66,7 +68,11 @@ the page size.
         "platforms": ["IOS", "MAC_OS"]
       }
     }
-  ]
+  ],
+  "links": {
+    "self": "https://api.appstoreconnect.apple.com/v1/appCategories?limit=200",
+    "next": "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=NEXT_CURSOR&limit=200"
+  }
 }
 ```
 

--- a/internal/cli/categories/categories.go
+++ b/internal/cli/categories/categories.go
@@ -64,7 +64,9 @@ and secondary categories.
 Examples:
   asc categories list
   asc categories list --output table
-  asc categories list --paginate`,
+  asc categories list --paginate
+  asc categories list --next "<links.next>"
+  asc categories list --paginate --next "<links.next>"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/categories/categories.go
+++ b/internal/cli/categories/categories.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -46,7 +47,9 @@ Examples:
 func CategoriesListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("categories list", flag.ExitOnError)
 
-	limit := fs.Int("limit", 200, "Maximum results to fetch (1-200)")
+	limit := fs.Int("limit", 200, "Maximum results per page (1-200)")
+	next := fs.String("next", "", "Fetch next page using a links.next URL")
+	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -60,10 +63,17 @@ and secondary categories.
 
 Examples:
   asc categories list
-  asc categories list --output table`,
+  asc categories list --output table
+  asc categories list --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateNextURL(*next); err != nil {
+				return fmt.Errorf("categories list: %w", err)
+			}
+			if err := rejectCategoriesListNextFlagConflicts(fs, *next); err != nil {
+				return err
+			}
 			if *limit < 1 || *limit > 200 {
 				return fmt.Errorf("categories list: --limit must be between 1 and 200")
 			}
@@ -76,7 +86,26 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			categories, err := client.GetAppCategories(requestCtx, asc.WithAppCategoriesLimit(*limit))
+			opts := []asc.AppCategoriesOption{
+				asc.WithAppCategoriesLimit(*limit),
+				asc.WithAppCategoriesNextURL(*next),
+			}
+
+			if *paginate {
+				firstPage, err := client.GetAppCategories(requestCtx, opts...)
+				if err != nil {
+					return fmt.Errorf("categories list: %w", err)
+				}
+				categories, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+					return client.GetAppCategories(ctx, asc.WithAppCategoriesNextURL(nextURL))
+				})
+				if err != nil {
+					return fmt.Errorf("categories list: %w", err)
+				}
+				return shared.PrintOutput(categories, *output.Output, *output.Pretty)
+			}
+
+			categories, err := client.GetAppCategories(requestCtx, opts...)
 			if err != nil {
 				return fmt.Errorf("categories list: %w", err)
 			}
@@ -84,6 +113,25 @@ Examples:
 			return shared.PrintOutput(categories, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+// rejectCategoriesListNextFlagConflicts rejects --limit when a --next cursor
+// URL is supplied, because the cursor already encodes the page size and the
+// CLI must never accept and silently ignore a flag.
+func rejectCategoriesListNextFlagConflicts(fs *flag.FlagSet, next string) error {
+	if strings.TrimSpace(next) == "" {
+		return nil
+	}
+	conflict := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "limit" {
+			conflict = true
+		}
+	})
+	if conflict {
+		return shared.UsageError("categories list: --next cannot be combined with --limit")
+	}
+	return nil
 }
 
 // CategoriesSetCommand returns the categories set subcommand.

--- a/internal/cli/cmdtest/categories_list_pagination_test.go
+++ b/internal/cli/cmdtest/categories_list_pagination_test.go
@@ -1,0 +1,316 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestCategoriesListSupportsPaginationFlags(t *testing.T) {
+	cmd := findCommandByPath(t, "categories", "list")
+
+	for _, name := range []string{"next", "paginate"} {
+		if cmd.FlagSet.Lookup(name) == nil {
+			t.Fatalf("expected --%s flag on categories list", name)
+		}
+	}
+}
+
+func TestCategoriesListRejectsNextQueryFlagsBeforeAuth(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=next"
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "limit before next",
+			args:    []string{"categories", "list", "--limit", "25", "--next", nextURL},
+			wantErr: "categories list: --next cannot be combined with --limit",
+		},
+		{
+			name:    "explicit default limit after next",
+			args:    []string{"categories", "list", "--next", nextURL, "--limit", "200"},
+			wantErr: "categories list: --next cannot be combined with --limit",
+		},
+		{
+			name:    "out of range limit after next",
+			args:    []string{"categories", "list", "--next", nextURL, "--limit", "201"},
+			wantErr: "categories list: --next cannot be combined with --limit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during validation")
+			})
+			defer restore()
+
+			assertUsageExit(t, test.args, test.wantErr)
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before --next conflict validation")
+			}
+		})
+	}
+}
+
+func TestCategoriesListInvalidNextPrecedesLimitConflict(t *testing.T) {
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{
+			"categories", "list",
+			"--next", "http://api.appstoreconnect.apple.com/v1/appCategories?cursor=next",
+			"--limit", "201",
+		}, "1.2.3")
+		if code != rootcmd.ExitError {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitError)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "categories list: --next must be an App Store Connect URL") {
+		t.Fatalf("stderr = %q, want invalid --next error", stderr)
+	}
+	if strings.Contains(stderr, "--limit") {
+		t.Fatalf("stderr = %q, want --next validation to take precedence", stderr)
+	}
+}
+
+func TestCategoriesListRejectsInvalidLimit(t *testing.T) {
+	clientFactoryCalled := false
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		clientFactoryCalled = true
+		return nil, errors.New("client factory must not run during validation")
+	})
+	defer restore()
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := rootcmd.Run([]string{"categories", "list", "--limit", "0"}, "1.2.3"); code != rootcmd.ExitError {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitError)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "categories list: --limit must be between 1 and 200") {
+		t.Fatalf("stderr = %q, want invalid --limit error", stderr)
+	}
+	if clientFactoryCalled {
+		t.Fatal("client factory ran before --limit validation")
+	}
+}
+
+func TestCategoriesListNextOnlyUsesCursorURL(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=page-2&limit=5"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appCategories" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		want := url.Values{"cursor": {"page-2"}, "limit": {"5"}}
+		if got := req.URL.Query(); got.Encode() != want.Encode() {
+			t.Errorf("query = %q, want %q", got.Encode(), want.Encode())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"appCategories","id":"category-next"}],"links":{"next":""}}`)
+	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"categories", "list", "--next", nextURL, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	assertCategoryResponseID(t, stdout, "category-next")
+}
+
+func TestCategoriesListDefaultsToMaximumPageSize(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appCategories" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		want := url.Values{"limit": {"200"}}
+		if got := req.URL.Query(); got.Encode() != want.Encode() {
+			t.Errorf("query = %q, want %q", got.Encode(), want.Encode())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"appCategories","id":"category-default"}],"links":{"next":""}}`)
+	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"categories", "list", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	assertCategoryResponseID(t, stdout, "category-default")
+}
+
+func TestCategoriesListPaginateAggregatesPages(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const secondURL = "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=BQ&limit=200"
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appCategories" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount {
+		case 1:
+			want := url.Values{"limit": {"200"}}
+			if got := req.URL.Query(); got.Encode() != want.Encode() {
+				t.Errorf("first query = %q, want %q", got.Encode(), want.Encode())
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"appCategories","id":"category-page-1"}],"links":{"next":"`+secondURL+`"}}`)
+		case 2:
+			want := url.Values{"cursor": {"BQ"}, "limit": {"200"}}
+			if got := req.URL.Query(); got.Encode() != want.Encode() {
+				t.Errorf("second query = %q, want %q", got.Encode(), want.Encode())
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"appCategories","id":"category-page-2"}],"links":{"next":""}}`)
+		default:
+			t.Errorf("unexpected extra request: %s", req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"categories", "list", "--paginate", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+
+	var response struct {
+		Data []struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"data"`
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("parse JSON output: %v\noutput: %s", err, stdout)
+	}
+	if len(response.Data) != 2 {
+		t.Fatalf("data = %#v, want two aggregated resources", response.Data)
+	}
+	if response.Data[0].ID != "category-page-1" || response.Data[1].ID != "category-page-2" {
+		t.Fatalf("data ids = %q, %q, want page order", response.Data[0].ID, response.Data[1].ID)
+	}
+	if response.Data[0].Type != "appCategories" {
+		t.Fatalf("data type = %q, want appCategories envelope preserved", response.Data[0].Type)
+	}
+	if response.Links.Next != "" {
+		t.Fatalf("links.next = %q, want cleared after aggregation", response.Links.Next)
+	}
+}
+
+func TestCategoriesListPaginateFromNextCursor(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const firstURL = "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=AQ&limit=200"
+	const secondURL = "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=BQ&limit=200"
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount {
+		case 1:
+			if got, want := req.URL.RequestURI(), "/v1/appCategories?cursor=AQ&limit=200"; got != want {
+				t.Errorf("first request = %q, want %q", got, want)
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"appCategories","id":"category-cursor-1"}],"links":{"next":"`+secondURL+`"}}`)
+		case 2:
+			if got, want := req.URL.RequestURI(), "/v1/appCategories?cursor=BQ&limit=200"; got != want {
+				t.Errorf("second request = %q, want %q", got, want)
+			}
+			_, _ = io.WriteString(w, `{"data":[{"type":"appCategories","id":"category-cursor-2"}],"links":{"next":""}}`)
+		default:
+			t.Errorf("unexpected extra request: %s", req.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+	installDefaultTransportForServer(t, server)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"categories", "list", "--paginate", "--next", firstURL, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+	for _, id := range []string{"category-cursor-1", "category-cursor-2"} {
+		if !strings.Contains(stdout, `"id":"`+id+`"`) {
+			t.Fatalf("stdout = %q, want to contain %q", stdout, id)
+		}
+	}
+}

--- a/internal/cli/cmdtest/categories_list_pagination_test.go
+++ b/internal/cli/cmdtest/categories_list_pagination_test.go
@@ -27,6 +27,18 @@ func TestCategoriesListSupportsPaginationFlags(t *testing.T) {
 	}
 }
 
+func TestCategoriesListHelpDocumentsCursorResumeExamples(t *testing.T) {
+	cmd := findCommandByPath(t, "categories", "list")
+	for _, example := range []string{
+		`asc categories list --next "<links.next>"`,
+		`asc categories list --paginate --next "<links.next>"`,
+	} {
+		if !strings.Contains(cmd.LongHelp, example) {
+			t.Fatalf("categories list help = %q, want example %q", cmd.LongHelp, example)
+		}
+	}
+}
+
 func TestCategoriesListRejectsNextQueryFlagsBeforeAuth(t *testing.T) {
 	const nextURL = "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=next"
 	tests := []struct {


### PR DESCRIPTION
## Problem

The shared truncation warning (`warnMorePages`, `internal/cli/shared/shared.go`) tells callers to "use `--paginate` or `--next` where supported" whenever a rendered page still has a `links.next`. `asc categories list` was one of the commands that triggered that hint while defining neither flag, so the advice was unactionable: `/v1/appCategories` is a paged collection (`PagedDocumentLinks` + `PagingInformation` in `docs/openapi/latest.json`), and an account with more than 200 categories had no way to reach page two.

The client already supported the cursor (`asc.WithAppCategoriesNextURL`, `internal/asc/categories.go`); only the CLI surface was missing. No client or shared-helper changes were needed.

## Behavior change

`asc categories list` gains two flags, mirroring its in-file sibling `asc categories subcategories`:

- `--next URL` — fetch a `links.next` cursor URL verbatim (validated by `shared.ValidateNextURL`).
- `--paginate` — walk every page and aggregate into a single Apple envelope via `asc.PaginateAll` (`links.next` cleared on the aggregate, page-local `links`/`meta` dropped, `data` concatenated in page order).
- `--next` now rejects an explicitly supplied `--limit` instead of silently ignoring it (the cursor already encodes page size), matching the `categories subcategories` conflict rule.
- `--limit` help text changed from "Maximum results to fetch" to "Maximum results per page", which is what it always was on the wire.

Unchanged: `--limit` still defaults to 200 (the endpoint maximum) and still rejects values outside 1–200 with the same message and exit code; the default request is still `GET /v1/appCategories?limit=200`; the printed envelope is Apple's, unmodified. `--paginate` honours an explicit `--limit` as the page size rather than overriding it.

## Example invocations

```bash
asc categories list                       # unchanged: one page, limit=200
asc categories list --paginate            # all pages, one merged envelope
asc categories list --next "https://api.appstoreconnect.apple.com/v1/appCategories?cursor=BQ&limit=200"
asc categories list --paginate --next "$CURSOR"   # resume pagination from a cursor
asc categories list --next "$CURSOR" --limit 25   # usage error: --next cannot be combined with --limit
```

## Tests

New `internal/cli/cmdtest/categories_list_pagination_test.go` (written RED first, against the pre-change binary):

- `--next` / `--paginate` are registered on the command.
- `--next` + explicit `--limit` is a usage error raised before the client factory runs (three variants, including an explicitly passed default value).
- An invalid `--next` URL is reported before the `--limit` conflict.
- `--limit 0` still fails with the existing message and exit code.
- `--next` alone issues exactly one request to the cursor path and query, verbatim.
- The default invocation still sends `limit=200`.
- `--paginate` walks two pages, preserves resource `type`, concatenates `data` in page order, clears `links.next`, and emits nothing on stderr.
- `--paginate --next` starts the walk at the supplied cursor.

Full gauntlet passing on this branch: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` (also enforced by the pre-commit hook on the commit itself). `docs/COMMANDS.md` regenerated — no diff, since it indexes command groups rather than per-flag help. No live API calls.

## Compatibility

Purely additive. No existing flag, default, error message, exit code, or JSON shape changes. The only removal of behavior is that `--next` plus an explicit `--limit` is now an error instead of a silently ignored flag, and `--next` did not exist before this PR.

## Scoped-out siblings

This branch was meant to cover three flagless list commands. Two turned out not to be paginable, verified against `docs/openapi/latest.json` rather than assumed, so they are deliberately untouched:

- **`asc build-bundles list`** — the API exposes no `/v1/builds/{id}/buildBundles` or `/v1/builds/{id}/relationships/buildBundles` endpoint (`docs/openapi/paths.txt`), so the command reads bundles out of `included` on `GET /v1/builds/{id}?include=buildBundles&limit[buildBundles]=N`. In the `Build` schema the `buildBundles` relationship carries only `meta` + `data` — no `links` (contrast `betaBuildLocalizations`, which has `RelationshipLinks`) — and `BuildResponse.links` is `DocumentLinks` (self only). There is no cursor to hand to `--next` and nothing for `--paginate` to follow; the ceiling is `limit[buildBundles]` (max 50), which the command already exposes. It also never emits the truncation warning, because the client constructs its response with empty links.
- **`asc eula list`** — `GET /v1/apps/{id}/endUserLicenseAgreement` is a to-one relationship returning a single resource (`data` is an object, `links` is `DocumentLinks`, the only query parameter is `fields[endUserLicenseAgreements]`), and there is no `GET /v1/endUserLicenseAgreements` collection endpoint. Nothing to page through; `EndUserLicenseAgreementResponse` is not even a `PaginatedResponse`, so the truncation hint never fires there either.

Both remain candidates for a different kind of follow-up (surfacing `meta.paging.total` for build bundles, renaming/aliasing the EULA "list"), not for pagination flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination to the categories list command.
  * Added options to resume from a cursor or retrieve all pages automatically.
  * Added validation for invalid or conflicting pagination options.

* **Documentation**
  * Updated help and usage guidance with pagination options and examples.

* **Tests**
  * Added comprehensive coverage for pagination, cursors, validation, page limits, and multi-page results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->