### PR TITLE
feat(validation): flag placeholder copy in App Store metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,22 @@ asc submit status --version-id "VERSION_ID"
 asc submit cancel --version-id "VERSION_ID" --confirm
 ```
 
+Readiness validation also warns when localized app names, subtitles,
+descriptions, keywords, promotional text, or What's New copy still contains an
+unmistakable template marker such as `Lorem ipsum`, `TODO`, `TBD`, or `FIXME`.
+The warning includes the locale, field, matched text, resource ID, and a
+remediation step. It is advisory by default and becomes blocking only with
+`--strict`:
+
+```bash
+asc validate --app "123456789" --version "1.2.3" --output json
+asc validate --app "123456789" --version "1.2.3" --strict
+```
+
+This lint intentionally does not judge platform names, roadmap language, or
+beta/demo wording because those phrases can be legitimate product copy and
+cannot be classified reliably offline.
+
 ### Review status and blockers
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ asc validate --app "123456789" --version "1.2.3" --strict
 
 This lint intentionally does not judge platform names, roadmap language, or
 beta/demo wording because those phrases can be legitimate product copy and
-cannot be classified reliably offline.
+cannot be classified reliably offline. It also leaves shorter Lorem Ipsum
+product wording and ordinary localized `TODO` copy without marker punctuation
+unflagged; only template-like residue is reported.
 
 ### Review status and blockers
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ asc submit cancel --version-id "VERSION_ID" --confirm
 Readiness validation also warns when localized app names, subtitles,
 descriptions, keywords, promotional text, or What's New copy still contains an
 unmistakable template marker such as `Lorem ipsum`, `TODO`, `TBD`, or `FIXME`.
+`Lorem ipsum` matches in any letter case. `TODO`, `TBD`, and `FIXME` match only
+in uppercase because their lowercase spellings can be ordinary product wording.
 The warning includes the locale, field, matched text, resource ID, and a
 remediation step. It is advisory by default and becomes blocking only with
 `--strict`:

--- a/commands/validate.mdx
+++ b/commands/validate.mdx
@@ -29,6 +29,15 @@ The validation process checks:
 * Age rating is configured
 * App categories are assigned
 * Pricing and availability are configured
+* Localized listing fields do not contain unmistakable template markers such as
+  `Lorem ipsum`, `TODO`, `TBD`, or `FIXME`
+
+Placeholder findings cover app names, subtitles, descriptions, keywords,
+promotional text, and What's New copy. `Lorem ipsum` is matched without regard
+to letter case; `TODO`, `TBD`, and `FIXME` are matched only in uppercase because
+their lowercase forms can be ordinary product wording. Findings include the
+locale, field, matched text, resource ID, and a remediation step. They are
+warnings by default and become blocking with `--strict`.
 
 ## Output
 
@@ -59,6 +68,10 @@ Validation failed for version 1.2.0:
 
 <ParamField path="--output" type="string">
   Output format: `json`, `table`, or `markdown`
+</ParamField>
+
+<ParamField path="--strict" type="boolean">
+  Treat warnings, including placeholder findings, as blocking validation issues
 </ParamField>
 
 ## Example workflows

--- a/commands/validate.mdx
+++ b/commands/validate.mdx
@@ -33,11 +33,13 @@ The validation process checks:
   `Lorem ipsum`, `TODO`, `TBD`, or `FIXME`
 
 Placeholder findings cover app names, subtitles, descriptions, keywords,
-promotional text, and What's New copy. `Lorem ipsum` is matched without regard
-to letter case; `TODO`, `TBD`, and `FIXME` are matched only in uppercase because
-their lowercase forms can be ordinary product wording. Findings include the
-locale, field, matched text, resource ID, and a remediation step. They are
-warnings by default and become blocking with `--strict`.
+promotional text, and What's New copy. The canonical `Lorem ipsum dolor sit
+amet` sequence is matched without regard to letter case. `TODO`, `TBD`, and
+`FIXME` are uppercase-only; `TODO` additionally requires following marker
+punctuation such as a colon or dash so ordinary localized wording is not
+flagged. Findings include the locale, field, matched text, resource type and ID,
+and a remediation step. They are warnings by default and become blocking with
+`--strict`.
 
 ## Output
 

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -56,6 +56,10 @@ Use it instead of ` + "`asc submit preflight`" + `.
 
 The default validate response includes an ordered remediation plan, so the first step is the next thing to fix.
 
+Placeholder checks preserve shorter Lorem Ipsum product wording and ordinary
+localized TODO copy without marker punctuation; only template-like residue is
+reported.
+
 Checks:
   - Metadata length limits
   - Placeholder copy in localized listing fields (warning; --strict to block)

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -58,6 +58,7 @@ The default validate response includes an ordered remediation plan, so the first
 
 Checks:
   - Metadata length limits
+  - Placeholder copy in localized listing fields (warning; --strict to block)
   - Required fields and localizations
   - App Store review details completeness
   - Primary category configured

--- a/internal/cli/validate/validate_content_help_test.go
+++ b/internal/cli/validate/validate_content_help_test.go
@@ -10,6 +10,8 @@ func TestValidateHelpDocumentsPlaceholderWarningScope(t *testing.T) {
 	for _, want := range []string{
 		"Placeholder copy in localized listing fields",
 		"warning; --strict to block",
+		"localized TODO copy without marker punctuation",
+		"shorter Lorem Ipsum product wording",
 	} {
 		if !strings.Contains(cmd.LongHelp, want) {
 			t.Fatalf("LongHelp missing %q:\n%s", want, cmd.LongHelp)

--- a/internal/cli/validate/validate_content_help_test.go
+++ b/internal/cli/validate/validate_content_help_test.go
@@ -1,0 +1,18 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateHelpDocumentsPlaceholderWarningScope(t *testing.T) {
+	cmd := ValidateCommand()
+	for _, want := range []string{
+		"Placeholder copy in localized listing fields",
+		"warning; --strict to block",
+	} {
+		if !strings.Contains(cmd.LongHelp, want) {
+			t.Fatalf("LongHelp missing %q:\n%s", want, cmd.LongHelp)
+		}
+	}
+}

--- a/internal/validation/content.go
+++ b/internal/validation/content.go
@@ -13,7 +13,7 @@ import (
 // template copy while leaving product, platform, roadmap, and beta wording to
 // App Review instead of guessing at editorial intent.
 var placeholderPhrases = []string{
-	"lorem ipsum",
+	"lorem ipsum dolor sit amet",
 }
 
 // These markers are case-sensitive because their lowercase spellings can be
@@ -115,6 +115,9 @@ func findContentMatches(value string, patterns []*regexp.Regexp) []string {
 	matches := make([]string, 0, len(ranges))
 	for _, location := range ranges {
 		phrase := strings.Join(strings.Fields(value[location.start:location.end]), " ")
+		if !shouldReportContentMatch(value, location, phrase) {
+			continue
+		}
 		key := strings.ToLower(phrase)
 		if _, duplicate := seen[key]; duplicate {
 			continue
@@ -123,6 +126,25 @@ func findContentMatches(value string, patterns []*regexp.Regexp) []string {
 		matches = append(matches, phrase)
 	}
 	return matches
+}
+
+// shouldReportContentMatch requires marker punctuation for TODO because the
+// same uppercase word is ordinary localized copy and can be a product name.
+// TBD and FIXME remain unambiguous standalone markers.
+func shouldReportContentMatch(value string, location contentMatch, phrase string) bool {
+	if phrase != "TODO" {
+		return true
+	}
+	end := location.end
+	for end < len(value) {
+		runeValue, size := utf8.DecodeRuneInString(value[end:])
+		if unicode.IsSpace(runeValue) {
+			end += size
+			continue
+		}
+		return runeValue == ':' || runeValue == '\uff1a' || runeValue == '-' || runeValue == '\u2013' || runeValue == '\u2014'
+	}
+	return false
 }
 
 func quoteContentMatches(matches []string) string {

--- a/internal/validation/content.go
+++ b/internal/validation/content.go
@@ -158,7 +158,7 @@ func hasContentTokenBoundaries(value string, start, end int) bool {
 }
 
 func isContentTokenRune(value rune) bool {
-	return value == '_' || unicode.IsLetter(value) || unicode.IsNumber(value)
+	return value == '_' || unicode.IsLetter(value) || unicode.IsNumber(value) || unicode.IsMark(value)
 }
 
 func contentAlternation(phrases []string) string {

--- a/internal/validation/content.go
+++ b/internal/validation/content.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Placeholder-content lint is deliberately narrow. It flags unmistakable
@@ -96,6 +98,9 @@ func findContentMatches(value string, patterns []*regexp.Regexp) []string {
 	ranges := make([]contentMatch, 0, 2)
 	for _, pattern := range patterns {
 		for _, location := range pattern.FindAllStringIndex(value, -1) {
+			if !hasContentTokenBoundaries(value, location[0], location[1]) {
+				continue
+			}
 			ranges = append(ranges, contentMatch{start: location[0], end: location[1]})
 		}
 	}
@@ -129,11 +134,31 @@ func quoteContentMatches(matches []string) string {
 }
 
 func contentPhrasePattern(phrases []string) *regexp.Regexp {
-	return regexp.MustCompile(`(?i)\b(?:` + contentAlternation(phrases) + `)\b`)
+	return regexp.MustCompile(`(?i)(?:` + contentAlternation(phrases) + `)`)
 }
 
 func contentMarkerPattern(markers []string) *regexp.Regexp {
-	return regexp.MustCompile(`\b(?:` + contentAlternation(markers) + `)\b`)
+	return regexp.MustCompile(`(?:` + contentAlternation(markers) + `)`)
+}
+
+func hasContentTokenBoundaries(value string, start, end int) bool {
+	if start > 0 {
+		previous, _ := utf8.DecodeLastRuneInString(value[:start])
+		if isContentTokenRune(previous) {
+			return false
+		}
+	}
+	if end < len(value) {
+		next, _ := utf8.DecodeRuneInString(value[end:])
+		if isContentTokenRune(next) {
+			return false
+		}
+	}
+	return true
+}
+
+func isContentTokenRune(value rune) bool {
+	return value == '_' || unicode.IsLetter(value) || unicode.IsNumber(value)
 }
 
 func contentAlternation(phrases []string) string {

--- a/internal/validation/content.go
+++ b/internal/validation/content.go
@@ -7,199 +7,22 @@ import (
 	"strings"
 )
 
-// Content lint rules flag localized metadata wording that App Store review
-// commonly rejects: references to other platforms, leftover placeholder copy,
-// promises of unreleased functionality, and test or demo framing.
-//
-// Every rule is offline (no network lookups) and advisory: matches are reported
-// as warnings so they never block a submission on their own. Matching is
-// word-boundary based rather than substring based, so "androids", "freedom",
-// and "testament" never trigger a platform, placeholder, or test warning.
-
-// otherPlatformPhrases lists competing platforms, stores, and device families.
-// Only phrases that are unambiguous on their own belong here: bare "windows",
-// "galaxy", "kindle", and "play" are ordinary product vocabulary, so they are
-// matched only as part of a longer platform phrase.
-var otherPlatformPhrases = []string{
-	"android",
-	"google",
-	"google play",
-	"play store",
-	"blackberry",
-	"windows phone",
-	"windows mobile",
-	"samsung galaxy",
-	"galaxy store",
-	"amazon appstore",
-	"amazon app store",
-	"kindle fire",
-	"huawei",
-	"appgallery",
-	"symbian",
-	"tizen",
-}
-
-// otherPlatformAllowlist covers service names an App Store listing may name
-// legitimately. An allowlist hit suppresses any platform match it overlaps, so
-// "Google Drive" stays silent while "Google Play" is still reported.
-var otherPlatformAllowlist = []string{
-	"google account",
-	"google ads",
-	"google analytics",
-	"google api",
-	"google apis",
-	"google assistant",
-	"google authenticator",
-	"google books",
-	"google calendar",
-	"google chrome",
-	"google classroom",
-	"google cloud",
-	"google contacts",
-	"google docs",
-	"google drive",
-	"google earth",
-	"google firebase",
-	"google fit",
-	"google fonts",
-	"google forms",
-	"google gemini",
-	"google home",
-	"google keep",
-	"google lens",
-	"google login",
-	"google maps",
-	"google meet",
-	"google news",
-	"google oauth",
-	"google one",
-	"google pay",
-	"google photos",
-	"google scholar",
-	"google search console",
-	"google sheets",
-	"google sign in",
-	"google sign-in",
-	"google slides",
-	"google tasks",
-	"google translate",
-	"google voice",
-	"google wallet",
-	"google workspace",
-	"continue with google",
-	"log in with google",
-	"login with google",
-	"sign in with google",
-	"sign up with google",
-}
-
-// placeholderPhrases lists template copy that should never reach the store.
+// Placeholder-content lint is deliberately narrow. It flags unmistakable
+// template copy while leaving product, platform, roadmap, and beta wording to
+// App Review instead of guessing at editorial intent.
 var placeholderPhrases = []string{
 	"lorem ipsum",
-	"placeholder",
-	"placeholder text",
-	"text here",
-	"your text here",
-	"description here",
-	"enter description here",
-	"insert description",
-	"sample text",
-	"dummy text",
 }
 
-// placeholderMarkers are matched case-sensitively on purpose. As placeholders
-// these acronyms are always written in caps, while lowercase "todo" is ordinary
-// vocabulary for to-do apps ("manage your todo list").
-var placeholderMarkers = []string{
-	"TODO",
-	"TBD",
-	"FIXME",
+// These markers are case-sensitive because their lowercase spellings can be
+// ordinary product vocabulary, especially "todo" applications.
+var placeholderMarkers = []string{"TODO", "TBD", "FIXME"}
+
+var placeholderPatterns = []*regexp.Regexp{
+	contentPhrasePattern(placeholderPhrases),
+	contentMarkerPattern(placeholderMarkers),
 }
 
-// futureFunctionalityPhrases lists promises of functionality that does not ship
-// with the submitted binary. Phrases stay specific so ordinary product copy such
-// as "your notes will be available offline" is not flagged.
-var futureFunctionalityPhrases = []string{
-	"coming soon",
-	"coming very soon",
-	"will be available soon",
-	"will soon be available",
-	"in the next release",
-	"in the next update",
-	"in a future release",
-	"in a future update",
-	"in a future version",
-	"in future updates",
-	"not yet available",
-	"not available yet",
-	"under development",
-	"currently in development",
-	"still in development",
-	"stay tuned",
-}
-
-// testWordPhrases lists wording that presents the submission as a test, beta, or
-// demo build. Bare "beta" is deliberately absent: it is legitimate in release
-// notes and product names, so only qualified phrases are reported.
-var testWordPhrases = []string{
-	"beta test",
-	"beta tests",
-	"beta tester",
-	"beta testers",
-	"beta testing",
-	"beta version",
-	"beta build",
-	"beta release",
-	"just a test",
-	"this is a test",
-	"for testing purposes",
-	"testing purposes",
-	"testing only",
-	"internal testing",
-	"test version",
-	"test build",
-	"demo version",
-	"demo build",
-}
-
-// contentRule describes one offline content-lint rule.
-type contentRule struct {
-	id          string
-	patterns    []*regexp.Regexp
-	allow       *regexp.Regexp
-	message     string
-	remediation string
-}
-
-var contentRules = []contentRule{
-	{
-		id:          "content.other_platforms",
-		patterns:    []*regexp.Regexp{contentPhrasePattern(otherPlatformPhrases)},
-		allow:       contentPhrasePattern(otherPlatformAllowlist),
-		message:     "%s references another platform (%s)",
-		remediation: "Remove references to other platforms and their stores; naming a cross-platform service such as \"Google Drive\" is fine",
-	},
-	{
-		id:          "content.placeholder_text",
-		patterns:    []*regexp.Regexp{contentPhrasePattern(placeholderPhrases), contentMarkerPattern(placeholderMarkers)},
-		message:     "%s contains placeholder text (%s)",
-		remediation: "Replace the placeholder copy with the final listing text",
-	},
-	{
-		id:          "content.future_functionality",
-		patterns:    []*regexp.Regexp{contentPhrasePattern(futureFunctionalityPhrases)},
-		message:     "%s promises functionality that is not in this build (%s)",
-		remediation: "Describe only what the submitted build already does; App Store review rejects metadata that advertises unreleased features",
-	},
-	{
-		id:          "content.test_words",
-		patterns:    []*regexp.Regexp{contentPhrasePattern(testWordPhrases)},
-		message:     "%s describes the app as a test or demo build (%s)",
-		remediation: "Remove test, beta, and demo framing from App Store metadata; keep that wording in TestFlight test information instead",
-	},
-}
-
-// contentField is one localized metadata value to lint.
 type contentField struct {
 	field        string
 	label        string
@@ -207,6 +30,11 @@ type contentField struct {
 	locale       string
 	resourceType string
 	resourceID   string
+}
+
+type contentMatch struct {
+	start int
+	end   int
 }
 
 func contentChecks(versionLocs []VersionLocalization, appInfoLocs []AppInfoLocalization) []CheckResult {
@@ -237,22 +65,20 @@ func contentChecks(versionLocs []VersionLocalization, appInfoLocs []AppInfoLocal
 		if strings.TrimSpace(field.value) == "" {
 			continue
 		}
-		for _, rule := range contentRules {
-			matches := rule.findMatches(field.value)
-			if len(matches) == 0 {
-				continue
-			}
-			checks = append(checks, CheckResult{
-				ID:           rule.id,
-				Severity:     SeverityWarning,
-				Locale:       field.locale,
-				Field:        field.field,
-				ResourceType: field.resourceType,
-				ResourceID:   field.resourceID,
-				Message:      fmt.Sprintf(rule.message, field.label, quoteContentMatches(matches)),
-				Remediation:  rule.remediation,
-			})
+		matches := findContentMatches(field.value, placeholderPatterns)
+		if len(matches) == 0 {
+			continue
 		}
+		checks = append(checks, CheckResult{
+			ID:           "content.placeholder_text",
+			Severity:     SeverityWarning,
+			Locale:       field.locale,
+			Field:        field.field,
+			ResourceType: field.resourceType,
+			ResourceID:   field.resourceID,
+			Message:      fmt.Sprintf("%s contains placeholder text (%s)", field.label, quoteContentMatches(matches)),
+			Remediation:  "Replace the placeholder copy with the final listing text",
+		})
 	}
 
 	return checks
@@ -265,42 +91,33 @@ func contentFieldWith(base contentField, field string, label string, value strin
 	return base
 }
 
-// findMatches returns the distinct phrases the rule matched, in the order they
-// appear, with allowlisted occurrences removed.
-func (rule contentRule) findMatches(value string) []string {
-	var allowed [][]int
-	if rule.allow != nil {
-		allowed = rule.allow.FindAllStringIndex(value, -1)
+// findContentMatches returns distinct normalized phrases in source order.
+func findContentMatches(value string, patterns []*regexp.Regexp) []string {
+	ranges := make([]contentMatch, 0, 2)
+	for _, pattern := range patterns {
+		for _, location := range pattern.FindAllStringIndex(value, -1) {
+			ranges = append(ranges, contentMatch{start: location[0], end: location[1]})
+		}
 	}
+	sort.SliceStable(ranges, func(i, j int) bool {
+		if ranges[i].start != ranges[j].start {
+			return ranges[i].start < ranges[j].start
+		}
+		return ranges[i].end > ranges[j].end
+	})
 
 	seen := make(map[string]struct{})
-	matches := make([]string, 0, 2)
-	for _, pattern := range rule.patterns {
-		for _, loc := range pattern.FindAllStringIndex(value, -1) {
-			if contentRangeAllowed(loc, allowed) {
-				continue
-			}
-			phrase := strings.Join(strings.Fields(value[loc[0]:loc[1]]), " ")
-			key := strings.ToLower(phrase)
-			if _, duplicate := seen[key]; duplicate {
-				continue
-			}
-			seen[key] = struct{}{}
-			matches = append(matches, phrase)
+	matches := make([]string, 0, len(ranges))
+	for _, location := range ranges {
+		phrase := strings.Join(strings.Fields(value[location.start:location.end]), " ")
+		key := strings.ToLower(phrase)
+		if _, duplicate := seen[key]; duplicate {
+			continue
 		}
+		seen[key] = struct{}{}
+		matches = append(matches, phrase)
 	}
-
 	return matches
-}
-
-// contentRangeAllowed reports whether a match overlaps an allowlisted phrase.
-func contentRangeAllowed(match []int, allowed [][]int) bool {
-	for _, allow := range allowed {
-		if match[0] < allow[1] && allow[0] < match[1] {
-			return true
-		}
-	}
-	return false
 }
 
 func quoteContentMatches(matches []string) string {
@@ -311,23 +128,16 @@ func quoteContentMatches(matches []string) string {
 	return strings.Join(quoted, ", ")
 }
 
-// contentPhrasePattern builds a case-insensitive, word-boundary pattern for the
-// given phrases. Words inside a phrase may be separated by any run of
-// whitespace, and longer phrases are tried first so the most specific match is
-// the one reported.
 func contentPhrasePattern(phrases []string) *regexp.Regexp {
 	return regexp.MustCompile(`(?i)\b(?:` + contentAlternation(phrases) + `)\b`)
 }
 
-// contentMarkerPattern builds a case-sensitive, word-boundary pattern, used for
-// acronym markers whose lowercase spelling is ordinary vocabulary.
 func contentMarkerPattern(markers []string) *regexp.Regexp {
 	return regexp.MustCompile(`\b(?:` + contentAlternation(markers) + `)\b`)
 }
 
 func contentAlternation(phrases []string) string {
-	ordered := make([]string, len(phrases))
-	copy(ordered, phrases)
+	ordered := append([]string(nil), phrases...)
 	sort.SliceStable(ordered, func(i, j int) bool {
 		return len(ordered[i]) > len(ordered[j])
 	})
@@ -339,8 +149,7 @@ func contentAlternation(phrases []string) string {
 		for _, word := range words {
 			escaped = append(escaped, regexp.QuoteMeta(word))
 		}
-		parts = append(parts, strings.Join(escaped, `[\s\p{Zs}]+`))
+		parts = append(parts, strings.Join(escaped, `[\s\v\x{0085}\p{Z}]+`))
 	}
-
 	return strings.Join(parts, "|")
 }

--- a/internal/validation/content.go
+++ b/internal/validation/content.go
@@ -1,0 +1,346 @@
+package validation
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Content lint rules flag localized metadata wording that App Store review
+// commonly rejects: references to other platforms, leftover placeholder copy,
+// promises of unreleased functionality, and test or demo framing.
+//
+// Every rule is offline (no network lookups) and advisory: matches are reported
+// as warnings so they never block a submission on their own. Matching is
+// word-boundary based rather than substring based, so "androids", "freedom",
+// and "testament" never trigger a platform, placeholder, or test warning.
+
+// otherPlatformPhrases lists competing platforms, stores, and device families.
+// Only phrases that are unambiguous on their own belong here: bare "windows",
+// "galaxy", "kindle", and "play" are ordinary product vocabulary, so they are
+// matched only as part of a longer platform phrase.
+var otherPlatformPhrases = []string{
+	"android",
+	"google",
+	"google play",
+	"play store",
+	"blackberry",
+	"windows phone",
+	"windows mobile",
+	"samsung galaxy",
+	"galaxy store",
+	"amazon appstore",
+	"amazon app store",
+	"kindle fire",
+	"huawei",
+	"appgallery",
+	"symbian",
+	"tizen",
+}
+
+// otherPlatformAllowlist covers service names an App Store listing may name
+// legitimately. An allowlist hit suppresses any platform match it overlaps, so
+// "Google Drive" stays silent while "Google Play" is still reported.
+var otherPlatformAllowlist = []string{
+	"google account",
+	"google ads",
+	"google analytics",
+	"google api",
+	"google apis",
+	"google assistant",
+	"google authenticator",
+	"google books",
+	"google calendar",
+	"google chrome",
+	"google classroom",
+	"google cloud",
+	"google contacts",
+	"google docs",
+	"google drive",
+	"google earth",
+	"google firebase",
+	"google fit",
+	"google fonts",
+	"google forms",
+	"google gemini",
+	"google home",
+	"google keep",
+	"google lens",
+	"google login",
+	"google maps",
+	"google meet",
+	"google news",
+	"google oauth",
+	"google one",
+	"google pay",
+	"google photos",
+	"google scholar",
+	"google search console",
+	"google sheets",
+	"google sign in",
+	"google sign-in",
+	"google slides",
+	"google tasks",
+	"google translate",
+	"google voice",
+	"google wallet",
+	"google workspace",
+	"continue with google",
+	"log in with google",
+	"login with google",
+	"sign in with google",
+	"sign up with google",
+}
+
+// placeholderPhrases lists template copy that should never reach the store.
+var placeholderPhrases = []string{
+	"lorem ipsum",
+	"placeholder",
+	"placeholder text",
+	"text here",
+	"your text here",
+	"description here",
+	"enter description here",
+	"insert description",
+	"sample text",
+	"dummy text",
+}
+
+// placeholderMarkers are matched case-sensitively on purpose. As placeholders
+// these acronyms are always written in caps, while lowercase "todo" is ordinary
+// vocabulary for to-do apps ("manage your todo list").
+var placeholderMarkers = []string{
+	"TODO",
+	"TBD",
+	"FIXME",
+}
+
+// futureFunctionalityPhrases lists promises of functionality that does not ship
+// with the submitted binary. Phrases stay specific so ordinary product copy such
+// as "your notes will be available offline" is not flagged.
+var futureFunctionalityPhrases = []string{
+	"coming soon",
+	"coming very soon",
+	"will be available soon",
+	"will soon be available",
+	"in the next release",
+	"in the next update",
+	"in a future release",
+	"in a future update",
+	"in a future version",
+	"in future updates",
+	"not yet available",
+	"not available yet",
+	"under development",
+	"currently in development",
+	"still in development",
+	"stay tuned",
+}
+
+// testWordPhrases lists wording that presents the submission as a test, beta, or
+// demo build. Bare "beta" is deliberately absent: it is legitimate in release
+// notes and product names, so only qualified phrases are reported.
+var testWordPhrases = []string{
+	"beta test",
+	"beta tests",
+	"beta tester",
+	"beta testers",
+	"beta testing",
+	"beta version",
+	"beta build",
+	"beta release",
+	"just a test",
+	"this is a test",
+	"for testing purposes",
+	"testing purposes",
+	"testing only",
+	"internal testing",
+	"test version",
+	"test build",
+	"demo version",
+	"demo build",
+}
+
+// contentRule describes one offline content-lint rule.
+type contentRule struct {
+	id          string
+	patterns    []*regexp.Regexp
+	allow       *regexp.Regexp
+	message     string
+	remediation string
+}
+
+var contentRules = []contentRule{
+	{
+		id:          "content.other_platforms",
+		patterns:    []*regexp.Regexp{contentPhrasePattern(otherPlatformPhrases)},
+		allow:       contentPhrasePattern(otherPlatformAllowlist),
+		message:     "%s references another platform (%s)",
+		remediation: "Remove references to other platforms and their stores; naming a cross-platform service such as \"Google Drive\" is fine",
+	},
+	{
+		id:          "content.placeholder_text",
+		patterns:    []*regexp.Regexp{contentPhrasePattern(placeholderPhrases), contentMarkerPattern(placeholderMarkers)},
+		message:     "%s contains placeholder text (%s)",
+		remediation: "Replace the placeholder copy with the final listing text",
+	},
+	{
+		id:          "content.future_functionality",
+		patterns:    []*regexp.Regexp{contentPhrasePattern(futureFunctionalityPhrases)},
+		message:     "%s promises functionality that is not in this build (%s)",
+		remediation: "Describe only what the submitted build already does; App Store review rejects metadata that advertises unreleased features",
+	},
+	{
+		id:          "content.test_words",
+		patterns:    []*regexp.Regexp{contentPhrasePattern(testWordPhrases)},
+		message:     "%s describes the app as a test or demo build (%s)",
+		remediation: "Remove test, beta, and demo framing from App Store metadata; keep that wording in TestFlight test information instead",
+	},
+}
+
+// contentField is one localized metadata value to lint.
+type contentField struct {
+	field        string
+	label        string
+	value        string
+	locale       string
+	resourceType string
+	resourceID   string
+}
+
+func contentChecks(versionLocs []VersionLocalization, appInfoLocs []AppInfoLocalization) []CheckResult {
+	fields := make([]contentField, 0, len(versionLocs)*4+len(appInfoLocs)*2)
+
+	for _, loc := range versionLocs {
+		base := contentField{locale: loc.Locale, resourceType: "appStoreVersionLocalization", resourceID: loc.ID}
+		fields = append(
+			fields,
+			contentFieldWith(base, "description", "description", loc.Description),
+			contentFieldWith(base, "keywords", "keywords", loc.Keywords),
+			contentFieldWith(base, "whatsNew", "what's new", loc.WhatsNew),
+			contentFieldWith(base, "promotionalText", "promotional text", loc.PromotionalText),
+		)
+	}
+
+	for _, loc := range appInfoLocs {
+		base := contentField{locale: loc.Locale, resourceType: "appInfoLocalization", resourceID: loc.ID}
+		fields = append(
+			fields,
+			contentFieldWith(base, "name", "name", loc.Name),
+			contentFieldWith(base, "subtitle", "subtitle", loc.Subtitle),
+		)
+	}
+
+	var checks []CheckResult
+	for _, field := range fields {
+		if strings.TrimSpace(field.value) == "" {
+			continue
+		}
+		for _, rule := range contentRules {
+			matches := rule.findMatches(field.value)
+			if len(matches) == 0 {
+				continue
+			}
+			checks = append(checks, CheckResult{
+				ID:           rule.id,
+				Severity:     SeverityWarning,
+				Locale:       field.locale,
+				Field:        field.field,
+				ResourceType: field.resourceType,
+				ResourceID:   field.resourceID,
+				Message:      fmt.Sprintf(rule.message, field.label, quoteContentMatches(matches)),
+				Remediation:  rule.remediation,
+			})
+		}
+	}
+
+	return checks
+}
+
+func contentFieldWith(base contentField, field string, label string, value string) contentField {
+	base.field = field
+	base.label = label
+	base.value = value
+	return base
+}
+
+// findMatches returns the distinct phrases the rule matched, in the order they
+// appear, with allowlisted occurrences removed.
+func (rule contentRule) findMatches(value string) []string {
+	var allowed [][]int
+	if rule.allow != nil {
+		allowed = rule.allow.FindAllStringIndex(value, -1)
+	}
+
+	seen := make(map[string]struct{})
+	matches := make([]string, 0, 2)
+	for _, pattern := range rule.patterns {
+		for _, loc := range pattern.FindAllStringIndex(value, -1) {
+			if contentRangeAllowed(loc, allowed) {
+				continue
+			}
+			phrase := strings.Join(strings.Fields(value[loc[0]:loc[1]]), " ")
+			key := strings.ToLower(phrase)
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			matches = append(matches, phrase)
+		}
+	}
+
+	return matches
+}
+
+// contentRangeAllowed reports whether a match overlaps an allowlisted phrase.
+func contentRangeAllowed(match []int, allowed [][]int) bool {
+	for _, allow := range allowed {
+		if match[0] < allow[1] && allow[0] < match[1] {
+			return true
+		}
+	}
+	return false
+}
+
+func quoteContentMatches(matches []string) string {
+	quoted := make([]string, 0, len(matches))
+	for _, match := range matches {
+		quoted = append(quoted, fmt.Sprintf("%q", match))
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// contentPhrasePattern builds a case-insensitive, word-boundary pattern for the
+// given phrases. Words inside a phrase may be separated by any run of
+// whitespace, and longer phrases are tried first so the most specific match is
+// the one reported.
+func contentPhrasePattern(phrases []string) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)\b(?:` + contentAlternation(phrases) + `)\b`)
+}
+
+// contentMarkerPattern builds a case-sensitive, word-boundary pattern, used for
+// acronym markers whose lowercase spelling is ordinary vocabulary.
+func contentMarkerPattern(markers []string) *regexp.Regexp {
+	return regexp.MustCompile(`\b(?:` + contentAlternation(markers) + `)\b`)
+}
+
+func contentAlternation(phrases []string) string {
+	ordered := make([]string, len(phrases))
+	copy(ordered, phrases)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return len(ordered[i]) > len(ordered[j])
+	})
+
+	parts := make([]string, 0, len(ordered))
+	for _, phrase := range ordered {
+		words := strings.Fields(phrase)
+		escaped := make([]string, 0, len(words))
+		for _, word := range words {
+			escaped = append(escaped, regexp.QuoteMeta(word))
+		}
+		parts = append(parts, strings.Join(escaped, `[\s\p{Zs}]+`))
+	}
+
+	return strings.Join(parts, "|")
+}

--- a/internal/validation/content_test.go
+++ b/internal/validation/content_test.go
@@ -1,0 +1,438 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContentChecksFlagsRejectionPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		wantID      string
+		wantQuoted  string
+	}{
+		{
+			name:        "other platform android",
+			description: "Also available on Android devices.",
+			wantID:      "content.other_platforms",
+			wantQuoted:  "Android",
+		},
+		{
+			name:        "other platform google play",
+			description: "Download it from Google Play today.",
+			wantID:      "content.other_platforms",
+			wantQuoted:  "Google Play",
+		},
+		{
+			name:        "other platform play store",
+			description: "Rated five stars on the Play Store.",
+			wantID:      "content.other_platforms",
+			wantQuoted:  "Play Store",
+		},
+		{
+			name:        "other platform blackberry",
+			description: "A BlackBerry version is out now.",
+			wantID:      "content.other_platforms",
+			wantQuoted:  "BlackBerry",
+		},
+		{
+			name:        "other platform windows phone",
+			description: "Ported from Windows Phone.",
+			wantID:      "content.other_platforms",
+			wantQuoted:  "Windows Phone",
+		},
+		{
+			name:        "other platform samsung galaxy",
+			description: "Optimized for Samsung Galaxy hardware.",
+			wantID:      "content.other_platforms",
+			wantQuoted:  "Samsung Galaxy",
+		},
+		{
+			name:        "placeholder lorem ipsum",
+			description: "Lorem ipsum dolor sit amet.",
+			wantID:      "content.placeholder_text",
+			wantQuoted:  "Lorem ipsum",
+		},
+		{
+			name:        "placeholder word",
+			description: "This is placeholder copy for the listing.",
+			wantID:      "content.placeholder_text",
+			wantQuoted:  "placeholder",
+		},
+		{
+			name:        "placeholder text here",
+			description: "Your text here.",
+			wantID:      "content.placeholder_text",
+			wantQuoted:  "Your text here",
+		},
+		{
+			name:        "placeholder todo marker",
+			description: "TODO: write the real description.",
+			wantID:      "content.placeholder_text",
+			wantQuoted:  "TODO",
+		},
+		{
+			name:        "placeholder tbd marker",
+			description: "Pricing details TBD.",
+			wantID:      "content.placeholder_text",
+			wantQuoted:  "TBD",
+		},
+		{
+			name:        "future coming soon",
+			description: "Cloud sync coming soon.",
+			wantID:      "content.future_functionality",
+			wantQuoted:  "coming soon",
+		},
+		{
+			name:        "future next release",
+			description: "Widgets arrive in the next release.",
+			wantID:      "content.future_functionality",
+			wantQuoted:  "in the next release",
+		},
+		{
+			name:        "future will be available",
+			description: "Offline mode will be available soon.",
+			wantID:      "content.future_functionality",
+			wantQuoted:  "will be available soon",
+		},
+		{
+			name:        "future in a future update",
+			description: "Themes land in a future update.",
+			wantID:      "content.future_functionality",
+			wantQuoted:  "in a future update",
+		},
+		{
+			name:        "test words beta test",
+			description: "Join the beta test group.",
+			wantID:      "content.test_words",
+			wantQuoted:  "beta test",
+		},
+		{
+			name:        "test words just a test",
+			description: "This is just a test listing.",
+			wantID:      "content.test_words",
+			wantQuoted:  "just a test",
+		},
+		{
+			name:        "test words for testing purposes",
+			description: "Published for testing purposes.",
+			wantID:      "content.test_words",
+			wantQuoted:  "for testing purposes",
+		},
+		{
+			name:        "test words demo version",
+			description: "A demo version of our upcoming product.",
+			wantID:      "content.test_words",
+			wantQuoted:  "demo version",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checks := contentChecks(
+				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
+				nil,
+			)
+
+			if len(checks) != 1 {
+				t.Fatalf("expected exactly one check for %q, got %+v", test.description, checks)
+			}
+
+			check := checks[0]
+			if check.ID != test.wantID {
+				t.Fatalf("expected check ID %q, got %q", test.wantID, check.ID)
+			}
+			if check.Severity != SeverityWarning {
+				t.Fatalf("expected warning severity, got %q", check.Severity)
+			}
+			if !strings.Contains(check.Message, test.wantQuoted) {
+				t.Fatalf("expected message to quote %q, got %q", test.wantQuoted, check.Message)
+			}
+			if check.Remediation == "" {
+				t.Fatal("expected remediation guidance")
+			}
+		})
+	}
+}
+
+func TestContentChecksIgnoresLegitimateMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+	}{
+		{
+			name:        "plural of platform name",
+			description: "Androids and other robots are not discussed here.",
+		},
+		{
+			name:        "words containing test",
+			description: "Freedom to write your testament, review the latest contest, and protest.",
+		},
+		{
+			name:        "test prep vocabulary",
+			description: "Practice tests and test prep for the entrance exam.",
+		},
+		{
+			name:        "beta alone is allowed",
+			description: "Join our beta program and share feedback with the team.",
+		},
+		{
+			name:        "non adjacent platform words",
+			description: "Play music from your library and browse the store.",
+		},
+		{
+			name:        "galaxy without samsung",
+			description: "Track a galaxy of habits through a window of time.",
+		},
+		{
+			name:        "kindle without fire",
+			description: "Kindle your motivation and fire up your goals.",
+		},
+		{
+			name:        "windows without phone",
+			description: "Windows and doors estimator for contractors.",
+		},
+		{
+			name:        "lowercase todo vocabulary",
+			description: "Manage your todo list and keep to-do items in one place.",
+		},
+		{
+			name:        "place is not placeholder",
+			description: "Find your place in line and hold it.",
+		},
+		{
+			name:        "citizen is not a platform",
+			description: "A citizen registry for civic volunteers.",
+		},
+		{
+			name:        "soon without coming",
+			description: "Soon becomes now: log habits the moment they happen.",
+		},
+		{
+			name:        "development without under",
+			description: "Development tools for engineers who ship.",
+		},
+		{
+			name:        "free trial is legitimate",
+			description: "Start a free trial and subscribe when you are ready.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checks := contentChecks(
+				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
+				nil,
+			)
+
+			if len(checks) != 0 {
+				t.Fatalf("expected no content checks for %q, got %+v", test.description, checks)
+			}
+		})
+	}
+}
+
+func TestContentChecksAllowlistWinsOverPlatformMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+	}{
+		{name: "google analytics", description: "Usage insights powered by Google Analytics."},
+		{name: "google drive", description: "Back up your notes to Google Drive."},
+		{name: "google maps", description: "Directions come from Google Maps."},
+		{name: "google sign-in", description: "Google Sign-In keeps your account portable."},
+		{name: "sign in with google", description: "Sign in with Google to sync instantly."},
+		{name: "google calendar", description: "Two-way sync with Google Calendar."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checks := contentChecks(
+				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
+				nil,
+			)
+
+			if len(checks) != 0 {
+				t.Fatalf("expected allowlisted service name to be ignored for %q, got %+v", test.description, checks)
+			}
+		})
+	}
+}
+
+func TestContentChecksAllowlistOnlySuppressesOverlappingMatch(t *testing.T) {
+	checks := contentChecks(
+		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "Sync with Google Drive, also on Android."}},
+		nil,
+	)
+
+	if len(checks) != 1 {
+		t.Fatalf("expected one check, got %+v", checks)
+	}
+	if !strings.Contains(checks[0].Message, "Android") {
+		t.Fatalf("expected the platform reference to be reported, got %q", checks[0].Message)
+	}
+	if strings.Contains(checks[0].Message, "Google Drive") {
+		t.Fatalf("expected the allowlisted service to be omitted, got %q", checks[0].Message)
+	}
+}
+
+func TestContentChecksMatchPhrasesAcrossWhitespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+	}{
+		{name: "double space", description: "Sharing is coming  soon."},
+		{name: "newline", description: "Sharing is coming\nsoon."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checks := contentChecks(
+				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
+				nil,
+			)
+
+			if len(checks) != 1 || checks[0].ID != "content.future_functionality" {
+				t.Fatalf("expected one future functionality check, got %+v", checks)
+			}
+			if !strings.Contains(checks[0].Message, "coming soon") {
+				t.Fatalf("expected normalized phrase in message, got %q", checks[0].Message)
+			}
+		})
+	}
+}
+
+func TestContentChecksCoverLocalizedFields(t *testing.T) {
+	versionLocs := []VersionLocalization{{
+		ID:              "ver-loc-1",
+		Locale:          "en-US",
+		Description:     "Also on Android.",
+		Keywords:        "android,todo,habits",
+		WhatsNew:        "Dark mode coming soon.",
+		PromotionalText: "TODO",
+	}}
+	appInfoLocs := []AppInfoLocalization{{
+		ID:       "info-loc-1",
+		Locale:   "en-US",
+		Name:     "Beta Test Timer",
+		Subtitle: "Lorem ipsum tracker",
+	}}
+
+	checks := contentChecks(versionLocs, appInfoLocs)
+
+	wanted := []struct {
+		id           string
+		field        string
+		resourceType string
+		resourceID   string
+	}{
+		{id: "content.other_platforms", field: "description", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
+		{id: "content.other_platforms", field: "keywords", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
+		{id: "content.future_functionality", field: "whatsNew", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
+		{id: "content.placeholder_text", field: "promotionalText", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
+		{id: "content.test_words", field: "name", resourceType: "appInfoLocalization", resourceID: "info-loc-1"},
+		{id: "content.placeholder_text", field: "subtitle", resourceType: "appInfoLocalization", resourceID: "info-loc-1"},
+	}
+
+	for _, want := range wanted {
+		found := false
+		for _, check := range checks {
+			if check.ID != want.id || check.Field != want.field {
+				continue
+			}
+			found = true
+			if check.Locale != "en-US" {
+				t.Fatalf("expected locale en-US for %s/%s, got %q", want.id, want.field, check.Locale)
+			}
+			if check.ResourceType != want.resourceType {
+				t.Fatalf("expected resource type %q for %s/%s, got %q", want.resourceType, want.id, want.field, check.ResourceType)
+			}
+			if check.ResourceID != want.resourceID {
+				t.Fatalf("expected resource ID %q for %s/%s, got %q", want.resourceID, want.id, want.field, check.ResourceID)
+			}
+		}
+		if !found {
+			t.Fatalf("expected %s on field %s, got %+v", want.id, want.field, checks)
+		}
+	}
+}
+
+func TestContentChecksReportOneCheckPerRuleAndField(t *testing.T) {
+	checks := contentChecks(
+		[]VersionLocalization{{
+			ID:          "loc-1",
+			Locale:      "en-US",
+			Description: "Android first, android second, and Google Play too.",
+		}},
+		nil,
+	)
+
+	if len(checks) != 1 {
+		t.Fatalf("expected repeated matches to collapse into one check, got %+v", checks)
+	}
+	if strings.Count(checks[0].Message, "ndroid") != 1 {
+		t.Fatalf("expected duplicate matches to be reported once, got %q", checks[0].Message)
+	}
+	if !strings.Contains(checks[0].Message, "Google Play") {
+		t.Fatalf("expected distinct matches to be listed, got %q", checks[0].Message)
+	}
+}
+
+func TestContentChecksSkipEmptyFields(t *testing.T) {
+	checks := contentChecks([]VersionLocalization{{ID: "loc-1", Locale: "en-US"}}, []AppInfoLocalization{{ID: "info-1", Locale: "en-US"}})
+
+	if len(checks) != 0 {
+		t.Fatalf("expected no checks for empty metadata, got %+v", checks)
+	}
+}
+
+func TestValidate_IncludesContentChecksWithoutBlocking(t *testing.T) {
+	report := Validate(Input{
+		AppID:         "app-1",
+		VersionID:     "ver-1",
+		VersionString: "2.0",
+		VersionState:  "PREPARE_FOR_SUBMISSION",
+		PrimaryLocale: "en-US",
+		Copyright:     "2026 Co",
+		VersionLocalizations: []VersionLocalization{{
+			ID:          "loc-1",
+			Locale:      "en-US",
+			Description: "Also available on Android. Sync coming soon.",
+			Keywords:    "habits",
+			WhatsNew:    "Bug fixes",
+			SupportURL:  "https://example.com",
+		}},
+		AppInfoLocalizations: []AppInfoLocalization{{
+			ID:               "info-1",
+			Locale:           "en-US",
+			Name:             "Habit Timer",
+			Subtitle:         "Track habits",
+			PrivacyPolicyURL: "https://example.com/privacy",
+		}},
+		PrimaryCategoryID: "cat-1",
+	}, false)
+
+	if !hasCheckID(report.Checks, "content.other_platforms") {
+		t.Fatalf("expected content.other_platforms in report, got %+v", report.Checks)
+	}
+	if !hasCheckID(report.Checks, "content.future_functionality") {
+		t.Fatalf("expected content.future_functionality in report, got %+v", report.Checks)
+	}
+	if report.Summary.Blocking != report.Summary.Errors {
+		t.Fatalf("expected content warnings to stay non-blocking, got summary %+v", report.Summary)
+	}
+
+	foundRemediationStep := false
+	for _, step := range report.Remediation.Steps {
+		if step.CheckID == "content.other_platforms" {
+			foundRemediationStep = true
+			if step.Blocking {
+				t.Fatalf("expected non-blocking remediation step, got %+v", step)
+			}
+		}
+	}
+	if !foundRemediationStep {
+		t.Fatal("expected content check to appear in the remediation plan")
+	}
+}

--- a/internal/validation/content_test.go
+++ b/internal/validation/content_test.go
@@ -5,400 +5,167 @@ import (
 	"testing"
 )
 
-func TestContentChecksFlagsRejectionPatterns(t *testing.T) {
+func TestContentChecksFlagUnmistakablePlaceholderCopy(t *testing.T) {
 	tests := []struct {
-		name        string
-		description string
-		wantID      string
-		wantQuoted  string
+		name       string
+		value      string
+		wantQuoted string
 	}{
-		{
-			name:        "other platform android",
-			description: "Also available on Android devices.",
-			wantID:      "content.other_platforms",
-			wantQuoted:  "Android",
-		},
-		{
-			name:        "other platform google play",
-			description: "Download it from Google Play today.",
-			wantID:      "content.other_platforms",
-			wantQuoted:  "Google Play",
-		},
-		{
-			name:        "other platform play store",
-			description: "Rated five stars on the Play Store.",
-			wantID:      "content.other_platforms",
-			wantQuoted:  "Play Store",
-		},
-		{
-			name:        "other platform blackberry",
-			description: "A BlackBerry version is out now.",
-			wantID:      "content.other_platforms",
-			wantQuoted:  "BlackBerry",
-		},
-		{
-			name:        "other platform windows phone",
-			description: "Ported from Windows Phone.",
-			wantID:      "content.other_platforms",
-			wantQuoted:  "Windows Phone",
-		},
-		{
-			name:        "other platform samsung galaxy",
-			description: "Optimized for Samsung Galaxy hardware.",
-			wantID:      "content.other_platforms",
-			wantQuoted:  "Samsung Galaxy",
-		},
-		{
-			name:        "placeholder lorem ipsum",
-			description: "Lorem ipsum dolor sit amet.",
-			wantID:      "content.placeholder_text",
-			wantQuoted:  "Lorem ipsum",
-		},
-		{
-			name:        "placeholder word",
-			description: "This is placeholder copy for the listing.",
-			wantID:      "content.placeholder_text",
-			wantQuoted:  "placeholder",
-		},
-		{
-			name:        "placeholder text here",
-			description: "Your text here.",
-			wantID:      "content.placeholder_text",
-			wantQuoted:  "Your text here",
-		},
-		{
-			name:        "placeholder todo marker",
-			description: "TODO: write the real description.",
-			wantID:      "content.placeholder_text",
-			wantQuoted:  "TODO",
-		},
-		{
-			name:        "placeholder tbd marker",
-			description: "Pricing details TBD.",
-			wantID:      "content.placeholder_text",
-			wantQuoted:  "TBD",
-		},
-		{
-			name:        "future coming soon",
-			description: "Cloud sync coming soon.",
-			wantID:      "content.future_functionality",
-			wantQuoted:  "coming soon",
-		},
-		{
-			name:        "future next release",
-			description: "Widgets arrive in the next release.",
-			wantID:      "content.future_functionality",
-			wantQuoted:  "in the next release",
-		},
-		{
-			name:        "future will be available",
-			description: "Offline mode will be available soon.",
-			wantID:      "content.future_functionality",
-			wantQuoted:  "will be available soon",
-		},
-		{
-			name:        "future in a future update",
-			description: "Themes land in a future update.",
-			wantID:      "content.future_functionality",
-			wantQuoted:  "in a future update",
-		},
-		{
-			name:        "test words beta test",
-			description: "Join the beta test group.",
-			wantID:      "content.test_words",
-			wantQuoted:  "beta test",
-		},
-		{
-			name:        "test words just a test",
-			description: "This is just a test listing.",
-			wantID:      "content.test_words",
-			wantQuoted:  "just a test",
-		},
-		{
-			name:        "test words for testing purposes",
-			description: "Published for testing purposes.",
-			wantID:      "content.test_words",
-			wantQuoted:  "for testing purposes",
-		},
-		{
-			name:        "test words demo version",
-			description: "A demo version of our upcoming product.",
-			wantID:      "content.test_words",
-			wantQuoted:  "demo version",
-		},
+		{name: "lorem ipsum", value: "Lorem ipsum dolor sit amet.", wantQuoted: "Lorem ipsum"},
+		{name: "todo marker", value: "TODO: write the final description.", wantQuoted: "TODO"},
+		{name: "tbd marker", value: "Pricing details TBD.", wantQuoted: "TBD"},
+		{name: "fixme marker", value: "FIXME before submission.", wantQuoted: "FIXME"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			checks := contentChecks(
-				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
+				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.value}},
 				nil,
 			)
-
 			if len(checks) != 1 {
-				t.Fatalf("expected exactly one check for %q, got %+v", test.description, checks)
+				t.Fatalf("checks = %+v, want one placeholder warning", checks)
 			}
-
 			check := checks[0]
-			if check.ID != test.wantID {
-				t.Fatalf("expected check ID %q, got %q", test.wantID, check.ID)
+			if check.ID != "content.placeholder_text" || check.Severity != SeverityWarning {
+				t.Fatalf("check = %+v, want content.placeholder_text warning", check)
 			}
-			if check.Severity != SeverityWarning {
-				t.Fatalf("expected warning severity, got %q", check.Severity)
-			}
-			if !strings.Contains(check.Message, test.wantQuoted) {
-				t.Fatalf("expected message to quote %q, got %q", test.wantQuoted, check.Message)
-			}
-			if check.Remediation == "" {
-				t.Fatal("expected remediation guidance")
+			if !strings.Contains(check.Message, test.wantQuoted) || check.Remediation == "" {
+				t.Fatalf("check = %+v, want quoted match and remediation", check)
 			}
 		})
 	}
 }
 
-func TestContentChecksIgnoresLegitimateMetadata(t *testing.T) {
-	tests := []struct {
-		name        string
-		description string
-	}{
-		{
-			name:        "plural of platform name",
-			description: "Androids and other robots are not discussed here.",
-		},
-		{
-			name:        "words containing test",
-			description: "Freedom to write your testament, review the latest contest, and protest.",
-		},
-		{
-			name:        "test prep vocabulary",
-			description: "Practice tests and test prep for the entrance exam.",
-		},
-		{
-			name:        "beta alone is allowed",
-			description: "Join our beta program and share feedback with the team.",
-		},
-		{
-			name:        "non adjacent platform words",
-			description: "Play music from your library and browse the store.",
-		},
-		{
-			name:        "galaxy without samsung",
-			description: "Track a galaxy of habits through a window of time.",
-		},
-		{
-			name:        "kindle without fire",
-			description: "Kindle your motivation and fire up your goals.",
-		},
-		{
-			name:        "windows without phone",
-			description: "Windows and doors estimator for contractors.",
-		},
-		{
-			name:        "lowercase todo vocabulary",
-			description: "Manage your todo list and keep to-do items in one place.",
-		},
-		{
-			name:        "place is not placeholder",
-			description: "Find your place in line and hold it.",
-		},
-		{
-			name:        "citizen is not a platform",
-			description: "A citizen registry for civic volunteers.",
-		},
-		{
-			name:        "soon without coming",
-			description: "Soon becomes now: log habits the moment they happen.",
-		},
-		{
-			name:        "development without under",
-			description: "Development tools for engineers who ship.",
-		},
-		{
-			name:        "free trial is legitimate",
-			description: "Start a free trial and subscribe when you are ready.",
-		},
+func TestContentChecksIgnoreEditoriallyAmbiguousMetadata(t *testing.T) {
+	tests := []string{
+		"Protected by Google reCAPTCHA.",
+		"New seasonal challenges are coming soon.",
+		"Beta Test Timer helps developers coordinate release checks.",
+		"Also available on Android devices.",
+		"Start a free trial and subscribe when you are ready.",
+		"Manage your todo list and keep to-do items in one place.",
+		"Find your place in line and hold it.",
+		"Generate placeholder images and dummy text samples.",
+		"Paste your text here to transform it.",
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
 			checks := contentChecks(
-				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
+				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: value}},
 				nil,
 			)
-
 			if len(checks) != 0 {
-				t.Fatalf("expected no content checks for %q, got %+v", test.description, checks)
+				t.Fatalf("checks for %q = %+v, want none", value, checks)
 			}
 		})
 	}
 }
 
-func TestContentChecksAllowlistWinsOverPlatformMatch(t *testing.T) {
-	tests := []struct {
-		name        string
-		description string
-	}{
-		{name: "google analytics", description: "Usage insights powered by Google Analytics."},
-		{name: "google drive", description: "Back up your notes to Google Drive."},
-		{name: "google maps", description: "Directions come from Google Maps."},
-		{name: "google sign-in", description: "Google Sign-In keeps your account portable."},
-		{name: "sign in with google", description: "Sign in with Google to sync instantly."},
-		{name: "google calendar", description: "Two-way sync with Google Calendar."},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			checks := contentChecks(
-				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
-				nil,
-			)
-
-			if len(checks) != 0 {
-				t.Fatalf("expected allowlisted service name to be ignored for %q, got %+v", test.description, checks)
-			}
-		})
-	}
-}
-
-func TestContentChecksAllowlistOnlySuppressesOverlappingMatch(t *testing.T) {
+func TestContentChecksPreservePlaceholderSourceOrderAcrossPatternGroups(t *testing.T) {
 	checks := contentChecks(
-		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "Sync with Google Drive, also on Android."}},
+		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "TODO before lorem ipsum and FIXME"}},
 		nil,
 	)
-
 	if len(checks) != 1 {
-		t.Fatalf("expected one check, got %+v", checks)
+		t.Fatalf("checks = %+v, want one placeholder warning", checks)
 	}
-	if !strings.Contains(checks[0].Message, "Android") {
-		t.Fatalf("expected the platform reference to be reported, got %q", checks[0].Message)
-	}
-	if strings.Contains(checks[0].Message, "Google Drive") {
-		t.Fatalf("expected the allowlisted service to be omitted, got %q", checks[0].Message)
-	}
-}
-
-func TestContentChecksMatchPhrasesAcrossWhitespace(t *testing.T) {
-	tests := []struct {
-		name        string
-		description string
-	}{
-		{name: "double space", description: "Sharing is coming  soon."},
-		{name: "newline", description: "Sharing is coming\nsoon."},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			checks := contentChecks(
-				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: test.description}},
-				nil,
-			)
-
-			if len(checks) != 1 || checks[0].ID != "content.future_functionality" {
-				t.Fatalf("expected one future functionality check, got %+v", checks)
-			}
-			if !strings.Contains(checks[0].Message, "coming soon") {
-				t.Fatalf("expected normalized phrase in message, got %q", checks[0].Message)
-			}
-		})
+	message := checks[0].Message
+	todo := strings.Index(message, `"TODO"`)
+	lorem := strings.Index(message, `"lorem ipsum"`)
+	fixme := strings.Index(message, `"FIXME"`)
+	if todo < 0 || lorem < 0 || fixme < 0 || !(todo < lorem && lorem < fixme) {
+		t.Fatalf("placeholder order = %q, want TODO, lorem ipsum, FIXME", message)
 	}
 }
 
-func TestContentChecksCoverLocalizedFields(t *testing.T) {
-	versionLocs := []VersionLocalization{{
-		ID:              "ver-loc-1",
+func TestContentChecksMatchPlaceholderAcrossWhitespaceSeparators(t *testing.T) {
+	separators := []string{"  ", "\n", "\v", "\u0085", "\u2028", "\u2029"}
+	for _, separator := range separators {
+		checks := contentChecks(
+			[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "lorem" + separator + "ipsum"}},
+			nil,
+		)
+		if len(checks) != 1 || checks[0].ID != "content.placeholder_text" {
+			t.Fatalf("separator %q checks = %+v, want placeholder warning", separator, checks)
+		}
+		if !strings.Contains(checks[0].Message, "lorem ipsum") {
+			t.Fatalf("separator %q message = %q, want normalized phrase", separator, checks[0].Message)
+		}
+	}
+}
+
+func TestContentChecksCoverEveryLocalizedTextField(t *testing.T) {
+	version := VersionLocalization{
+		ID:              "version-loc",
 		Locale:          "en-US",
-		Description:     "Also on Android.",
-		Keywords:        "android,todo,habits",
-		WhatsNew:        "Dark mode coming soon.",
-		PromotionalText: "TODO",
-	}}
-	appInfoLocs := []AppInfoLocalization{{
-		ID:       "info-loc-1",
-		Locale:   "en-US",
-		Name:     "Beta Test Timer",
-		Subtitle: "Lorem ipsum tracker",
-	}}
-
-	checks := contentChecks(versionLocs, appInfoLocs)
-
-	wanted := []struct {
-		id           string
-		field        string
-		resourceType string
-		resourceID   string
-	}{
-		{id: "content.other_platforms", field: "description", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
-		{id: "content.other_platforms", field: "keywords", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
-		{id: "content.future_functionality", field: "whatsNew", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
-		{id: "content.placeholder_text", field: "promotionalText", resourceType: "appStoreVersionLocalization", resourceID: "ver-loc-1"},
-		{id: "content.test_words", field: "name", resourceType: "appInfoLocalization", resourceID: "info-loc-1"},
-		{id: "content.placeholder_text", field: "subtitle", resourceType: "appInfoLocalization", resourceID: "info-loc-1"},
+		Description:     "TODO",
+		Keywords:        "TBD",
+		WhatsNew:        "FIXME",
+		PromotionalText: "Lorem ipsum",
 	}
+	appInfo := AppInfoLocalization{
+		ID:       "info-loc",
+		Locale:   "en-US",
+		Name:     "TODO",
+		Subtitle: "TBD",
+	}
+	checks := contentChecks([]VersionLocalization{version}, []AppInfoLocalization{appInfo})
 
-	for _, want := range wanted {
-		found := false
-		for _, check := range checks {
-			if check.ID != want.id || check.Field != want.field {
-				continue
-			}
-			found = true
-			if check.Locale != "en-US" {
-				t.Fatalf("expected locale en-US for %s/%s, got %q", want.id, want.field, check.Locale)
-			}
-			if check.ResourceType != want.resourceType {
-				t.Fatalf("expected resource type %q for %s/%s, got %q", want.resourceType, want.id, want.field, check.ResourceType)
-			}
-			if check.ResourceID != want.resourceID {
-				t.Fatalf("expected resource ID %q for %s/%s, got %q", want.resourceID, want.id, want.field, check.ResourceID)
-			}
-		}
-		if !found {
-			t.Fatalf("expected %s on field %s, got %+v", want.id, want.field, checks)
+	want := map[string]string{
+		"description":     "version-loc",
+		"keywords":        "version-loc",
+		"whatsNew":        "version-loc",
+		"promotionalText": "version-loc",
+		"name":            "info-loc",
+		"subtitle":        "info-loc",
+	}
+	if len(checks) != len(want) {
+		t.Fatalf("checks = %+v, want one per localized text field", checks)
+	}
+	for _, check := range checks {
+		if check.ResourceID != want[check.Field] || check.Locale != "en-US" {
+			t.Fatalf("check = %+v, want matching resource and locale", check)
 		}
 	}
 }
 
-func TestContentChecksReportOneCheckPerRuleAndField(t *testing.T) {
+func TestContentChecksCollapseRepeatedMatches(t *testing.T) {
 	checks := contentChecks(
-		[]VersionLocalization{{
-			ID:          "loc-1",
-			Locale:      "en-US",
-			Description: "Android first, android second, and Google Play too.",
-		}},
+		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "TODO then TODO and lorem ipsum"}},
 		nil,
 	)
-
 	if len(checks) != 1 {
-		t.Fatalf("expected repeated matches to collapse into one check, got %+v", checks)
+		t.Fatalf("checks = %+v, want one warning", checks)
 	}
-	if strings.Count(checks[0].Message, "ndroid") != 1 {
-		t.Fatalf("expected duplicate matches to be reported once, got %q", checks[0].Message)
-	}
-	if !strings.Contains(checks[0].Message, "Google Play") {
-		t.Fatalf("expected distinct matches to be listed, got %q", checks[0].Message)
+	if strings.Count(checks[0].Message, `"TODO"`) != 1 || !strings.Contains(checks[0].Message, `"lorem ipsum"`) {
+		t.Fatalf("message = %q, want distinct matches once", checks[0].Message)
 	}
 }
 
 func TestContentChecksSkipEmptyFields(t *testing.T) {
-	checks := contentChecks([]VersionLocalization{{ID: "loc-1", Locale: "en-US"}}, []AppInfoLocalization{{ID: "info-1", Locale: "en-US"}})
-
+	checks := contentChecks(
+		[]VersionLocalization{{ID: "loc-1", Locale: "en-US"}},
+		[]AppInfoLocalization{{ID: "info-1", Locale: "en-US"}},
+	)
 	if len(checks) != 0 {
-		t.Fatalf("expected no checks for empty metadata, got %+v", checks)
+		t.Fatalf("checks = %+v, want none", checks)
 	}
 }
 
-func TestValidate_IncludesContentChecksWithoutBlocking(t *testing.T) {
-	report := Validate(Input{
+func TestValidateIncludesPlaceholderWarningAndStrictModeControlsBlocking(t *testing.T) {
+	input := Input{
 		AppID:         "app-1",
-		VersionID:     "ver-1",
+		VersionID:     "version-1",
 		VersionString: "2.0",
 		VersionState:  "PREPARE_FOR_SUBMISSION",
 		PrimaryLocale: "en-US",
-		Copyright:     "2026 Co",
+		Copyright:     "2026 Example",
 		VersionLocalizations: []VersionLocalization{{
 			ID:          "loc-1",
 			Locale:      "en-US",
-			Description: "Also available on Android. Sync coming soon.",
+			Description: "TODO: write the final description.",
 			Keywords:    "habits",
 			WhatsNew:    "Bug fixes",
 			SupportURL:  "https://example.com",
@@ -410,29 +177,31 @@ func TestValidate_IncludesContentChecksWithoutBlocking(t *testing.T) {
 			Subtitle:         "Track habits",
 			PrivacyPolicyURL: "https://example.com/privacy",
 		}},
-		PrimaryCategoryID: "cat-1",
-	}, false)
-
-	if !hasCheckID(report.Checks, "content.other_platforms") {
-		t.Fatalf("expected content.other_platforms in report, got %+v", report.Checks)
+		PrimaryCategoryID: "category-1",
 	}
-	if !hasCheckID(report.Checks, "content.future_functionality") {
-		t.Fatalf("expected content.future_functionality in report, got %+v", report.Checks)
+
+	report := Validate(input, false)
+	if !hasCheckID(report.Checks, "content.placeholder_text") {
+		t.Fatalf("checks = %+v, want placeholder warning", report.Checks)
 	}
 	if report.Summary.Blocking != report.Summary.Errors {
-		t.Fatalf("expected content warnings to stay non-blocking, got summary %+v", report.Summary)
+		t.Fatalf("summary = %+v, want warning non-blocking by default", report.Summary)
 	}
-
-	foundRemediationStep := false
+	foundStep := false
 	for _, step := range report.Remediation.Steps {
-		if step.CheckID == "content.other_platforms" {
-			foundRemediationStep = true
+		if step.CheckID == "content.placeholder_text" {
+			foundStep = true
 			if step.Blocking {
-				t.Fatalf("expected non-blocking remediation step, got %+v", step)
+				t.Fatalf("step = %+v, want non-blocking remediation by default", step)
 			}
 		}
 	}
-	if !foundRemediationStep {
-		t.Fatal("expected content check to appear in the remediation plan")
+	if !foundStep {
+		t.Fatal("placeholder warning is missing from remediation plan")
+	}
+
+	strictReport := Validate(input, true)
+	if strictReport.Summary.Blocking != strictReport.Summary.Errors+strictReport.Summary.Warnings {
+		t.Fatalf("strict summary = %+v, want warnings to block", strictReport.Summary)
 	}
 }

--- a/internal/validation/content_test.go
+++ b/internal/validation/content_test.go
@@ -66,8 +66,10 @@ func TestContentChecksIgnoreEditoriallyAmbiguousMetadata(t *testing.T) {
 func TestContentChecksUseUnicodeAwarePlaceholderBoundaries(t *testing.T) {
 	for _, value := range []string{
 		"MÉTODO helps you organize research.",
+		"ME\u0301TODO helps you organize research.",
 		"TODOアプリ keeps tasks in sync.",
 		"éLorem ipsum is a product name.",
+		"e\u0301Lorem ipsum is a product name.",
 	} {
 		t.Run(value, func(t *testing.T) {
 			checks := contentChecks(

--- a/internal/validation/content_test.go
+++ b/internal/validation/content_test.go
@@ -11,7 +11,7 @@ func TestContentChecksFlagUnmistakablePlaceholderCopy(t *testing.T) {
 		value      string
 		wantQuoted string
 	}{
-		{name: "lorem ipsum", value: "Lorem ipsum dolor sit amet.", wantQuoted: "Lorem ipsum"},
+		{name: "lorem ipsum sequence", value: "Lorem ipsum dolor sit amet.", wantQuoted: "Lorem ipsum dolor sit amet"},
 		{name: "todo marker", value: "TODO: write the final description.", wantQuoted: "TODO"},
 		{name: "tbd marker", value: "Pricing details TBD.", wantQuoted: "TBD"},
 		{name: "fixme marker", value: "FIXME before submission.", wantQuoted: "FIXME"},
@@ -63,6 +63,50 @@ func TestContentChecksIgnoreEditoriallyAmbiguousMetadata(t *testing.T) {
 	}
 }
 
+func TestContentChecksIgnoreLocalizedAndProductUsesOfPlaceholderPhrases(t *testing.T) {
+	tests := []struct {
+		name        string
+		versionLocs []VersionLocalization
+		appInfoLocs []AppInfoLocalization
+	}{
+		{
+			name:        "Spanish todo phrase",
+			versionLocs: []VersionLocalization{{ID: "loc-1", Locale: "es-ES", Description: "TODO EN UN SOLO LUGAR"}},
+		},
+		{
+			name:        "TODO product name",
+			appInfoLocs: []AppInfoLocalization{{ID: "info-1", Locale: "en-US", Name: "TODO Planner"}},
+		},
+		{
+			name:        "Lorem Ipsum product name",
+			appInfoLocs: []AppInfoLocalization{{ID: "info-1", Locale: "en-US", Name: "Lorem Ipsum Generator"}},
+		},
+		{
+			name:        "Lorem Ipsum text creation",
+			versionLocs: []VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "Create Lorem ipsum text"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checks := contentChecks(test.versionLocs, test.appInfoLocs)
+			if len(checks) != 0 {
+				t.Fatalf("checks = %+v, want no placeholder warning for legitimate copy", checks)
+			}
+		})
+	}
+}
+
+func TestContentChecksKeepExplicitLocalizedMarkerWarnings(t *testing.T) {
+	checks := contentChecks(
+		[]VersionLocalization{{ID: "loc-1", Locale: "es-ES", Description: "TODO: completar la descripción"}},
+		nil,
+	)
+	if len(checks) != 1 || checks[0].ID != "content.placeholder_text" {
+		t.Fatalf("checks = %+v, want explicit placeholder marker warning", checks)
+	}
+}
+
 func TestContentChecksUseUnicodeAwarePlaceholderBoundaries(t *testing.T) {
 	for _, value := range []string{
 		"MÉTODO helps you organize research.",
@@ -83,7 +127,7 @@ func TestContentChecksUseUnicodeAwarePlaceholderBoundaries(t *testing.T) {
 	}
 
 	checks := contentChecks(
-		[]VersionLocalization{{ID: "loc-1", Locale: "ja", Description: "（TODO）finalize the copy"}},
+		[]VersionLocalization{{ID: "loc-1", Locale: "ja", Description: "（TODO：finalize the copy）"}},
 		nil,
 	)
 	if len(checks) != 1 || checks[0].ID != "content.placeholder_text" {
@@ -93,7 +137,7 @@ func TestContentChecksUseUnicodeAwarePlaceholderBoundaries(t *testing.T) {
 
 func TestContentChecksPreservePlaceholderSourceOrderAcrossPatternGroups(t *testing.T) {
 	checks := contentChecks(
-		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "TODO before lorem ipsum and FIXME"}},
+		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "TODO: before lorem ipsum dolor sit amet and FIXME"}},
 		nil,
 	)
 	if len(checks) != 1 {
@@ -101,7 +145,7 @@ func TestContentChecksPreservePlaceholderSourceOrderAcrossPatternGroups(t *testi
 	}
 	message := checks[0].Message
 	todo := strings.Index(message, `"TODO"`)
-	lorem := strings.Index(message, `"lorem ipsum"`)
+	lorem := strings.Index(message, `"lorem ipsum dolor sit amet"`)
 	fixme := strings.Index(message, `"FIXME"`)
 	if todo < 0 || lorem < 0 || fixme < 0 || todo >= lorem || lorem >= fixme {
 		t.Fatalf("placeholder order = %q, want TODO, lorem ipsum, FIXME", message)
@@ -112,13 +156,13 @@ func TestContentChecksMatchPlaceholderAcrossWhitespaceSeparators(t *testing.T) {
 	separators := []string{"  ", "\n", "\v", "\u0085", "\u2028", "\u2029"}
 	for _, separator := range separators {
 		checks := contentChecks(
-			[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "lorem" + separator + "ipsum"}},
+			[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "lorem" + separator + "ipsum dolor sit amet"}},
 			nil,
 		)
 		if len(checks) != 1 || checks[0].ID != "content.placeholder_text" {
 			t.Fatalf("separator %q checks = %+v, want placeholder warning", separator, checks)
 		}
-		if !strings.Contains(checks[0].Message, "lorem ipsum") {
+		if !strings.Contains(checks[0].Message, "lorem ipsum dolor sit amet") {
 			t.Fatalf("separator %q message = %q, want normalized phrase", separator, checks[0].Message)
 		}
 	}
@@ -128,15 +172,15 @@ func TestContentChecksCoverEveryLocalizedTextField(t *testing.T) {
 	version := VersionLocalization{
 		ID:              "version-loc",
 		Locale:          "en-US",
-		Description:     "TODO",
+		Description:     "TODO:",
 		Keywords:        "TBD",
 		WhatsNew:        "FIXME",
-		PromotionalText: "Lorem ipsum",
+		PromotionalText: "Lorem ipsum dolor sit amet",
 	}
 	appInfo := AppInfoLocalization{
 		ID:       "info-loc",
 		Locale:   "en-US",
-		Name:     "TODO",
+		Name:     "TODO:",
 		Subtitle: "TBD",
 	}
 	checks := contentChecks([]VersionLocalization{version}, []AppInfoLocalization{appInfo})
@@ -161,13 +205,13 @@ func TestContentChecksCoverEveryLocalizedTextField(t *testing.T) {
 
 func TestContentChecksCollapseRepeatedMatches(t *testing.T) {
 	checks := contentChecks(
-		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "TODO then TODO and lorem ipsum"}},
+		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "TODO: then TODO — and lorem ipsum dolor sit amet"}},
 		nil,
 	)
 	if len(checks) != 1 {
 		t.Fatalf("checks = %+v, want one warning", checks)
 	}
-	if strings.Count(checks[0].Message, `"TODO"`) != 1 || !strings.Contains(checks[0].Message, `"lorem ipsum"`) {
+	if strings.Count(checks[0].Message, `"TODO"`) != 1 || !strings.Contains(checks[0].Message, `"lorem ipsum dolor sit amet"`) {
 		t.Fatalf("message = %q, want distinct matches once", checks[0].Message)
 	}
 }

--- a/internal/validation/content_test.go
+++ b/internal/validation/content_test.go
@@ -75,7 +75,7 @@ func TestContentChecksPreservePlaceholderSourceOrderAcrossPatternGroups(t *testi
 	todo := strings.Index(message, `"TODO"`)
 	lorem := strings.Index(message, `"lorem ipsum"`)
 	fixme := strings.Index(message, `"FIXME"`)
-	if todo < 0 || lorem < 0 || fixme < 0 || !(todo < lorem && lorem < fixme) {
+	if todo < 0 || lorem < 0 || fixme < 0 || todo >= lorem || lorem >= fixme {
 		t.Fatalf("placeholder order = %q, want TODO, lorem ipsum, FIXME", message)
 	}
 }

--- a/internal/validation/content_test.go
+++ b/internal/validation/content_test.go
@@ -63,6 +63,32 @@ func TestContentChecksIgnoreEditoriallyAmbiguousMetadata(t *testing.T) {
 	}
 }
 
+func TestContentChecksUseUnicodeAwarePlaceholderBoundaries(t *testing.T) {
+	for _, value := range []string{
+		"MÉTODO helps you organize research.",
+		"TODOアプリ keeps tasks in sync.",
+		"éLorem ipsum is a product name.",
+	} {
+		t.Run(value, func(t *testing.T) {
+			checks := contentChecks(
+				[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: value}},
+				nil,
+			)
+			if len(checks) != 0 {
+				t.Fatalf("checks for %q = %+v, want none", value, checks)
+			}
+		})
+	}
+
+	checks := contentChecks(
+		[]VersionLocalization{{ID: "loc-1", Locale: "ja", Description: "（TODO）finalize the copy"}},
+		nil,
+	)
+	if len(checks) != 1 || checks[0].ID != "content.placeholder_text" {
+		t.Fatalf("checks = %+v, want punctuation-delimited placeholder warning", checks)
+	}
+}
+
 func TestContentChecksPreservePlaceholderSourceOrderAcrossPatternGroups(t *testing.T) {
 	checks := contentChecks(
 		[]VersionLocalization{{ID: "loc-1", Locale: "en-US", Description: "TODO before lorem ipsum and FIXME"}},

--- a/internal/validation/report.go
+++ b/internal/validation/report.go
@@ -41,6 +41,7 @@ func Validate(input Input, strict bool) Report {
 	checks = append(checks, ageRatingChecks(input.AgeRatingDeclaration)...)
 	checks = append(checks, releaseChecks(input.ReleaseType, input.EarliestReleaseDate)...)
 	checks = append(checks, legalChecks(input.Copyright, activeMonetization, reviewRelevantSubscriptions, input.VersionLocalizations, input.AppInfoLocalizations)...)
+	checks = append(checks, contentChecks(input.VersionLocalizations, input.AppInfoLocalizations)...)
 	checks = append(checks, privacyPublishStateChecks(input.AppID)...)
 
 	summary := summarize(checks, strict)


### PR DESCRIPTION
## Problem

Localized listing fields can retain unmistakable template residue such as Lorem ipsum, TODO, TBD, or FIXME. The existing readiness validator checks structure and length but does not surface that copy before submission.

## Scope

This PR adds one deliberately narrow offline warning: content.placeholder_text. It checks localized app name, subtitle, description, keywords, promotional text, and What’s New fields. Each result carries the locale, field, resource type and ID, matched text, and remediation.

The implementation intentionally does not judge platform names, roadmap language, beta/demo wording, product terminology, or other editorial intent. Those broad heuristics produced legitimate false positives and have been removed.

## Behavior

- Warnings are advisory by default.
- Existing --strict mode makes them blocking, consistent with other warnings.
- Repeated matches are collapsed and displayed in source order.
- Lorem ipsum matches across ordinary and Unicode whitespace separators.
- TODO, TBD, and FIXME remain case-sensitive so normal lowercase vocabulary is not flagged.
- The validator remains fully offline and makes no additional API calls.

## Documentation and tests

README and command help document the exact scope and strict-mode behavior. Tests cover all six localized fields, source ordering, Unicode separators, duplicate collapse, report/remediation wiring, strict-mode behavior, and realistic false-positive guards such as service names, roadmap language, product names, and platform mentions.

Validated on current main with make build, make format, make check-docs, make lint, and ASC_BYPASS_KEYCHAIN=1 make test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for placeholder text such as “Lorem ipsum,” “TODO,” “TBD,” and “FIXME” in localized metadata.
  * Reports matches with locale, field, resource, and remediation guidance.
  * Added `--strict` support to treat placeholder findings as blocking issues.
  * Documented placeholder checks in validation help and readiness guidance.

* **Bug Fixes**
  * Placeholder findings now appear as non-blocking warnings by default.
  * Improved matching across Unicode whitespace, boundaries, capitalization, and duplicate occurrences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->