### PR TITLE
fix(search): prioritize precise command paths

### DIFF
--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -185,6 +185,31 @@ func TestSearchPrioritizesPreciseCommandPathsForNaturalLanguage(t *testing.T) {
 	}
 }
 
+func TestSearchKeepsBuildDownloadsAheadOfGenericDownloads(t *testing.T) {
+	var code int
+	stdout, stderr := captureOutput(t, func() {
+		code = rootcmd.Run([]string{"search", "--output", "json", "--limit", "5", "download", "build"}, "1.2.3")
+	})
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+	}
+	if len(response.Results) == 0 {
+		t.Fatalf("expected search results, got %#v", response)
+	}
+	if response.Results[0].Command != "asc builds dsyms" {
+		t.Fatalf("expected build dSYM download command first, got %#v", response.Results)
+	}
+}
+
 func TestSearchKeepsExactBuildUploadAheadOfBroaderPublishWorkflows(t *testing.T) {
 	for _, query := range [][]string{
 		{"upload", "build"},

--- a/internal/cli/cmdtest/search_command_test.go
+++ b/internal/cli/cmdtest/search_command_test.go
@@ -145,6 +145,46 @@ func TestSearchPrioritizesCanonicalPublishWorkflowForNaturalLanguage(t *testing.
 	}
 }
 
+func TestSearchPrioritizesPreciseCommandPathsForNaturalLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    []string
+		expected string
+	}{
+		{name: "create app", query: []string{"create", "app"}, expected: "asc web apps create"},
+		{name: "build status", query: []string{"build", "status"}, expected: "asc xcode-cloud status"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				args := []string{"search", "--output", "json", "--limit", "5"}
+				args = append(args, test.query...)
+				code = rootcmd.Run(args, "1.2.3")
+			})
+
+			if code != 0 {
+				t.Fatalf("expected exit code 0, got %d with stderr %q", code, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			var response searchResponse
+			if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+				t.Fatalf("failed to unmarshal search JSON: %v\nstdout=%s", err, stdout)
+			}
+			if len(response.Results) == 0 {
+				t.Fatalf("expected search results, got %#v", response)
+			}
+			if response.Results[0].Command != test.expected {
+				t.Fatalf("expected precise command %q first, got %#v", test.expected, response.Results)
+			}
+		})
+	}
+}
+
 func TestSearchKeepsExactBuildUploadAheadOfBroaderPublishWorkflows(t *testing.T) {
 	for _, query := range [][]string{
 		{"upload", "build"},

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -401,7 +401,7 @@ func scoreCommandDoc(doc commandDoc, queryTokens []string) (int, []string) {
 		}
 	}
 	if len(queryTokens) > 1 {
-		if leafToken, ok := exactLeafQueryToken(doc.Command, queryTokens); ok {
+		if leafToken, ok := exactLeafQueryToken(doc.Command, queryTokens); ok && hasSupportingQueryToken(doc, queryTokens, leafToken) {
 			score += exactLeafCommandBoost
 			addReason(&reasons, seenReasons, "command-leaf:"+leafToken)
 		}
@@ -488,6 +488,20 @@ func exactLeafQueryToken(command string, queryTokens []string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func hasSupportingQueryToken(doc commandDoc, queryTokens []string, leafToken string) bool {
+	for _, token := range queryTokens {
+		if sameSearchStem(token, leafToken) {
+			continue
+		}
+		if tokenContains(doc.PathTokens, token) ||
+			tokenContains(doc.SummaryTokens, token) ||
+			tokenContains(doc.UsageTokens, token) {
+			return true
+		}
+	}
+	return false
 }
 
 func canonicalBoostFor(command string, queryTokens []string) (int, string) {

--- a/internal/cli/search/search.go
+++ b/internal/cli/search/search.go
@@ -17,8 +17,11 @@ import (
 )
 
 const (
-	defaultLimit         = 10
-	canonicalIntentBoost = 300
+	defaultLimit           = 10
+	canonicalIntentBoost   = 300
+	exactPathTokenScore    = 60
+	compoundPathTokenScore = 30
+	exactLeafCommandBoost  = 40
 )
 
 var tokenPattern = regexp.MustCompile(`[a-z0-9][a-z0-9-]*`)
@@ -397,6 +400,12 @@ func scoreCommandDoc(doc commandDoc, queryTokens []string) (int, []string) {
 			}
 		}
 	}
+	if len(queryTokens) > 1 {
+		if leafToken, ok := exactLeafQueryToken(doc.Command, queryTokens); ok {
+			score += exactLeafCommandBoost
+			addReason(&reasons, seenReasons, "command-leaf:"+leafToken)
+		}
+	}
 
 	if boost, reason := canonicalBoostFor(doc.Command, queryTokens); boost > 0 {
 		score += boost
@@ -419,8 +428,8 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 	if exactCommandMatch {
 		return 120, []string{reason, "command:" + term}
 	}
-	if !exactCommandMatch && tokenContains(doc.PathTokens, term) {
-		score += 60
+	if pathScore := commandPathScore(doc, term); pathScore > 0 {
+		score += pathScore
 		reasons = append(reasons, reason, "command:"+term)
 	}
 	if tokenContains(doc.SummaryTokens, term) {
@@ -455,6 +464,30 @@ func scoreTerm(doc commandDoc, term, reason string) (int, []string) {
 	}
 
 	return score, uniqueStrings(reasons)
+}
+
+func commandPathScore(doc commandDoc, term string) int {
+	if exactTokenContains(doc.PathTokens, term) {
+		return exactPathTokenScore
+	}
+	if tokenContains(doc.PathTokens, term) {
+		return compoundPathTokenScore
+	}
+	return 0
+}
+
+func exactLeafQueryToken(command string, queryTokens []string) (string, bool) {
+	commandParts := strings.Fields(strings.TrimPrefix(command, "asc "))
+	if len(commandParts) == 0 {
+		return "", false
+	}
+	leafForms := searchTokenForms(commandParts[len(commandParts)-1])
+	for _, token := range queryTokens {
+		if searchTokenFormsOverlap(leafForms, searchTokenForms(token)) {
+			return token, true
+		}
+	}
+	return "", false
 }
 
 func canonicalBoostFor(command string, queryTokens []string) (int, string) {
@@ -592,6 +625,16 @@ func uniqueTokens(text string) []string {
 func tokenContains(tokens []string, term string) bool {
 	for _, token := range tokens {
 		if searchTokensMatch(token, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func exactTokenContains(tokens []string, term string) bool {
+	termForms := searchTokenForms(strings.ToLower(strings.TrimSpace(term)))
+	for _, token := range tokens {
+		if searchTokenFormsOverlap(searchTokenForms(strings.ToLower(strings.TrimSpace(token))), termForms) {
 			return true
 		}
 	}

--- a/internal/cli/search/search_test.go
+++ b/internal/cli/search/search_test.go
@@ -21,6 +21,45 @@ func TestScoreCommandDocSkipsSelfReferentialAliases(t *testing.T) {
 	}
 }
 
+func TestCommandPathScorePrefersWholeSegmentsOverHyphenatedComponents(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  commandDoc
+		term string
+		want int
+	}{
+		{
+			name: "whole path segment",
+			doc:  commandDoc{Command: "asc web apps create", PathTokens: []string{"web", "apps", "create"}},
+			term: "app",
+			want: exactPathTokenScore,
+		},
+		{
+			name: "hyphenated component",
+			doc:  commandDoc{Command: "asc app-events create", PathTokens: []string{"app-events", "create"}},
+			term: "app",
+			want: compoundPathTokenScore,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := commandPathScore(test.doc, test.term); got != test.want {
+				t.Fatalf("commandPathScore(%q, %q) = %d, want %d", test.doc.Command, test.term, got, test.want)
+			}
+		})
+	}
+}
+
+func TestExactLeafQueryTokenMatchesWholeLeafOnly(t *testing.T) {
+	if token, ok := exactLeafQueryToken("asc xcode-cloud status", []string{"build", "status"}); !ok || token != "status" {
+		t.Fatalf("exactLeafQueryToken() = %q, %t, want status, true", token, ok)
+	}
+	if token, ok := exactLeafQueryToken("asc app-clips domain-status", []string{"build", "status"}); ok {
+		t.Fatalf("exactLeafQueryToken() = %q, true, want compound leaf not to match", token)
+	}
+}
+
 func TestScoreTermDoesNotStackExactCommandAndPathTokenScores(t *testing.T) {
 	doc := commandDoc{
 		Command:    "asc search",


### PR DESCRIPTION
## Summary

- distinguish exact command-path segments from matches inside hyphenated segments
- modestly favor an exact leaf action for multi-word intent searches
- keep generic one-word searches and existing canonical workflow boosts unchanged

## Why

Natural queries such as `create app` and `build status` ranked unrelated, over-specific commands ahead of the direct command because every path fragment received the same score. The new rule is generic: whole path segments carry more intent than fragments, and a multi-word query benefits when one word names the command's exact leaf action.

## Compatibility

No command, flag, output field, or exit code changes. Search scores and ordering improve for precision; exact command matching, typo fallback, singular/plural matching, and canonical publish/upload ranking remain covered.

## Verification

- captured both observed ranking failures as RED command-integration tests
- full search and adjacent command tests
- manual table-output checks for the two corrected intents and a generic one-word query
- `make format`
- `make check-docs`
- `make lint`
- isolated-cache `ASC_BYPASS_KEYCHAIN=1 go test ./...`

The first full-suite attempt was interrupted by local disk exhaustion, and a second saw concurrent shared-cache invalidation. After removing completed temporary worktrees and assigning this branch an isolated Go build cache, the entire suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved command search relevance for natural-language queries.
  * Search results now better prioritize precise command paths and complete command names over partial or hyphenated matches.
  * Multi-word queries more reliably surface commands matching the intended action.
  * Build download searches now prioritize the most relevant build download command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->