### PR TITLE
feat(testflight): expose sort, include, and invite-type on testers list

### DIFF
--- a/commands/testflight.mdx
+++ b/commands/testflight.mdx
@@ -75,12 +75,17 @@ asc testflight testers add-groups --id TESTER_ID --group GROUP_ID
 
 `--include` adds related resources (`apps`, `betaGroups`, `builds`) to the
 response's top-level `included` array, so one call can audit group membership
-for every tester instead of one lookup per tester. `--paginate` merges
-`included` across pages:
+for every tester instead of one lookup per tester. Only JSON output renders
+that array, so pass `--output json` when running interactively. `--paginate`
+merges `included` across pages:
 
 ```bash  theme={null}
-asc testflight testers list --app APP_ID --include betaGroups --paginate
+asc testflight testers list --app APP_ID --include betaGroups --paginate --output json
 ```
+
+`--invite-type`, `--sort`, and `--include` cannot be combined with `--next`. A
+`links.next` URL already carries the query it came from, so those values would
+never reach the request; the command fails instead of dropping them.
 
 ### Feedback and crashes
 

--- a/commands/testflight.mdx
+++ b/commands/testflight.mdx
@@ -78,19 +78,29 @@ accepts `firstName`, `lastName`, `email`, `inviteType`, or `state`; prefix the
 field with `-` for descending order.
 
 `--include` adds related resources (`apps`, `betaGroups`, `builds`) to the
-response's top-level `included` array, so one call can audit group membership
-for every tester instead of one lookup per tester. Only JSON output renders
-that array, so pass `--output json` when running interactively. `--paginate`
-merges `included` across pages:
+response's top-level `included` array. App Store Connect returns at most 50
+related resources per included relationship. `--paginate` pages the tester
+collection and merges the included resources that those pages return; it does
+not page an individual tester's included relationships. Only JSON output
+renders the `included` array, so pass `--output json` when running
+interactively:
 
 ```bash  theme={null}
 asc testflight testers list --app APP_ID --include betaGroups --paginate --output json
+```
+
+For complete group membership, page the relationship for each tester:
+
+```bash  theme={null}
+asc testflight testers groups list --id TESTER_ID --paginate
 ```
 
 `--invite-type`, `--sort`, and `--include` cannot be combined with `--next`. A
 `links.next` URL already carries the query it came from, so those values would
 never reach the request; the command fails instead of dropping them. When the
 URL carries `include`, use `--output json` to render its included resources.
+Invalid `--invite-type`, `--sort`, or `--include` values, and these incompatible
+`--next` combinations, exit `2` before making a request.
 
 ### Feedback and crashes
 

--- a/commands/testflight.mdx
+++ b/commands/testflight.mdx
@@ -59,16 +59,27 @@ build page. A partial lookup prints the matches and per-group failures with
 ### Testers
 
 List testers, add new testers, and manage their group/build access. `list`
-accepts `--email`, `--first-name`, and `--last-name` exact-match filters, and
-`testers groups list` shows the groups a tester belongs to:
+accepts `--email`, `--first-name`, and `--last-name` exact-match filters plus
+`--invite-type` (`EMAIL`, `PUBLIC_LINK`) and `--sort`, and `testers groups list`
+shows the groups a tester belongs to:
 
 ```bash  theme={null}
 asc testflight testers list --app APP_ID
 asc testflight testers list --app APP_ID --first-name "Ada" --last-name "Lovelace"
+asc testflight testers list --app APP_ID --invite-type PUBLIC_LINK --sort -lastName
 asc testflight testers add --app APP_ID --email user@example.com --group "Beta"
 asc testflight testers view --id TESTER_ID
 asc testflight testers groups list --id TESTER_ID
 asc testflight testers add-groups --id TESTER_ID --group GROUP_ID
+```
+
+`--include` adds related resources (`apps`, `betaGroups`, `builds`) to the
+response's top-level `included` array, so one call can audit group membership
+for every tester instead of one lookup per tester. `--paginate` merges
+`included` across pages:
+
+```bash  theme={null}
+asc testflight testers list --app APP_ID --include betaGroups --paginate
 ```
 
 ### Feedback and crashes

--- a/commands/testflight.mdx
+++ b/commands/testflight.mdx
@@ -73,6 +73,10 @@ asc testflight testers groups list --id TESTER_ID
 asc testflight testers add-groups --id TESTER_ID --group GROUP_ID
 ```
 
+The `--invite-type`, `--sort`, and `--include` flags are experimental. `--sort`
+accepts `firstName`, `lastName`, `email`, `inviteType`, or `state`; prefix the
+field with `-` for descending order.
+
 `--include` adds related resources (`apps`, `betaGroups`, `builds`) to the
 response's top-level `included` array, so one call can audit group membership
 for every tester instead of one lookup per tester. Only JSON output renders
@@ -85,7 +89,8 @@ asc testflight testers list --app APP_ID --include betaGroups --paginate --outpu
 
 `--invite-type`, `--sort`, and `--include` cannot be combined with `--next`. A
 `links.next` URL already carries the query it came from, so those values would
-never reach the request; the command fails instead of dropping them.
+never reach the request; the command fails instead of dropping them. When the
+URL carries `include`, use `--output json` to render its included resources.
 
 ### Feedback and crashes
 

--- a/internal/asc/client_pagination.go
+++ b/internal/asc/client_pagination.go
@@ -310,7 +310,7 @@ func mergeRawJSONArray(dst, src json.RawMessage) (json.RawMessage, error) {
 	seen := make(map[string]struct{}, len(dstItems)+len(srcItems))
 	appendUnique := func(items []json.RawMessage) {
 		for _, item := range items {
-			key := string(item)
+			key := rawJSONArrayItemKey(item)
 			if _, ok := seen[key]; ok {
 				continue
 			}
@@ -326,4 +326,18 @@ func mergeRawJSONArray(dst, src json.RawMessage) (json.RawMessage, error) {
 		return nil, fmt.Errorf("marshal merged array: %w", err)
 	}
 	return result, nil
+}
+
+// rawJSONArrayItemKey follows JSON:API's resource identity rule when an item
+// has both type and id. Items without a usable resource identity retain the
+// previous raw-JSON equality behavior instead of being collapsed together.
+func rawJSONArrayItemKey(item json.RawMessage) string {
+	var identity struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	}
+	if err := json.Unmarshal(item, &identity); err == nil && identity.Type != "" && identity.ID != "" {
+		return "resource\x00" + identity.Type + "\x00" + identity.ID
+	}
+	return "raw\x00" + string(item)
 }

--- a/internal/asc/client_pagination_test.go
+++ b/internal/asc/client_pagination_test.go
@@ -673,6 +673,45 @@ func TestPaginateAll_BuildsPreservesIncluded(t *testing.T) {
 	}
 }
 
+func TestMergeRawJSONArrayDeduplicatesJSONAPIResourcesByIdentity(t *testing.T) {
+	merged, err := mergeRawJSONArray(
+		json.RawMessage(`[
+			{"type":"betaGroups","id":"group-a","attributes":{"name":"Alpha"}},
+			{"type":"apps","id":"shared-id"}
+		]`),
+		json.RawMessage(`[
+			{"id":"group-a","type":"betaGroups","attributes":{"name":"Alpha updated"}},
+			{"type":"betaGroups","id":"group-b","attributes":{"name":"Bravo"}},
+			{"type":"builds","id":"shared-id"}
+		]`),
+	)
+	if err != nil {
+		t.Fatalf("mergeRawJSONArray() error: %v", err)
+	}
+
+	var included []struct {
+		Type       string `json:"type"`
+		ID         string `json:"id"`
+		Attributes struct {
+			Name string `json:"name"`
+		} `json:"attributes"`
+	}
+	if err := json.Unmarshal(merged, &included); err != nil {
+		t.Fatalf("decode merged resources: %v", err)
+	}
+	if len(included) != 4 {
+		t.Fatalf("expected four distinct type-and-ID resources, got %+v", included)
+	}
+	if included[0].Type != "betaGroups" || included[0].ID != "group-a" || included[0].Attributes.Name != "Alpha" {
+		t.Fatalf("expected the first group-a representation to win, got %+v", included[0])
+	}
+	if included[1].Type != "apps" || included[1].ID != "shared-id" ||
+		included[2].Type != "betaGroups" || included[2].ID != "group-b" ||
+		included[3].Type != "builds" || included[3].ID != "shared-id" {
+		t.Fatalf("expected stable order with type-scoped identities, got %+v", included)
+	}
+}
+
 func TestPaginateAll_GameCenterEnabledVersions(t *testing.T) {
 	const totalPages = 2
 	const perPage = 3

--- a/internal/asc/client_query_beta_testers_test.go
+++ b/internal/asc/client_query_beta_testers_test.go
@@ -1,0 +1,98 @@
+package asc
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestBuildBetaTestersQueryEmitsSortIncludeAndInviteType(t *testing.T) {
+	query := &betaTestersQuery{}
+	opts := []BetaTestersOption{
+		WithBetaTestersSort("-lastName"),
+		WithBetaTestersInclude([]string{"betaGroups", " apps "}),
+		WithBetaTestersInviteTypes([]string{"EMAIL", " PUBLIC_LINK "}),
+	}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	qs, err := buildBetaTestersQuery("APP_ID", query)
+	if err != nil {
+		t.Fatalf("buildBetaTestersQuery() error: %v", err)
+	}
+	values, parseErr := url.ParseQuery(qs)
+	if parseErr != nil {
+		t.Fatalf("parse query: %v", parseErr)
+	}
+
+	if got := values.Get("sort"); got != "-lastName" {
+		t.Fatalf("expected sort=-lastName, got %q", got)
+	}
+	if got := values.Get("include"); got != "betaGroups,apps" {
+		t.Fatalf("expected include=betaGroups,apps, got %q", got)
+	}
+	if got := values.Get("filter[inviteType]"); got != "EMAIL,PUBLIC_LINK" {
+		t.Fatalf("expected filter[inviteType]=EMAIL,PUBLIC_LINK, got %q", got)
+	}
+	if got := values.Get("filter[apps]"); got != "APP_ID" {
+		t.Fatalf("expected filter[apps]=APP_ID, got %q", got)
+	}
+}
+
+func TestBuildBetaTestersQueryOmitsUnsetSortIncludeAndInviteType(t *testing.T) {
+	query := &betaTestersQuery{}
+	opts := []BetaTestersOption{
+		WithBetaTestersSort("   "),
+		WithBetaTestersInclude(nil),
+		WithBetaTestersInviteTypes([]string{" "}),
+	}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	qs, err := buildBetaTestersQuery("APP_ID", query)
+	if err != nil {
+		t.Fatalf("buildBetaTestersQuery() error: %v", err)
+	}
+	values, parseErr := url.ParseQuery(qs)
+	if parseErr != nil {
+		t.Fatalf("parse query: %v", parseErr)
+	}
+
+	for _, key := range []string{"sort", "include", "filter[inviteType]"} {
+		if _, present := values[key]; present {
+			t.Fatalf("expected %s to be omitted, got %q", key, values.Get(key))
+		}
+	}
+}
+
+func TestBuildBetaTestersQueryKeepsInviteTypeWithGroupFilter(t *testing.T) {
+	query := &betaTestersQuery{}
+	opts := []BetaTestersOption{
+		WithBetaTestersGroupIDs([]string{"group-1"}),
+		WithBetaTestersInviteTypes([]string{"PUBLIC_LINK"}),
+		WithBetaTestersInclude([]string{"betaGroups"}),
+	}
+	for _, opt := range opts {
+		opt(query)
+	}
+
+	qs, err := buildBetaTestersQuery("APP_ID", query)
+	if err != nil {
+		t.Fatalf("buildBetaTestersQuery() error: %v", err)
+	}
+	values, parseErr := url.ParseQuery(qs)
+	if parseErr != nil {
+		t.Fatalf("parse query: %v", parseErr)
+	}
+
+	if got := values.Get("filter[betaGroups]"); got != "group-1" {
+		t.Fatalf("expected filter[betaGroups]=group-1, got %q", got)
+	}
+	if got := values.Get("filter[inviteType]"); got != "PUBLIC_LINK" {
+		t.Fatalf("expected filter[inviteType]=PUBLIC_LINK, got %q", got)
+	}
+	if got := values.Get("include"); got != "betaGroups" {
+		t.Fatalf("expected include=betaGroups, got %q", got)
+	}
+}

--- a/internal/asc/client_query_testflight.go
+++ b/internal/asc/client_query_testflight.go
@@ -83,6 +83,9 @@ type betaTestersQuery struct {
 	ids          []string
 	groupIDs     []string
 	filterBuilds string
+	inviteTypes  []string
+	sort         string
+	include      []string
 }
 
 type betaAppReviewDetailsQuery struct {
@@ -227,6 +230,9 @@ func buildBetaTestersQuery(appID string, query *betaTestersQuery) (string, error
 		values.Set("filter[lastName]", strings.TrimSpace(query.lastName))
 	}
 	addCSV(values, "filter[id]", query.ids)
+	addCSV(values, "filter[inviteType]", query.inviteTypes)
+	addCSV(values, "include", query.include)
+	addValue(values, "sort", query.sort)
 	addLimit(values, query.limit)
 	return values.Encode(), nil
 }
@@ -681,6 +687,35 @@ func WithBetaTestersGroupIDs(ids []string) BetaTestersOption {
 func WithBetaTestersBuildID(buildID string) BetaTestersOption {
 	return func(q *betaTestersQuery) {
 		q.filterBuilds = strings.TrimSpace(buildID)
+	}
+}
+
+// WithBetaTestersInviteTypes filters beta testers by invite type
+// (EMAIL, PUBLIC_LINK). Unlike the relationship filters, filter[inviteType]
+// combines freely with the app, group, and build filters.
+func WithBetaTestersInviteTypes(inviteTypes []string) BetaTestersOption {
+	return func(q *betaTestersQuery) {
+		q.inviteTypes = normalizeList(inviteTypes)
+	}
+}
+
+// WithBetaTestersSort sets the sort order for beta testers.
+func WithBetaTestersSort(sort string) BetaTestersOption {
+	return func(q *betaTestersQuery) {
+		if strings.TrimSpace(sort) != "" {
+			q.sort = strings.TrimSpace(sort)
+		}
+	}
+}
+
+// WithBetaTestersInclude specifies related resources to include in beta tester
+// responses (apps, betaGroups, builds). Including betaGroups returns each
+// tester's group memberships in one call instead of a per-tester lookup.
+func WithBetaTestersInclude(include []string) BetaTestersOption {
+	return func(q *betaTestersQuery) {
+		if normalized := normalizeList(include); len(normalized) > 0 {
+			q.include = normalized
+		}
 	}
 }
 

--- a/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
@@ -108,6 +108,7 @@ func TestTestFlightBetaTestersListNotesIncludeIsJSONOnly(t *testing.T) {
 		{name: "table drops included", format: "table", wantNote: true},
 		{name: "markdown drops included", format: "markdown", wantNote: true},
 		{name: "json renders included", format: "json", wantNote: false},
+		{name: "uppercase json renders included", format: "JSON", wantNote: false},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
@@ -1,0 +1,278 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func TestTestFlightBetaTestersListSendsSortIncludeAndInviteType(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var captured *http.Request
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		captured = req
+		return okJSONResponse(`{"data":[],"links":{}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "list",
+			"--app", "app-1",
+			"--sort", "-lastName",
+			"--include", "betaGroups",
+			"--invite-type", "EMAIL,PUBLIC_LINK",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if captured == nil {
+		t.Fatal("expected an outbound request")
+	}
+
+	query := captured.URL.Query()
+	if got := query.Get("sort"); got != "-lastName" {
+		t.Fatalf("expected sort=-lastName, got %q", got)
+	}
+	if got := query.Get("include"); got != "betaGroups" {
+		t.Fatalf("expected include=betaGroups, got %q", got)
+	}
+	if got := query.Get("filter[inviteType]"); got != "EMAIL,PUBLIC_LINK" {
+		t.Fatalf("expected filter[inviteType]=EMAIL,PUBLIC_LINK, got %q", got)
+	}
+	if got := query.Get("filter[apps]"); got != "app-1" {
+		t.Fatalf("expected filter[apps]=app-1, got %q", got)
+	}
+}
+
+func TestTestFlightBetaTestersListLowercaseInviteTypeIsNormalized(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	var captured *http.Request
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		captured = req
+		return okJSONResponse(`{"data":[],"links":{}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "list",
+			"--app", "app-1",
+			"--invite-type", "public_link",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if captured == nil {
+		t.Fatal("expected an outbound request")
+	}
+	if got := captured.URL.Query().Get("filter[inviteType]"); got != "PUBLIC_LINK" {
+		t.Fatalf("expected filter[inviteType]=PUBLIC_LINK, got %q", got)
+	}
+}
+
+func TestTestFlightBetaTestersListRejectsInvalidFilterValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantHint string
+	}{
+		{
+			name:     "invalid sort",
+			args:     []string{"testflight", "testers", "list", "--app", "app-1", "--sort", "createdDate"},
+			wantHint: "--sort must be one of: firstName, -firstName, lastName, -lastName, email, -email, inviteType, -inviteType, state, -state",
+		},
+		{
+			name:     "invalid include",
+			args:     []string{"testflight", "testers", "list", "--app", "app-1", "--include", "appDevices"},
+			wantHint: "--include must be a comma-separated list of: apps, betaGroups, builds",
+		},
+		{
+			name:     "invalid invite type",
+			args:     []string{"testflight", "testers", "list", "--app", "app-1", "--invite-type", "SMS"},
+			wantHint: "--invite-type must be a comma-separated list of: EMAIL, PUBLIC_LINK",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				return nil, nil
+			}))
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(test.args, "1.2.3"); code != cmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantHint) {
+				t.Fatalf("expected stderr to list valid values %q, got %q", test.wantHint, stderr)
+			}
+		})
+	}
+}
+
+func TestTestFlightBetaTestersListRejectsFiltersWithNextURL(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/betaTesters?cursor=AQ&limit=200"
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "sort",
+			args:    []string{"testflight", "testers", "list", "--next", nextURL, "--sort", "email"},
+			wantErr: "--next cannot be combined with --sort",
+		},
+		{
+			name:    "include",
+			args:    []string{"testflight", "testers", "list", "--next", nextURL, "--include", "betaGroups"},
+			wantErr: "--next cannot be combined with --include",
+		},
+		{
+			name:    "invite type",
+			args:    []string{"testflight", "testers", "list", "--next", nextURL, "--invite-type", "EMAIL"},
+			wantErr: "--next cannot be combined with --invite-type",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+			installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				return nil, nil
+			}))
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(test.args, "1.2.3"); code != cmd.ExitUsage {
+					t.Fatalf("expected exit code %d, got %d", cmd.ExitUsage, code)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.wantErr, stderr)
+			}
+		})
+	}
+}
+
+func TestTestFlightBetaTestersListPaginateMergesIncludedBetaGroups(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const secondURL = "https://api.appstoreconnect.apple.com/v1/betaTesters?cursor=BQ&filter%5Bapps%5D=app-1&include=betaGroups&limit=200"
+
+	requestCount := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			query := req.URL.Query()
+			if got := query.Get("include"); got != "betaGroups" {
+				t.Fatalf("expected first page include=betaGroups, got %q", got)
+			}
+			if got := query.Get("limit"); got != "200" {
+				t.Fatalf("expected first page limit=200, got %q", got)
+			}
+			return okJSONResponse(`{"data":[{"type":"betaTesters","id":"tester-1","relationships":{"betaGroups":{"data":[{"type":"betaGroups","id":"group-a"}]}}}],` +
+				`"included":[{"type":"betaGroups","id":"group-a","attributes":{"name":"Alpha"}}],` +
+				`"links":{"next":"` + secondURL + `"}}`), nil
+		case 2:
+			if req.URL.String() != secondURL {
+				t.Fatalf("unexpected second request URL %q", req.URL.String())
+			}
+			return okJSONResponse(`{"data":[{"type":"betaTesters","id":"tester-2","relationships":{"betaGroups":{"data":[{"type":"betaGroups","id":"group-b"}]}}}],` +
+				`"included":[{"type":"betaGroups","id":"group-b","attributes":{"name":"Bravo"}}],` +
+				`"links":{}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "list",
+			"--app", "app-1",
+			"--include", "betaGroups",
+			"--paginate",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if requestCount != 2 {
+		t.Fatalf("expected 2 requests, got %d", requestCount)
+	}
+
+	var response struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+		Included []struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"included"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("decode stdout: %v (stdout=%q)", err, stdout)
+	}
+	if len(response.Data) != 2 {
+		t.Fatalf("expected 2 aggregated testers, got %d (stdout=%q)", len(response.Data), stdout)
+	}
+
+	includedIDs := make([]string, 0, len(response.Included))
+	for _, item := range response.Included {
+		includedIDs = append(includedIDs, item.ID)
+	}
+	if len(includedIDs) != 2 || !strings.Contains(strings.Join(includedIDs, ","), "group-a") ||
+		!strings.Contains(strings.Join(includedIDs, ","), "group-b") {
+		t.Fatalf("expected included beta groups from both pages, got %v (stdout=%q)", includedIDs, stdout)
+	}
+}

--- a/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
@@ -137,11 +137,43 @@ func TestTestFlightBetaTestersListNotesIncludeIsJSONOnly(t *testing.T) {
 				}
 			})
 
-			gotNote := strings.Contains(stderr, "--include resources are only rendered in JSON output")
+			gotNote := strings.Contains(stderr, "included resources are only rendered in JSON output")
 			if gotNote != test.wantNote {
 				t.Fatalf("note presence = %v, want %v (stderr=%q)", gotNote, test.wantNote, stderr)
 			}
 		})
+	}
+}
+
+func TestTestFlightBetaTestersListNotesNextURLIncludedResourcesAreJSONOnly(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/betaTesters?cursor=AQ&include=betaGroups"
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != nextURL {
+			t.Fatalf("unexpected request URL %q", req.URL.String())
+		}
+		return okJSONResponse(`{"data":[],"included":[{"type":"betaGroups","id":"group-a"}],"links":{}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "list",
+			"--next", nextURL,
+			"--output", "table",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "included resources are only rendered in JSON output") {
+		t.Fatalf("expected JSON-only included-resource note, got %q", stderr)
 	}
 }
 
@@ -267,7 +299,7 @@ func TestTestFlightBetaTestersListPaginateMergesIncludedBetaGroups(t *testing.T)
 				t.Fatalf("unexpected second request URL %q", req.URL.String())
 			}
 			return okJSONResponse(`{"data":[{"type":"betaTesters","id":"tester-2","relationships":{"betaGroups":{"data":[{"type":"betaGroups","id":"group-b"}]}}}],` +
-				`"included":[{"type":"betaGroups","id":"group-b","attributes":{"name":"Bravo"}}],` +
+				`"included":[{"type":"betaGroups","id":"group-a","attributes":{"name":"Alpha updated"}},{"type":"betaGroups","id":"group-b","attributes":{"name":"Bravo"}}],` +
 				`"links":{}}`), nil
 		default:
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
@@ -302,8 +334,11 @@ func TestTestFlightBetaTestersListPaginateMergesIncludedBetaGroups(t *testing.T)
 			ID string `json:"id"`
 		} `json:"data"`
 		Included []struct {
-			Type string `json:"type"`
-			ID   string `json:"id"`
+			Type       string `json:"type"`
+			ID         string `json:"id"`
+			Attributes struct {
+				Name string `json:"name"`
+			} `json:"attributes"`
 		} `json:"included"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
@@ -313,12 +348,28 @@ func TestTestFlightBetaTestersListPaginateMergesIncludedBetaGroups(t *testing.T)
 		t.Fatalf("expected 2 aggregated testers, got %d (stdout=%q)", len(response.Data), stdout)
 	}
 
-	includedIDs := make([]string, 0, len(response.Included))
-	for _, item := range response.Included {
-		includedIDs = append(includedIDs, item.ID)
+	if len(response.Included) != 2 {
+		t.Fatalf("expected one included resource per type and ID, got %+v (stdout=%q)", response.Included, stdout)
 	}
-	if len(includedIDs) != 2 || !strings.Contains(strings.Join(includedIDs, ","), "group-a") ||
-		!strings.Contains(strings.Join(includedIDs, ","), "group-b") {
-		t.Fatalf("expected included beta groups from both pages, got %v (stdout=%q)", includedIDs, stdout)
+	if response.Included[0].ID != "group-a" || response.Included[0].Attributes.Name != "Alpha" ||
+		response.Included[1].ID != "group-b" {
+		t.Fatalf("expected first group-a representation followed by group-b, got %+v (stdout=%q)", response.Included, stdout)
+	}
+}
+
+func TestTestFlightBetaTestersListQueryFlagsAreExperimental(t *testing.T) {
+	list := findSubcommand(RootCommand("1.2.3"), "testflight", "testers", "list")
+	if list == nil {
+		t.Fatal("testflight testers list command not found")
+	}
+
+	for _, name := range []string{"invite-type", "sort", "include"} {
+		flag := list.FlagSet.Lookup(name)
+		if flag == nil {
+			t.Fatalf("--%s flag not found", name)
+		}
+		if !strings.HasPrefix(flag.Usage, "[experimental] ") {
+			t.Errorf("--%s usage = %q, want [experimental] prefix", name, flag.Usage)
+		}
 	}
 }

--- a/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
@@ -99,6 +99,52 @@ func TestTestFlightBetaTestersListLowercaseInviteTypeIsNormalized(t *testing.T) 
 	}
 }
 
+func TestTestFlightBetaTestersListNotesIncludeIsJSONOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		wantNote bool
+	}{
+		{name: "table drops included", format: "table", wantNote: true},
+		{name: "markdown drops included", format: "markdown", wantNote: true},
+		{name: "json renders included", format: "json", wantNote: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+			installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return okJSONResponse(`{"data":[{"type":"betaTesters","id":"tester-1","attributes":{"email":"tester@example.com"}}],` +
+					`"included":[{"type":"betaGroups","id":"group-a","attributes":{"name":"Alpha"}}],"links":{}}`), nil
+			}))
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			_, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"testflight", "testers", "list",
+					"--app", "app-1",
+					"--include", "betaGroups",
+					"--output", test.format,
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			gotNote := strings.Contains(stderr, "--include resources are only rendered in JSON output")
+			if gotNote != test.wantNote {
+				t.Fatalf("note presence = %v, want %v (stderr=%q)", gotNote, test.wantNote, stderr)
+			}
+		})
+	}
+}
+
 func TestTestFlightBetaTestersListRejectsInvalidFilterValues(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go
@@ -40,8 +40,8 @@ func TestTestFlightBetaTestersListSendsSortIncludeAndInviteType(t *testing.T) {
 			t.Fatalf("run error: %v", err)
 		}
 	})
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	if !strings.Contains(stderr, "included relationships can be partial") {
+		t.Fatalf("expected included-relationship completeness warning, got %q", stderr)
 	}
 	if captured == nil {
 		t.Fatal("expected an outbound request")
@@ -141,6 +141,9 @@ func TestTestFlightBetaTestersListNotesIncludeIsJSONOnly(t *testing.T) {
 			if gotNote != test.wantNote {
 				t.Fatalf("note presence = %v, want %v (stderr=%q)", gotNote, test.wantNote, stderr)
 			}
+			if !strings.Contains(stderr, "included relationships can be partial") {
+				t.Fatalf("expected included-relationship completeness warning, got %q", stderr)
+			}
 		})
 	}
 }
@@ -174,6 +177,9 @@ func TestTestFlightBetaTestersListNotesNextURLIncludedResourcesAreJSONOnly(t *te
 	})
 	if !strings.Contains(stderr, "included resources are only rendered in JSON output") {
 		t.Fatalf("expected JSON-only included-resource note, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "included relationships can be partial") {
+		t.Fatalf("expected included-relationship completeness warning, got %q", stderr)
 	}
 }
 
@@ -371,5 +377,27 @@ func TestTestFlightBetaTestersListQueryFlagsAreExperimental(t *testing.T) {
 		if !strings.HasPrefix(flag.Usage, "[experimental] ") {
 			t.Errorf("--%s usage = %q, want [experimental] prefix", name, flag.Usage)
 		}
+	}
+}
+
+func TestTestFlightBetaTestersListHelpExplainsIncludedRelationshipBounds(t *testing.T) {
+	list := findSubcommand(RootCommand("1.2.3"), "testflight", "testers", "list")
+	if list == nil {
+		t.Fatal("testflight testers list command not found")
+	}
+
+	normalizedHelp := strings.Join(strings.Fields(list.LongHelp), " ")
+	for _, want := range []string{
+		"at most 50 related resources per included relationship",
+		"--paginate pages the tester collection, not included relationships",
+		`asc testflight testers groups list --id "TESTER_ID" --paginate`,
+		"exit 2 before making a request",
+	} {
+		if !strings.Contains(normalizedHelp, want) {
+			t.Errorf("help missing %q: %q", want, list.LongHelp)
+		}
+	}
+	if strings.Contains(normalizedHelp, "audit group membership for every tester in one call") {
+		t.Errorf("help still promises complete included group membership: %q", list.LongHelp)
 	}
 }

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -114,7 +114,7 @@ func BetaTestersListCommand() *ffcli.Command {
 array, which only JSON output renders. App Store Connect returns at most 50
 related resources per included relationship. --paginate pages the tester
 collection, not included relationships. For complete group membership, run
-asc testflight beta-testers beta-groups list --id "TESTER_ID" --paginate.
+asc testflight testers groups list --id "TESTER_ID" --paginate.
 The --invite-type, --sort, and --include flags are experimental.
 A --next URL retains any include query from its original request; JSON output
 is still required to render those included resources.

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -84,6 +84,8 @@ var betaTesterIncludeValues = []string{"apps", "betaGroups", "builds"}
 // betaTesterInviteTypeValues lists the accepted filter[inviteType] values.
 var betaTesterInviteTypeValues = []string{"EMAIL", "PUBLIC_LINK"}
 
+const betaTesterIncludedRelationshipsWarning = "Warning: included relationships can be partial; App Store Connect returns at most 50 related resources per included relationship. --paginate pages the tester collection, not included relationships."
+
 // BetaTestersListCommand returns the beta testers list subcommand.
 func BetaTestersListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
@@ -109,15 +111,18 @@ func BetaTestersListCommand() *ffcli.Command {
 		LongHelp: `List TestFlight beta testers for an app.
 
 --include adds the related resources to the response's top-level "included"
-array, which only JSON output renders. Use --include betaGroups to audit group
-membership for every tester in one call instead of one lookup per tester.
+array, which only JSON output renders. App Store Connect returns at most 50
+related resources per included relationship. --paginate pages the tester
+collection, not included relationships. For complete group membership, run
+asc testflight beta-testers beta-groups list --id "TESTER_ID" --paginate.
 The --invite-type, --sort, and --include flags are experimental.
 A --next URL retains any include query from its original request; JSON output
 is still required to render those included resources.
 
 --invite-type, --sort, and --include cannot be combined with --next: a
 links.next URL already carries the query it was produced from, so those values
-would never reach the request.
+would never reach the request. Invalid values and these incompatible flag
+combinations exit 2 before making a request.
 
 Examples:
   asc testflight beta-testers list --app "APP_ID"
@@ -221,8 +226,12 @@ Examples:
 			// Only the JSON renderer emits the envelope's included array. A
 			// continuation URL can carry include even though --include itself is
 			// rejected beside --next, so cover both request shapes.
-			if (len(includeValues) > 0 || betaTestersNextURLHasInclude(*next)) && *output.Output != "json" {
-				fmt.Fprintln(os.Stderr, "Note: included resources are only rendered in JSON output; re-run with --output json to see them.")
+			requestHasIncludes := len(includeValues) > 0 || betaTestersNextURLHasInclude(*next)
+			if requestHasIncludes {
+				fmt.Fprintln(os.Stderr, betaTesterIncludedRelationshipsWarning)
+				if *output.Output != "json" {
+					fmt.Fprintln(os.Stderr, "Note: included resources are only rendered in JSON output; re-run with --output json to see them.")
+				}
 			}
 
 			if strings.TrimSpace(*group) != "" && strings.TrimSpace(*next) == "" {

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -108,8 +108,12 @@ func BetaTestersListCommand() *ffcli.Command {
 		LongHelp: `List TestFlight beta testers for an app.
 
 --include adds the related resources to the response's top-level "included"
-array (JSON output). Use --include betaGroups to audit group membership for
-every tester in one call instead of one lookup per tester.
+array, which only JSON output renders. Use --include betaGroups to audit group
+membership for every tester in one call instead of one lookup per tester.
+
+--invite-type, --sort, and --include cannot be combined with --next: a
+links.next URL already carries the query it was produced from, so those values
+would never reach the request.
 
 Examples:
   asc testflight beta-testers list --app "APP_ID"
@@ -118,7 +122,7 @@ Examples:
   asc testflight beta-testers list --app "APP_ID" --first-name "Ada" --last-name "Lovelace"
   asc testflight beta-testers list --app "APP_ID" --invite-type "PUBLIC_LINK"
   asc testflight beta-testers list --app "APP_ID" --sort "-lastName"
-  asc testflight beta-testers list --app "APP_ID" --include "betaGroups" --paginate
+  asc testflight beta-testers list --app "APP_ID" --include "betaGroups" --paginate --output json
   asc testflight beta-testers list --app "APP_ID" --limit 25
   asc testflight beta-testers list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
@@ -206,8 +210,14 @@ Examples:
 				opts = append(opts, asc.WithBetaTestersSort(*sortBy))
 			}
 
-			if includeValues := shared.SplitCSV(*include); len(includeValues) > 0 {
+			includeValues := shared.SplitCSV(*include)
+			if len(includeValues) > 0 {
 				opts = append(opts, asc.WithBetaTestersInclude(includeValues))
+				// Only the JSON renderer emits the envelope's included array, so
+				// say so rather than fetching relationships the caller never sees.
+				if *output.Output != "json" {
+					fmt.Fprintf(os.Stderr, "Note: --include resources are only rendered in JSON output; re-run with --output json to see them.\n")
+				}
 			}
 
 			if strings.TrimSpace(*group) != "" && strings.TrimSpace(*next) == "" {

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -93,9 +94,9 @@ func BetaTestersListCommand() *ffcli.Command {
 	email := fs.String("email", "", "Filter by tester email")
 	firstName := fs.String("first-name", "", "Filter by tester first name (exact match)")
 	lastName := fs.String("last-name", "", "Filter by tester last name (exact match)")
-	inviteType := fs.String("invite-type", "", "Filter by invite type(s), comma-separated: "+strings.Join(betaTesterInviteTypeValues, ", "))
-	sortBy := fs.String("sort", "", "Sort by: "+strings.Join(betaTesterSortValues, ", "))
-	include := fs.String("include", "", "Include related resources, comma-separated: "+strings.Join(betaTesterIncludeValues, ", "))
+	inviteType := fs.String("invite-type", "", "[experimental] Filter by invite type(s), comma-separated: "+strings.Join(betaTesterInviteTypeValues, ", "))
+	sortBy := fs.String("sort", "", "[experimental] Sort by: "+strings.Join(betaTesterSortValues, ", "))
+	include := fs.String("include", "", "[experimental] Include related resources, comma-separated: "+strings.Join(betaTesterIncludeValues, ", "))
 	output := shared.BindOutputFlags(fs)
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -110,6 +111,9 @@ func BetaTestersListCommand() *ffcli.Command {
 --include adds the related resources to the response's top-level "included"
 array, which only JSON output renders. Use --include betaGroups to audit group
 membership for every tester in one call instead of one lookup per tester.
+The --invite-type, --sort, and --include flags are experimental.
+A --next URL retains any include query from its original request; JSON output
+is still required to render those included resources.
 
 --invite-type, --sort, and --include cannot be combined with --next: a
 links.next URL already carries the query it was produced from, so those values
@@ -213,11 +217,12 @@ Examples:
 			includeValues := shared.SplitCSV(*include)
 			if len(includeValues) > 0 {
 				opts = append(opts, asc.WithBetaTestersInclude(includeValues))
-				// Only the JSON renderer emits the envelope's included array, so
-				// say so rather than fetching relationships the caller never sees.
-				if *output.Output != "json" {
-					fmt.Fprintf(os.Stderr, "Note: --include resources are only rendered in JSON output; re-run with --output json to see them.\n")
-				}
+			}
+			// Only the JSON renderer emits the envelope's included array. A
+			// continuation URL can carry include even though --include itself is
+			// rejected beside --next, so cover both request shapes.
+			if (len(includeValues) > 0 || betaTestersNextURLHasInclude(*next)) && *output.Output != "json" {
+				fmt.Fprintln(os.Stderr, "Note: included resources are only rendered in JSON output; re-run with --output json to see them.")
 			}
 
 			if strings.TrimSpace(*group) != "" && strings.TrimSpace(*next) == "" {
@@ -266,6 +271,14 @@ func normalizeBetaTesterInviteTypes(value string) ([]string, error) {
 		}
 	}
 	return values, nil
+}
+
+func betaTestersNextURLHasInclude(next string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(next))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(parsed.Query().Get("include")) != ""
 }
 
 // rejectBetaTestersNextFlagConflicts fails when a caller pairs --next with a

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -67,6 +68,21 @@ Examples:
 	}
 }
 
+// betaTesterSortValues lists the sort expressions GET /v1/betaTesters accepts.
+var betaTesterSortValues = []string{
+	"firstName", "-firstName",
+	"lastName", "-lastName",
+	"email", "-email",
+	"inviteType", "-inviteType",
+	"state", "-state",
+}
+
+// betaTesterIncludeValues lists the relationships GET /v1/betaTesters can include.
+var betaTesterIncludeValues = []string{"apps", "betaGroups", "builds"}
+
+// betaTesterInviteTypeValues lists the accepted filter[inviteType] values.
+var betaTesterInviteTypeValues = []string{"EMAIL", "PUBLIC_LINK"}
+
 // BetaTestersListCommand returns the beta testers list subcommand.
 func BetaTestersListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
@@ -77,6 +93,9 @@ func BetaTestersListCommand() *ffcli.Command {
 	email := fs.String("email", "", "Filter by tester email")
 	firstName := fs.String("first-name", "", "Filter by tester first name (exact match)")
 	lastName := fs.String("last-name", "", "Filter by tester last name (exact match)")
+	inviteType := fs.String("invite-type", "", "Filter by invite type(s), comma-separated: "+strings.Join(betaTesterInviteTypeValues, ", "))
+	sortBy := fs.String("sort", "", "Sort by: "+strings.Join(betaTesterSortValues, ", "))
+	include := fs.String("include", "", "Include related resources, comma-separated: "+strings.Join(betaTesterIncludeValues, ", "))
 	output := shared.BindOutputFlags(fs)
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
@@ -88,11 +107,18 @@ func BetaTestersListCommand() *ffcli.Command {
 		ShortHelp:  "List TestFlight beta testers for an app.",
 		LongHelp: `List TestFlight beta testers for an app.
 
+--include adds the related resources to the response's top-level "included"
+array (JSON output). Use --include betaGroups to audit group membership for
+every tester in one call instead of one lookup per tester.
+
 Examples:
   asc testflight beta-testers list --app "APP_ID"
   asc testflight beta-testers list --app "APP_ID" --build-id "BUILD_ID"
   asc testflight beta-testers list --app "APP_ID" --group "Beta"
   asc testflight beta-testers list --app "APP_ID" --first-name "Ada" --last-name "Lovelace"
+  asc testflight beta-testers list --app "APP_ID" --invite-type "PUBLIC_LINK"
+  asc testflight beta-testers list --app "APP_ID" --sort "-lastName"
+  asc testflight beta-testers list --app "APP_ID" --include "betaGroups" --paginate
   asc testflight beta-testers list --app "APP_ID" --limit 25
   asc testflight beta-testers list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
@@ -110,6 +136,24 @@ Examples:
 			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("beta-testers list: %w", err)
+			}
+			if err := shared.ValidateSort(*sortBy, betaTesterSortValues...); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+				return shared.InvalidValueUsageError("--sort")
+			}
+			if err := shared.ValidateInclude(*include, betaTesterIncludeValues...); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+				return shared.InvalidValueUsageError("--include")
+			}
+			inviteTypes, err := normalizeBetaTesterInviteTypes(*inviteType)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+				return shared.InvalidValueUsageError("--invite-type")
+			}
+			// A links.next URL already carries the query it was produced from, so
+			// these flags would be accepted and silently dropped.
+			if err := rejectBetaTestersNextFlagConflicts(fs, *next, "invite-type", "sort", "include"); err != nil {
+				return err
 			}
 			if strings.TrimSpace(*group) != "" && strings.TrimSpace(*buildID) != "" && strings.TrimSpace(*next) == "" {
 				return shared.WithDiagnostic(
@@ -154,6 +198,18 @@ Examples:
 				opts = append(opts, asc.WithBetaTestersLastName(*lastName))
 			}
 
+			if len(inviteTypes) > 0 {
+				opts = append(opts, asc.WithBetaTestersInviteTypes(inviteTypes))
+			}
+
+			if strings.TrimSpace(*sortBy) != "" {
+				opts = append(opts, asc.WithBetaTestersSort(*sortBy))
+			}
+
+			if includeValues := shared.SplitCSV(*include); len(includeValues) > 0 {
+				opts = append(opts, asc.WithBetaTestersInclude(includeValues))
+			}
+
 			if strings.TrimSpace(*group) != "" && strings.TrimSpace(*next) == "" {
 				groupID, err := resolveBetaGroupID(requestCtx, client, resolvedAppID, *group)
 				if err != nil {
@@ -188,6 +244,41 @@ Examples:
 			return shared.PrintOutput(testers, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+// normalizeBetaTesterInviteTypes upper-cases and validates a comma-separated
+// --invite-type value against the filter[inviteType] enum.
+func normalizeBetaTesterInviteTypes(value string) ([]string, error) {
+	values := shared.SplitCSVUpper(value)
+	for _, item := range values {
+		if !slices.Contains(betaTesterInviteTypeValues, item) {
+			return nil, fmt.Errorf("--invite-type must be a comma-separated list of: %s", strings.Join(betaTesterInviteTypeValues, ", "))
+		}
+	}
+	return values, nil
+}
+
+// rejectBetaTestersNextFlagConflicts fails when a caller pairs --next with a
+// flag whose value cannot reach the request, because a links.next URL is
+// followed verbatim.
+func rejectBetaTestersNextFlagConflicts(fs *flag.FlagSet, next string, names ...string) error {
+	if strings.TrimSpace(next) == "" {
+		return nil
+	}
+	provided := make(map[string]struct{})
+	fs.Visit(func(f *flag.Flag) {
+		provided[f.Name] = struct{}{}
+	})
+	for _, name := range names {
+		if _, ok := provided[name]; ok {
+			return shared.WithDiagnostic(
+				shared.UsageErrorf("beta-testers list: --next cannot be combined with --%s", name),
+				shared.DiagnosticConflictingInput,
+				"--"+name,
+			)
+		}
+	}
+	return nil
 }
 
 // BetaTestersGetCommand returns the beta testers get subcommand.

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -229,7 +229,7 @@ Examples:
 			requestHasIncludes := len(includeValues) > 0 || betaTestersNextURLHasInclude(*next)
 			if requestHasIncludes {
 				fmt.Fprintln(os.Stderr, betaTesterIncludedRelationshipsWarning)
-				if *output.Output != "json" {
+				if shared.NormalizeOutputFormat(*output.Output) != "json" {
 					fmt.Fprintln(os.Stderr, "Note: included resources are only rendered in JSON output; re-run with --output json to see them.")
 				}
 			}

--- a/internal/cli/testflight/beta_testers_help_test.go
+++ b/internal/cli/testflight/beta_testers_help_test.go
@@ -1,0 +1,17 @@
+package testflight
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBetaTestersListHelpUsesPublicGroupMembershipCommand(t *testing.T) {
+	help := BetaTestersListCommand().LongHelp
+	want := `asc testflight testers groups list --id "TESTER_ID" --paginate`
+	if !strings.Contains(help, want) {
+		t.Fatalf("help missing public group-membership command %q: %q", want, help)
+	}
+	if strings.Contains(help, "asc testflight beta-testers beta-groups") {
+		t.Fatalf("help exposes internal group-membership command path: %q", help)
+	}
+}


### PR DESCRIPTION
## Problem

`GET /v1/betaTesters` supports `sort`, `include`, and `filter[inviteType]`, but none of the three were reachable from `asc testflight testers list`:

- `betaTestersQuery` had no fields for them and `buildBetaTestersQuery` emitted none.
- `filter[inviteType]` appeared nowhere in `internal/`.

The practical cost was `--include betaGroups`. Auditing which groups a set of testers belongs to meant listing testers and then issuing `asc testflight testers groups list --id ...` once per tester — an N+1 fan-out for data Apple will return in the same envelope.

## Behavior change

Three additive flags on `asc testflight testers list`:

| Flag | Emits | Accepted values |
| --- | --- | --- |
| `--sort` | `sort` | `firstName`, `-firstName`, `lastName`, `-lastName`, `email`, `-email`, `inviteType`, `-inviteType`, `state`, `-state` |
| `--include` | `include` | `apps`, `betaGroups`, `builds` (comma-separated) |
| `--invite-type` | `filter[inviteType]` | `EMAIL`, `PUBLIC_LINK` (comma-separated, case-normalized) |

All three enums are validated against `docs/openapi/latest.json`. An invalid value exits `2` and prints the accepted values to stderr; no request is made.

Combining any of the three with `--next` is rejected (exit `2`, `--next cannot be combined with --<flag>`) rather than accepted and dropped: a `links.next` URL is followed verbatim, so those values could never reach the request.

`--include` with `--paginate` merges each page's `included` array into one envelope. That merge already existed generically in `PaginateAll` (`aggregateJSONRawArrayField`, deduplicating by raw item); this PR adds the coverage that pins it for this path, so `--include` + `--paginate` cannot silently lose included resources.

Apple's envelope is still printed unmodified. No existing flag, default, or output shape changes.

## Example invocations

```bash
# every tester's group membership in one call instead of one call per tester
asc testflight testers list --app APP_ID --include betaGroups --paginate

# who joined via the public link, newest surnames last
asc testflight testers list --app APP_ID --invite-type PUBLIC_LINK --sort -lastName

# combine with the existing relationship filters
asc testflight testers list --app APP_ID --group "Beta" --include betaGroups
```

Rejections:

```console
$ asc testflight testers list --app APP_ID --sort createdDate
Error: --sort must be one of: firstName, -firstName, lastName, -lastName, email, -email, inviteType, -inviteType, state, -state
# exit 2

$ asc testflight testers list --next "https://api.appstoreconnect.apple.com/v1/betaTesters?cursor=AQ" --include betaGroups
Error: beta-testers list: --next cannot be combined with --include
# exit 2
```

## Tests

New `internal/asc/client_query_beta_testers_test.go`:

- emitted `sort` / `include` / `filter[inviteType]` params, including whitespace normalization
- unset values omit the params entirely
- `filter[inviteType]` and `include` survive alongside the `filter[betaGroups]` relationship filter

New `internal/cli/cmdtest/testflight_beta_testers_list_filters_test.go`:

- end-to-end query params for all three flags on the real command path
- lowercase `--invite-type public_link` normalizes to `PUBLIC_LINK`
- invalid `--sort` / `--include` / `--invite-type` each exit `2` with the accepted values on stderr and issue no request
- `--next` paired with each of the three exits `2` and issues no request
- `--paginate --include betaGroups` across two pages yields two testers and both pages' `included` beta groups in one envelope

Gauntlet: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` all pass (the pre-commit hook reran docs/format/lint/tests on the commit).

## Compatibility

Purely additive. Every existing invocation emits the same query it did before — the new params are only set when the corresponding flag is passed. No API calls were made during development; all coverage is `httptest`/`cmdtest`.

Docs: `commands/testflight.mdx` gains the new flags. `docs/COMMANDS.md` is unchanged (it lists command families, not flags) and `make check-docs` confirms it is in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TestFlight beta tester filtering by invite type, sorting, and related-resource inclusion.
  - Pagination now combines tester data and deduplicates included beta groups across pages.
  - Added validation for filter values and incompatible pagination options, with clear errors before requests are made.
  - Included resources are available with JSON output, with notices for other formats and relationship completeness limits.

- **Documentation**
  - Updated TestFlight guidance with new options, examples, JSON-output requirements, resource limits, and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->