### PR TITLE
fix(subscriptions): correct localization selector flag ergonomics

### DIFF
--- a/internal/cli/cmdtest/analytics_flag_aliases_surface_test.go
+++ b/internal/cli/cmdtest/analytics_flag_aliases_surface_test.go
@@ -60,7 +60,11 @@ func TestAnalyticsRankedAmbiguousFlagsRemainRejected(t *testing.T) {
 		{path: []string{"screenshots", "list"}, flag: "paginate"},
 		{path: []string{"localizations", "update"}, flag: "localization-id"},
 		{path: []string{"profiles", "list"}, flag: "bundle-id"},
-		{path: []string{"subscriptions", "localizations", "update"}, flag: "subscription-id"},
+		// `subscriptions localizations update --subscription-id` stays a
+		// non-alias too, but it is now recognized purely so the command can
+		// explain that --id addresses the localization. Its surface and
+		// runtime contracts live in
+		// subscriptions_localizations_selector_flags_test.go.
 	}
 
 	root := RootCommand("1.2.3")

--- a/internal/cli/cmdtest/subscriptions_localizations_selector_flags_test.go
+++ b/internal/cli/cmdtest/subscriptions_localizations_selector_flags_test.go
@@ -1,0 +1,270 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+const (
+	subscriptionsLocalizationsUpdateDeprecationWarning = "Warning: `asc subscriptions localizations update` is deprecated by App Store Connect API 4.4.1. Use `asc subscriptions versions localizations update --id \"LOCALIZATION_ID\" --name \"NAME\"`."
+	subscriptionsLocalizationsProductIDAliasWarning    = "Warning: `--product-id` is deprecated. Use `--subscription-id`."
+)
+
+func failingTransport(t *testing.T) {
+	t.Helper()
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("expected no HTTP request, got %s %s", req.Method, req.URL.String())
+		return nil, nil
+	})
+}
+
+func subscriptionsLocalizationsCommand(t *testing.T, root *ffcli.Command, name string) *ffcli.Command {
+	t.Helper()
+
+	command := findSubcommand(root, "subscriptions", "localizations", name)
+	if command == nil {
+		t.Fatalf("command %q not found", "subscriptions localizations "+name)
+	}
+	return command
+}
+
+func runSubscriptionsLocalizationsArgs(t *testing.T, root *ffcli.Command, args []string) (string, string, error) {
+	t.Helper()
+
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	return stdout, stderr, runErr
+}
+
+func TestSubscriptionsLocalizationsCreateProductIDAliasResolvesSubscription(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	root := RootCommand("1.2.3")
+	create := subscriptionsLocalizationsCommand(t, root, "create")
+	if create.FlagSet.Lookup("product-id") == nil {
+		t.Fatal("expected --product-id compatibility alias on subscriptions localizations create")
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/subscriptions/123456789/subscriptionLocalizations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"subscriptionLocalizations","id":"loc-1","attributes":{"name":"Pro","locale":"en-US","description":"Premium features."}}],"links":{"next":""}}`), nil
+	})
+
+	stdout, stderr, runErr := runSubscriptionsLocalizationsArgs(t, root, []string{
+		"subscriptions", "localizations", "create",
+		"--product-id", "123456789",
+		"--locale", "en-us",
+		"--name", "Pro",
+		"--description", "Premium features.",
+		"--output", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected the alias to select the same subscription, got %d requests", requestCount)
+	}
+
+	requireStderrContainsWarning(t, stderr, subscriptionsLocalizationsCreateDeprecationWarning)
+	requireStderrContainsWarning(t, stderr, subscriptionsLocalizationsProductIDAliasWarning)
+
+	var result struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%q", err, stdout)
+	}
+	if result.Data.ID != "loc-1" {
+		t.Fatalf("unexpected localization output: %+v", result)
+	}
+}
+
+func TestSubscriptionsLocalizationsCreateProductIDAliasConflictErrors(t *testing.T) {
+	failingTransport(t)
+
+	root := RootCommand("1.2.3")
+	stdout, stderr, runErr := runSubscriptionsLocalizationsArgs(t, root, []string{
+		"subscriptions", "localizations", "create",
+		"--subscription-id", "123456789",
+		"--product-id", "com.example.pro",
+		"--locale", "en-US",
+		"--name", "Pro",
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Error: --product-id conflicts with --subscription-id; use only --subscription-id") {
+		t.Fatalf("expected conflicting subscription selector error, got %q", stderr)
+	}
+}
+
+func TestSubscriptionsLocalizationsCreateRejectsVersionIDWithVersionScopedGuidance(t *testing.T) {
+	failingTransport(t)
+
+	root := RootCommand("1.2.3")
+	create := subscriptionsLocalizationsCommand(t, root, "create")
+	if create.FlagSet.Lookup("version-id") == nil {
+		t.Fatal("expected --version-id to be recognized for guidance on subscriptions localizations create")
+	}
+
+	stdout, stderr, runErr := runSubscriptionsLocalizationsArgs(t, root, []string{
+		"subscriptions", "localizations", "create",
+		"--version-id", "SUBSCRIPTION_VERSION_ID",
+		"--locale", "en-US",
+		"--name", "Pro",
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--version-id is not accepted here") {
+		t.Fatalf("expected version selector rejection, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "--subscription-id") {
+		t.Fatalf("expected product-scoped selector guidance, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "asc subscriptions versions localizations create --version-id") {
+		t.Fatalf("expected version-scoped command guidance, got %q", stderr)
+	}
+	if got := create.FlagSet.Lookup("subscription-id").Value.String(); got != "" {
+		t.Fatalf("expected --version-id never to populate --subscription-id, got %q", got)
+	}
+}
+
+func TestSubscriptionsLocalizationsUpdateRejectsSubscriptionIDWithLocalizationGuidance(t *testing.T) {
+	failingTransport(t)
+
+	root := RootCommand("1.2.3")
+	update := subscriptionsLocalizationsCommand(t, root, "update")
+	if update.FlagSet.Lookup("subscription-id") == nil {
+		t.Fatal("expected --subscription-id to be recognized for guidance on subscriptions localizations update")
+	}
+
+	stdout, stderr, runErr := runSubscriptionsLocalizationsArgs(t, root, []string{
+		"subscriptions", "localizations", "update",
+		"--subscription-id", "123456789",
+		"--name", "Pro+",
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp usage error, got %v", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--subscription-id is not accepted here") {
+		t.Fatalf("expected subscription selector rejection, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "--id is the localization ID, not the subscription ID") {
+		t.Fatalf("expected localization identity explanation, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "asc subscriptions localizations list --subscription-id") {
+		t.Fatalf("expected localization discovery guidance, got %q", stderr)
+	}
+	if got := update.FlagSet.Lookup("id").Value.String(); got != "" {
+		t.Fatalf("expected --subscription-id never to populate --id, got %q", got)
+	}
+}
+
+func TestSubscriptionsLocalizationsUpdateSubscriptionIDGuidanceOutranksMissingID(t *testing.T) {
+	failingTransport(t)
+
+	root := RootCommand("1.2.3")
+	_, stderr, runErr := runSubscriptionsLocalizationsArgs(t, root, []string{
+		"subscriptions", "localizations", "update",
+		"--subscription-id", "123456789",
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp usage error, got %v", runErr)
+	}
+	if strings.Contains(stderr, "Error: --id is required") {
+		t.Fatalf("expected selector guidance instead of a bare missing-flag error, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "--subscription-id is not accepted here") {
+		t.Fatalf("expected subscription selector rejection, got %q", stderr)
+	}
+}
+
+func TestSubscriptionsLocalizationsCompatibilityFlagsStayHiddenFromHelp(t *testing.T) {
+	root := RootCommand("1.2.3")
+
+	tests := []struct {
+		command string
+		flags   []string
+	}{
+		{command: "create", flags: []string{"product-id", "version-id"}},
+		{command: "update", flags: []string{"subscription-id"}},
+	}
+
+	for _, test := range tests {
+		command := subscriptionsLocalizationsCommand(t, root, test.command)
+		usage := command.UsageFunc(command)
+		for _, name := range test.flags {
+			if command.FlagSet.Lookup(name) == nil {
+				t.Fatalf("expected subscriptions localizations %s to recognize --%s", test.command, name)
+			}
+			if strings.Contains(usage, "\n  --"+name+" ") {
+				t.Fatalf("expected --%s to stay hidden from subscriptions localizations %s help: %q", name, test.command, usage)
+			}
+		}
+	}
+}
+
+func TestSubscriptionsLocalizationsCanonicalSelectorsStayQuiet(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/subscriptionLocalizations/loc-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"subscriptionLocalizations","id":"loc-1","attributes":{"name":"Pro+","locale":"en-US","description":"Premium features."}}}`), nil
+	})
+
+	root := RootCommand("1.2.3")
+	_, stderr, runErr := runSubscriptionsLocalizationsArgs(t, root, []string{
+		"subscriptions", "localizations", "update",
+		"--id", "loc-1",
+		"--name", "Pro+",
+		"--output", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	assertOnlyCommandDeprecationWarning(t, stderr, subscriptionsLocalizationsUpdateDeprecationWarning)
+}

--- a/internal/cli/subscriptions/localization_selector_flags.go
+++ b/internal/cli/subscriptions/localization_selector_flags.go
@@ -1,0 +1,71 @@
+package subscriptions
+
+import (
+	"flag"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// Product-scoped subscription localization commands sit between two selector
+// vocabularies: sibling subscription commands select a product with
+// `--subscription-id`/`--product-id`, while the version-scoped replacements
+// select a subscription version with `--version-id`. Spellings that mean the
+// same resource as the canonical flag become hidden aliases. Spellings that
+// name a different resource are recognized only so the command can reject them
+// with the distinction spelled out, because leaving them unknown lets the
+// parser suggest a same-shaped flag that would honor the wrong mental model.
+
+const (
+	subscriptionLocalizationCreateVersionSelectorGuidance      = "subscriptions localizations create: --version-id is not accepted here; this product-scoped command selects the subscription with --subscription-id. Use `asc subscriptions versions localizations create --version-id \"SUBSCRIPTION_VERSION_ID\" --locale \"LOCALE\" --name \"NAME\"` for version-scoped localizations."
+	subscriptionLocalizationUpdateSubscriptionSelectorGuidance = "subscriptions localizations update: --subscription-id is not accepted here; --id is the localization ID, not the subscription ID. Run `asc subscriptions localizations list --subscription-id \"SUB_ID\"` to find LOCALIZATION_ID, then rerun with --id \"LOCALIZATION_ID\"."
+)
+
+// subscriptionLocalizationRejectedSelector records whether a caller supplied a
+// selector spelling that names a different resource than the command addresses.
+type subscriptionLocalizationRejectedSelector struct {
+	value string
+	set   bool
+}
+
+// String returns the supplied value for flag.Value formatting.
+func (f *subscriptionLocalizationRejectedSelector) String() string {
+	if f == nil {
+		return ""
+	}
+	return f.value
+}
+
+// Set records that the rejected spelling was explicitly supplied.
+func (f *subscriptionLocalizationRejectedSelector) Set(value string) error {
+	f.value = value
+	f.set = true
+	return nil
+}
+
+// Used reports whether the rejected spelling was explicitly supplied.
+func (f *subscriptionLocalizationRejectedSelector) Used() bool {
+	return f != nil && f.set
+}
+
+// bindSubscriptionLocalizationRejectedSelector recognizes a selector spelling
+// without advertising it, so the command can explain the resource distinction
+// instead of failing as an unknown flag.
+func bindSubscriptionLocalizationRejectedSelector(fs *flag.FlagSet, name, usage string) *subscriptionLocalizationRejectedSelector {
+	selector := &subscriptionLocalizationRejectedSelector{}
+	fs.Var(selector, name, usage)
+	shared.HideFlagFromHelp(fs.Lookup(name))
+	return selector
+}
+
+// rejectSubscriptionLocalizationSelector fails before command side effects when
+// a caller selected the wrong resource, and never populates the canonical flag.
+func rejectSubscriptionLocalizationSelector(selector *subscriptionLocalizationRejectedSelector, guidance, parameter string) error {
+	if !selector.Used() {
+		return nil
+	}
+	return shared.WithDiagnostic(
+		shared.UsageError(guidance),
+		shared.DiagnosticInvalidInput,
+		parameter,
+	)
+}

--- a/internal/cli/subscriptions/localizations.go
+++ b/internal/cli/subscriptions/localizations.go
@@ -200,6 +200,12 @@ func SubscriptionsLocalizationsCreateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("localizations create", flag.ExitOnError)
 
 	subscriptionID := fs.String("subscription-id", "", "Subscription ID, product ID, or exact current name")
+	legacyProductID := shared.BindDeprecatedStringFlagAlias(fs, "product-id", "subscription-id")
+	rejectedVersionID := bindSubscriptionLocalizationRejectedSelector(
+		fs,
+		"version-id",
+		"REJECTED: use --subscription-id, or `asc subscriptions versions localizations create`",
+	)
 	appID := addSubscriptionLookupAppFlag(fs)
 	locale := fs.String("locale", "", "Locale (e.g., en-US)")
 	name := fs.String("name", "", "Localized name")
@@ -217,6 +223,17 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectSubscriptionLocalizationSelector(
+				rejectedVersionID,
+				subscriptionLocalizationCreateVersionSelectorGuidance,
+				"--version-id",
+			); err != nil {
+				return err
+			}
+			if err := legacyProductID.Apply(subscriptionID); err != nil {
+				return err
+			}
+
 			id := strings.TrimSpace(*subscriptionID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --subscription-id is required")
@@ -341,6 +358,11 @@ func SubscriptionsLocalizationsUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("localizations update", flag.ExitOnError)
 
 	localizationID := fs.String("id", "", "Subscription localization ID")
+	rejectedSubscriptionID := bindSubscriptionLocalizationRejectedSelector(
+		fs,
+		"subscription-id",
+		"REJECTED: --id is the localization ID; find it with `asc subscriptions localizations list --subscription-id`",
+	)
 	name := fs.String("name", "", "Localized name")
 	description := fs.String("description", "", "Localized description")
 	output := shared.BindOutputFlags(fs)
@@ -356,6 +378,14 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := rejectSubscriptionLocalizationSelector(
+				rejectedSubscriptionID,
+				subscriptionLocalizationUpdateSubscriptionSelectorGuidance,
+				"--subscription-id",
+			); err != nil {
+				return err
+			}
+
 			id := strings.TrimSpace(*localizationID)
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --id is required")


### PR DESCRIPTION
## Problem

Telemetry shows `--subscription-id` on `asc subscriptions localizations update` and a cluster of unrecognized selectors on `asc subscriptions localizations create` are among the most-guessed unknown flags on this command group.

Both failures were worse than a plain rejection:

- `subscriptions localizations update --subscription-id SUB` was unknown, and the parser suggested `Try: --id`. On this command `--id` is the **localization** ID, so acting on that suggestion sends a subscription ID to `PATCH /v1/subscriptionLocalizations/{id}` and earns a 404. The CLI was steering callers into a wrong mental model.
- `subscriptions localizations create` rejected several plausible selectors with **no** suggestion at all, because they are too far from anything registered.

## Investigation

Current flag surfaces at HEAD (`asc subscriptions localizations <cmd> --help`):

| command | selector flags |
| --- | --- |
| `list` | `--subscription-id`, `--app`, … |
| `create` | `--subscription-id`, `--app`, `--locale`, `--name`, `--description` |
| `update` | `--id` (localization ID), `--name`, `--description` |

So `create` already takes the subscription selector under the canonical domain spelling. The 2.0k/30d bucket must therefore be *other* spellings. Probing each plausible guess against HEAD:

| command | guess | HEAD behavior | verdict |
| --- | --- | --- | --- |
| `create` | `--version-id` | unknown, **no suggestion** | reject with guidance (different resource) |
| `create` | `--product-id` | unknown, **no suggestion** | alias (identical meaning) |
| `create` | `--subscription` | unknown, suggests `--subscription-id` | leave as-is, recoverable |
| `create` | `--language` | unknown, no suggestion | leave as-is, ambiguous |
| `update` | `--subscription-id` | unknown, suggests `--id` (**wrong**) | reject with guidance |
| `update` | `--localization-id` | unknown, suggests `--id` (correct) | leave as-is, recoverable |

`--version-id` is the standout no-suggestion guess because the command's own deprecation text tells callers to use `asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID"` — an agent that half-reads that guidance applies the flag to the command it already typed.

## Decisions

**Correct beats convenient.** Two of the three guesses name a different resource than the command addresses, so they are recognized *only* to explain the distinction. Neither ever populates the canonical flag:

- `update --subscription-id` →
  `--subscription-id is not accepted here; --id is the localization ID, not the subscription ID. Run `asc subscriptions localizations list --subscription-id "SUB_ID"` to find LOCALIZATION_ID, then rerun with --id "LOCALIZATION_ID".`
- `create --version-id` →
  `--version-id is not accepted here; this product-scoped command selects the subscription with --subscription-id. Use `asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "LOCALE" --name "NAME"` for version-scoped localizations.`

Aliasing either one would have been the convenient fix and the wrong one — `--subscription-id` → `--id` would have honored the exact misconception that produces the 404, and a subscription version ID is not a subscription ID.

**One guess is an exact synonym, so it becomes an alias.** `--product-id` is real sibling vocabulary (`asc subscriptions create --product-id`, `asc subscriptions setup --product-id`, `asc iap create --product-id`) and `--subscription-id` already documents itself as *"Subscription ID, product ID, or exact current name"*. It is bound through `shared.BindDeprecatedStringFlagAlias`, inheriting that helper's exact warning and conflict behavior:

```
$ asc subscriptions localizations create --product-id com.example.pro --locale en-US --name Pro
Warning: `--product-id` is deprecated. Use `--subscription-id`.

$ asc subscriptions localizations create --subscription-id A --product-id B ...
Error: --product-id conflicts with --subscription-id; use only --subscription-id
```

All three flags are hidden from help via `shared.HideFlagFromHelp`, so `docs/COMMANDS.md` is unchanged and the canonical surface stays the documented one.

## Compatibility

Purely additive. No existing invocation changes: canonical `--subscription-id` on create and `--id` on update behave exactly as before and emit no new stderr. Every spelling touched here previously exited 2 as an unknown flag, and still exits 2 — with a message that names the right next command.

`TestAnalyticsRankedAmbiguousFlagsRemainRejected` previously asserted `subscriptions localizations update --subscription-id` is not registered. Its intent — never an alias — is preserved and now enforced more strongly: the new tests assert the flag never populates `--id`, on top of the surface check. The entry moved to the new test file with a pointer left behind.

## Tests

New `internal/cli/cmdtest/subscriptions_localizations_selector_flags_test.go`:

- `--product-id` resolves the same subscription as `--subscription-id` and warns
- `--subscription-id` + `--product-id` with different values → conflict usage error, no HTTP
- `create --version-id` → version-scoped guidance, `--subscription-id` stays empty
- `update --subscription-id` → localization guidance, `--id` stays empty
- guidance outranks the bare `--id is required` error
- all three compatibility flags stay hidden from help
- canonical `update --id` emits only the command deprecation warning

Gauntlet green: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test`. `make generate-command-docs` produced no diff. No live API calls.

## Follow-ups (not in this PR)

- `asc iap localizations update` names its canonical flag `--localization-id` and keeps `--id` as a hidden alias; `asc subscriptions localizations update` uses bare `--id` for the same concept, which is the root cause of the conflation. Aligning it is a stability-ladder change and belongs in its own PR.
- `subscriptions localizations view`/`delete` share the bare `--id` shape and the same conflation risk, with no telemetry yet.
- `update --version-id` still fuzzy-matches to `--id`; same failure mode as the fixed case but currently unevidenced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--product-id` support for creating subscription localizations as a compatibility alias.
  * Added clearer guidance when unsupported selector flags are used.

* **Bug Fixes**
  * Invalid version- and subscription-level flags are now rejected before changes are submitted.
  * Conflicting selector flags produce a clear error.
  * Compatibility flags remain hidden from help output, while valid canonical selectors work as expected with only the applicable deprecation warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->