### PR TITLE
feat(auth): detect swapped key and issuer IDs before the 401

### DIFF
--- a/internal/auth/credential_shape.go
+++ b/internal/auth/credential_shape.go
@@ -32,8 +32,7 @@ type CredentialShapeFinding struct {
 	Message        string
 	Recommendation string
 	// DefiniteSwap marks the only unambiguous case: the key ID is an issuer
-	// UUID and the issuer ID is not, so the two values can only have been
-	// pasted into the wrong fields.
+	// UUID and the issuer ID also resembles an API key ID.
 	DefiniteSwap bool
 }
 
@@ -88,7 +87,12 @@ func InspectCredentialShapes(labels CredentialShapeLabels, keyID, issuerID strin
 	keyLooksLikeIssuer := LooksLikeIssuerID(keyID)
 	issuerIsMalformed := issuerID != "" && !LooksLikeIssuerID(issuerID)
 	issuerLooksLikeKey := issuerIsMalformed && LooksLikeKeyID(issuerID)
-	definiteSwap := keyLooksLikeIssuer && issuerLooksLikeKey
+	swapHintSupported := keyLooksLikeIssuer && issuerLooksLikeKey
+	definiteSwap := swapHintSupported
+	swapSuffix := ""
+	if swapHintSupported {
+		swapSuffix = " — the values may be swapped"
+	}
 
 	recommendation := fmt.Sprintf(
 		"Set %s to the App Store Connect API key ID and %s to the issuer UUID",
@@ -100,7 +104,7 @@ func InspectCredentialShapes(labels CredentialShapeLabels, keyID, issuerID strin
 	if keyLooksLikeIssuer {
 		findings = append(findings, CredentialShapeFinding{
 			Field:          labels.KeyID,
-			Message:        fmt.Sprintf("%s looks like an issuer ID — the values may be swapped", labels.KeyID),
+			Message:        fmt.Sprintf("%s looks like an issuer ID%s", labels.KeyID, swapSuffix),
 			Recommendation: recommendation,
 			DefiniteSwap:   definiteSwap,
 		})
@@ -109,9 +113,7 @@ func InspectCredentialShapes(labels CredentialShapeLabels, keyID, issuerID strin
 		message := fmt.Sprintf("%s is not a UUID", labels.IssuerID)
 		switch {
 		case issuerLooksLikeKey:
-			message = fmt.Sprintf("%s looks like a key ID — the values may be swapped", labels.IssuerID)
-		case keyLooksLikeIssuer:
-			message = fmt.Sprintf("%s is not a UUID — the values may be swapped", labels.IssuerID)
+			message = fmt.Sprintf("%s looks like a key ID%s", labels.IssuerID, swapSuffix)
 		}
 		findings = append(findings, CredentialShapeFinding{
 			Field:          labels.IssuerID,

--- a/internal/auth/credential_shape.go
+++ b/internal/auth/credential_shape.go
@@ -1,0 +1,124 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// keyIDMinLength and keyIDMaxLength bracket the App Store Connect API key ID
+// shape. Apple issues 10-character identifiers such as 39MX87M9Y4; the wider
+// range keeps the heuristic conservative because it is only ever used to
+// strengthen a hint, never to reject a value.
+const (
+	keyIDMinLength = 8
+	keyIDMaxLength = 12
+)
+
+// CredentialShapeLabels names the fields being inspected so findings speak in
+// the caller's vocabulary: environment variables for `auth doctor`, flags for
+// `auth login`.
+type CredentialShapeLabels struct {
+	KeyID    string
+	IssuerID string
+}
+
+// CredentialShapeFinding is a non-blocking observation about the shape of a key
+// ID or issuer ID. Messages never include the inspected values so reports stay
+// safe to paste into a bug report or CI log.
+type CredentialShapeFinding struct {
+	Field          string
+	Message        string
+	Recommendation string
+	// DefiniteSwap marks the only unambiguous case: the key ID is an issuer
+	// UUID and the issuer ID is not, so the two values can only have been
+	// pasted into the wrong fields.
+	DefiniteSwap bool
+}
+
+// LooksLikeIssuerID reports whether value has the App Store Connect issuer ID
+// shape: a canonical hyphenated UUID such as
+// 69a6de00-aaaa-bbbb-cccc-123456789abc. Non-canonical spellings accepted by
+// uuid.Parse (braced, URN, unhyphenated) are rejected because Apple only ever
+// issues the canonical form.
+func LooksLikeIssuerID(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return false
+	}
+	parsed, err := uuid.Parse(trimmed)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(trimmed, parsed.String())
+}
+
+// LooksLikeKeyID reports whether value has the App Store Connect API key ID
+// shape: a short uppercase alphanumeric identifier such as 39MX87M9Y4. A false
+// result never means the value is invalid; it only means the value carries no
+// evidence of being a key ID.
+func LooksLikeKeyID(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < keyIDMinLength || len(trimmed) > keyIDMaxLength {
+		return false
+	}
+	for _, r := range trimmed {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// InspectCredentialShapes reports key ID and issuer ID values whose shapes
+// suggest the two were swapped, or an issuer ID that cannot be a UUID.
+//
+// Only the issuer ID has a format Apple guarantees, so key IDs are never
+// format-policed: an unusual but plausible key ID (all digits, mixed case,
+// shorter or longer than 10 characters) produces no finding. The key ID is
+// flagged only when it is itself a canonical UUID, which is the shape of the
+// other field.
+func InspectCredentialShapes(labels CredentialShapeLabels, keyID, issuerID string) []CredentialShapeFinding {
+	keyID = strings.TrimSpace(keyID)
+	issuerID = strings.TrimSpace(issuerID)
+
+	keyLooksLikeIssuer := LooksLikeIssuerID(keyID)
+	issuerIsMalformed := issuerID != "" && !LooksLikeIssuerID(issuerID)
+	issuerLooksLikeKey := issuerIsMalformed && LooksLikeKeyID(issuerID)
+	definiteSwap := keyLooksLikeIssuer && issuerIsMalformed
+
+	recommendation := fmt.Sprintf(
+		"Set %s to the App Store Connect API key ID and %s to the issuer UUID",
+		labels.KeyID,
+		labels.IssuerID,
+	)
+
+	var findings []CredentialShapeFinding
+	if keyLooksLikeIssuer {
+		findings = append(findings, CredentialShapeFinding{
+			Field:          labels.KeyID,
+			Message:        fmt.Sprintf("%s looks like an issuer ID — the values may be swapped", labels.KeyID),
+			Recommendation: recommendation,
+			DefiniteSwap:   definiteSwap,
+		})
+	}
+	if issuerIsMalformed {
+		message := fmt.Sprintf("%s is not a UUID", labels.IssuerID)
+		switch {
+		case issuerLooksLikeKey:
+			message = fmt.Sprintf("%s looks like a key ID — the values may be swapped", labels.IssuerID)
+		case keyLooksLikeIssuer:
+			message = fmt.Sprintf("%s is not a UUID — the values may be swapped", labels.IssuerID)
+		}
+		findings = append(findings, CredentialShapeFinding{
+			Field:          labels.IssuerID,
+			Message:        message,
+			Recommendation: recommendation,
+			DefiniteSwap:   definiteSwap,
+		})
+	}
+	return findings
+}

--- a/internal/auth/credential_shape.go
+++ b/internal/auth/credential_shape.go
@@ -88,7 +88,7 @@ func InspectCredentialShapes(labels CredentialShapeLabels, keyID, issuerID strin
 	keyLooksLikeIssuer := LooksLikeIssuerID(keyID)
 	issuerIsMalformed := issuerID != "" && !LooksLikeIssuerID(issuerID)
 	issuerLooksLikeKey := issuerIsMalformed && LooksLikeKeyID(issuerID)
-	definiteSwap := keyLooksLikeIssuer && issuerIsMalformed
+	definiteSwap := keyLooksLikeIssuer && issuerLooksLikeKey
 
 	recommendation := fmt.Sprintf(
 		"Set %s to the App Store Connect API key ID and %s to the issuer UUID",

--- a/internal/auth/credential_shape_test.go
+++ b/internal/auth/credential_shape_test.go
@@ -133,6 +133,18 @@ func TestInspectCredentialShapesStaysUncertainWithoutBothSignals(t *testing.T) {
 		}
 	})
 
+	t.Run("uuid key id with generic malformed issuer", func(t *testing.T) {
+		findings := InspectCredentialShapes(labels, "69a6de00-aaaa-bbbb-cccc-123456789abc", "issuer-uuid")
+		if len(findings) != 2 {
+			t.Fatalf("InspectCredentialShapes() = %#v, want 2 findings", findings)
+		}
+		for _, finding := range findings {
+			if finding.DefiniteSwap {
+				t.Fatal("expected no definite swap without a key-shaped issuer ID")
+			}
+		}
+	})
+
 	t.Run("malformed issuer id only", func(t *testing.T) {
 		findings := InspectCredentialShapes(labels, "39MX87M9Y4", "ENVISS")
 		if len(findings) != 1 {

--- a/internal/auth/credential_shape_test.go
+++ b/internal/auth/credential_shape_test.go
@@ -1,0 +1,185 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLooksLikeIssuerID(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "lowercase canonical uuid", value: "69a6de00-aaaa-bbbb-cccc-123456789abc", want: true},
+		{name: "uppercase canonical uuid", value: "A7EFEF21-3432-404F-A488-083800B570FF", want: true},
+		{name: "surrounding whitespace", value: "  09f4080c-6ee7-4e52-8103-e1241eaaa58a  ", want: true},
+		{name: "empty", value: "", want: false},
+		{name: "key id", value: "39MX87M9Y4", want: false},
+		{name: "unhyphenated hex", value: "69a6de0000aabbbbccccdd123456789a", want: false},
+		{name: "braced uuid", value: "{69a6de00-aaaa-bbbb-cccc-123456789abc}", want: false},
+		{name: "urn uuid", value: "urn:uuid:69a6de00-aaaa-bbbb-cccc-123456789abc", want: false},
+		{name: "placeholder", value: "issuer-uuid", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := LooksLikeIssuerID(test.value); got != test.want {
+				t.Fatalf("LooksLikeIssuerID(%q) = %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeKeyID(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "typical key id", value: "39MX87M9Y4", want: true},
+		{name: "all digits", value: "1234567890", want: true},
+		{name: "letters and digits", value: "TEAM123456", want: true},
+		{name: "twelve characters", value: "ABC123SECRET", want: true},
+		{name: "surrounding whitespace", value: "  39MX87M9Y4  ", want: true},
+		{name: "empty", value: "", want: false},
+		{name: "issuer uuid", value: "69a6de00-aaaa-bbbb-cccc-123456789abc", want: false},
+		{name: "lowercase", value: "39mx87m9y4", want: false},
+		{name: "underscore", value: "TEST_KEY_ID", want: false},
+		{name: "too short", value: "ENVKEY", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := LooksLikeKeyID(test.value); got != test.want {
+				t.Fatalf("LooksLikeKeyID(%q) = %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestInspectCredentialShapesAcceptsValidAndUnusualCredentials(t *testing.T) {
+	labels := CredentialShapeLabels{KeyID: "ASC_KEY_ID", IssuerID: "ASC_ISSUER_ID"}
+
+	for _, test := range []struct {
+		name     string
+		keyID    string
+		issuerID string
+	}{
+		{name: "typical pair", keyID: "39MX87M9Y4", issuerID: "69a6de00-aaaa-bbbb-cccc-123456789abc"},
+		{name: "all digit key id", keyID: "1234567890", issuerID: "69a6de00-aaaa-bbbb-cccc-123456789abc"},
+		{name: "lowercase key id", keyID: "39mx87m9y4", issuerID: "69a6de00-aaaa-bbbb-cccc-123456789abc"},
+		{name: "mixed case key id", keyID: "39Mx87M9y4", issuerID: "09f4080c-6ee7-4e52-8103-e1241eaaa58a"},
+		{name: "short key id", keyID: "KEY123", issuerID: "A7EFEF21-3432-404F-A488-083800B570FF"},
+		{name: "underscore key id", keyID: "TEST_KEY_ID", issuerID: "A7EFEF21-3432-404F-A488-083800B570FF"},
+		{name: "uppercase issuer uuid", keyID: "39MX87M9Y4", issuerID: "A7EFEF21-3432-404F-A488-083800B570FF"},
+		{name: "individual key without issuer", keyID: "39MX87M9Y4", issuerID: ""},
+		{name: "nothing provided", keyID: "", issuerID: ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if findings := InspectCredentialShapes(labels, test.keyID, test.issuerID); len(findings) != 0 {
+				t.Fatalf("InspectCredentialShapes(%q, %q) = %#v, want no findings", test.keyID, test.issuerID, findings)
+			}
+		})
+	}
+}
+
+func TestInspectCredentialShapesDetectsSwappedValues(t *testing.T) {
+	labels := CredentialShapeLabels{KeyID: "ASC_KEY_ID", IssuerID: "ASC_ISSUER_ID"}
+	findings := InspectCredentialShapes(labels, "69a6de00-aaaa-bbbb-cccc-123456789abc", "39MX87M9Y4")
+
+	if len(findings) != 2 {
+		t.Fatalf("InspectCredentialShapes() = %#v, want 2 findings", findings)
+	}
+	if findings[0].Field != "ASC_KEY_ID" {
+		t.Fatalf("findings[0].Field = %q, want ASC_KEY_ID", findings[0].Field)
+	}
+	if findings[0].Message != "ASC_KEY_ID looks like an issuer ID — the values may be swapped" {
+		t.Fatalf("findings[0].Message = %q", findings[0].Message)
+	}
+	if !findings[0].DefiniteSwap {
+		t.Fatal("expected findings[0].DefiniteSwap to be true when the key ID is a UUID and the issuer ID is not")
+	}
+	if findings[1].Field != "ASC_ISSUER_ID" {
+		t.Fatalf("findings[1].Field = %q, want ASC_ISSUER_ID", findings[1].Field)
+	}
+	if !strings.Contains(findings[1].Message, "looks like a key ID") ||
+		!strings.Contains(findings[1].Message, "the values may be swapped") {
+		t.Fatalf("findings[1].Message = %q, want a key ID swap hint", findings[1].Message)
+	}
+	for _, finding := range findings {
+		if finding.Recommendation == "" {
+			t.Fatalf("finding %+v has no recommendation", finding)
+		}
+	}
+}
+
+func TestInspectCredentialShapesStaysUncertainWithoutBothSignals(t *testing.T) {
+	labels := CredentialShapeLabels{KeyID: "ASC_KEY_ID", IssuerID: "ASC_ISSUER_ID"}
+
+	t.Run("uuid key id without issuer id", func(t *testing.T) {
+		findings := InspectCredentialShapes(labels, "69a6de00-aaaa-bbbb-cccc-123456789abc", "")
+		if len(findings) != 1 {
+			t.Fatalf("InspectCredentialShapes() = %#v, want 1 finding", findings)
+		}
+		if findings[0].DefiniteSwap {
+			t.Fatal("expected no definite swap when the issuer ID is absent")
+		}
+	})
+
+	t.Run("both values are uuids", func(t *testing.T) {
+		findings := InspectCredentialShapes(labels, "69a6de00-aaaa-bbbb-cccc-123456789abc", "09f4080c-6ee7-4e52-8103-e1241eaaa58a")
+		if len(findings) != 1 {
+			t.Fatalf("InspectCredentialShapes() = %#v, want 1 finding", findings)
+		}
+		if findings[0].DefiniteSwap {
+			t.Fatal("expected no definite swap when the issuer ID is a valid UUID")
+		}
+	})
+
+	t.Run("malformed issuer id only", func(t *testing.T) {
+		findings := InspectCredentialShapes(labels, "39MX87M9Y4", "ENVISS")
+		if len(findings) != 1 {
+			t.Fatalf("InspectCredentialShapes() = %#v, want 1 finding", findings)
+		}
+		if findings[0].Field != "ASC_ISSUER_ID" {
+			t.Fatalf("findings[0].Field = %q, want ASC_ISSUER_ID", findings[0].Field)
+		}
+		if !strings.Contains(findings[0].Message, "is not a UUID") {
+			t.Fatalf("findings[0].Message = %q, want a UUID shape message", findings[0].Message)
+		}
+		if strings.Contains(findings[0].Message, "swapped") {
+			t.Fatalf("findings[0].Message = %q, want no swap claim without evidence", findings[0].Message)
+		}
+		if findings[0].DefiniteSwap {
+			t.Fatal("expected no definite swap when only the issuer ID is malformed")
+		}
+	})
+}
+
+func TestInspectCredentialShapesUsesFlagLabels(t *testing.T) {
+	labels := CredentialShapeLabels{KeyID: "--key-id", IssuerID: "--issuer-id"}
+	findings := InspectCredentialShapes(labels, "69a6de00-aaaa-bbbb-cccc-123456789abc", "39MX87M9Y4")
+
+	if len(findings) != 2 {
+		t.Fatalf("InspectCredentialShapes() = %#v, want 2 findings", findings)
+	}
+	if !strings.HasPrefix(findings[0].Message, "--key-id ") {
+		t.Fatalf("findings[0].Message = %q, want a --key-id prefix", findings[0].Message)
+	}
+	if !strings.HasPrefix(findings[1].Message, "--issuer-id ") {
+		t.Fatalf("findings[1].Message = %q, want an --issuer-id prefix", findings[1].Message)
+	}
+}
+
+func TestInspectCredentialShapesNeverEchoesCredentialValues(t *testing.T) {
+	labels := CredentialShapeLabels{KeyID: "ASC_KEY_ID", IssuerID: "ASC_ISSUER_ID"}
+	keyID := "09f4080c-6ee7-4e52-8103-e1241eaaa58a"
+	issuerID := "ABC123SECRET"
+
+	for _, finding := range InspectCredentialShapes(labels, keyID, issuerID) {
+		combined := finding.Message + " " + finding.Recommendation
+		if strings.Contains(combined, keyID) {
+			t.Fatalf("finding leaked the key ID: %q", combined)
+		}
+		if strings.Contains(combined, issuerID) {
+			t.Fatalf("finding leaked the issuer ID: %q", combined)
+		}
+	}
+}

--- a/internal/auth/credential_shape_test.go
+++ b/internal/auth/credential_shape_test.go
@@ -121,6 +121,9 @@ func TestInspectCredentialShapesStaysUncertainWithoutBothSignals(t *testing.T) {
 		if findings[0].DefiniteSwap {
 			t.Fatal("expected no definite swap when the issuer ID is absent")
 		}
+		if strings.Contains(findings[0].Message, "swapped") {
+			t.Fatalf("findings[0].Message = %q, want no swap hint without both signals", findings[0].Message)
+		}
 	})
 
 	t.Run("both values are uuids", func(t *testing.T) {
@@ -130,6 +133,9 @@ func TestInspectCredentialShapesStaysUncertainWithoutBothSignals(t *testing.T) {
 		}
 		if findings[0].DefiniteSwap {
 			t.Fatal("expected no definite swap when the issuer ID is a valid UUID")
+		}
+		if strings.Contains(findings[0].Message, "swapped") {
+			t.Fatalf("findings[0].Message = %q, want no swap hint without both signals", findings[0].Message)
 		}
 	})
 
@@ -141,6 +147,9 @@ func TestInspectCredentialShapesStaysUncertainWithoutBothSignals(t *testing.T) {
 		for _, finding := range findings {
 			if finding.DefiniteSwap {
 				t.Fatal("expected no definite swap without a key-shaped issuer ID")
+			}
+			if strings.Contains(finding.Message, "swapped") {
+				t.Fatalf("finding.Message = %q, want no swap hint without both signals", finding.Message)
 			}
 		}
 	})

--- a/internal/auth/doctor.go
+++ b/internal/auth/doctor.go
@@ -391,13 +391,14 @@ func inspectEnvironment() DoctorSection {
 	keyTypeRaw := strings.TrimSpace(os.Getenv("ASC_KEY_TYPE"))
 	keyType := config.NormalizeCredentialKeyType(keyTypeRaw)
 	keyTypeValid := keyTypeRaw == "" || config.IsValidCredentialKeyType(keyType)
+	individualKey := keyTypeValid && config.IsIndividualCredentialKeyType(keyType)
 	hasKeyPath := strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_PATH")) != "" ||
 		strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY")) != "" ||
 		strings.TrimSpace(os.Getenv("ASC_PRIVATE_KEY_B64")) != ""
 	envProvided := keyID != "" || issuerID != "" || hasKeyPath || keyTypeRaw != ""
 	envComplete := keyID != "" && hasKeyPath &&
 		keyTypeValid &&
-		(issuerID != "" || config.IsIndividualCredentialKeyType(keyType))
+		(issuerID != "" || individualKey)
 	if keyTypeRaw != "" && !keyTypeValid {
 		checks = append(checks, DoctorCheck{
 			Status:         DoctorWarn,
@@ -414,7 +415,11 @@ func inspectEnvironment() DoctorSection {
 	}
 
 	shapeLabels := CredentialShapeLabels{KeyID: "ASC_KEY_ID", IssuerID: "ASC_ISSUER_ID"}
-	for _, finding := range InspectCredentialShapes(shapeLabels, keyID, issuerID) {
+	shapeIssuerID := issuerID
+	if individualKey {
+		shapeIssuerID = ""
+	}
+	for _, finding := range InspectCredentialShapes(shapeLabels, keyID, shapeIssuerID) {
 		checks = append(checks, DoctorCheck{
 			Status:         DoctorWarn,
 			Message:        finding.Message,
@@ -432,7 +437,7 @@ func inspectEnvironment() DoctorSection {
 					Recommendation: "Use --profile or clear conflicting env vars",
 				})
 			}
-			if issuerID != "" && defaultCreds.IssuerID != "" && issuerID != defaultCreds.IssuerID {
+			if !individualKey && issuerID != "" && defaultCreds.IssuerID != "" && issuerID != defaultCreds.IssuerID {
 				checks = append(checks, DoctorCheck{
 					Status:         DoctorWarn,
 					Message:        "ASC_ISSUER_ID differs from default stored credentials",

--- a/internal/auth/doctor.go
+++ b/internal/auth/doctor.go
@@ -415,16 +415,14 @@ func inspectEnvironment() DoctorSection {
 	}
 
 	shapeLabels := CredentialShapeLabels{KeyID: "ASC_KEY_ID", IssuerID: "ASC_ISSUER_ID"}
-	shapeIssuerID := issuerID
-	if individualKey {
-		shapeIssuerID = ""
-	}
-	for _, finding := range InspectCredentialShapes(shapeLabels, keyID, shapeIssuerID) {
-		checks = append(checks, DoctorCheck{
-			Status:         DoctorWarn,
-			Message:        finding.Message,
-			Recommendation: finding.Recommendation,
-		})
+	if !individualKey {
+		for _, finding := range InspectCredentialShapes(shapeLabels, keyID, issuerID) {
+			checks = append(checks, DoctorCheck{
+				Status:         DoctorWarn,
+				Message:        finding.Message,
+				Recommendation: finding.Recommendation,
+			})
+		}
 	}
 
 	if envProvided {

--- a/internal/auth/doctor.go
+++ b/internal/auth/doctor.go
@@ -413,6 +413,15 @@ func inspectEnvironment() DoctorSection {
 		})
 	}
 
+	shapeLabels := CredentialShapeLabels{KeyID: "ASC_KEY_ID", IssuerID: "ASC_ISSUER_ID"}
+	for _, finding := range InspectCredentialShapes(shapeLabels, keyID, issuerID) {
+		checks = append(checks, DoctorCheck{
+			Status:         DoctorWarn,
+			Message:        finding.Message,
+			Recommendation: finding.Recommendation,
+		})
+	}
+
 	if envProvided {
 		defaultCreds, err := GetDefaultCredentials()
 		if err == nil && defaultCreds != nil {

--- a/internal/auth/doctor_test.go
+++ b/internal/auth/doctor_test.go
@@ -103,6 +103,7 @@ func TestDoctorEnvironmentWarnsWhenCredentialIdentifiersLookSwapped(t *testing.T
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 	t.Setenv("ASC_KEY_ID", "69a6de00-aaaa-bbbb-cccc-123456789abc")
 	t.Setenv("ASC_ISSUER_ID", "39MX87M9Y4")
+	t.Setenv("ASC_KEY_TYPE", "team")
 	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
 
 	report := Doctor(DoctorOptions{})
@@ -125,6 +126,7 @@ func TestDoctorEnvironmentWarnsForNonUUIDIssuerID(t *testing.T) {
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 	t.Setenv("ASC_KEY_ID", "39MX87M9Y4")
 	t.Setenv("ASC_ISSUER_ID", "not-a-uuid")
+	t.Setenv("ASC_KEY_TYPE", "team")
 	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
 
 	report := Doctor(DoctorOptions{})
@@ -180,6 +182,7 @@ func TestDoctorEnvironmentAcceptsUnusualButValidCredentialShapes(t *testing.T) {
 			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 			t.Setenv("ASC_KEY_ID", test.keyID)
 			t.Setenv("ASC_ISSUER_ID", test.issuerID)
+			t.Setenv("ASC_KEY_TYPE", "team")
 			t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
 
 			report := Doctor(DoctorOptions{})

--- a/internal/auth/doctor_test.go
+++ b/internal/auth/doctor_test.go
@@ -98,6 +98,73 @@ func TestDoctorEnvironmentWarnsForInvalidKeyType(t *testing.T) {
 	}
 }
 
+func TestDoctorEnvironmentWarnsWhenCredentialIdentifiersLookSwapped(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_KEY_ID", "69a6de00-aaaa-bbbb-cccc-123456789abc")
+	t.Setenv("ASC_ISSUER_ID", "39MX87M9Y4")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+
+	report := Doctor(DoctorOptions{})
+	section := findDoctorSection(t, report, "Environment")
+	if !sectionHasStatus(section, DoctorWarn, "ASC_KEY_ID looks like an issuer ID — the values may be swapped") {
+		t.Fatalf("expected swapped key ID warning, got %#v", section.Checks)
+	}
+	if !sectionHasStatus(section, DoctorWarn, "ASC_ISSUER_ID looks like a key ID — the values may be swapped") {
+		t.Fatalf("expected swapped issuer ID warning, got %#v", section.Checks)
+	}
+	for _, check := range section.Checks {
+		if strings.Contains(check.Message, "69a6de00") || strings.Contains(check.Message, "39MX87M9Y4") {
+			t.Fatalf("credential identifier leaked in message: %q", check.Message)
+		}
+	}
+}
+
+func TestDoctorEnvironmentWarnsForNonUUIDIssuerID(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_KEY_ID", "39MX87M9Y4")
+	t.Setenv("ASC_ISSUER_ID", "not-a-uuid")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+
+	report := Doctor(DoctorOptions{})
+	section := findDoctorSection(t, report, "Environment")
+	if !sectionHasStatus(section, DoctorWarn, "ASC_ISSUER_ID is not a UUID") {
+		t.Fatalf("expected issuer ID shape warning, got %#v", section.Checks)
+	}
+	if sectionHasStatus(section, DoctorWarn, "ASC_KEY_ID looks like an issuer ID") {
+		t.Fatalf("expected no key ID warning for a plausible key ID, got %#v", section.Checks)
+	}
+}
+
+func TestDoctorEnvironmentAcceptsUnusualButValidCredentialShapes(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		keyID    string
+		issuerID string
+	}{
+		{name: "digits only key id", keyID: "1234567890", issuerID: "69a6de00-aaaa-bbbb-cccc-123456789abc"},
+		{name: "mixed case key id", keyID: "39Mx87M9y4", issuerID: "09f4080c-6ee7-4e52-8103-e1241eaaa58a"},
+		{name: "uppercase issuer uuid", keyID: "39MX87M9Y4", issuerID: "A7EFEF21-3432-404F-A488-083800B570FF"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+			t.Setenv("ASC_KEY_ID", test.keyID)
+			t.Setenv("ASC_ISSUER_ID", test.issuerID)
+			t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+
+			report := Doctor(DoctorOptions{})
+			section := findDoctorSection(t, report, "Environment")
+			for _, check := range section.Checks {
+				if check.Status == DoctorWarn && (strings.Contains(check.Message, "swapped") || strings.Contains(check.Message, "not a UUID")) {
+					t.Fatalf("unexpected credential shape warning: %q", check.Message)
+				}
+			}
+		})
+	}
+}
+
 func TestDoctorTempFilesWarns(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))

--- a/internal/auth/doctor_test.go
+++ b/internal/auth/doctor_test.go
@@ -137,6 +137,23 @@ func TestDoctorEnvironmentWarnsForNonUUIDIssuerID(t *testing.T) {
 	}
 }
 
+func TestDoctorEnvironmentIgnoresIssuerShapeForIndividualKey(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_KEY_ID", "39MX87M9Y4")
+	t.Setenv("ASC_ISSUER_ID", "stale-team-value")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+	t.Setenv("ASC_KEY_TYPE", "individual")
+
+	report := Doctor(DoctorOptions{})
+	section := findDoctorSection(t, report, "Environment")
+	for _, check := range section.Checks {
+		if check.Status == DoctorWarn && (strings.Contains(check.Message, "ASC_ISSUER_ID") || strings.Contains(check.Message, "swapped")) {
+			t.Fatalf("unexpected warning for ignored individual-key issuer: %q", check.Message)
+		}
+	}
+}
+
 func TestDoctorEnvironmentAcceptsUnusualButValidCredentialShapes(t *testing.T) {
 	for _, test := range []struct {
 		name     string

--- a/internal/auth/doctor_test.go
+++ b/internal/auth/doctor_test.go
@@ -138,19 +138,30 @@ func TestDoctorEnvironmentWarnsForNonUUIDIssuerID(t *testing.T) {
 }
 
 func TestDoctorEnvironmentIgnoresIssuerShapeForIndividualKey(t *testing.T) {
-	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
-	t.Setenv("ASC_KEY_ID", "39MX87M9Y4")
-	t.Setenv("ASC_ISSUER_ID", "stale-team-value")
-	t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
-	t.Setenv("ASC_KEY_TYPE", "individual")
+	for _, test := range []struct {
+		name     string
+		keyID    string
+		issuerID string
+	}{
+		{name: "stale issuer is ignored", keyID: "39MX87M9Y4", issuerID: "stale-team-value"},
+		{name: "uuid-shaped key without issuer", keyID: "69a6de00-aaaa-bbbb-cccc-123456789abc"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+			t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+			t.Setenv("ASC_KEY_ID", test.keyID)
+			t.Setenv("ASC_ISSUER_ID", test.issuerID)
+			t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+			t.Setenv("ASC_KEY_TYPE", "individual")
 
-	report := Doctor(DoctorOptions{})
-	section := findDoctorSection(t, report, "Environment")
-	for _, check := range section.Checks {
-		if check.Status == DoctorWarn && (strings.Contains(check.Message, "ASC_ISSUER_ID") || strings.Contains(check.Message, "swapped")) {
-			t.Fatalf("unexpected warning for ignored individual-key issuer: %q", check.Message)
-		}
+			report := Doctor(DoctorOptions{})
+			section := findDoctorSection(t, report, "Environment")
+			for _, check := range section.Checks {
+				if check.Status == DoctorWarn && (strings.Contains(check.Message, "ASC_ISSUER_ID") || strings.Contains(check.Message, "issuer ID") || strings.Contains(check.Message, "swapped")) {
+					t.Fatalf("unexpected team credential warning for individual key: %q", check.Message)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -473,7 +473,10 @@ func loginStorageMessage(bypassKeychain, local bool) (string, error) {
 // the issuer ID is not, which can only mean the two values were swapped.
 // Everything less certain is written to stderr as a warning so valid but
 // unusual credentials never block a login.
-func reportLoginCredentialShapes(keyID, issuerID string) error {
+func reportLoginCredentialShapes(keyID, issuerID string, individualKey bool) error {
+	if individualKey {
+		return nil
+	}
 	findings := authsvc.InspectCredentialShapes(
 		authsvc.CredentialShapeLabels{KeyID: "--key-id", IssuerID: "--issuer-id"},
 		keyID,
@@ -566,7 +569,7 @@ so commands continue to work even if the original .p8 file is removed.`,
 			if *skipValidation && *network {
 				return shared.WithDiagnostic(shared.UsageError("--skip-validation and --network are mutually exclusive"), shared.DiagnosticConflictingInput, "--skip-validation")
 			}
-			if err := reportLoginCredentialShapes(*keyID, *issuerID); err != nil {
+			if err := reportLoginCredentialShapes(*keyID, *issuerID, normalizedKeyType == config.CredentialKeyTypeIndividual); err != nil {
 				return err
 			}
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -469,6 +469,32 @@ func loginStorageMessage(bypassKeychain, local bool) (string, error) {
 	return fmt.Sprintf("System keychain unavailable; storing credentials in config file at %s", path), nil
 }
 
+// reportLoginCredentialShapes fails only when the key ID is an issuer UUID and
+// the issuer ID is not, which can only mean the two values were swapped.
+// Everything less certain is written to stderr as a warning so valid but
+// unusual credentials never block a login.
+func reportLoginCredentialShapes(keyID, issuerID string) error {
+	findings := authsvc.InspectCredentialShapes(
+		authsvc.CredentialShapeLabels{KeyID: "--key-id", IssuerID: "--issuer-id"},
+		keyID,
+		issuerID,
+	)
+	for _, finding := range findings {
+		if !finding.DefiniteSwap {
+			continue
+		}
+		return shared.WithDiagnostic(
+			shared.UsageErrorf("auth login: %s. %s", finding.Message, finding.Recommendation),
+			shared.DiagnosticInvalidInput,
+			finding.Field,
+		)
+	}
+	for _, finding := range findings {
+		fmt.Fprintf(os.Stderr, "Warning: %s. %s\n", finding.Message, finding.Recommendation)
+	}
+	return nil
+}
+
 // AuthLogin command factory
 func AuthLoginCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("auth login", flag.ExitOnError)
@@ -539,6 +565,9 @@ so commands continue to work even if the original .p8 file is removed.`,
 			}
 			if *skipValidation && *network {
 				return shared.WithDiagnostic(shared.UsageError("--skip-validation and --network are mutually exclusive"), shared.DiagnosticConflictingInput, "--skip-validation")
+			}
+			if err := reportLoginCredentialShapes(*keyID, *issuerID); err != nil {
+				return err
 			}
 
 			if err := authsvc.ValidateKeyFile(*keyPath); err != nil {

--- a/internal/cli/auth/auth_credential_shape_test.go
+++ b/internal/cli/auth/auth_credential_shape_test.go
@@ -1,0 +1,167 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func runCredentialShapeLogin(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	keyPath := writeTempECDSAKeyFile(t)
+	cmd := AuthLoginCommand()
+	parsed := append([]string{
+		"--bypass-keychain",
+		"--local",
+		"--name", "demo",
+		"--private-key", keyPath,
+	}, args...)
+	if err := cmd.FlagSet.Parse(parsed); err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureAuthOutput(t, func() {
+		runErr = cmd.Exec(context.Background(), []string{})
+	})
+	return stderr, runErr
+}
+
+func TestAuthLoginRejectsSwappedCredentialIdentifiers(t *testing.T) {
+	withTempRepo(t, func(repo string) {
+		clearResolvedAuthEnv(t)
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
+
+		stderr, err := runCredentialShapeLogin(
+			t,
+			"--key-id", "69a6de00-aaaa-bbbb-cccc-123456789abc",
+			"--issuer-id", "39MX87M9Y4",
+		)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
+		}
+		assertAuthDiagnostic(t, err, shared.DiagnosticInvalidInput, "--key-id")
+
+		if !strings.Contains(stderr, "--key-id looks like an issuer ID — the values may be swapped") {
+			t.Fatalf("expected swap error in stderr, got %q", stderr)
+		}
+		if strings.Contains(stderr, "69a6de00") || strings.Contains(stderr, "39MX87M9Y4") {
+			t.Fatalf("expected credential identifiers to stay out of stderr, got %q", stderr)
+		}
+		if _, statErr := os.Stat(filepath.Join(repo, ".asc", "config.json")); statErr == nil || !os.IsNotExist(statErr) {
+			t.Fatalf("expected credentials not to be stored, stat error = %v", statErr)
+		}
+	})
+}
+
+func TestAuthLoginWarnsWithoutFailingForUncertainCredentialShapes(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		keyID       string
+		issuerID    string
+		wantWarning string
+	}{
+		{
+			name:        "both identifiers are uuids",
+			keyID:       "69a6de00-aaaa-bbbb-cccc-123456789abc",
+			issuerID:    "09f4080c-6ee7-4e52-8103-e1241eaaa58a",
+			wantWarning: "--key-id looks like an issuer ID",
+		},
+		{
+			name:        "issuer id is not a uuid",
+			keyID:       "39MX87M9Y4",
+			issuerID:    "ISS456",
+			wantWarning: "--issuer-id is not a UUID",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			withTempRepo(t, func(repo string) {
+				clearResolvedAuthEnv(t)
+				t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+				t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
+
+				stderr, err := runCredentialShapeLogin(
+					t,
+					"--key-id", test.keyID,
+					"--issuer-id", test.issuerID,
+				)
+				if err != nil {
+					t.Fatalf("Exec() error: %v", err)
+				}
+				if !strings.Contains(stderr, test.wantWarning) {
+					t.Fatalf("expected %q warning in stderr, got %q", test.wantWarning, stderr)
+				}
+				if !strings.HasPrefix(strings.TrimSpace(stderr), "Warning:") {
+					t.Fatalf("expected a warning rather than an error, got %q", stderr)
+				}
+				if _, statErr := os.Stat(filepath.Join(repo, ".asc", "config.json")); statErr != nil {
+					t.Fatalf("expected credentials to be stored, stat error = %v", statErr)
+				}
+			})
+		})
+	}
+}
+
+func TestAuthLoginAcceptsUnusualButValidCredentialShapesSilently(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		keyID    string
+		issuerID string
+	}{
+		{name: "typical pair", keyID: "39MX87M9Y4", issuerID: "69a6de00-aaaa-bbbb-cccc-123456789abc"},
+		{name: "digits only key id", keyID: "1234567890", issuerID: "69a6de00-aaaa-bbbb-cccc-123456789abc"},
+		{name: "mixed case key id", keyID: "39Mx87M9y4", issuerID: "09f4080c-6ee7-4e52-8103-e1241eaaa58a"},
+		{name: "short key id", keyID: "KEY123", issuerID: "A7EFEF21-3432-404F-A488-083800B570FF"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			withTempRepo(t, func(repo string) {
+				clearResolvedAuthEnv(t)
+				t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+				t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
+
+				stderr, err := runCredentialShapeLogin(
+					t,
+					"--key-id", test.keyID,
+					"--issuer-id", test.issuerID,
+				)
+				if err != nil {
+					t.Fatalf("Exec() error: %v", err)
+				}
+				if strings.Contains(stderr, "swapped") || strings.Contains(stderr, "not a UUID") {
+					t.Fatalf("expected no credential shape warning, got %q", stderr)
+				}
+			})
+		})
+	}
+}
+
+func TestAuthLoginIndividualKeyWithUUIDKeyIDWarnsWithoutFailing(t *testing.T) {
+	withTempRepo(t, func(repo string) {
+		clearResolvedAuthEnv(t)
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
+
+		stderr, err := runCredentialShapeLogin(
+			t,
+			"--key-id", "69a6de00-aaaa-bbbb-cccc-123456789abc",
+			"--key-type", "individual",
+		)
+		if err != nil {
+			t.Fatalf("Exec() error: %v", err)
+		}
+		if !strings.Contains(stderr, "--key-id looks like an issuer ID") {
+			t.Fatalf("expected key ID warning in stderr, got %q", stderr)
+		}
+		if _, statErr := os.Stat(filepath.Join(repo, ".asc", "config.json")); statErr != nil {
+			t.Fatalf("expected credentials to be stored, stat error = %v", statErr)
+		}
+	})
+}

--- a/internal/cli/auth/auth_credential_shape_test.go
+++ b/internal/cli/auth/auth_credential_shape_test.go
@@ -143,7 +143,7 @@ func TestAuthLoginAcceptsUnusualButValidCredentialShapesSilently(t *testing.T) {
 	}
 }
 
-func TestAuthLoginIndividualKeyWithUUIDKeyIDWarnsWithoutFailing(t *testing.T) {
+func TestAuthLoginIndividualKeyWithUUIDKeyIDSkipsTeamShapeWarnings(t *testing.T) {
 	withTempRepo(t, func(repo string) {
 		clearResolvedAuthEnv(t)
 		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
@@ -157,8 +157,8 @@ func TestAuthLoginIndividualKeyWithUUIDKeyIDWarnsWithoutFailing(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Exec() error: %v", err)
 		}
-		if !strings.Contains(stderr, "--key-id looks like an issuer ID") {
-			t.Fatalf("expected key ID warning in stderr, got %q", stderr)
+		if strings.Contains(stderr, "issuer") || strings.Contains(stderr, "swapped") {
+			t.Fatalf("unexpected team credential warning in stderr: %q", stderr)
 		}
 		if _, statErr := os.Stat(filepath.Join(repo, ".asc", "config.json")); statErr != nil {
 			t.Fatalf("expected credentials to be stored, stat error = %v", statErr)

--- a/internal/cli/auth/auth_credential_shape_test.go
+++ b/internal/cli/auth/auth_credential_shape_test.go
@@ -81,6 +81,12 @@ func TestAuthLoginWarnsWithoutFailingForUncertainCredentialShapes(t *testing.T) 
 			issuerID:    "ISS456",
 			wantWarning: "--issuer-id is not a UUID",
 		},
+		{
+			name:        "uuid key id with generic malformed issuer",
+			keyID:       "69a6de00-aaaa-bbbb-cccc-123456789abc",
+			issuerID:    "issuer-uuid",
+			wantWarning: "--key-id looks like an issuer ID",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			withTempRepo(t, func(repo string) {

--- a/internal/cli/cmdtest/auth_credential_shape_test.go
+++ b/internal/cli/cmdtest/auth_credential_shape_test.go
@@ -17,6 +17,7 @@ func TestAuthDoctorWarnsWhenEnvironmentIdentifiersLookSwapped(t *testing.T) {
 		t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
 		t.Setenv("ASC_KEY_ID", "69a6de00-aaaa-bbbb-cccc-123456789abc")
 		t.Setenv("ASC_ISSUER_ID", "39MX87M9Y4")
+		t.Setenv("ASC_KEY_TYPE", "team")
 		t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
 
 		root := RootCommand("1.2.3")
@@ -49,6 +50,7 @@ func TestAuthDoctorStaysQuietForValidEnvironmentIdentifiers(t *testing.T) {
 		t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
 		t.Setenv("ASC_KEY_ID", "1234567890")
 		t.Setenv("ASC_ISSUER_ID", "A7EFEF21-3432-404F-A488-083800B570FF")
+		t.Setenv("ASC_KEY_TYPE", "team")
 		t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
 
 		root := RootCommand("1.2.3")

--- a/internal/cli/cmdtest/auth_credential_shape_test.go
+++ b/internal/cli/cmdtest/auth_credential_shape_test.go
@@ -1,0 +1,67 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAuthDoctorWarnsWhenEnvironmentIdentifiersLookSwapped(t *testing.T) {
+	withTempRepo(t, func(repo string) {
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
+		t.Setenv("ASC_KEY_ID", "69a6de00-aaaa-bbbb-cccc-123456789abc")
+		t.Setenv("ASC_ISSUER_ID", "39MX87M9Y4")
+		t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+
+		stdout, _ := captureOutput(t, func() {
+			if err := root.Parse([]string{"auth", "doctor"}); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if err := root.Run(context.Background()); err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+		})
+
+		if !strings.Contains(stdout, "[WARN] ASC_KEY_ID looks like an issuer ID — the values may be swapped") {
+			t.Fatalf("expected swapped key ID warning, got %q", stdout)
+		}
+		if !strings.Contains(stdout, "[WARN] ASC_ISSUER_ID looks like a key ID — the values may be swapped") {
+			t.Fatalf("expected swapped issuer ID warning, got %q", stdout)
+		}
+		if strings.Contains(stdout, "69a6de00") || strings.Contains(stdout, "39MX87M9Y4") {
+			t.Fatalf("expected credential identifiers to be redacted, got %q", stdout)
+		}
+	})
+}
+
+func TestAuthDoctorStaysQuietForValidEnvironmentIdentifiers(t *testing.T) {
+	withTempRepo(t, func(repo string) {
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
+		t.Setenv("ASC_KEY_ID", "1234567890")
+		t.Setenv("ASC_ISSUER_ID", "A7EFEF21-3432-404F-A488-083800B570FF")
+		t.Setenv("ASC_PRIVATE_KEY_PATH", "/tmp/AuthKey.p8")
+
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+
+		stdout, _ := captureOutput(t, func() {
+			if err := root.Parse([]string{"auth", "doctor"}); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if err := root.Run(context.Background()); err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+		})
+
+		if strings.Contains(stdout, "swapped") || strings.Contains(stdout, "is not a UUID") {
+			t.Fatalf("expected no credential shape warning, got %q", stdout)
+		}
+	})
+}

--- a/internal/cli/cmdtest/auth_credential_shape_test.go
+++ b/internal/cli/cmdtest/auth_credential_shape_test.go
@@ -2,7 +2,10 @@ package cmdtest
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -62,6 +65,45 @@ func TestAuthDoctorStaysQuietForValidEnvironmentIdentifiers(t *testing.T) {
 
 		if strings.Contains(stdout, "swapped") || strings.Contains(stdout, "is not a UUID") {
 			t.Fatalf("expected no credential shape warning, got %q", stdout)
+		}
+	})
+}
+
+func TestAuthLoginFailsWhenCredentialIdentifiersAreSwapped(t *testing.T) {
+	withTempRepo(t, func(repo string) {
+		keyPath := filepath.Join(repo, "AuthKey.p8")
+		writeECDSAPEM(t, keyPath)
+
+		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+		t.Setenv("ASC_CONFIG_PATH", filepath.Join(repo, "config.json"))
+
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+
+		_, stderr := captureOutput(t, func() {
+			if err := root.Parse([]string{
+				"auth", "login",
+				"--bypass-keychain",
+				"--local",
+				"--name", "CI",
+				"--key-id", "69a6de00-aaaa-bbbb-cccc-123456789abc",
+				"--issuer-id", "39MX87M9Y4",
+				"--private-key", keyPath,
+			}); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			err := root.Run(context.Background())
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("expected usage error, got %v", err)
+			}
+		})
+
+		if !strings.Contains(stderr, "auth login: --key-id looks like an issuer ID — the values may be swapped") {
+			t.Fatalf("expected swap usage error in stderr, got %q", stderr)
+		}
+
+		if _, err := os.Stat(filepath.Join(repo, ".asc", "config.json")); err == nil || !os.IsNotExist(err) {
+			t.Fatalf("expected no credentials to be written, stat error = %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

Pasting the issuer ID into `ASC_KEY_ID` (or the key ID into `ASC_ISSUER_ID`) is a classic CI setup mistake, and today it only surfaces as a raw `401 NOT_AUTHORIZED` from Apple — no hint about which value is wrong. The two shapes are unambiguous: issuer IDs are canonical UUIDs, key IDs are short uppercase alphanumeric strings such as `39MX87M9Y4`.

## Behavior change

**`asc auth doctor`** adds WARN findings to the Environment section when `ASC_KEY_ID` parses as a canonical UUID, or when `ASC_ISSUER_ID` cannot be one. The swap hint is only claimed when the evidence supports it: a malformed issuer ID that also looks like a key ID says so, an issuer ID that is merely malformed does not claim a swap.

**`asc auth login`** fails with a usage error for the one unambiguous case — `--key-id` is an issuer UUID **and** `--issuer-id` is not, which can only mean the values were swapped. Every weaker signal stays a stderr warning and the login proceeds.

Key IDs are never format-policed. Only the issuer ID has a shape Apple guarantees, so the key ID is flagged solely when it takes the shape of the *other* field. All-digit, mixed-case, short, and long key IDs pass silently — the checks were derived from the identifier fixtures this repo already treats as valid (`39MX87M9Y4`, `1234567890`, `TEAM123456`, `KEY123`, `ENVKEY`, `TEST_KEY_ID`).

### Example doctor output

```
Environment:
  [INFO] ASC_KEY_ID is set
  [INFO] ASC_ISSUER_ID is set
  [INFO] ASC_PRIVATE_KEY_PATH is set
  [WARN] ASC_KEY_ID looks like an issuer ID — the values may be swapped
  [WARN] ASC_ISSUER_ID looks like a key ID — the values may be swapped

Recommendations:
  1. Set ASC_KEY_ID to the App Store Connect API key ID and ASC_ISSUER_ID to the issuer UUID
```

### Example login failure

```
$ asc auth login --name CI --key-id "69a6de00-aaaa-bbbb-cccc-123456789abc" --issuer-id "39MX87M9Y4" --private-key AuthKey.p8
Error: auth login: --key-id looks like an issuer ID — the values may be swapped. Set --key-id to the App Store Connect API key ID and --issuer-id to the issuer UUID
```

Nothing is stored, and the usage error carries the `invalid_input` diagnostic on `--key-id`.

## Implementation

`internal/auth/credential_shape.go` holds `LooksLikeIssuerID`, `LooksLikeKeyID`, and `InspectCredentialShapes`, which returns label-aware findings (`ASC_KEY_ID`/`ASC_ISSUER_ID` for doctor, `--key-id`/`--issuer-id` for login) plus a `DefiniteSwap` marker for the only case that justifies an error. `LooksLikeIssuerID` requires the canonical hyphenated form, matching the existing `normalizeIdentityProfileUUID` pattern in `internal/cli/signing`, so braced/URN/unhyphenated spellings that `uuid.Parse` accepts are rejected.

Findings never echo the inspected values, so `auth doctor` output stays safe to paste into a bug report or CI log.

## Tests

- `internal/auth/credential_shape_test.go`: predicate tables and finding construction, including no-finding cases for unusual-but-valid key IDs (all digits, mixed case, 6-char, underscored), uppercase issuer UUIDs, and individual keys with no issuer ID; plus a redaction test.
- `internal/auth/doctor_test.go`: swapped env pair warns on both variables, non-UUID issuer warns without accusing the key ID, valid pairs produce no shape warning, identifiers stay redacted.
- `internal/cli/auth/auth_credential_shape_test.go`: login rejects the definite swap (usage error, `invalid_input` on `--key-id`, nothing written), warns-but-succeeds for the uncertain cases, stays silent for valid pairs, and warns without failing for an individual key whose key ID is a UUID.
- `internal/cli/cmdtest/auth_credential_shape_test.go`: end-to-end `auth doctor` text output and the `auth login` usage error through the root command.

## Compatibility

Additive. No flags, help text, or JSON fields change, so `docs/COMMANDS.md` is untouched. `auth doctor` gains WARN checks inside the existing Environment section (JSON shape unchanged); warnings raise the doctor warning count but never its error count, so its exit code is unaffected. The only new failure path is `auth login` with a definitively swapped pair, which previously failed anyway — later, with a 401 from Apple.

Known follow-up: the placeholder `--issuer-id "DEF456"` in the `auth login` help examples, `README.md`, and the website docs is not UUID-shaped and now trips the new warning. Left alone here to keep this PR off contended doc surfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added credential checks to `auth login` and `auth doctor`.
  * Detects likely key and issuer ID swaps, malformed issuer IDs, and uncertain formats.
  * Blocks login for definite swaps while allowing valid or uncertain credentials with warnings.
  * Provides actionable diagnostics without exposing credential values.
  * Handles individual-key credentials without irrelevant issuer warnings.

* **Tests**
  * Added coverage for validation outcomes, warnings, redaction, and credential persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->