### PR TITLE
feat(cli): suggest common tasks on unknown subcommands

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -134,6 +134,10 @@ func printConciseUnknownCommand(analysis invocationAnalysis, commandName string)
 		for _, suggestion := range suggestions {
 			fmt.Fprintf(os.Stderr, "  %s %s\n", commandName, shared.SanitizeTerminal(suggestion))
 		}
+	} else {
+		// A near match already answers the caller. Curated task hints are for the
+		// other case: a plausible verb this group never had.
+		printUnknownChildTaskHints(commandName)
 	}
 	fmt.Fprintln(os.Stderr, "For help:")
 	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1344,6 +1344,7 @@ func TestRun_UnknownCommandsReturnConciseRecovery(t *testing.T) {
 			name: "no close match",
 			args: []string{"builds", "qqqqq"},
 			wantStderr: "Error: unknown command `asc builds qqqqq`\n" +
+				buildsTaskHintBlock +
 				"For help:\n" +
 				"  asc builds --help\n",
 		},
@@ -1702,6 +1703,7 @@ func TestRun_CommonWrongCommandPathDoesNotCopyUnsupportedSuffix(t *testing.T) {
 		{"versions", "info", "--version-id", "VERSION_ID", "--include-build=maybe"},
 	}
 	want := "Error: unknown command `asc versions info`\n" +
+		versionsTaskHintBlock +
 		"For help:\n" +
 		"  asc versions --help\n"
 

--- a/cmd/task_hints.go
+++ b/cmd/task_hints.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+)
+
+// taskHint is one curated entry of a command group's "Common tasks" map.
+type taskHint struct {
+	task    string
+	command string
+}
+
+// unknownChildTaskHints maps a fully qualified command group to the handful of
+// tasks callers most often reach for there. The nearest-match suggester already
+// recovers typos; these hints answer the other failure mode, where a caller
+// guesses a verb the group never had (`asc builds latest`, `asc builds status`)
+// and the bare unknown-command error offers nothing to act on.
+//
+// Every command must be a copy-paste valid invocation of a real leaf command in
+// the group, using long-form flags that command defines. Tests in
+// task_hints_test.go resolve each entry against the live command tree, so keep
+// the table in sync with the commands themselves rather than with memory.
+var unknownChildTaskHints = map[string][]taskHint{
+	"asc apps": {
+		{task: "list apps", command: "asc apps list"},
+		{task: "find by bundle ID", command: "asc apps list --bundle-id <bundle-id>"},
+		{task: "view one app", command: "asc apps view --id <app-id>"},
+		{task: "view app metadata", command: "asc apps info view --app <app-id>"},
+	},
+	"asc auth": {
+		{task: "check credentials", command: "asc auth status"},
+		{task: "diagnose problems", command: "asc auth doctor"},
+		{task: "switch profile", command: "asc auth switch --name <profile>"},
+		{
+			task:    "store an API key",
+			command: "asc auth login --name <name> --key-id <key-id> --issuer-id <issuer-id> --private-key <path>",
+		},
+	},
+	"asc builds": {
+		{task: "list builds", command: "asc builds list --app <app-id>"},
+		{task: "latest build", command: "asc builds info --app <app-id> --latest"},
+		{task: "wait for processing", command: "asc builds wait --app <app-id> --latest"},
+		{task: "upload a build", command: "asc builds upload --app <app-id> --ipa <path>"},
+		{task: "expire a build", command: "asc builds expire --app <app-id> --latest --confirm"},
+	},
+	"asc iap": {
+		{task: "list purchases", command: "asc iap list --app <app-id>"},
+		{task: "view a purchase", command: "asc iap view --id <iap-id>"},
+		{task: "list versions", command: "asc iap versions list --iap-id <iap-id>"},
+		{task: "pricing summary", command: "asc iap pricing summary --app <app-id>"},
+	},
+	"asc review": {
+		{task: "review status", command: "asc review status --app <app-id>"},
+		{task: "explain blockers", command: "asc review doctor --app <app-id>"},
+		{
+			task:    "submit for review",
+			command: "asc review submit --app <app-id> --version <version> --build <build-id> --confirm",
+		},
+		{task: "past submissions", command: "asc review history --app <app-id>"},
+	},
+	"asc subscriptions": {
+		{task: "list groups", command: "asc subscriptions groups list --app <app-id>"},
+		{task: "list subscriptions", command: "asc subscriptions list --app <app-id>"},
+		{task: "view a subscription", command: "asc subscriptions view --id <subscription-id>"},
+		{task: "pricing summary", command: "asc subscriptions pricing summary --app <app-id>"},
+	},
+	"asc testflight": {
+		{task: "list beta groups", command: "asc testflight groups list --app <app-id>"},
+		{task: "list testers", command: "asc testflight testers list --app <app-id>"},
+		{task: "read feedback", command: "asc testflight feedback list --app <app-id>"},
+		{task: "notify testers", command: "asc testflight notifications send --build-id <build-id>"},
+	},
+	"asc testflight groups": {
+		{task: "list groups", command: "asc testflight groups list --app <app-id>"},
+		{task: "view a group", command: "asc testflight groups view --id <group-id>"},
+		{task: "create a group", command: "asc testflight groups create --app <app-id> --name <name>"},
+		{
+			task:    "add testers",
+			command: "asc testflight groups add-testers --group <group-id> --email <email>",
+		},
+	},
+	"asc versions": {
+		{task: "list versions", command: "asc versions list --app <app-id>"},
+		{task: "view a version", command: "asc versions view --version-id <version-id>"},
+		{task: "create a version", command: "asc versions create --app <app-id> --version <version>"},
+		{
+			task:    "attach a build",
+			command: "asc versions attach-build --version-id <version-id> --build-id <build-id>",
+		},
+		{task: "release a version", command: "asc versions release --version-id <version-id> --confirm"},
+	},
+}
+
+// printUnknownChildTaskHints writes the curated task map for a command group,
+// or nothing when the group has no curated entries. Callers print it after the
+// error line and before the help pointer, so the error stays the first thing on
+// stderr and the exit code is unaffected.
+func printUnknownChildTaskHints(commandName string) {
+	hints := unknownChildTaskHints[commandName]
+	if len(hints) == 0 {
+		return
+	}
+
+	width := 0
+	for _, hint := range hints {
+		if len(hint.task) > width {
+			width = len(hint.task)
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "Common tasks:")
+	for _, hint := range hints {
+		fmt.Fprintf(os.Stderr, "  %-*s  %s\n", width, hint.task, hint.command)
+	}
+}

--- a/cmd/task_hints.go
+++ b/cmd/task_hints.go
@@ -21,6 +21,11 @@ type taskHint struct {
 // the group, using long-form flags that command defines. Tests in
 // task_hints_test.go resolve each entry against the live command tree, so keep
 // the table in sync with the commands themselves rather than with memory.
+//
+// Prefer the canonical first-class command for a task over a generic equivalent
+// that happens to produce the same answer: `asc builds info --app X --latest`
+// rather than a sorted single-result list, and `asc builds next-build-number`
+// rather than arithmetic on a listing.
 var unknownChildTaskHints = map[string][]taskHint{
 	"asc apps": {
 		{task: "list apps", command: "asc apps list"},
@@ -40,9 +45,9 @@ var unknownChildTaskHints = map[string][]taskHint{
 	"asc builds": {
 		{task: "list builds", command: "asc builds list --app <app-id>"},
 		{task: "latest build", command: "asc builds info --app <app-id> --latest"},
-		{task: "wait for processing", command: "asc builds wait --app <app-id> --latest"},
+		{task: "next build number", command: "asc builds next-build-number --app <app-id>"},
 		{task: "upload a build", command: "asc builds upload --app <app-id> --ipa <path>"},
-		{task: "expire a build", command: "asc builds expire --app <app-id> --latest --confirm"},
+		{task: "wait for processing", command: "asc builds wait --app <app-id> --latest"},
 	},
 	"asc iap": {
 		{task: "list purchases", command: "asc iap list --app <app-id>"},

--- a/cmd/task_hints.go
+++ b/cmd/task_hints.go
@@ -26,74 +26,79 @@ type taskHint struct {
 // that happens to produce the same answer: `asc builds info --app X --latest`
 // rather than a sorted single-result list, and `asc builds next-build-number`
 // rather than arithmetic on a listing.
+//
+// Placeholders use bare uppercase words (APP_ID, IPA_PATH) to match the nearest
+// -match suggester rendered just above them on the same stderr surface. Angle
+// brackets would be read as redirections by a POSIX shell, so a pasted hint
+// would fail before `asc` ever ran.
 var unknownChildTaskHints = map[string][]taskHint{
 	"asc apps": {
 		{task: "list apps", command: "asc apps list"},
-		{task: "find by bundle ID", command: "asc apps list --bundle-id <bundle-id>"},
-		{task: "view one app", command: "asc apps view --id <app-id>"},
-		{task: "view app metadata", command: "asc apps info view --app <app-id>"},
+		{task: "find by bundle ID", command: "asc apps list --bundle-id BUNDLE_ID"},
+		{task: "view one app", command: "asc apps view --id APP_ID"},
+		{task: "view app metadata", command: "asc apps info view --app APP_ID"},
 	},
 	"asc auth": {
 		{task: "check credentials", command: "asc auth status"},
 		{task: "diagnose problems", command: "asc auth doctor"},
-		{task: "switch profile", command: "asc auth switch --name <profile>"},
+		{task: "switch profile", command: "asc auth switch --name PROFILE"},
 		{
 			task:    "store an API key",
-			command: "asc auth login --name <name> --key-id <key-id> --issuer-id <issuer-id> --private-key <path>",
+			command: "asc auth login --name NAME --key-id KEY_ID --issuer-id ISSUER_ID --private-key KEY_PATH",
 		},
 	},
 	"asc builds": {
-		{task: "list builds", command: "asc builds list --app <app-id>"},
-		{task: "latest build", command: "asc builds info --app <app-id> --latest"},
-		{task: "next build number", command: "asc builds next-build-number --app <app-id>"},
-		{task: "upload a build", command: "asc builds upload --app <app-id> --ipa <path>"},
-		{task: "wait for processing", command: "asc builds wait --app <app-id> --latest"},
+		{task: "list builds", command: "asc builds list --app APP_ID"},
+		{task: "latest build", command: "asc builds info --app APP_ID --latest"},
+		{task: "next build number", command: "asc builds next-build-number --app APP_ID"},
+		{task: "upload a build", command: "asc builds upload --app APP_ID --ipa IPA_PATH"},
+		{task: "wait for processing", command: "asc builds wait --app APP_ID --latest"},
 	},
 	"asc iap": {
-		{task: "list purchases", command: "asc iap list --app <app-id>"},
-		{task: "view a purchase", command: "asc iap view --id <iap-id>"},
-		{task: "list versions", command: "asc iap versions list --iap-id <iap-id>"},
-		{task: "pricing summary", command: "asc iap pricing summary --app <app-id>"},
+		{task: "list purchases", command: "asc iap list --app APP_ID"},
+		{task: "view a purchase", command: "asc iap view --id IAP_ID"},
+		{task: "list versions", command: "asc iap versions list --iap-id IAP_ID"},
+		{task: "pricing summary", command: "asc iap pricing summary --app APP_ID"},
 	},
 	"asc review": {
-		{task: "review status", command: "asc review status --app <app-id>"},
-		{task: "explain blockers", command: "asc review doctor --app <app-id>"},
+		{task: "review status", command: "asc review status --app APP_ID"},
+		{task: "explain blockers", command: "asc review doctor --app APP_ID"},
 		{
 			task:    "submit for review",
-			command: "asc review submit --app <app-id> --version <version> --build <build-id> --confirm",
+			command: "asc review submit --app APP_ID --version VERSION --build BUILD_ID --confirm",
 		},
-		{task: "past submissions", command: "asc review history --app <app-id>"},
+		{task: "past submissions", command: "asc review history --app APP_ID"},
 	},
 	"asc subscriptions": {
-		{task: "list groups", command: "asc subscriptions groups list --app <app-id>"},
-		{task: "list subscriptions", command: "asc subscriptions list --app <app-id>"},
-		{task: "view a subscription", command: "asc subscriptions view --id <subscription-id>"},
-		{task: "pricing summary", command: "asc subscriptions pricing summary --app <app-id>"},
+		{task: "list groups", command: "asc subscriptions groups list --app APP_ID"},
+		{task: "list subscriptions", command: "asc subscriptions list --app APP_ID"},
+		{task: "view a subscription", command: "asc subscriptions view --id SUB_ID"},
+		{task: "pricing summary", command: "asc subscriptions pricing summary --app APP_ID"},
 	},
 	"asc testflight": {
-		{task: "list beta groups", command: "asc testflight groups list --app <app-id>"},
-		{task: "list testers", command: "asc testflight testers list --app <app-id>"},
-		{task: "read feedback", command: "asc testflight feedback list --app <app-id>"},
-		{task: "notify testers", command: "asc testflight notifications send --build-id <build-id>"},
+		{task: "list beta groups", command: "asc testflight groups list --app APP_ID"},
+		{task: "list testers", command: "asc testflight testers list --app APP_ID"},
+		{task: "read feedback", command: "asc testflight feedback list --app APP_ID"},
+		{task: "notify testers", command: "asc testflight notifications send --build-id BUILD_ID"},
 	},
 	"asc testflight groups": {
-		{task: "list groups", command: "asc testflight groups list --app <app-id>"},
-		{task: "view a group", command: "asc testflight groups view --id <group-id>"},
-		{task: "create a group", command: "asc testflight groups create --app <app-id> --name <name>"},
+		{task: "list groups", command: "asc testflight groups list --app APP_ID"},
+		{task: "view a group", command: "asc testflight groups view --id GROUP_ID"},
+		{task: "create a group", command: "asc testflight groups create --app APP_ID --name NAME"},
 		{
 			task:    "add testers",
-			command: "asc testflight groups add-testers --group <group-id> --email <email>",
+			command: "asc testflight groups add-testers --group GROUP_ID --email EMAIL",
 		},
 	},
 	"asc versions": {
-		{task: "list versions", command: "asc versions list --app <app-id>"},
-		{task: "view a version", command: "asc versions view --version-id <version-id>"},
-		{task: "create a version", command: "asc versions create --app <app-id> --version <version>"},
+		{task: "list versions", command: "asc versions list --app APP_ID"},
+		{task: "view a version", command: "asc versions view --version-id VERSION_ID"},
+		{task: "create a version", command: "asc versions create --app APP_ID --version VERSION"},
 		{
 			task:    "attach a build",
-			command: "asc versions attach-build --version-id <version-id> --build-id <build-id>",
+			command: "asc versions attach-build --version-id VERSION_ID --build-id BUILD_ID",
 		},
-		{task: "release a version", command: "asc versions release --version-id <version-id> --confirm"},
+		{task: "release a version", command: "asc versions release --version-id VERSION_ID --confirm"},
 	},
 }
 

--- a/cmd/task_hints_test.go
+++ b/cmd/task_hints_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+// Rendered task maps shared with the older unknown-command tests so a table
+// edit fails in one place instead of drifting silently across files.
+const (
+	buildsTaskHintBlock = "Common tasks:\n" +
+		"  list builds          asc builds list --app <app-id>\n" +
+		"  latest build         asc builds info --app <app-id> --latest\n" +
+		"  wait for processing  asc builds wait --app <app-id> --latest\n" +
+		"  upload a build       asc builds upload --app <app-id> --ipa <path>\n" +
+		"  expire a build       asc builds expire --app <app-id> --latest --confirm\n"
+
+	versionsTaskHintBlock = "Common tasks:\n" +
+		"  list versions      asc versions list --app <app-id>\n" +
+		"  view a version     asc versions view --version-id <version-id>\n" +
+		"  create a version   asc versions create --app <app-id> --version <version>\n" +
+		"  attach a build     asc versions attach-build --version-id <version-id> --build-id <build-id>\n" +
+		"  release a version  asc versions release --version-id <version-id> --confirm\n"
+)
+
+func TestRun_UnknownChildAppendsCuratedTaskHints(t *testing.T) {
+	resetReportFlags(t)
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name: "listed group without a near match",
+			args: []string{"builds", "latest"},
+			wantStderr: "Error: unknown command `asc builds latest`\n" +
+				buildsTaskHintBlock +
+				"For help:\n" +
+				"  asc builds --help\n",
+		},
+		{
+			name: "listed nested group without a near match",
+			args: []string{"testflight", "groups", "invite"},
+			wantStderr: "Error: unknown command `asc testflight groups invite`\n" +
+				"Common tasks:\n" +
+				"  list groups     asc testflight groups list --app <app-id>\n" +
+				"  view a group    asc testflight groups view --id <group-id>\n" +
+				"  create a group  asc testflight groups create --app <app-id> --name <name>\n" +
+				"  add testers     asc testflight groups add-testers --group <group-id> --email <email>\n" +
+				"For help:\n" +
+				"  asc testflight groups --help\n",
+		},
+		{
+			name: "listed group with a near match keeps the typo suggestion only",
+			args: []string{"builds", "lsit"},
+			wantStderr: "Error: unknown command `asc builds lsit`\n" +
+				"Try:\n" +
+				"  asc builds list\n" +
+				"For help:\n" +
+				"  asc builds --help\n",
+		},
+		{
+			name: "unlisted group is unchanged",
+			args: []string{"xcode-cloud", "workflows", "qqqqq"},
+			wantStderr: "Error: unknown command `asc xcode-cloud workflows qqqqq`\n" +
+				"For help:\n" +
+				"  asc xcode-cloud workflows --help\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if stderr != test.wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, test.wantStderr)
+			}
+		})
+	}
+}
+
+func TestUnknownChildTaskHintsCoverTheDocumentedGroups(t *testing.T) {
+	wantGroups := []string{
+		"asc apps",
+		"asc auth",
+		"asc builds",
+		"asc iap",
+		"asc review",
+		"asc subscriptions",
+		"asc testflight",
+		"asc testflight groups",
+		"asc versions",
+	}
+
+	if len(unknownChildTaskHints) != len(wantGroups) {
+		t.Fatalf("task hint groups = %d, want %d", len(unknownChildTaskHints), len(wantGroups))
+	}
+	for _, group := range wantGroups {
+		hints, ok := unknownChildTaskHints[group]
+		if !ok {
+			t.Fatalf("missing task hints for %q", group)
+		}
+		if len(hints) < 3 || len(hints) > 5 {
+			t.Fatalf("%q task hints = %d, want between 3 and 5", group, len(hints))
+		}
+		for _, hint := range hints {
+			if strings.TrimSpace(hint.task) == "" || strings.TrimSpace(hint.command) == "" {
+				t.Fatalf("%q has an empty task hint: %+v", group, hint)
+			}
+		}
+	}
+}
+
+// Every curated invocation must stay copy-paste valid: it has to resolve to a
+// real leaf command under its group and use only long-form flags that command
+// actually defines.
+func TestUnknownChildTaskHintsResolveToRealCommands(t *testing.T) {
+	root := RootCommand("1.0.0")
+
+	for group, hints := range unknownChildTaskHints {
+		groupPath := strings.Fields(group)
+		if len(groupPath) < 2 || groupPath[0] != "asc" {
+			t.Fatalf("task hint key %q must be a full `asc ...` group path", group)
+		}
+		if resolveCommandPath(root, groupPath[1:]) == nil {
+			t.Fatalf("task hint group %q does not resolve to a command", group)
+		}
+
+		for _, hint := range hints {
+			tokens := strings.Fields(hint.command)
+			if len(tokens) == 0 || tokens[0] != "asc" {
+				t.Fatalf("%q hint %q must start with `asc`", group, hint.command)
+			}
+			commandPath := []string{}
+			flagTokens := []string{}
+			for _, token := range tokens[1:] {
+				if strings.HasPrefix(token, "-") {
+					flagTokens = append(flagTokens, token)
+					continue
+				}
+				if len(flagTokens) == 0 {
+					commandPath = append(commandPath, token)
+				}
+			}
+			if !strings.HasPrefix(hint.command+" ", group+" ") {
+				t.Fatalf("%q hint %q must stay inside its group", group, hint.command)
+			}
+
+			command := resolveCommandPath(root, commandPath)
+			if command == nil {
+				t.Fatalf("%q hint %q does not resolve to a command", group, hint.command)
+			}
+			if len(command.Subcommands) > 0 {
+				t.Fatalf("%q hint %q resolves to a group, not a runnable command", group, hint.command)
+			}
+			for _, token := range flagTokens {
+				if !strings.HasPrefix(token, "--") {
+					t.Fatalf("%q hint %q uses the short flag %q", group, hint.command, token)
+				}
+				name, _, _ := strings.Cut(strings.TrimPrefix(token, "--"), "=")
+				if lookupTaskHintFlag(command.FlagSet, name) == nil {
+					t.Fatalf("%q hint %q uses undefined flag --%s", group, hint.command, name)
+				}
+			}
+		}
+	}
+}
+
+func lookupTaskHintFlag(flagSet *flag.FlagSet, name string) *flag.Flag {
+	if flagSet == nil {
+		return nil
+	}
+	return flagSet.Lookup(name)
+}

--- a/cmd/task_hints_test.go
+++ b/cmd/task_hints_test.go
@@ -10,18 +10,18 @@ import (
 // edit fails in one place instead of drifting silently across files.
 const (
 	buildsTaskHintBlock = "Common tasks:\n" +
-		"  list builds          asc builds list --app <app-id>\n" +
-		"  latest build         asc builds info --app <app-id> --latest\n" +
-		"  next build number    asc builds next-build-number --app <app-id>\n" +
-		"  upload a build       asc builds upload --app <app-id> --ipa <path>\n" +
-		"  wait for processing  asc builds wait --app <app-id> --latest\n"
+		"  list builds          asc builds list --app APP_ID\n" +
+		"  latest build         asc builds info --app APP_ID --latest\n" +
+		"  next build number    asc builds next-build-number --app APP_ID\n" +
+		"  upload a build       asc builds upload --app APP_ID --ipa IPA_PATH\n" +
+		"  wait for processing  asc builds wait --app APP_ID --latest\n"
 
 	versionsTaskHintBlock = "Common tasks:\n" +
-		"  list versions      asc versions list --app <app-id>\n" +
-		"  view a version     asc versions view --version-id <version-id>\n" +
-		"  create a version   asc versions create --app <app-id> --version <version>\n" +
-		"  attach a build     asc versions attach-build --version-id <version-id> --build-id <build-id>\n" +
-		"  release a version  asc versions release --version-id <version-id> --confirm\n"
+		"  list versions      asc versions list --app APP_ID\n" +
+		"  view a version     asc versions view --version-id VERSION_ID\n" +
+		"  create a version   asc versions create --app APP_ID --version VERSION\n" +
+		"  attach a build     asc versions attach-build --version-id VERSION_ID --build-id BUILD_ID\n" +
+		"  release a version  asc versions release --version-id VERSION_ID --confirm\n"
 )
 
 func TestRun_UnknownChildAppendsCuratedTaskHints(t *testing.T) {
@@ -45,10 +45,10 @@ func TestRun_UnknownChildAppendsCuratedTaskHints(t *testing.T) {
 			args: []string{"testflight", "groups", "invite"},
 			wantStderr: "Error: unknown command `asc testflight groups invite`\n" +
 				"Common tasks:\n" +
-				"  list groups     asc testflight groups list --app <app-id>\n" +
-				"  view a group    asc testflight groups view --id <group-id>\n" +
-				"  create a group  asc testflight groups create --app <app-id> --name <name>\n" +
-				"  add testers     asc testflight groups add-testers --group <group-id> --email <email>\n" +
+				"  list groups     asc testflight groups list --app APP_ID\n" +
+				"  view a group    asc testflight groups view --id GROUP_ID\n" +
+				"  create a group  asc testflight groups create --app APP_ID --name NAME\n" +
+				"  add testers     asc testflight groups add-testers --group GROUP_ID --email EMAIL\n" +
 				"For help:\n" +
 				"  asc testflight groups --help\n",
 		},
@@ -162,6 +162,11 @@ func TestUnknownChildTaskHintsResolveToRealCommands(t *testing.T) {
 			if len(command.Subcommands) > 0 {
 				t.Fatalf("%q hint %q resolves to a group, not a runnable command", group, hint.command)
 			}
+			for _, token := range tokens {
+				if !isShellSafeHintToken(token) {
+					t.Fatalf("%q hint %q has shell-unsafe token %q", group, hint.command, token)
+				}
+			}
 			for _, token := range flagTokens {
 				if !strings.HasPrefix(token, "--") {
 					t.Fatalf("%q hint %q uses the short flag %q", group, hint.command, token)
@@ -173,6 +178,22 @@ func TestUnknownChildTaskHintsResolveToRealCommands(t *testing.T) {
 			}
 		}
 	}
+}
+
+// isShellSafeHintToken mirrors the unquoted-safe character set that
+// shellSafeCommandArg uses for the nearest-match suggester. A hint that needs
+// shell quoting is not copy-pasteable, and angle-bracket placeholders in
+// particular would be read as redirections.
+func isShellSafeHintToken(token string) bool {
+	if token == "" {
+		return false
+	}
+	return strings.IndexFunc(token, func(r rune) bool {
+		isASCIILetterOrDigit := (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9')
+		return !isASCIILetterOrDigit && !strings.ContainsRune("_@%+=:,./-", r)
+	}) == -1
 }
 
 func lookupTaskHintFlag(flagSet *flag.FlagSet, name string) *flag.Flag {

--- a/cmd/task_hints_test.go
+++ b/cmd/task_hints_test.go
@@ -12,9 +12,9 @@ const (
 	buildsTaskHintBlock = "Common tasks:\n" +
 		"  list builds          asc builds list --app <app-id>\n" +
 		"  latest build         asc builds info --app <app-id> --latest\n" +
-		"  wait for processing  asc builds wait --app <app-id> --latest\n" +
+		"  next build number    asc builds next-build-number --app <app-id>\n" +
 		"  upload a build       asc builds upload --app <app-id> --ipa <path>\n" +
-		"  expire a build       asc builds expire --app <app-id> --latest --confirm\n"
+		"  wait for processing  asc builds wait --app <app-id> --latest\n"
 
 	versionsTaskHintBlock = "Common tasks:\n" +
 		"  list versions      asc versions list --app <app-id>\n" +

--- a/internal/cli/cmdtest/unknown_command_task_hints_test.go
+++ b/internal/cli/cmdtest/unknown_command_task_hints_test.go
@@ -25,24 +25,25 @@ func TestRunUnknownSubcommandTaskHints(t *testing.T) {
 			args:      []string{"builds", "latest"},
 			wantOrder: []string{"Error: unknown command `asc builds latest`", "Common tasks:", "For help:"},
 			wantContains: []string{
-				"  list builds          asc builds list --app <app-id>\n",
+				"  list builds          asc builds list --app APP_ID\n",
 				// The canonical latest-build lookup, not a sorted single-result list.
-				"  latest build         asc builds info --app <app-id> --latest\n",
+				"  latest build         asc builds info --app APP_ID --latest\n",
 				// The first-class command, not arithmetic over a build listing.
-				"  next build number    asc builds next-build-number --app <app-id>\n",
-				"  wait for processing  asc builds wait --app <app-id> --latest\n",
+				"  next build number    asc builds next-build-number --app APP_ID\n",
+				"  wait for processing  asc builds wait --app APP_ID --latest\n",
 				"  asc builds --help\n",
 			},
-			wantAbsent: []string{"Try:", "--sort -uploadedDate"},
+			// Angle brackets would be shell redirections in a pasted hint.
+			wantAbsent: []string{"Try:", "--sort -uploadedDate", "<", ">"},
 		},
 		{
 			name:      "guessed verb on a curated nested group",
 			args:      []string{"testflight", "groups", "invite"},
 			wantOrder: []string{"Error: unknown command `asc testflight groups invite`", "Common tasks:", "For help:"},
 			wantContains: []string{
-				"  add testers     asc testflight groups add-testers --group <group-id> --email <email>\n",
+				"  add testers     asc testflight groups add-testers --group GROUP_ID --email EMAIL\n",
 			},
-			wantAbsent: []string{"Try:"},
+			wantAbsent: []string{"Try:", "<", ">"},
 		},
 		{
 			name:         "typo keeps the nearest-match suggestion",

--- a/internal/cli/cmdtest/unknown_command_task_hints_test.go
+++ b/internal/cli/cmdtest/unknown_command_task_hints_test.go
@@ -26,11 +26,14 @@ func TestRunUnknownSubcommandTaskHints(t *testing.T) {
 			wantOrder: []string{"Error: unknown command `asc builds latest`", "Common tasks:", "For help:"},
 			wantContains: []string{
 				"  list builds          asc builds list --app <app-id>\n",
+				// The canonical latest-build lookup, not a sorted single-result list.
 				"  latest build         asc builds info --app <app-id> --latest\n",
+				// The first-class command, not arithmetic over a build listing.
+				"  next build number    asc builds next-build-number --app <app-id>\n",
 				"  wait for processing  asc builds wait --app <app-id> --latest\n",
 				"  asc builds --help\n",
 			},
-			wantAbsent: []string{"Try:"},
+			wantAbsent: []string{"Try:", "--sort -uploadedDate"},
 		},
 		{
 			name:      "guessed verb on a curated nested group",

--- a/internal/cli/cmdtest/unknown_command_task_hints_test.go
+++ b/internal/cli/cmdtest/unknown_command_task_hints_test.go
@@ -1,0 +1,93 @@
+package cmdtest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+// A guessed verb that never existed gets a curated task map, while a typo keeps
+// the nearest-match suggestion it already had. Both keep the error first and the
+// help pointer last on stderr.
+func TestRunUnknownSubcommandTaskHints(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantOrder    []string
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:      "guessed verb on a curated group",
+			args:      []string{"builds", "latest"},
+			wantOrder: []string{"Error: unknown command `asc builds latest`", "Common tasks:", "For help:"},
+			wantContains: []string{
+				"  list builds          asc builds list --app <app-id>\n",
+				"  latest build         asc builds info --app <app-id> --latest\n",
+				"  wait for processing  asc builds wait --app <app-id> --latest\n",
+				"  asc builds --help\n",
+			},
+			wantAbsent: []string{"Try:"},
+		},
+		{
+			name:      "guessed verb on a curated nested group",
+			args:      []string{"testflight", "groups", "invite"},
+			wantOrder: []string{"Error: unknown command `asc testflight groups invite`", "Common tasks:", "For help:"},
+			wantContains: []string{
+				"  add testers     asc testflight groups add-testers --group <group-id> --email <email>\n",
+			},
+			wantAbsent: []string{"Try:"},
+		},
+		{
+			name:         "typo keeps the nearest-match suggestion",
+			args:         []string{"builds", "lsit"},
+			wantOrder:    []string{"Error: unknown command `asc builds lsit`", "Try:", "For help:"},
+			wantContains: []string{"  asc builds list\n"},
+			wantAbsent:   []string{"Common tasks:"},
+		},
+		{
+			name:       "group without curated hints is unchanged",
+			args:       []string{"xcode-cloud", "workflows", "qqqqq"},
+			wantOrder:  []string{"Error: unknown command `asc xcode-cloud workflows qqqqq`", "For help:"},
+			wantAbsent: []string{"Common tasks:", "Try:"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(test.args, "1.2.3"); code != cmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			previous := -1
+			for _, marker := range test.wantOrder {
+				index := strings.Index(stderr, marker)
+				if index < 0 {
+					t.Fatalf("stderr missing %q: %q", marker, stderr)
+				}
+				if index <= previous {
+					t.Fatalf("stderr has %q out of order: %q", marker, stderr)
+				}
+				previous = index
+			}
+			for _, fragment := range test.wantContains {
+				if !strings.Contains(stderr, fragment) {
+					t.Fatalf("stderr missing %q: %q", fragment, stderr)
+				}
+			}
+			for _, fragment := range test.wantAbsent {
+				if strings.Contains(stderr, fragment) {
+					t.Fatalf("stderr unexpectedly contains %q: %q", fragment, stderr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`asc builds latest` and `asc builds status` produce only:

```
Error: unknown command `asc builds latest`
For help:
  asc builds --help
```

The nearest-match suggester recovers typos (`asc builds lst` -> "Try: asc builds list"), but a caller guessing a verb the group never had gets nothing actionable and has to go read the full group help.

Product telemetry shows unknown-subcommand attempts are the largest error class for the CLI (tens of thousands per month, concentrated in a small number of groups: `builds`, `apps`, `versions`, `review`, `subscriptions`, `auth`, `testflight`, `testflight groups`, `iap`).

## Change

When the unknown-child error fires for one of those groups **and no near match exists**, append a short curated task map:

```
Error: unknown command `asc builds status`
Common tasks:
  list builds          asc builds list --app <app-id>
  latest build         asc builds info --app <app-id> --latest
  wait for processing  asc builds wait --app <app-id> --latest
  upload a build       asc builds upload --app <app-id> --ipa <path>
  expire a build       asc builds expire --app <app-id> --latest --confirm
For help:
  asc builds --help
```

- The typo path is untouched. A `Try:` suggestion still wins; the task map only fills the gap where there is currently no suggestion at all.
- Groups outside the curated table are byte-for-byte unchanged.
- stderr contract preserved: error line first, hints after, help pointer last, exit code still `ExitUsage` (2). Nothing is written to stdout.
- The table is a small static map keyed by group path in `cmd/task_hints.go`; the only change in `cmd/invocation_context.go` is one `else` branch inside `printConciseUnknownCommand` (the unknown-*flag* path is not touched).

## Accuracy of the suggested invocations

Every curated invocation was derived from the group's real help at HEAD, uses long-form flags, and resolves to a runnable leaf command. `TestUnknownChildTaskHintsResolveToRealCommands` enforces that mechanically: it walks the live command tree, resolves each hint's command path, asserts it is a leaf, and asserts every `--flag` in the hint is defined on that command's `FlagSet`. Hints cannot drift into commands or flags that do not exist.

Hints point at canonical first-class commands rather than generic equivalents that happen to produce the same answer: the latest-build row uses the `asc builds info --app X --latest` selector mode (documented in that command's own usage line) rather than a sorted single-result listing, and `asc builds next-build-number` is surfaced instead of leaving callers to derive the next `CFBundleVersion` from a listing.

## Tests

- `cmd/task_hints_test.go`: exact-stderr coverage for the curated group, a curated nested group (`testflight groups`), the typo case (still `Try:`, no task map), and an uncurated group (unchanged); plus table-shape and command/flag-resolution guards.
- `internal/cli/cmdtest/unknown_command_task_hints_test.go`: CLI-level ordering coverage through `cmd.Run` (error first, `Common tasks:` after, `For help:` last) with exit code and empty-stdout assertions.
- Updated the two existing expectations that pinned the pre-change output for curated groups (`builds qqqqq`, `versions info` suffix fallback). Shared rendered blocks are defined once so a table edit fails in one place instead of drifting.

`make build`, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` all pass. No command help changed, so `docs/COMMANDS.md` is untouched (`generate-command-docs --check` confirms it is up to date).

## Notes

- `asc apps get` / `asc <group> set` keep their existing legacy full-usage output; those tokens intentionally bypass the concise path, and that behavior is unchanged here.
- Adding a group later is a single table entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual task hints when an unrecognized command has no close match.
  * Added guidance for common tasks across app, authentication, build, purchase, review, subscription, TestFlight, and version commands.
  * Added guidance for finding the latest build and requesting the next build number.

* **Bug Fixes**
  * Preserved concise typo suggestions when a close command match is available.
  * Improved unknown-command recovery with clearer, actionable guidance and consistent error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
