### PR TITLE
fix(testflight): make post-upload test-notes failures recoverable

### DIFF
--- a/internal/asc/output_publish.go
+++ b/internal/asc/output_publish.go
@@ -5,6 +5,16 @@ import (
 	"strings"
 )
 
+// TestNotesRecovery describes a shell-neutral retry after a build exists but
+// setting its What to Test notes fails.
+type TestNotesRecovery struct {
+	BuildID        string   `json:"buildId"`
+	Locale         string   `json:"locale"`
+	SubmittedNotes string   `json:"submittedNotes"`
+	Command        string   `json:"command"`
+	Arguments      []string `json:"arguments"`
+}
+
 func testFlightPublishResultRows(result *TestFlightPublishResult) ([]string, [][]string) {
 	headers := []string{"Build ID", "Version", "Build Number", "Processing", "Groups", "Uploaded", "Notified", "Notification Action", "Beta Review Submitted", "Beta Review Submission ID"}
 	notified := ""

--- a/internal/asc/publish.go
+++ b/internal/asc/publish.go
@@ -74,6 +74,7 @@ type TestFlightPublishResult struct {
 	FailureStage           string                            `json:"failureStage,omitempty"`
 	Failure                string                            `json:"failure,omitempty"`
 	CompletedStages        []string                          `json:"completedStages,omitempty"`
+	Recovery               *TestNotesRecovery                `json:"recovery,omitempty"`
 	Mode                   PublishMode                       `json:"mode,omitempty"`
 	BuildID                string                            `json:"buildId"`
 	BuildVersion           string                            `json:"buildVersion,omitempty"`

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -365,7 +365,7 @@ Examples:
 					if testNotesValue != "" {
 						fmt.Fprintf(os.Stderr, "Build %s discovered; setting What to Test notes...\n", buildResp.Data.ID)
 						if _, err := shared.UpsertBetaBuildLocalization(requestCtx, client, buildResp.Data.ID, localeValue, testNotesValue); err != nil {
-							return fmt.Errorf("builds upload: %w", err)
+							return fmt.Errorf("builds upload: %w", shared.NewTestNotesRecoveryError(buildResp.Data.ID, localeValue, testNotesValue, err))
 						}
 					}
 

--- a/internal/cli/cmdtest/builds_upload_wait_test.go
+++ b/internal/cli/cmdtest/builds_upload_wait_test.go
@@ -330,6 +330,88 @@ func TestBuildsUploadTestNotesWritesBeforeProcessingCompletes(t *testing.T) {
 	}
 }
 
+func TestBuildsUploadTestNotesFailurePreservesDiscoveredBuildRecoveryContext(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	testNotes := "Line one\nLine two\x1b[31m"
+
+	ipaPath := writeBuildUploadIPA(t, "com.example.demo")
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/123456789":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"apps","id":"123456789","attributes":{"name":"Demo","bundleId":"com.example.demo"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","attributes":{"cfBundleShortVersionString":"1.0.0","cfBundleVersion":"42","platform":"IOS"}}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"app.ipa","fileSize":4,"uti":"com.apple.itunes.ipa","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":4,"offset":0,"requestHeaders":[{"name":"Content-Type","value":"application/octet-stream"}]}]}}}`)
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"uploaded":true}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/buildUploads/upload-1":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"buildUploads","id":"upload-1","relationships":{"build":{"data":{"type":"builds","id":"build-1"}}}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/build-1":
+			return jsonResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"version":"42","processingState":"PROCESSING"}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/build-1/betaBuildLocalizations":
+			return jsonResponse(http.StatusOK, `{"data":[]}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/betaBuildLocalizations":
+			return jsonResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"The provided entity has an invalid attribute","detail":"What to Test was rejected by the server"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"builds", "upload",
+			"--app", "123456789",
+			"--ipa", ipaPath,
+			"--version", "1.0.0",
+			"--build-number", "42",
+			"--test-notes", testNotes,
+			"--locale", "en-US",
+			"--poll-interval", "1ms",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil {
+		t.Fatal("expected test notes rejection after upload")
+	}
+	if stdout != "" {
+		t.Fatalf("expected no new structured output contract on failure, got %q", stdout)
+	}
+	wantParts := []string{
+		`build "build-1" is available`,
+		`locale "en-US"`,
+		"The provided entity has an invalid attribute: What to Test was rejected by the server",
+		"retry without uploading the build again",
+		"reuse the original notes",
+		"asc builds test-notes create --build-id BUILD_ID --locale LOCALE --whats-new NOTES",
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(runErr.Error(), want) {
+			t.Fatalf("expected recovery error to contain %q, got %v", want, runErr)
+		}
+	}
+	if asc.HasInterpretedTerminalSequence(runErr.Error()) || strings.Contains(runErr.Error(), "Line one") {
+		t.Fatalf("expected sanitized human recovery without embedded notes, got %q", runErr)
+	}
+}
+
 func TestBuildsUploadPostCommitVerificationUsesFreshTimeoutWindow(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -403,7 +403,9 @@ Examples:
 
 			if testNotesValue != "" {
 				if _, err := shared.UpsertBetaBuildLocalization(requestCtx, client, buildResp.Data.ID, localeValue, testNotesValue); err != nil {
-					return reportPartialFailure(publishFailureStageTestNotes, fmt.Errorf("publish testflight: %w", err))
+					recoveryErr := shared.NewTestNotesRecoveryError(buildResp.Data.ID, localeValue, testNotesValue, err)
+					result.Recovery = recoveryErr.Recovery()
+					return reportPartialFailure(publishFailureStageTestNotes, fmt.Errorf("publish testflight: %w", recoveryErr))
 				}
 				completedStages = append(completedStages, publishCompletedStageTestNotes)
 			}

--- a/internal/cli/publish/publish_local_build_test.go
+++ b/internal/cli/publish/publish_local_build_test.go
@@ -774,6 +774,149 @@ func TestPublishTestFlightUploadReportsStructuredRecoveryResultAfterBetaReviewFa
 	}
 }
 
+func TestPublishTestFlightUploadTestNotesFailurePreservesStructuredRecoveryContext(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+	testNotes := "Line one\nLine two\x1b[31m"
+
+	getPublishASCClientFn = func(time.Duration) (*asc.Client, error) { return newPublishCommandTestClient(t), nil }
+	resolvePublishAppIDWithLookupFn = func(_ context.Context, _ *asc.Client, _ string) (string, error) {
+		return "app-123", nil
+	}
+	validatePublishIPAPathFn = func(string) (os.FileInfo, error) {
+		return newPublishTestFileInfo(t)
+	}
+	uploadCalls := 0
+	uploadBuildAndWaitForIDFn = func(_ context.Context, _ *asc.Client, _ string, _ string, _ os.FileInfo, version, buildNumber string, _ asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
+		uploadCalls++
+		return &publishUploadResult{
+			Build: &asc.BuildResponse{Data: asc.Resource[asc.BuildAttributes]{
+				ID: "build-123",
+				Attributes: asc.BuildAttributes{
+					Version:         buildNumber,
+					ProcessingState: asc.BuildProcessingStateProcessing,
+				},
+			}},
+			Version:     version,
+			BuildNumber: buildNumber,
+		}, nil
+	}
+	waitForPublishBuildProcessingFn = func(context.Context, *asc.Client, string, time.Duration) (*asc.BuildResponse, error) {
+		return &asc.BuildResponse{Data: asc.Resource[asc.BuildAttributes]{
+			ID: "build-123",
+			Attributes: asc.BuildAttributes{
+				Version:         "42",
+				ProcessingState: asc.BuildProcessingStateValid,
+			},
+		}}, nil
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	requestCount := 0
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-123/betaGroups" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"betaGroups","id":"group-1","attributes":{"name":"External","isInternalGroup":false}}]}`)
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/build-123/betaBuildLocalizations" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[]}`)
+		case 3:
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaBuildLocalizations" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return publishCommandJSONResponse(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"ENTITY_ERROR.ATTRIBUTE.INVALID","title":"The provided entity has an invalid attribute","detail":"What to Test was rejected by the server"}]}`)
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	cmd := PublishTestFlightCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "app-123",
+		"--ipa", "Demo.ipa",
+		"--version", "1.2.3",
+		"--build-number", "42",
+		"--group", "External",
+		"--test-notes", testNotes,
+		"--locale", "en-US",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	var runErr error
+	stdout, _ := capturePublishCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if runErr == nil {
+		t.Fatal("expected post-upload test notes rejection")
+	}
+	if uploadCalls != 1 {
+		t.Fatalf("upload calls = %d, want 1", uploadCalls)
+	}
+	wantParts := []string{
+		`build "build-123" is available`,
+		`locale "en-US"`,
+		"The provided entity has an invalid attribute: What to Test was rejected by the server",
+		"retry without uploading the build again",
+		"reuse the original notes",
+		"asc builds test-notes create --build-id BUILD_ID --locale LOCALE --whats-new NOTES",
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(runErr.Error(), want) {
+			t.Fatalf("expected recovery error to contain %q, got %v", want, runErr)
+		}
+	}
+	if asc.HasInterpretedTerminalSequence(runErr.Error()) || strings.Contains(runErr.Error(), "Line one") {
+		t.Fatalf("expected sanitized human recovery without embedded notes, got %q", runErr)
+	}
+
+	var result asc.TestFlightPublishResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode partial publish result: %v\nstdout=%s", err, stdout)
+	}
+	if result.Status != publishPartialStatus || result.FailureStage != publishFailureStageTestNotes {
+		t.Fatalf("unexpected partial status: status=%q stage=%q", result.Status, result.FailureStage)
+	}
+	if result.BuildID != "build-123" || !result.Uploaded {
+		t.Fatalf("expected recoverable uploaded build, got buildId=%q uploaded=%t", result.BuildID, result.Uploaded)
+	}
+	wantCompleted := []string{publishCompletedStageUpload, publishCompletedStageBuildProcessing}
+	if !slices.Equal(result.CompletedStages, wantCompleted) {
+		t.Fatalf("completed stages = %v, want %v", result.CompletedStages, wantCompleted)
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(result.Failure, want) {
+			t.Fatalf("expected structured failure to contain %q, got %q", want, result.Failure)
+		}
+	}
+	if result.Recovery == nil {
+		t.Fatalf("expected typed test-notes recovery, got %#v", result)
+	}
+	if result.Recovery.BuildID != "build-123" || result.Recovery.Locale != "en-US" || result.Recovery.SubmittedNotes != testNotes {
+		t.Fatalf("structured recovery lost exact values: %#v", result.Recovery)
+	}
+	wantArguments := []string{
+		"builds", "test-notes", "create",
+		"--build-id", "build-123",
+		"--locale", "en-US",
+		"--whats-new", testNotes,
+	}
+	if result.Recovery.Command != "asc" || !slices.Equal(result.Recovery.Arguments, wantArguments) {
+		t.Fatalf("structured recovery command = %q %#v, want asc %#v", result.Recovery.Command, result.Recovery.Arguments, wantArguments)
+	}
+}
+
 func TestPublishTestFlightUploadReportsTerminalProcessingStateAfterWaitFailure(t *testing.T) {
 	restore := overridePublishCommandTestHooks(t)
 	defer restore()

--- a/internal/cli/shared/test_notes.go
+++ b/internal/cli/shared/test_notes.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
@@ -89,15 +91,85 @@ func (e *TestNotesRecoveryError) Error() string {
 }
 
 func redactTestNotes(message, notes string) string {
-	for _, candidate := range []string{
-		asc.SanitizeTerminalText(notes),
-		asc.SanitizeTerminalText(strings.TrimSpace(notes)),
-	} {
-		if candidate != "" {
-			message = strings.ReplaceAll(message, candidate, "(original notes omitted)")
+	const redacted = "(original notes omitted)"
+
+	sanitizedNotes := asc.SanitizeTerminalText(notes)
+	candidate := strings.TrimSpace(sanitizedNotes)
+	if candidate == "" {
+		return message
+	}
+
+	// A cause that consists of the submitted value is unambiguous, even for
+	// short notes such as "a" or "invalid".
+	if strings.TrimSpace(message) == candidate {
+		return redacted
+	}
+
+	// Quoted values are also unambiguous. Keep the surrounding quotes so the
+	// shape of Apple's diagnostic remains useful to the operator.
+	for _, quote := range []string{`"`, `'`, "`"} {
+		if strings.Contains(candidate, quote) {
+			continue
 		}
+		message = strings.ReplaceAll(message, quote+candidate+quote, quote+redacted+quote)
+	}
+
+	// Terminal-sensitive notes can be echoed after sanitization turns their
+	// separators into spaces. Redact only a whole phrase in that case; plain
+	// short notes are intentionally not treated as secrets inside arbitrary
+	// diagnostic text because there is no reliable way to distinguish an echo
+	// from normal prose.
+	if asc.HasInterpretedTerminalSequence(notes) && hasTestNotesBoundary(candidate) {
+		message = replaceWholeTestNotes(message, candidate, redacted)
 	}
 	return message
+}
+
+func hasTestNotesBoundary(candidate string) bool {
+	for _, r := range candidate {
+		if unicode.IsSpace(r) || !isTestNotesWordRune(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTestNotesWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsMark(r) || r == '_'
+}
+
+func replaceWholeTestNotes(message, candidate, replacement string) string {
+	for offset := 0; offset < len(message); {
+		relativeStart := strings.Index(message[offset:], candidate)
+		if relativeStart < 0 {
+			break
+		}
+		start := offset + relativeStart
+		end := start + len(candidate)
+		if testNotesBoundaryAt(message, start, end) {
+			message = message[:start] + replacement + message[end:]
+			offset = start + len(replacement)
+			continue
+		}
+		offset = end
+	}
+	return message
+}
+
+func testNotesBoundaryAt(message string, start, end int) bool {
+	if start > 0 {
+		before, _ := utf8.DecodeLastRuneInString(message[:start])
+		if isTestNotesWordRune(before) {
+			return false
+		}
+	}
+	if end < len(message) {
+		after, _ := utf8.DecodeRuneInString(message[end:])
+		if isTestNotesWordRune(after) {
+			return false
+		}
+	}
+	return true
 }
 
 // Unwrap preserves API error status and exit classification.

--- a/internal/cli/shared/test_notes.go
+++ b/internal/cli/shared/test_notes.go
@@ -78,7 +78,7 @@ func (e *TestNotesRecoveryError) Error() string {
 	locale := asc.SanitizeTerminalText(e.locale)
 	cause := "unknown error"
 	if e.cause != nil {
-		cause = asc.SanitizeTerminalText(e.cause.Error())
+		cause = redactTestNotes(asc.SanitizeTerminalText(e.cause.Error()), e.notes)
 	}
 	return fmt.Sprintf(
 		"build %q is available, but setting What to Test notes for locale %q failed: %s; retry without uploading the build again and reuse the original notes: asc builds test-notes create --build-id BUILD_ID --locale LOCALE --whats-new NOTES",
@@ -86,6 +86,18 @@ func (e *TestNotesRecoveryError) Error() string {
 		locale,
 		cause,
 	)
+}
+
+func redactTestNotes(message, notes string) string {
+	for _, candidate := range []string{
+		asc.SanitizeTerminalText(notes),
+		asc.SanitizeTerminalText(strings.TrimSpace(notes)),
+	} {
+		if candidate != "" {
+			message = strings.ReplaceAll(message, candidate, "(original notes omitted)")
+		}
+	}
+	return message
 }
 
 // Unwrap preserves API error status and exit classification.

--- a/internal/cli/shared/test_notes.go
+++ b/internal/cli/shared/test_notes.go
@@ -52,3 +52,59 @@ func UpsertBetaBuildLocalization(ctx context.Context, client *asc.Client, buildI
 	}
 	return client.CreateBetaBuildLocalization(ctx, buildID, attrs)
 }
+
+// TestNotesRecoveryError preserves a discovered build and the exact retry
+// arguments while keeping its human-facing diagnostic terminal-safe.
+type TestNotesRecoveryError struct {
+	buildID string
+	locale  string
+	notes   string
+	cause   error
+}
+
+// NewTestNotesRecoveryError returns recovery context for a failed post-upload
+// What to Test request.
+func NewTestNotesRecoveryError(buildID, locale, notes string, cause error) *TestNotesRecoveryError {
+	return &TestNotesRecoveryError{
+		buildID: buildID,
+		locale:  locale,
+		notes:   notes,
+		cause:   cause,
+	}
+}
+
+func (e *TestNotesRecoveryError) Error() string {
+	buildID := asc.SanitizeTerminalText(e.buildID)
+	locale := asc.SanitizeTerminalText(e.locale)
+	cause := "unknown error"
+	if e.cause != nil {
+		cause = asc.SanitizeTerminalText(e.cause.Error())
+	}
+	return fmt.Sprintf(
+		"build %q is available, but setting What to Test notes for locale %q failed: %s; retry without uploading the build again and reuse the original notes: asc builds test-notes create --build-id BUILD_ID --locale LOCALE --whats-new NOTES",
+		buildID,
+		locale,
+		cause,
+	)
+}
+
+// Unwrap preserves API error status and exit classification.
+func (e *TestNotesRecoveryError) Unwrap() error {
+	return e.cause
+}
+
+// Recovery returns exact, shell-neutral retry data for structured output.
+func (e *TestNotesRecoveryError) Recovery() *asc.TestNotesRecovery {
+	return &asc.TestNotesRecovery{
+		BuildID:        e.buildID,
+		Locale:         e.locale,
+		SubmittedNotes: e.notes,
+		Command:        "asc",
+		Arguments: []string{
+			"builds", "test-notes", "create",
+			"--build-id", e.buildID,
+			"--locale", e.locale,
+			"--whats-new", e.notes,
+		},
+	}
+}

--- a/internal/cli/shared/test_notes_test.go
+++ b/internal/cli/shared/test_notes_test.go
@@ -57,3 +57,14 @@ func TestNewTestNotesRecoveryErrorSeparatesHumanAndMachineRecovery(t *testing.T)
 		}
 	}
 }
+
+func TestNewTestNotesRecoveryErrorDoesNotEchoNotesFromServerDetail(t *testing.T) {
+	notes := "First line\nSecond line"
+	cause := errors.New("server rejected value: " + notes)
+
+	err := NewTestNotesRecoveryError("build-1", "en-US", notes, cause)
+	human := err.Error()
+	if strings.Contains(human, "First line") || strings.Contains(human, "Second line") {
+		t.Fatalf("human recovery error must not echo submitted notes from server detail: %q", human)
+	}
+}

--- a/internal/cli/shared/test_notes_test.go
+++ b/internal/cli/shared/test_notes_test.go
@@ -59,12 +59,61 @@ func TestNewTestNotesRecoveryErrorSeparatesHumanAndMachineRecovery(t *testing.T)
 }
 
 func TestNewTestNotesRecoveryErrorDoesNotEchoNotesFromServerDetail(t *testing.T) {
-	notes := "First line\nSecond line"
+	notes := "First line\nSecond line\x1b[31m"
 	cause := errors.New("server rejected value: " + notes)
 
 	err := NewTestNotesRecoveryError("build-1", "en-US", notes, cause)
 	human := err.Error()
-	if strings.Contains(human, "First line") || strings.Contains(human, "Second line") {
+	if !strings.Contains(human, "server rejected value: (original notes omitted)") {
+		t.Fatalf("human recovery error lost the non-sensitive server diagnostic: %q", human)
+	}
+	if strings.Contains(human, "First line") || strings.Contains(human, "Second line") || strings.Contains(human, "[31m") {
 		t.Fatalf("human recovery error must not echo submitted notes from server detail: %q", human)
+	}
+}
+
+func TestNewTestNotesRecoveryErrorRedactsExactEchoesWithoutCorruptingDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		notes  string
+		cause  string
+		redact bool
+	}{
+		{
+			name:   "short exact echo",
+			notes:  "invalid",
+			cause:  "invalid",
+			redact: true,
+		},
+		{
+			name:   "short quoted echo",
+			notes:  "invalid",
+			cause:  `value "invalid" is not accepted`,
+			redact: true,
+		},
+		{
+			name:  "short diagnostic word",
+			notes: "invalid",
+			cause: "invalid attribute",
+		},
+		{
+			name:  "single-letter substring collision",
+			notes: "a",
+			cause: "request failed while validating an attribute",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewTestNotesRecoveryError("build-1", "en-US", tt.notes, errors.New(tt.cause))
+			human := err.Error()
+			gotRedaction := strings.Contains(human, "(original notes omitted)")
+			if gotRedaction != tt.redact {
+				t.Fatalf("redaction = %t, want %t: %q", gotRedaction, tt.redact, human)
+			}
+			if !tt.redact && !strings.Contains(human, tt.cause) {
+				t.Fatalf("normal diagnostic was rewritten: %q", human)
+			}
+		})
 	}
 }

--- a/internal/cli/shared/test_notes_test.go
+++ b/internal/cli/shared/test_notes_test.go
@@ -1,0 +1,59 @@
+package shared
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestNewTestNotesRecoveryErrorSeparatesHumanAndMachineRecovery(t *testing.T) {
+	cause := errors.New("server rejected notes\x1b[31m\nforged line")
+	buildID := `build 'quoted' $(touch build)`
+	locale := `en-US; touch locale`
+	notes := "First line; $(touch notes)\nIt's still quoted\x1b[0m"
+
+	err := NewTestNotesRecoveryError(buildID, locale, notes, cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("expected recovery error to wrap cause, got %v", err)
+	}
+	if asc.HasInterpretedTerminalSequence(err.Error()) {
+		t.Fatalf("human recovery error contains terminal controls: %q", err)
+	}
+	if strings.Contains(err.Error(), "First line") {
+		t.Fatalf("human recovery error must not embed notes: %q", err)
+	}
+	wantHumanParts := []string{
+		"retry without uploading the build again",
+		"reuse the original notes",
+		"asc builds test-notes create --build-id BUILD_ID --locale LOCALE --whats-new NOTES",
+	}
+	for _, want := range wantHumanParts {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("human recovery error missing %q: %q", want, err)
+		}
+	}
+
+	recovery := err.Recovery()
+	if recovery.BuildID != buildID || recovery.Locale != locale || recovery.SubmittedNotes != notes {
+		t.Fatalf("recovery fields lost exact values: %#v", recovery)
+	}
+	if recovery.Command != "asc" {
+		t.Fatalf("recovery command = %q, want asc", recovery.Command)
+	}
+	want := []string{
+		"builds", "test-notes", "create",
+		"--build-id", buildID,
+		"--locale", locale,
+		"--whats-new", notes,
+	}
+	if len(recovery.Arguments) != len(want) {
+		t.Fatalf("retry args = %#v, want %#v", recovery.Arguments, want)
+	}
+	for i := range want {
+		if recovery.Arguments[i] != want[i] {
+			t.Fatalf("retry arg %d = %q, want %q; all args=%#v", i, recovery.Arguments[i], want[i], recovery.Arguments)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A build upload can succeed and the build can be discovered before the separate What to Test request is rejected. The previous behavior returned only the API error, so operators and automation lost the build ID and the direct recovery path. Retrying the original upload command could waste time and create ambiguity around an artifact that already exists.

The API schema defines betaBuildLocalizations whatsNew as a string and does not publish a maximum length. This change therefore keeps the server authoritative instead of enforcing a guessed local ceiling.

## Behavior

When asc builds upload or asc publish testflight reaches a discovered build and setting What to Test notes fails, the human error now preserves the sanitized build ID, locale, and original API detail. It explicitly says not to upload again and shows this shell-neutral template:

asc builds test-notes create --build-id BUILD_ID --locale LOCALE --whats-new NOTES

BUILD_ID and LOCALE refer to the values reported earlier in the same error, and NOTES means reuse the original notes. The human error never embeds the notes themselves, so multiline text and terminal controls cannot forge logs or terminal output. It also avoids claiming one quoting convention works across every supported shell.

For asc publish testflight uploads, the existing partial result remains: status is partial, failureStage is test_notes, and completed stages are retained. JSON output also adds a typed recovery object containing:

- exact buildId, locale, and submittedNotes values
- command set to asc
- a shell-neutral arguments array suitable for direct process execution

JSON preserves multiline and control-heavy notes exactly; automation does not need to parse or evaluate a shell command. Human table and Markdown output continue to rely on the sanitized error guidance.

asc builds upload receives the same human recovery context without changing its structured output schema. Direct asc builds test-notes create and update calls remain server-authoritative and otherwise unchanged.

## Scope

- remove the undocumented numeric preflight and all tests that encoded it
- add one typed post-upload recovery error with separate human and machine representations
- apply it only at the builds upload and publish testflight post-discovery notes failure sites
- preserve wrapped API errors so existing status and exit classification continue to work

No command, flag, help text, success output, or existing JSON field changes. The recovery JSON object is additive and only appears on the partial publish failure it describes.

## Verification

TDD established failures in both upload entry points before implementation. Coverage now verifies:

- a 422 after build discovery preserves build, locale, and complete server detail
- human diagnostics omit raw notes and all interpreted terminal controls
- human retry guidance is cross-platform and never implies another upload
- publish partial JSON preserves multiline and control-heavy submitted notes exactly
- the typed command and argument array round-trip hostile whitespace and metacharacters without a shell
- wrapped API error classification remains available

Local gates passed:

- make build
- make format
- make check-docs
- make lint (0 issues)
- ASC_BYPASS_KEYCHAIN=1 make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when TestFlight notes cannot be created or updated during build upload and publishing.
  - Errors now include build and locale context, server details, and sanitized diagnostic information.
  - Added copyable retry commands with safely quoted values.
  - Publishing preserves partial results, including completed upload and processing stages, when notes fail.
  - Structured output now includes recovery details for retrying failed notes updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->