### PR TITLE
feat(completion): support nested commands and flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,12 +20,15 @@ var versionRequested bool
 // RootCommand returns the root command
 func RootCommand(version string) *ffcli.Command {
 	catalog := registry.NewCatalog(version)
-	return newRootCommand(version, catalog.All())
+	root := newRootCommand(version, catalog.All())
+	catalog.SetCompletionRootFlagSet(root.FlagSet)
+	return root
 }
 
 func rootCommandForArgs(version string, args []string) *ffcli.Command {
 	catalog := registry.NewCatalog(version)
 	root := newRootCommand(version, catalog.MetadataCommands())
+	catalog.SetCompletionRootFlagSet(root.FlagSet)
 	// Command discovery must understand the same liberal `--bool false` form
 	// as final parsing. Otherwise the separated value looks positional and the
 	// lazy catalog can materialize the wrong command tree.

--- a/commands/completion.mdx
+++ b/commands/completion.mdx
@@ -97,22 +97,24 @@ The completion script provides tab completion for:
 
 Deprecated compatibility commands and hidden flag aliases are not suggested. Completion tracks flags that consume a value, so a flag value that matches a subcommand name does not move completion into the wrong command path. It does not query App Store Connect for remote resource IDs or other flag values.
 
-**Example:**
+**Abbreviated examples:**
 
 ```bash  theme={null}
 $ asc <TAB>
-auth          builds        completion    devices
-migrate       metadata      notify        profiles
-submit        testflight    users         webhooks
-workflow      xcode-cloud
+--api-debug   --debug       --profile     --report
+apps          auth          builds        completion
+devices       metadata      profiles      testflight
+...           users         webhooks      xcode-cloud
 
 $ asc builds <TAB>
 count         info          list          upload        wait
 
 $ asc builds list <TAB>
---app                 --build-number        --limit
+--app                 --build-number        --exclude-expired
+--limit               --next                --not-expired
 --output              --paginate            --platform
---processing-state    --version
+--pretty              --processing-state    --sort
+--version
 ```
 
 ## Manual Installation

--- a/commands/completion.mdx
+++ b/commands/completion.mdx
@@ -92,17 +92,27 @@ fish_update_completions
 
 The completion script provides tab completion for:
 
-* Top-level commands (e.g., `builds`, `testflight`, `metadata`)
-* Common flags (basic support)
+* Top-level and nested subcommands (for example, `builds list` and `apps info view`)
+* Flags accepted by the command at the current path
+
+Deprecated compatibility commands and hidden flag aliases are not suggested. Completion tracks flags that consume a value, so a flag value that matches a subcommand name does not move completion into the wrong command path. It does not query App Store Connect for remote resource IDs or other flag values.
 
 **Example:**
 
 ```bash  theme={null}
 $ asc <TAB>
-auth          builds        completion    devices       
-migrate       metadata      notify        profiles      
-submit        testflight    users         webhooks      
+auth          builds        completion    devices
+migrate       metadata      notify        profiles
+submit        testflight    users         webhooks
 workflow      xcode-cloud
+
+$ asc builds <TAB>
+count         info          list          upload        wait
+
+$ asc builds list <TAB>
+--app                 --build-number        --limit
+--output              --paginate            --platform
+--processing-state    --version
 ```
 
 ## Manual Installation
@@ -160,7 +170,11 @@ Test that completion is working:
 # Type the command and press TAB
 asc <TAB>
 
-# Should show available commands
+# Nested commands and flags are also completed
+asc builds <TAB>
+asc builds list <TAB>
+
+# These should show commands and flags valid at the current path
 ```
 
 If completion doesn't work:

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -163,19 +163,38 @@ func TestCompletionZshPrintsScriptToStdout(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	const rootGroupPrefix = "_ASC_COMPLETION_SUBCOMMAND_GROUPS=('"
-	rootGroupStart := strings.Index(stdout, rootGroupPrefix)
-	if rootGroupStart < 0 {
-		t.Fatalf("expected root command completion data, got %q", stdout)
+	completionRootGroup := func(variable string) string {
+		t.Helper()
+		prefix := variable + "=('"
+		start := strings.Index(stdout, prefix)
+		if start < 0 {
+			t.Fatalf("expected %s root completion data, got %q", variable, stdout)
+		}
+		group := stdout[start+len(prefix):]
+		end := strings.IndexByte(group, '\'')
+		if end < 0 {
+			t.Fatalf("expected terminated %s root completion data, got %q", variable, group)
+		}
+		return group[:end]
 	}
-	rootGroup := stdout[rootGroupStart+len(rootGroupPrefix):]
-	rootGroupEnd := strings.IndexByte(rootGroup, '\'')
-	if rootGroupEnd < 0 {
-		t.Fatalf("expected terminated root command completion data, got %q", rootGroup)
-	}
-	rootGroup = rootGroup[:rootGroupEnd]
+	rootGroup := completionRootGroup("_ASC_COMPLETION_SUBCOMMAND_GROUPS")
 	if strings.Contains(rootGroup, "offer-codes") || strings.Contains(rootGroup, "win-back-offers") || strings.Contains(rootGroup, "promoted-purchases") {
 		t.Fatalf("expected hidden deprecated root commands to be omitted from root completions, got %q", rootGroup)
+	}
+	rootFlags := completionRootGroup("_ASC_COMPLETION_FLAG_GROUPS")
+	for _, expected := range []string{"--profile", "--report", "--version"} {
+		if !strings.Contains(rootFlags, expected) {
+			t.Fatalf("expected root flag completion metadata %q, got %q", expected, rootFlags)
+		}
+	}
+	rootValueFlags := completionRootGroup("_ASC_COMPLETION_VALUE_FLAG_GROUPS")
+	for _, expected := range []string{"--profile", "--report", "--report-file"} {
+		if !strings.Contains(rootValueFlags, expected) {
+			t.Fatalf("expected root value flag completion metadata %q, got %q", expected, rootValueFlags)
+		}
+	}
+	if strings.Contains(rootValueFlags, "--version") {
+		t.Fatalf("expected boolean root flag to be omitted from value flags, got %q", rootValueFlags)
 	}
 	for _, expected := range []string{"apps info", "builds list", "--bundle-id", "--processing-state"} {
 		if !strings.Contains(stdout, expected) {

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -163,8 +163,24 @@ func TestCompletionZshPrintsScriptToStdout(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if strings.Contains(stdout, "offer-codes") || strings.Contains(stdout, "win-back-offers") || strings.Contains(stdout, "promoted-purchases") {
-		t.Fatalf("expected hidden deprecated root commands to be omitted from completion output, got %q", stdout)
+	const rootGroupPrefix = "_ASC_COMPLETION_SUBCOMMAND_GROUPS=('"
+	rootGroupStart := strings.Index(stdout, rootGroupPrefix)
+	if rootGroupStart < 0 {
+		t.Fatalf("expected root command completion data, got %q", stdout)
+	}
+	rootGroup := stdout[rootGroupStart+len(rootGroupPrefix):]
+	rootGroupEnd := strings.IndexByte(rootGroup, '\'')
+	if rootGroupEnd < 0 {
+		t.Fatalf("expected terminated root command completion data, got %q", rootGroup)
+	}
+	rootGroup = rootGroup[:rootGroupEnd]
+	if strings.Contains(rootGroup, "offer-codes") || strings.Contains(rootGroup, "win-back-offers") || strings.Contains(rootGroup, "promoted-purchases") {
+		t.Fatalf("expected hidden deprecated root commands to be omitted from root completions, got %q", rootGroup)
+	}
+	for _, expected := range []string{"apps info", "builds list", "--bundle-id", "--processing-state"} {
+		if !strings.Contains(stdout, expected) {
+			t.Fatalf("expected nested command completion metadata %q, got %q", expected, stdout)
+		}
 	}
 }
 

--- a/internal/cli/completion/completion.go
+++ b/internal/cli/completion/completion.go
@@ -13,9 +13,18 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
+type completionNode struct {
+	path        string
+	subcommands []string
+	flags       []string
+	valueFlags  []string
+}
+
 // CompletionCommand prints shell completion scripts to stdout.
-// It is intentionally simple and does not require auth or network access.
-func CompletionCommand(rootSubcommands []*ffcli.Command) *ffcli.Command {
+// The full command tree is resolved only after the requested shell is valid,
+// so normal command startup remains lazy and completion needs no auth or network
+// access.
+func CompletionCommand(resolveCommands func() []*ffcli.Command) *ffcli.Command {
 	fs := flag.NewFlagSet("completion", flag.ExitOnError)
 	shell := fs.String("shell", "", "Shell: bash, zsh, or fish")
 
@@ -36,44 +45,97 @@ func CompletionCommand(rootSubcommands []*ffcli.Command) *ffcli.Command {
 			fmt.Fprintln(os.Stderr, "Error: --shell is required")
 			return shared.MissingRequiredUsageError("--shell")
 		}
-
-		names := rootCommandNames(rootSubcommands)
-		switch s {
-		case "bash":
-			fmt.Fprint(os.Stdout, bashScript(names))
-			return nil
-		case "zsh":
-			fmt.Fprint(os.Stdout, zshScript(names))
-			return nil
-		case "fish":
-			fmt.Fprint(os.Stdout, fishScript(names))
-			return nil
-		default:
+		if s != "bash" && s != "zsh" && s != "fish" {
 			fmt.Fprintf(os.Stderr, "Error: unsupported shell: %s\n", shared.SanitizeTerminal(s))
 			return flag.ErrHelp
 		}
+
+		var commands []*ffcli.Command
+		if resolveCommands != nil {
+			commands = resolveCommands()
+		}
+		nodes := completionNodes(commands)
+		switch s {
+		case "bash":
+			fmt.Fprint(os.Stdout, bashScript(nodes))
+		case "zsh":
+			fmt.Fprint(os.Stdout, zshScript(nodes))
+		case "fish":
+			fmt.Fprint(os.Stdout, fishScript(nodes))
+		}
+		return nil
 	}
 
 	return cmd
 }
 
-func rootCommandNames(rootSubcommands []*ffcli.Command) []string {
-	set := make(map[string]struct{}, len(rootSubcommands)+1)
-	for _, c := range rootSubcommands {
-		if c == nil {
-			continue
-		}
-		name := strings.TrimSpace(c.Name)
-		if name == "" {
-			continue
-		}
-		set[name] = struct{}{}
+func completionNodes(rootSubcommands []*ffcli.Command) []completionNode {
+	byPath := map[string]completionNode{"": {path: ""}}
+	rootNames := visibleSubcommandNames(rootSubcommands)
+	if !containsString(rootNames, "completion") {
+		rootNames = append(rootNames, "completion")
+		sort.Strings(rootNames)
 	}
+	root := byPath[""]
+	root.subcommands = rootNames
+	byPath[""] = root
 
-	// Ensure the completion command can complete itself even if the slice passed
-	// doesn't include it (by design).
-	set["completion"] = struct{}{}
+	var visit func(parentPath string, commands []*ffcli.Command)
+	visit = func(parentPath string, commands []*ffcli.Command) {
+		for _, command := range commands {
+			if hiddenCommand(command) {
+				continue
+			}
+			name := strings.TrimSpace(command.Name)
+			if name == "" {
+				continue
+			}
+			path := name
+			if parentPath != "" {
+				path = parentPath + " " + name
+			}
+			node := completionNode{
+				path:        path,
+				subcommands: visibleSubcommandNames(command.Subcommands),
+			}
+			for _, commandFlag := range shared.VisibleHelpFlags(command.FlagSet) {
+				flagName := "--" + commandFlag.Name
+				node.flags = append(node.flags, flagName)
+				if flagRequiresValue(commandFlag) {
+					node.valueFlags = append(node.valueFlags, flagName)
+				}
+			}
+			sort.Strings(node.flags)
+			sort.Strings(node.valueFlags)
+			byPath[path] = node
+			visit(path, command.Subcommands)
+		}
+	}
+	visit("", rootSubcommands)
 
+	paths := make([]string, 0, len(byPath))
+	for path := range byPath {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	nodes := make([]completionNode, 0, len(paths))
+	for _, path := range paths {
+		nodes = append(nodes, byPath[path])
+	}
+	return nodes
+}
+
+func visibleSubcommandNames(commands []*ffcli.Command) []string {
+	set := make(map[string]struct{}, len(commands))
+	for _, command := range commands {
+		if hiddenCommand(command) {
+			continue
+		}
+		name := strings.TrimSpace(command.Name)
+		if name != "" {
+			set[name] = struct{}{}
+		}
+	}
 	names := make([]string, 0, len(set))
 	for name := range set {
 		names = append(names, name)
@@ -82,38 +144,323 @@ func rootCommandNames(rootSubcommands []*ffcli.Command) []string {
 	return names
 }
 
-func bashScript(subcommands []string) string {
-	words := strings.Join(subcommands, " ")
-	return fmt.Sprintf(`# bash completion for asc
-_asc_completions() {
-  local cur
-  COMPREPLY=()
-  cur="${COMP_WORDS[COMP_CWORD]}"
+func hiddenCommand(command *ffcli.Command) bool {
+	if command == nil {
+		return true
+	}
+	shortHelp := strings.TrimSpace(command.ShortHelp)
+	return strings.HasPrefix(shortHelp, "DEPRECATED:") ||
+		strings.HasPrefix(shortHelp, "REMOVED:") ||
+		strings.HasPrefix(shortHelp, "Compatibility alias:")
+}
 
-  if [[ $COMP_CWORD -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "%s" -- "$cur") )
+func flagRequiresValue(commandFlag *flag.Flag) bool {
+	if commandFlag == nil || commandFlag.Value == nil {
+		return false
+	}
+	boolValue, ok := commandFlag.Value.(interface{ IsBoolFlag() bool })
+	return !ok || !boolValue.IsBoolFlag()
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func bashScript(nodes []completionNode) string {
+	var b strings.Builder
+	b.WriteString("# bash completion for asc\n")
+	writeShellCompletionData(&b, nodes)
+	b.WriteString(`
+_asc_completion_lookup() {
+  _asc_subcommands=()
+  _asc_flags=()
+  _asc_value_flags=()
+  local index
+  for ((index = 0; index < ${#_ASC_COMPLETION_PATHS[@]}; index++)); do
+    if [[ "${_ASC_COMPLETION_PATHS[index]}" == "$1" ]]; then
+      read -r -a _asc_subcommands <<< "${_ASC_COMPLETION_SUBCOMMAND_GROUPS[index]}"
+      read -r -a _asc_flags <<< "${_ASC_COMPLETION_FLAG_GROUPS[index]}"
+      read -r -a _asc_value_flags <<< "${_ASC_COMPLETION_VALUE_FLAG_GROUPS[index]}"
+      return 0
+    fi
+  done
+}
+
+_asc_completion_candidates() {
+  local path="" token subcommand value_flag
+  local expect_value=0
+  local -a _asc_subcommands _asc_flags _asc_value_flags
+
+  for token in "$@"; do
+    if [[ $expect_value -eq 1 ]]; then
+      expect_value=0
+      continue
+    fi
+
+    _asc_completion_lookup "$path"
+    if [[ "$token" == --*=* ]]; then
+      continue
+    fi
+    if [[ "$token" == --* ]]; then
+      for value_flag in "${_asc_value_flags[@]}"; do
+        if [[ "$token" == "$value_flag" ]]; then
+          expect_value=1
+          break
+        fi
+      done
+      continue
+    fi
+    for subcommand in "${_asc_subcommands[@]}"; do
+      if [[ "$token" == "$subcommand" ]]; then
+        if [[ -n "$path" ]]; then
+          path="$path $token"
+        else
+          path="$token"
+        fi
+        break
+      fi
+    done
+  done
+
+  if [[ $expect_value -eq 1 ]]; then
     return 0
+  fi
+  _asc_completion_lookup "$path"
+  if [[ ${#_asc_subcommands[@]} -gt 0 ]]; then
+    printf '%s\n' "${_asc_subcommands[@]}"
+  fi
+  if [[ ${#_asc_flags[@]} -gt 0 ]]; then
+    printf '%s\n' "${_asc_flags[@]}"
   fi
 }
 
+_asc_completions() {
+  local cur candidates
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  candidates="$(_asc_completion_candidates "${COMP_WORDS[@]:1:COMP_CWORD-1}")"
+  COMPREPLY=( $(compgen -W "$candidates" -- "$cur") )
+}
+
 complete -F _asc_completions asc
-`, words)
+`)
+	return b.String()
 }
 
-func zshScript(subcommands []string) string {
-	// zsh _arguments wants a space-separated list inside ((...))
-	words := strings.Join(subcommands, " ")
-	return fmt.Sprintf(`#compdef asc
-
-_arguments \
-  '1:command:(%s)' \
-  '*::arg:->args'
-`, words)
+func zshScript(nodes []completionNode) string {
+	var b strings.Builder
+	b.WriteString("#compdef asc\n\n")
+	writeShellCompletionData(&b, nodes)
+	b.WriteString(`
+_asc_completion_lookup() {
+  _asc_subcommands=()
+  _asc_flags=()
+  _asc_value_flags=()
+  local index
+  for ((index = 1; index <= ${#_ASC_COMPLETION_PATHS[@]}; index++)); do
+    if [[ "${_ASC_COMPLETION_PATHS[index]}" == "$1" ]]; then
+      _asc_subcommands=(${=_ASC_COMPLETION_SUBCOMMAND_GROUPS[index]})
+      _asc_flags=(${=_ASC_COMPLETION_FLAG_GROUPS[index]})
+      _asc_value_flags=(${=_ASC_COMPLETION_VALUE_FLAG_GROUPS[index]})
+      return 0
+    fi
+  done
 }
 
-func fishScript(subcommands []string) string {
-	words := strings.Join(subcommands, " ")
-	return fmt.Sprintf(`# fish completion for asc
-complete -c asc -f -a '%s'
-`, words)
+_asc_completion_candidates() {
+  local path="" token subcommand value_flag
+  local -i expect_value=0
+  local -a _asc_subcommands _asc_flags _asc_value_flags
+
+  for token in "$@"; do
+    if (( expect_value )); then
+      expect_value=0
+      continue
+    fi
+
+    _asc_completion_lookup "$path"
+    if [[ "$token" == --*=* ]]; then
+      continue
+    fi
+    if [[ "$token" == --* ]]; then
+      for value_flag in "${_asc_value_flags[@]}"; do
+        if [[ "$token" == "$value_flag" ]]; then
+          expect_value=1
+          break
+        fi
+      done
+      continue
+    fi
+    for subcommand in "${_asc_subcommands[@]}"; do
+      if [[ "$token" == "$subcommand" ]]; then
+        if [[ -n "$path" ]]; then
+          path="$path $token"
+        else
+          path="$token"
+        fi
+        break
+      fi
+    done
+  done
+
+  if (( expect_value )); then
+    return 0
+  fi
+  _asc_completion_lookup "$path"
+  if (( ${#_asc_subcommands[@]} )); then
+    print -rl -- "${_asc_subcommands[@]}"
+  fi
+  if (( ${#_asc_flags[@]} )); then
+    print -rl -- "${_asc_flags[@]}"
+  fi
+}
+
+_asc() {
+  local -a candidates prior_words
+  if (( CURRENT > 2 )); then
+    prior_words=("${words[2,$((CURRENT - 1))][@]}")
+  fi
+  candidates=("${(@f)$(_asc_completion_candidates "${prior_words[@]}")}")
+  compadd -- "${candidates[@]}"
+}
+
+compdef _asc asc
+`)
+	return b.String()
+}
+
+func fishScript(nodes []completionNode) string {
+	var b strings.Builder
+	b.WriteString("# fish completion for asc\n")
+	writeFishCompletionData(&b, nodes)
+	b.WriteString(`
+function __asc_completion_index
+    contains -i -- "$argv[1]" $__asc_completion_paths
+end
+
+function __asc_completion_candidates
+    set -l path ''
+    set -l expect_value 0
+
+    for token in $argv
+        if test $expect_value -eq 1
+            set expect_value 0
+            continue
+        end
+
+        set -l index (__asc_completion_index "$path")
+        set -l subcommands
+        set -l subcommand_group "$__asc_completion_subcommand_groups[$index]"
+        if test -n "$subcommand_group"
+            set subcommands (string split ' ' -- "$subcommand_group")
+        end
+        set -l value_flags
+        set -l value_flag_group "$__asc_completion_value_flag_groups[$index]"
+        if test -n "$value_flag_group"
+            set value_flags (string split ' ' -- "$value_flag_group")
+        end
+        if string match -q -- '--*=*' "$token"
+            continue
+        end
+        if string match -q -- '--*' "$token"
+            if contains -- "$token" $value_flags
+                set expect_value 1
+            end
+            continue
+        end
+        if contains -- "$token" $subcommands
+            if test -n "$path"
+                set path "$path $token"
+            else
+                set path "$token"
+            end
+        end
+    end
+
+    if test $expect_value -eq 1
+        return 0
+    end
+    set -l index (__asc_completion_index "$path")
+    set -l subcommand_group "$__asc_completion_subcommand_groups[$index]"
+    if test -n "$subcommand_group"
+        string split ' ' -- "$subcommand_group"
+    end
+    set -l flag_group "$__asc_completion_flag_groups[$index]"
+    if test -n "$flag_group"
+        string split ' ' -- "$flag_group"
+    end
+end
+
+function __asc_completion_current
+    set -l tokens (commandline -opc)
+    if test (count $tokens) -gt 0
+        set -e tokens[1]
+    end
+    __asc_completion_candidates $tokens
+end
+
+complete -c asc -f -a '(__asc_completion_current)'
+`)
+	return b.String()
+}
+
+func writeShellCompletionData(b *strings.Builder, nodes []completionNode) {
+	writeShellGroups(b, "_ASC_COMPLETION_PATHS", nodes, func(node completionNode) string { return node.path })
+	writeShellGroups(b, "_ASC_COMPLETION_SUBCOMMAND_GROUPS", nodes, func(node completionNode) string {
+		return strings.Join(node.subcommands, " ")
+	})
+	writeShellGroups(b, "_ASC_COMPLETION_FLAG_GROUPS", nodes, func(node completionNode) string {
+		return strings.Join(node.flags, " ")
+	})
+	writeShellGroups(b, "_ASC_COMPLETION_VALUE_FLAG_GROUPS", nodes, func(node completionNode) string {
+		return strings.Join(node.valueFlags, " ")
+	})
+}
+
+func writeShellGroups(b *strings.Builder, variable string, nodes []completionNode, value func(completionNode) string) {
+	b.WriteString(variable)
+	b.WriteString("=(")
+	for i, node := range nodes {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(shellSingleQuote(value(node)))
+	}
+	b.WriteString(")\n")
+}
+
+func writeFishCompletionData(b *strings.Builder, nodes []completionNode) {
+	writeFishGroups(b, "__asc_completion_paths", nodes, func(node completionNode) string { return node.path })
+	writeFishGroups(b, "__asc_completion_subcommand_groups", nodes, func(node completionNode) string {
+		return strings.Join(node.subcommands, " ")
+	})
+	writeFishGroups(b, "__asc_completion_flag_groups", nodes, func(node completionNode) string {
+		return strings.Join(node.flags, " ")
+	})
+	writeFishGroups(b, "__asc_completion_value_flag_groups", nodes, func(node completionNode) string {
+		return strings.Join(node.valueFlags, " ")
+	})
+}
+
+func writeFishGroups(b *strings.Builder, variable string, nodes []completionNode, value func(completionNode) string) {
+	b.WriteString("set -g ")
+	b.WriteString(variable)
+	for _, node := range nodes {
+		b.WriteByte(' ')
+		b.WriteString(fishSingleQuote(value(node)))
+	}
+	b.WriteByte('\n')
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func fishSingleQuote(value string) string {
+	return "'" + strings.NewReplacer("\\", "\\\\", "'", "\\'").Replace(value) + "'"
 }

--- a/internal/cli/completion/completion.go
+++ b/internal/cli/completion/completion.go
@@ -24,7 +24,7 @@ type completionNode struct {
 // The full command tree is resolved only after the requested shell is valid,
 // so normal command startup remains lazy and completion needs no auth or network
 // access.
-func CompletionCommand(resolveCommands func() []*ffcli.Command) *ffcli.Command {
+func CompletionCommand(resolveCommands func() []*ffcli.Command, resolveRootFlags func() *flag.FlagSet) *ffcli.Command {
 	fs := flag.NewFlagSet("completion", flag.ExitOnError)
 	shell := fs.String("shell", "", "Shell: bash, zsh, or fish")
 
@@ -54,7 +54,11 @@ func CompletionCommand(resolveCommands func() []*ffcli.Command) *ffcli.Command {
 		if resolveCommands != nil {
 			commands = resolveCommands()
 		}
-		nodes := completionNodes(commands)
+		var rootFlags *flag.FlagSet
+		if resolveRootFlags != nil {
+			rootFlags = resolveRootFlags()
+		}
+		nodes := completionNodes(commands, rootFlags)
 		switch s {
 		case "bash":
 			fmt.Fprint(os.Stdout, bashScript(nodes))
@@ -69,15 +73,11 @@ func CompletionCommand(resolveCommands func() []*ffcli.Command) *ffcli.Command {
 	return cmd
 }
 
-func completionNodes(rootSubcommands []*ffcli.Command) []completionNode {
+func completionNodes(rootSubcommands []*ffcli.Command, rootFlags *flag.FlagSet) []completionNode {
 	byPath := map[string]completionNode{"": {path: ""}}
-	rootNames := visibleSubcommandNames(rootSubcommands)
-	if !containsString(rootNames, "completion") {
-		rootNames = append(rootNames, "completion")
-		sort.Strings(rootNames)
-	}
 	root := byPath[""]
-	root.subcommands = rootNames
+	root.subcommands = visibleSubcommandNames(rootSubcommands)
+	root.flags, root.valueFlags = completionFlags(rootFlags)
 	byPath[""] = root
 
 	var visit func(parentPath string, commands []*ffcli.Command)
@@ -98,15 +98,7 @@ func completionNodes(rootSubcommands []*ffcli.Command) []completionNode {
 				path:        path,
 				subcommands: visibleSubcommandNames(command.Subcommands),
 			}
-			for _, commandFlag := range shared.VisibleHelpFlags(command.FlagSet) {
-				flagName := "--" + commandFlag.Name
-				node.flags = append(node.flags, flagName)
-				if flagRequiresValue(commandFlag) {
-					node.valueFlags = append(node.valueFlags, flagName)
-				}
-			}
-			sort.Strings(node.flags)
-			sort.Strings(node.valueFlags)
+			node.flags, node.valueFlags = completionFlags(command.FlagSet)
 			byPath[path] = node
 			visit(path, command.Subcommands)
 		}
@@ -123,6 +115,21 @@ func completionNodes(rootSubcommands []*ffcli.Command) []completionNode {
 		nodes = append(nodes, byPath[path])
 	}
 	return nodes
+}
+
+func completionFlags(fs *flag.FlagSet) ([]string, []string) {
+	var flags []string
+	var valueFlags []string
+	for _, commandFlag := range shared.VisibleHelpFlags(fs) {
+		flagName := "--" + commandFlag.Name
+		flags = append(flags, flagName)
+		if flagRequiresValue(commandFlag) {
+			valueFlags = append(valueFlags, flagName)
+		}
+	}
+	sort.Strings(flags)
+	sort.Strings(valueFlags)
+	return flags, valueFlags
 }
 
 func visibleSubcommandNames(commands []*ffcli.Command) []string {
@@ -160,15 +167,6 @@ func flagRequiresValue(commandFlag *flag.Flag) bool {
 	}
 	boolValue, ok := commandFlag.Value.(interface{ IsBoolFlag() bool })
 	return !ok || !boolValue.IsBoolFlag()
-}
-
-func containsString(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
 }
 
 func bashScript(nodes []completionNode) string {
@@ -354,6 +352,9 @@ function __asc_completion_candidates
         end
 
         set -l index (__asc_completion_index "$path")
+        if test -z "$index"
+            return 0
+        end
         set -l subcommands
         set -l subcommand_group "$__asc_completion_subcommand_groups[$index]"
         if test -n "$subcommand_group"
@@ -386,6 +387,9 @@ function __asc_completion_candidates
         return 0
     end
     set -l index (__asc_completion_index "$path")
+    if test -z "$index"
+        return 0
+    end
     set -l subcommand_group "$__asc_completion_subcommand_groups[$index]"
     if test -n "$subcommand_group"
         string split ' ' -- "$subcommand_group"

--- a/internal/cli/completion/completion.go
+++ b/internal/cli/completion/completion.go
@@ -158,7 +158,8 @@ func hiddenCommand(command *ffcli.Command) bool {
 	shortHelp := strings.TrimSpace(command.ShortHelp)
 	return strings.HasPrefix(shortHelp, "DEPRECATED:") ||
 		strings.HasPrefix(shortHelp, "REMOVED:") ||
-		strings.HasPrefix(shortHelp, "Compatibility alias:")
+		strings.HasPrefix(shortHelp, "Compatibility alias:") ||
+		strings.HasPrefix(shortHelp, "Compatibility aliases ")
 }
 
 func flagRequiresValue(commandFlag *flag.Flag) bool {

--- a/internal/cli/completion/completion_test.go
+++ b/internal/cli/completion/completion_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestCompletionNodesIncludeNestedCommandsAndVisibleFlags(t *testing.T) {
+	rootFlags := flag.NewFlagSet("asc", flag.ContinueOnError)
+	rootFlags.String("profile", "", "Authentication profile")
+	rootFlags.Bool("version", false, "Print version")
+
 	appsFlags := flag.NewFlagSet("apps", flag.ContinueOnError)
 	appsFlags.String("app", "", "App ID")
 	appsFlags.Bool("paginate", false, "Fetch every page")
@@ -38,14 +42,21 @@ func TestCompletionNodesIncludeNestedCommandsAndVisibleFlags(t *testing.T) {
 				{Name: "compat-view", ShortHelp: "Compatibility alias: use view"},
 			},
 		},
+		{Name: "completion"},
 		{Name: "old-apps", ShortHelp: "DEPRECATED: use apps"},
 		nil,
 		{Name: "   "},
-	})
+	}, rootFlags)
 
 	root := findCompletionNode(t, nodes, "")
 	if got, want := root.subcommands, []string{"apps", "completion"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("root subcommands = %v, want %v", got, want)
+	}
+	if got, want := root.flags, []string{"--profile", "--version"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("root flags = %v, want %v", got, want)
+	}
+	if got, want := root.valueFlags, []string{"--profile"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("root value flags = %v, want %v", got, want)
 	}
 	apps := findCompletionNode(t, nodes, "apps")
 	if got, want := apps.subcommands, []string{"view"}; !reflect.DeepEqual(got, want) {
@@ -79,7 +90,10 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 			{Name: "builds"},
 		}
 	}
-	cmd := CompletionCommand(resolve)
+	rootFlags := flag.NewFlagSet("asc", flag.ContinueOnError)
+	rootFlags.String("profile", "", "Authentication profile")
+	resolveRootFlags := func() *flag.FlagSet { return rootFlags }
+	cmd := CompletionCommand(resolve, resolveRootFlags)
 	if resolveCalls != 0 {
 		t.Fatalf("command tree resolved during command construction")
 	}
@@ -96,7 +110,7 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 	}
 
 	// Unsupported shell should fail with ErrHelp.
-	cmd = CompletionCommand(resolve)
+	cmd = CompletionCommand(resolve, resolveRootFlags)
 	if err := cmd.FlagSet.Parse([]string{"--shell", "tcsh"}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
@@ -108,7 +122,7 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 	}
 
 	// Supported shell should print script and succeed.
-	cmd = CompletionCommand(resolve)
+	cmd = CompletionCommand(resolve, resolveRootFlags)
 	if err := cmd.FlagSet.Parse([]string{"--shell", "bash"}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
@@ -118,6 +132,12 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 	if !strings.Contains(stdout, "complete -F _asc_completions asc") {
 		t.Fatalf("expected bash completion script output, got %q", stdout)
 	}
+	if !strings.Contains(stdout, "--profile") {
+		t.Fatalf("expected root flag completion data, got %q", stdout)
+	}
+	if strings.Contains(stdout, "apps builds completion") {
+		t.Fatalf("completion command was synthesized despite being absent from the resolver: %q", stdout)
+	}
 	if resolveCalls != 1 {
 		t.Fatalf("command tree resolve calls = %d, want 1", resolveCalls)
 	}
@@ -125,7 +145,7 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 
 func TestCompletionScriptsContainNestedPathsAndFlags(t *testing.T) {
 	nodes := []completionNode{
-		{path: "", subcommands: []string{"apps"}},
+		{path: "", subcommands: []string{"apps"}, flags: []string{"--profile", "--version"}, valueFlags: []string{"--profile"}},
 		{path: "apps", subcommands: []string{"view"}, flags: []string{"--app", "--paginate"}, valueFlags: []string{"--app"}},
 		{path: "apps view", flags: []string{"--id"}, valueFlags: []string{"--id"}},
 	}
@@ -147,6 +167,13 @@ func TestCompletionScriptsContainNestedPathsAndFlags(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFishCompletionGuardsUnknownMetadataPaths(t *testing.T) {
+	script := fishScript([]completionNode{{path: "", subcommands: []string{"apps"}}})
+	if got := strings.Count(script, `if test -z "$index"`); got != 2 {
+		t.Fatalf("fish completion index guards = %d, want 2:\n%s", got, script)
 	}
 }
 
@@ -177,7 +204,7 @@ func TestBashCompletionTracksNestedPathsAndSkipsFlagValues(t *testing.T) {
 	}
 
 	nodes := []completionNode{
-		{path: "", subcommands: []string{"apps"}},
+		{path: "", subcommands: []string{"apps"}, flags: []string{"--profile", "--version"}, valueFlags: []string{"--profile"}},
 		{path: "apps", subcommands: []string{"view"}, flags: []string{"--app"}, valueFlags: []string{"--app"}},
 		{path: "apps view", flags: []string{"--id"}, valueFlags: []string{"--id"}},
 	}
@@ -193,6 +220,8 @@ printf '%s\n' NESTED
 _asc_completion_candidates apps view
 printf '%s\n' FLAG_VALUE_MATCHES_SUBCOMMAND
 _asc_completion_candidates apps --app view
+printf '%s\n' ROOT_FLAG_VALUE_MATCHES_SUBCOMMAND
+_asc_completion_candidates --profile apps
 `
 	out, err := exec.Command(bash, "--noprofile", "--norc", "-c", command, "bash", scriptPath).CombinedOutput()
 	if err != nil {
@@ -203,6 +232,7 @@ _asc_completion_candidates apps --app view
 		"ROOT\napps\n",
 		"NESTED\n--id\n",
 		"FLAG_VALUE_MATCHES_SUBCOMMAND\nview\n--app\n",
+		"ROOT_FLAG_VALUE_MATCHES_SUBCOMMAND\napps\n--profile\n--version\n",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("bash resolver output missing %q:\n%s", want, got)
@@ -217,7 +247,7 @@ func TestZshCompletionPassesPriorWordsAsSeparateArguments(t *testing.T) {
 	}
 
 	nodes := []completionNode{
-		{path: "", subcommands: []string{"apps"}},
+		{path: "", subcommands: []string{"apps"}, flags: []string{"--profile", "--version"}, valueFlags: []string{"--profile"}},
 		{path: "apps", subcommands: []string{"view"}, flags: []string{"--app"}, valueFlags: []string{"--app"}},
 		{path: "apps view", flags: []string{"--id"}, valueFlags: []string{"--id"}},
 	}
@@ -237,6 +267,10 @@ printf '%s\n' FLAG_VALUE_MATCHES_SUBCOMMAND
 words=(asc apps --app view '')
 CURRENT=5
 _asc
+printf '%s\n' ROOT_FLAG_VALUE_MATCHES_SUBCOMMAND
+words=(asc --profile apps '')
+CURRENT=4
+_asc
 `
 	out, err := exec.Command(zsh, "-f", "-c", command, "zsh", scriptPath).CombinedOutput()
 	if err != nil {
@@ -246,6 +280,7 @@ _asc
 	for _, want := range []string{
 		"NESTED\n--\n--id\n",
 		"FLAG_VALUE_MATCHES_SUBCOMMAND\n--\nview\n--app\n",
+		"ROOT_FLAG_VALUE_MATCHES_SUBCOMMAND\n--\napps\n--profile\n--version\n",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("zsh wrapper output missing %q:\n%s", want, got)

--- a/internal/cli/completion/completion_test.go
+++ b/internal/cli/completion/completion_test.go
@@ -40,6 +40,7 @@ func TestCompletionNodesIncludeNestedCommandsAndVisibleFlags(t *testing.T) {
 				{Name: "old-view", ShortHelp: "DEPRECATED: use view"},
 				{Name: "removed-view", ShortHelp: "REMOVED: use view"},
 				{Name: "compat-view", ShortHelp: "Compatibility alias: use view"},
+				{Name: "compat-views", ShortHelp: "Compatibility aliases for view"},
 			},
 		},
 		{Name: "completion"},
@@ -74,7 +75,7 @@ func TestCompletionNodesIncludeNestedCommandsAndVisibleFlags(t *testing.T) {
 	}
 
 	serialized := completionNodeText(nodes)
-	for _, hidden := range []string{"legacy-app", "old-view", "removed-view", "compat-view", "old-apps"} {
+	for _, hidden := range []string{"legacy-app", "old-view", "removed-view", "compat-view", "compat-views", "old-apps"} {
 		if strings.Contains(serialized, hidden) {
 			t.Fatalf("hidden lifecycle entry %q leaked into completion nodes: %s", hidden, serialized)
 		}

--- a/internal/cli/completion/completion_test.go
+++ b/internal/cli/completion/completion_test.go
@@ -7,37 +7,82 @@ import (
 	"flag"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-func TestRootCommandNamesSortedAndDeduplicated(t *testing.T) {
-	names := rootCommandNames([]*ffcli.Command{
-		{Name: "apps"},
-		{Name: "builds"},
-		{Name: "apps"},
+func TestCompletionNodesIncludeNestedCommandsAndVisibleFlags(t *testing.T) {
+	appsFlags := flag.NewFlagSet("apps", flag.ContinueOnError)
+	appsFlags.String("app", "", "App ID")
+	appsFlags.Bool("paginate", false, "Fetch every page")
+	appsFlags.String("legacy-app", "", "Deprecated alias")
+	shared.HideFlagFromHelp(appsFlags.Lookup("legacy-app"))
+
+	viewFlags := flag.NewFlagSet("view", flag.ContinueOnError)
+	viewFlags.String("id", "", "Resource ID")
+	nodes := completionNodes([]*ffcli.Command{
+		{
+			Name:    "apps",
+			FlagSet: appsFlags,
+			Subcommands: []*ffcli.Command{
+				{Name: "view", FlagSet: viewFlags},
+				{Name: "old-view", ShortHelp: "DEPRECATED: use view"},
+				{Name: "removed-view", ShortHelp: "REMOVED: use view"},
+				{Name: "compat-view", ShortHelp: "Compatibility alias: use view"},
+			},
+		},
+		{Name: "old-apps", ShortHelp: "DEPRECATED: use apps"},
 		nil,
 		{Name: "   "},
 	})
 
-	expected := []string{"apps", "builds", "completion"}
-	if len(names) != len(expected) {
-		t.Fatalf("unexpected names length: got %d want %d (%v)", len(names), len(expected), names)
+	root := findCompletionNode(t, nodes, "")
+	if got, want := root.subcommands, []string{"apps", "completion"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("root subcommands = %v, want %v", got, want)
 	}
-	for i := range expected {
-		if names[i] != expected[i] {
-			t.Fatalf("unexpected names[%d]: got %q want %q", i, names[i], expected[i])
+	apps := findCompletionNode(t, nodes, "apps")
+	if got, want := apps.subcommands, []string{"view"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("apps subcommands = %v, want %v", got, want)
+	}
+	if got, want := apps.flags, []string{"--app", "--paginate"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("apps flags = %v, want %v", got, want)
+	}
+	if got, want := apps.valueFlags, []string{"--app"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("apps value flags = %v, want %v", got, want)
+	}
+	view := findCompletionNode(t, nodes, "apps view")
+	if got, want := view.flags, []string{"--id"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("view flags = %v, want %v", got, want)
+	}
+
+	serialized := completionNodeText(nodes)
+	for _, hidden := range []string{"legacy-app", "old-view", "removed-view", "compat-view", "old-apps"} {
+		if strings.Contains(serialized, hidden) {
+			t.Fatalf("hidden lifecycle entry %q leaked into completion nodes: %s", hidden, serialized)
 		}
 	}
 }
 
 func TestCompletionCommandValidationAndOutput(t *testing.T) {
-	cmd := CompletionCommand([]*ffcli.Command{
-		{Name: "apps"},
-		{Name: "builds"},
-	})
+	resolveCalls := 0
+	resolve := func() []*ffcli.Command {
+		resolveCalls++
+		return []*ffcli.Command{
+			{Name: "apps"},
+			{Name: "builds"},
+		}
+	}
+	cmd := CompletionCommand(resolve)
+	if resolveCalls != 0 {
+		t.Fatalf("command tree resolved during command construction")
+	}
 
 	// Missing shell should fail with ErrHelp.
 	if err := cmd.FlagSet.Parse([]string{}); err != nil {
@@ -46,18 +91,24 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 	if err := cmd.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp for missing shell, got %v", err)
 	}
+	if resolveCalls != 0 {
+		t.Fatalf("command tree resolved before shell validation")
+	}
 
 	// Unsupported shell should fail with ErrHelp.
-	cmd = CompletionCommand([]*ffcli.Command{{Name: "apps"}})
+	cmd = CompletionCommand(resolve)
 	if err := cmd.FlagSet.Parse([]string{"--shell", "tcsh"}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 	if err := cmd.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("expected flag.ErrHelp for unsupported shell, got %v", err)
 	}
+	if resolveCalls != 0 {
+		t.Fatalf("command tree resolved for unsupported shell")
+	}
 
 	// Supported shell should print script and succeed.
-	cmd = CompletionCommand([]*ffcli.Command{{Name: "apps"}, {Name: "builds"}})
+	cmd = CompletionCommand(resolve)
 	if err := cmd.FlagSet.Parse([]string{"--shell", "bash"}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
@@ -67,18 +118,161 @@ func TestCompletionCommandValidationAndOutput(t *testing.T) {
 	if !strings.Contains(stdout, "complete -F _asc_completions asc") {
 		t.Fatalf("expected bash completion script output, got %q", stdout)
 	}
+	if resolveCalls != 1 {
+		t.Fatalf("command tree resolve calls = %d, want 1", resolveCalls)
+	}
 }
 
-func TestCompletionScriptHelpers(t *testing.T) {
-	if !strings.Contains(bashScript([]string{"apps"}), "apps") {
-		t.Fatalf("bash script missing command names")
+func TestCompletionScriptsContainNestedPathsAndFlags(t *testing.T) {
+	nodes := []completionNode{
+		{path: "", subcommands: []string{"apps"}},
+		{path: "apps", subcommands: []string{"view"}, flags: []string{"--app", "--paginate"}, valueFlags: []string{"--app"}},
+		{path: "apps view", flags: []string{"--id"}, valueFlags: []string{"--id"}},
 	}
-	if !strings.Contains(zshScript([]string{"apps"}), "#compdef asc") {
-		t.Fatalf("zsh script missing compdef header")
+
+	tests := []struct {
+		name   string
+		script string
+		marker string
+	}{
+		{name: "bash", script: bashScript(nodes), marker: "complete -F _asc_completions asc"},
+		{name: "zsh", script: zshScript(nodes), marker: "compdef _asc asc"},
+		{name: "fish", script: fishScript(nodes), marker: "complete -c asc"},
 	}
-	if !strings.Contains(fishScript([]string{"apps"}), "complete -c asc") {
-		t.Fatalf("fish script missing completion command")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, want := range []string{tt.marker, "apps view", "--app", "--paginate", "--id"} {
+				if !strings.Contains(tt.script, want) {
+					t.Fatalf("script missing %q:\n%s", want, tt.script)
+				}
+			}
+		})
 	}
+}
+
+func TestCompletionScriptsEscapeGeneratedMetadata(t *testing.T) {
+	nodes := []completionNode{
+		{path: "", subcommands: []string{"what's-new"}},
+		{path: "what's-new", flags: []string{"--owner's-id"}, valueFlags: []string{"--owner's-id"}},
+	}
+
+	for name, script := range map[string]string{
+		"bash": bashScript(nodes),
+		"zsh":  zshScript(nodes),
+	} {
+		if !strings.Contains(script, `'what'"'"'s-new'`) || !strings.Contains(script, `'--owner'"'"'s-id'`) {
+			t.Fatalf("%s script did not shell-escape metadata:\n%s", name, script)
+		}
+	}
+	fish := fishScript(nodes)
+	if !strings.Contains(fish, `'what\'s-new'`) || !strings.Contains(fish, `'--owner\'s-id'`) {
+		t.Fatalf("fish script did not shell-escape metadata:\n%s", fish)
+	}
+}
+
+func TestBashCompletionTracksNestedPathsAndSkipsFlagValues(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is not installed")
+	}
+
+	nodes := []completionNode{
+		{path: "", subcommands: []string{"apps"}},
+		{path: "apps", subcommands: []string{"view"}, flags: []string{"--app"}, valueFlags: []string{"--app"}},
+		{path: "apps view", flags: []string{"--id"}, valueFlags: []string{"--id"}},
+	}
+	scriptPath := filepath.Join(t.TempDir(), "asc-completion.bash")
+	if err := os.WriteFile(scriptPath, []byte(bashScript(nodes)), 0o600); err != nil {
+		t.Fatalf("write completion script: %v", err)
+	}
+
+	command := `source "$1"
+printf '%s\n' ROOT
+_asc_completion_candidates
+printf '%s\n' NESTED
+_asc_completion_candidates apps view
+printf '%s\n' FLAG_VALUE_MATCHES_SUBCOMMAND
+_asc_completion_candidates apps --app view
+`
+	out, err := exec.Command(bash, "--noprofile", "--norc", "-c", command, "bash", scriptPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("exercise bash completion: %v\n%s", err, out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"ROOT\napps\n",
+		"NESTED\n--id\n",
+		"FLAG_VALUE_MATCHES_SUBCOMMAND\nview\n--app\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("bash resolver output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestZshCompletionPassesPriorWordsAsSeparateArguments(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh is not installed")
+	}
+
+	nodes := []completionNode{
+		{path: "", subcommands: []string{"apps"}},
+		{path: "apps", subcommands: []string{"view"}, flags: []string{"--app"}, valueFlags: []string{"--app"}},
+		{path: "apps view", flags: []string{"--id"}, valueFlags: []string{"--id"}},
+	}
+	scriptPath := filepath.Join(t.TempDir(), "_asc")
+	if err := os.WriteFile(scriptPath, []byte(zshScript(nodes)), 0o600); err != nil {
+		t.Fatalf("write completion script: %v", err)
+	}
+
+	command := `compdef() { :; }
+compadd() { print -rl -- "$@"; }
+source "$1"
+printf '%s\n' NESTED
+words=(asc apps view '')
+CURRENT=4
+_asc
+printf '%s\n' FLAG_VALUE_MATCHES_SUBCOMMAND
+words=(asc apps --app view '')
+CURRENT=5
+_asc
+`
+	out, err := exec.Command(zsh, "-f", "-c", command, "zsh", scriptPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("exercise zsh completion: %v\n%s", err, out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"NESTED\n--\n--id\n",
+		"FLAG_VALUE_MATCHES_SUBCOMMAND\n--\nview\n--app\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("zsh wrapper output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func findCompletionNode(t *testing.T, nodes []completionNode, path string) completionNode {
+	t.Helper()
+	for _, node := range nodes {
+		if node.path == path {
+			return node
+		}
+	}
+	t.Fatalf("completion node %q not found in %v", path, nodes)
+	return completionNode{}
+}
+
+func completionNodeText(nodes []completionNode) string {
+	var b strings.Builder
+	for _, node := range nodes {
+		b.WriteString(node.path)
+		b.WriteString(strings.Join(node.subcommands, " "))
+		b.WriteString(strings.Join(node.flags, " "))
+		b.WriteString(strings.Join(node.valueFlags, " "))
+	}
+	return b.String()
 }
 
 func captureStdout(t *testing.T, fn func() error) string {

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -200,7 +200,7 @@ func NewCatalog(version string) *Catalog {
 			return VersionCommand(version)
 		}),
 		commandFactory("completion", "Print shell completion scripts.", func() *ffcli.Command {
-			return completion.CompletionCommand(catalog.MetadataCommands())
+			return completion.CompletionCommand(catalog.All)
 		}),
 	}
 	return catalog

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"strings"
 
@@ -107,7 +108,8 @@ type factory struct {
 
 // Catalog constructs root commands on demand while preserving display order.
 type Catalog struct {
-	factories []factory
+	factories   []factory
+	rootFlagSet *flag.FlagSet
 }
 
 // NewCatalog returns the current root command catalog.
@@ -200,10 +202,17 @@ func NewCatalog(version string) *Catalog {
 			return VersionCommand(version)
 		}),
 		commandFactory("completion", "Print shell completion scripts.", func() *ffcli.Command {
-			return completion.CompletionCommand(catalog.All)
+			return completion.CompletionCommand(catalog.All, func() *flag.FlagSet {
+				return catalog.rootFlagSet
+			})
 		}),
 	}
 	return catalog
+}
+
+// SetCompletionRootFlagSet supplies the flags accepted by the root command.
+func (c *Catalog) SetCompletionRootFlagSet(fs *flag.FlagSet) {
+	c.rootFlagSet = fs
 }
 
 func commandFactory(name, shortHelp string, newCommand func() *ffcli.Command) factory {


### PR DESCRIPTION
## Summary

- generate completion metadata from the complete visible command tree only when a valid shell is requested
- complete nested subcommands and command-local flags in bash, zsh, and fish
- track flags that consume values so value tokens cannot be mistaken for subcommands
- omit deprecated commands and hidden flag aliases, and document that remote flag values are outside this static completion surface

The generated metadata is stored compactly in each script. On macOS, the full bash and zsh scripts source in roughly 15-20 ms while covering the complete CLI tree.

## Test plan

- `go test ./internal/cli/completion ./internal/cli/registry ./internal/cli/cmdtest`
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- generated bash and zsh syntax checks
- live bash and zsh completion checks for nested paths, leaf flags, and flag values matching subcommand names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-sensitive shell completion for nested commands and flags in Bash, Zsh, and Fish.
  * Completion now includes global root flags and path-specific options, including pagination, filtering, formatting, and sorting.
  * Flag values are handled correctly without irrelevant suggestions, including excluding boolean version flags.
  * Command and flag suggestions are resolved at execution time for more accurate results.
  * Completion excludes deprecated, hidden, removed, and compatibility-only commands.

* **Documentation**
  * Updated completion guidance with global and nested command examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->