### PR TITLE
feat(pricing): availability platforms command + app-wide removal guard

### DIFF
--- a/internal/asc/output_availability.go
+++ b/internal/asc/output_availability.go
@@ -12,6 +12,7 @@ type AvailabilityPlatformListing struct {
 	VersionString string `json:"versionString"`
 	State         string `json:"state"`
 	Live          bool   `json:"live"`
+	StateKnown    bool   `json:"stateKnown"`
 	CreatedDate   string `json:"createdDate,omitempty"`
 }
 
@@ -25,20 +26,22 @@ type AvailabilityPlatformsResult struct {
 // AvailabilityRemoveFromSaleResult summarizes a verified remove-from-sale
 // operation.
 type AvailabilityRemoveFromSaleResult struct {
-	AppID                          string                        `json:"appId"`
-	AvailabilityID                 string                        `json:"availabilityId"`
-	Status                         string                        `json:"status"`
-	AvailableInNewTerritories      bool                          `json:"availableInNewTerritories"`
-	TotalTerritories               int                           `json:"totalTerritories"`
-	UpdatedTerritories             int                           `json:"updatedTerritories"`
-	AlreadyUnavailableTerritories  int                           `json:"alreadyUnavailableTerritories"`
-	VerifiedUnavailableTerritories int                           `json:"verifiedUnavailableTerritories"`
-	FailedTerritories              []string                      `json:"failedTerritories"`
-	RemovedPlatformListings        []AvailabilityPlatformListing `json:"removedPlatformListings,omitempty"`
+	AppID                             string                        `json:"appId"`
+	AvailabilityID                    string                        `json:"availabilityId"`
+	Status                            string                        `json:"status"`
+	AvailableInNewTerritories         bool                          `json:"availableInNewTerritories"`
+	TotalTerritories                  int                           `json:"totalTerritories"`
+	UpdatedTerritories                int                           `json:"updatedTerritories"`
+	AlreadyUnavailableTerritories     int                           `json:"alreadyUnavailableTerritories"`
+	VerifiedUnavailableTerritories    int                           `json:"verifiedUnavailableTerritories"`
+	FailedTerritories                 []string                      `json:"failedTerritories"`
+	PlatformListingsVerified          bool                          `json:"platformListingsVerified"`
+	PlatformListingsVerificationError string                        `json:"platformListingsVerificationError,omitempty"`
+	RemovedPlatformListings           []AvailabilityPlatformListing `json:"removedPlatformListings,omitempty"`
 }
 
 func availabilityPlatformsResultRows(result *AvailabilityPlatformsResult) ([]string, [][]string) {
-	headers := []string{"Platform", "Version", "State", "Live", "Created"}
+	headers := []string{"Platform", "Version", "State", "Live", "State known", "Created"}
 	rows := make([][]string, 0, len(result.Platforms))
 	for _, listing := range result.Platforms {
 		rows = append(rows, []string{
@@ -46,6 +49,7 @@ func availabilityPlatformsResultRows(result *AvailabilityPlatformsResult) ([]str
 			listing.VersionString,
 			listing.State,
 			fmt.Sprintf("%t", listing.Live),
+			fmt.Sprintf("%t", listing.StateKnown),
 			listing.CreatedDate,
 		})
 	}
@@ -63,6 +67,8 @@ func availabilityRemoveFromSaleResultRows(result *AvailabilityRemoveFromSaleResu
 		{"Already unavailable", fmt.Sprintf("%d", result.AlreadyUnavailableTerritories)},
 		{"Verified unavailable", fmt.Sprintf("%d", result.VerifiedUnavailableTerritories)},
 		{"Failed territories", strings.Join(result.FailedTerritories, ", ")},
+		{"Platform listings verified", fmt.Sprintf("%t", result.PlatformListingsVerified)},
+		{"Platform listings verification error", result.PlatformListingsVerificationError},
 		{"Removed platform listings", availabilityPlatformListingSummary(result.RemovedPlatformListings)},
 	}
 }

--- a/internal/asc/output_availability.go
+++ b/internal/asc/output_availability.go
@@ -1,0 +1,85 @@
+package asc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AvailabilityPlatformListing summarizes the selected App Store version for
+// one platform.
+type AvailabilityPlatformListing struct {
+	Platform      string `json:"platform"`
+	VersionString string `json:"versionString"`
+	State         string `json:"state"`
+	Live          bool   `json:"live"`
+	CreatedDate   string `json:"createdDate,omitempty"`
+}
+
+// AvailabilityPlatformsResult summarizes per-platform App Store listings for
+// an app.
+type AvailabilityPlatformsResult struct {
+	AppID     string                        `json:"appId"`
+	Platforms []AvailabilityPlatformListing `json:"platforms"`
+}
+
+// AvailabilityRemoveFromSaleResult summarizes a verified remove-from-sale
+// operation.
+type AvailabilityRemoveFromSaleResult struct {
+	AppID                          string                        `json:"appId"`
+	AvailabilityID                 string                        `json:"availabilityId"`
+	Status                         string                        `json:"status"`
+	AvailableInNewTerritories      bool                          `json:"availableInNewTerritories"`
+	TotalTerritories               int                           `json:"totalTerritories"`
+	UpdatedTerritories             int                           `json:"updatedTerritories"`
+	AlreadyUnavailableTerritories  int                           `json:"alreadyUnavailableTerritories"`
+	VerifiedUnavailableTerritories int                           `json:"verifiedUnavailableTerritories"`
+	FailedTerritories              []string                      `json:"failedTerritories"`
+	RemovedPlatformListings        []AvailabilityPlatformListing `json:"removedPlatformListings,omitempty"`
+}
+
+func availabilityPlatformsResultRows(result *AvailabilityPlatformsResult) ([]string, [][]string) {
+	headers := []string{"Platform", "Version", "State", "Live", "Created"}
+	rows := make([][]string, 0, len(result.Platforms))
+	for _, listing := range result.Platforms {
+		rows = append(rows, []string{
+			listing.Platform,
+			listing.VersionString,
+			listing.State,
+			fmt.Sprintf("%t", listing.Live),
+			listing.CreatedDate,
+		})
+	}
+	return headers, rows
+}
+
+func availabilityRemoveFromSaleResultRows(result *AvailabilityRemoveFromSaleResult) ([]string, [][]string) {
+	return []string{"Field", "Value"}, [][]string{
+		{"App ID", result.AppID},
+		{"Availability ID", result.AvailabilityID},
+		{"Status", result.Status},
+		{"Available in new territories", fmt.Sprintf("%t", result.AvailableInNewTerritories)},
+		{"Total territories", fmt.Sprintf("%d", result.TotalTerritories)},
+		{"Updated territories", fmt.Sprintf("%d", result.UpdatedTerritories)},
+		{"Already unavailable", fmt.Sprintf("%d", result.AlreadyUnavailableTerritories)},
+		{"Verified unavailable", fmt.Sprintf("%d", result.VerifiedUnavailableTerritories)},
+		{"Failed territories", strings.Join(result.FailedTerritories, ", ")},
+		{"Removed platform listings", availabilityPlatformListingSummary(result.RemovedPlatformListings)},
+	}
+}
+
+func availabilityPlatformListingSummary(listings []AvailabilityPlatformListing) string {
+	values := make([]string, 0, len(listings))
+	for _, listing := range listings {
+		value := strings.TrimSpace(listing.Platform)
+		if version := strings.TrimSpace(listing.VersionString); version != "" {
+			if value != "" {
+				value += " "
+			}
+			value += version
+		}
+		if value != "" {
+			values = append(values, value)
+		}
+	}
+	return strings.Join(values, ", ")
+}

--- a/internal/asc/output_availability_test.go
+++ b/internal/asc/output_availability_test.go
@@ -13,6 +13,7 @@ func TestAvailabilityPlatformsResultUsesOutputRegistry(t *testing.T) {
 			VersionString: "4.2.0",
 			State:         "READY_FOR_DISTRIBUTION",
 			Live:          true,
+			StateKnown:    true,
 			CreatedDate:   "2026-08-19T00:00:00Z",
 		}},
 	}
@@ -25,10 +26,10 @@ func TestAvailabilityPlatformsResultUsesOutputRegistry(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("renderByRegistry() error: %v", err)
 	}
-	if want := []string{"Platform", "Version", "State", "Live", "Created"}; !reflect.DeepEqual(headers, want) {
+	if want := []string{"Platform", "Version", "State", "Live", "State known", "Created"}; !reflect.DeepEqual(headers, want) {
 		t.Fatalf("headers = %#v, want %#v", headers, want)
 	}
-	if want := [][]string{{"IOS", "4.2.0", "READY_FOR_DISTRIBUTION", "true", "2026-08-19T00:00:00Z"}}; !reflect.DeepEqual(rows, want) {
+	if want := [][]string{{"IOS", "4.2.0", "READY_FOR_DISTRIBUTION", "true", "true", "2026-08-19T00:00:00Z"}}; !reflect.DeepEqual(rows, want) {
 		t.Fatalf("rows = %#v, want %#v", rows, want)
 	}
 }
@@ -48,7 +49,9 @@ func TestAvailabilityRemoveFromSaleResultUsesOutputRegistry(t *testing.T) {
 			Platform:      "IOS",
 			VersionString: "4.2.0",
 			Live:          true,
+			StateKnown:    true,
 		}},
+		PlatformListingsVerified: true,
 	}
 
 	var headers []string
@@ -62,7 +65,7 @@ func TestAvailabilityRemoveFromSaleResultUsesOutputRegistry(t *testing.T) {
 	if want := []string{"Field", "Value"}; !reflect.DeepEqual(headers, want) {
 		t.Fatalf("headers = %#v, want %#v", headers, want)
 	}
-	if len(rows) != 10 || rows[1][1] != "availability-1" || rows[7][1] != "2" || rows[9][1] != "IOS 4.2.0" {
+	if len(rows) != 12 || rows[1][1] != "availability-1" || rows[7][1] != "2" || rows[9][1] != "true" || rows[11][1] != "IOS 4.2.0" {
 		t.Fatalf("unexpected rows: %#v", rows)
 	}
 }

--- a/internal/asc/output_availability_test.go
+++ b/internal/asc/output_availability_test.go
@@ -1,0 +1,68 @@
+package asc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAvailabilityPlatformsResultUsesOutputRegistry(t *testing.T) {
+	result := &AvailabilityPlatformsResult{
+		AppID: "app-1",
+		Platforms: []AvailabilityPlatformListing{{
+			Platform:      "IOS",
+			VersionString: "4.2.0",
+			State:         "READY_FOR_DISTRIBUTION",
+			Live:          true,
+			CreatedDate:   "2026-08-19T00:00:00Z",
+		}},
+	}
+
+	var headers []string
+	var rows [][]string
+	if err := renderByRegistry(result, func(gotHeaders []string, gotRows [][]string) {
+		headers = gotHeaders
+		rows = gotRows
+	}); err != nil {
+		t.Fatalf("renderByRegistry() error: %v", err)
+	}
+	if want := []string{"Platform", "Version", "State", "Live", "Created"}; !reflect.DeepEqual(headers, want) {
+		t.Fatalf("headers = %#v, want %#v", headers, want)
+	}
+	if want := [][]string{{"IOS", "4.2.0", "READY_FOR_DISTRIBUTION", "true", "2026-08-19T00:00:00Z"}}; !reflect.DeepEqual(rows, want) {
+		t.Fatalf("rows = %#v, want %#v", rows, want)
+	}
+}
+
+func TestAvailabilityRemoveFromSaleResultUsesOutputRegistry(t *testing.T) {
+	result := &AvailabilityRemoveFromSaleResult{
+		AppID:                          "app-1",
+		AvailabilityID:                 "availability-1",
+		Status:                         "removedFromSale",
+		AvailableInNewTerritories:      false,
+		TotalTerritories:               2,
+		UpdatedTerritories:             1,
+		AlreadyUnavailableTerritories:  1,
+		VerifiedUnavailableTerritories: 2,
+		FailedTerritories:              []string{},
+		RemovedPlatformListings: []AvailabilityPlatformListing{{
+			Platform:      "IOS",
+			VersionString: "4.2.0",
+			Live:          true,
+		}},
+	}
+
+	var headers []string
+	var rows [][]string
+	if err := renderByRegistry(result, func(gotHeaders []string, gotRows [][]string) {
+		headers = gotHeaders
+		rows = gotRows
+	}); err != nil {
+		t.Fatalf("renderByRegistry() error: %v", err)
+	}
+	if want := []string{"Field", "Value"}; !reflect.DeepEqual(headers, want) {
+		t.Fatalf("headers = %#v, want %#v", headers, want)
+	}
+	if len(rows) != 10 || rows[1][1] != "availability-1" || rows[7][1] != "2" || rows[9][1] != "IOS 4.2.0" {
+		t.Fatalf("unexpected rows: %#v", rows)
+	}
+}

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -155,6 +155,8 @@ func registerAllOutputRenderers() {
 	registerRows(appAvailabilityRows)
 	registerRows(territoryAvailabilitiesRows)
 	registerRows(endAppAvailabilityPreOrderRows)
+	registerRows(availabilityPlatformsResultRows)
+	registerRows(availabilityRemoveFromSaleResultRows)
 	registerRowsWithSingleResourceAdapter(appStoreVersionLocalizationsRows)
 	registerRowsWithSingleResourceAdapter(betaAppLocalizationsRows)
 	registerRowsWithSingleResourceAdapter(betaBuildLocalizationsRows)

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -157,6 +157,9 @@ func TestPricingAvailabilityRemoveFromSaleOutputFormats(t *testing.T) {
 			if !strings.Contains(stdout, test.want) {
 				t.Fatalf("%s output missing %q: %s", test.format, test.want, stdout)
 			}
+			if !strings.Contains(stdout, "Platform listings verified") {
+				t.Fatalf("%s output missing platform verification field: %s", test.format, stdout)
+			}
 		})
 	}
 }
@@ -348,7 +351,11 @@ func singlePlatformAppStoreVersionsResponse() *http.Response {
 }
 
 func multiPlatformAppStoreVersionsResponse() *http.Response {
-	return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-ios","attributes":{"platform":"IOS","versionString":"4.1.0","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2026-07-14T00:00:00Z"}},{"type":"appStoreVersions","id":"ver-vision","attributes":{"platform":"VISION_OS","versionString":"1.3.1","appStoreState":"PREORDER_READY_FOR_SALE","createdDate":"2024-07-06T00:00:00Z"}}],"links":{}}`)
+	return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-ios","attributes":{"platform":"IOS","versionString":"4.1.0","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2026-07-14T00:00:00Z"}},{"type":"appStoreVersions","id":"ver-vision","attributes":{"platform":"VISION_OS","versionString":"1.3.1","appStoreState":"PREORDER_READY_FOR_SALE","appVersionState":"PREORDER_READY_FOR_SALE","createdDate":"2024-07-06T00:00:00Z"}}],"links":{}}`)
+}
+
+func unknownPlatformStateAppStoreVersionsResponse() *http.Response {
+	return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-ios","attributes":{"platform":"IOS","versionString":"4.1.0","appStoreState":"FUTURE_SALE_STATE","createdDate":"2026-07-14T00:00:00Z"}}],"links":{}}`)
 }
 
 func TestPricingAvailabilityRemoveFromSaleRequiresAllPlatformsWhenMultiplePlatformsLive(t *testing.T) {
@@ -425,6 +432,44 @@ func TestPricingAvailabilityRemoveFromSaleFailsClosedWhenPlatformsCannotBeVerifi
 	}
 }
 
+func TestPricingAvailabilityRemoveFromSaleFailsClosedWhenPlatformStateIsUnverifiable(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var requests atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions" {
+			return unknownPlatformStateAppStoreVersionsResponse(), nil
+		}
+		return nil, fmt.Errorf("unexpected request after failed platform state verification: %s %s", req.Method, req.URL.String())
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected unverifiable platform state failure")
+		}
+		for _, want := range []string{"could not verify live platform listings", "FUTURE_SALE_STATE", "--all-platforms"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected no stdout before mutation, got %q", stdout)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want only the platform lookup", got)
+	}
+}
+
 func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T) {
 	setupAuth(t)
 	originalTransport := http.DefaultTransport
@@ -468,8 +513,10 @@ func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T)
 		t.Fatalf("PATCH count = %d, want 1", got)
 	}
 	var result struct {
-		Status                  string `json:"status"`
-		RemovedPlatformListings []struct {
+		Status                    string `json:"status"`
+		PlatformListingsVerified  bool   `json:"platformListingsVerified"`
+		PlatformListingsVerifyErr string `json:"platformListingsVerificationError"`
+		RemovedPlatformListings   []struct {
 			Platform      string `json:"platform"`
 			VersionString string `json:"versionString"`
 			Live          bool   `json:"live"`
@@ -478,14 +525,107 @@ func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T)
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
 	}
-	if result.Status != "removedFromSale" {
+	if result.Status != "removedFromSale" || !result.PlatformListingsVerified || result.PlatformListingsVerifyErr != "" {
 		t.Fatalf("status = %q, want removedFromSale", result.Status)
 	}
 	if len(result.RemovedPlatformListings) != 2 {
 		t.Fatalf("removedPlatformListings = %d, want 2", len(result.RemovedPlatformListings))
 	}
-	if result.RemovedPlatformListings[0].Platform != "IOS" || result.RemovedPlatformListings[1].Platform != "VISION_OS" {
-		t.Fatalf("unexpected platform order: %+v", result.RemovedPlatformListings)
+	wantListings := []struct {
+		platform string
+		version  string
+		live     bool
+	}{
+		{platform: "IOS", version: "4.1.0", live: true},
+		{platform: "VISION_OS", version: "1.3.1", live: true},
+	}
+	for i, want := range wantListings {
+		got := result.RemovedPlatformListings[i]
+		if got.Platform != want.platform || got.VersionString != want.version || got.Live != want.live {
+			t.Fatalf("unexpected removed listing at index %d: %+v", i, got)
+		}
+	}
+}
+
+func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledgedReportsUnverifiedListings(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	states := map[string]bool{"USA": true}
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return unknownPlatformStateAppStoreVersionsResponse(), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			return territoryAvailabilityResponse(t, states), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
+			states["USA"] = false
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm", "--all-platforms", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	var result struct {
+		Status                   string `json:"status"`
+		PlatformListingsVerified bool   `json:"platformListingsVerified"`
+		VerificationError        string `json:"platformListingsVerificationError"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if result.Status != "removedFromSale" || result.PlatformListingsVerified || !strings.Contains(result.VerificationError, "FUTURE_SALE_STATE") {
+		t.Fatalf("unexpected verification receipt: %+v", result)
+	}
+}
+
+func TestPricingAvailabilityPlatformsPreservesUnverifiableListingVisibility(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions" {
+			return unknownPlatformStateAppStoreVersionsResponse(), nil
+		}
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "platforms", "--app", "app-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	var result struct {
+		Platforms []struct {
+			Platform   string `json:"platform"`
+			State      string `json:"state"`
+			Live       bool   `json:"live"`
+			StateKnown bool   `json:"stateKnown"`
+		} `json:"platforms"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Platforms) != 1 || result.Platforms[0].Platform != "IOS" || result.Platforms[0].State != "FUTURE_SALE_STATE" || result.Platforms[0].Live || result.Platforms[0].StateKnown {
+		t.Fatalf("unexpected unverifiable platform listing: %+v", result.Platforms)
 	}
 }
 

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -26,6 +26,8 @@ func TestPricingAvailabilityRemoveFromSaleUpdatesAndVerifiesTerritories(t *testi
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return singlePlatformAppStoreVersionsResponse(), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":true}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
@@ -122,6 +124,8 @@ func TestPricingAvailabilityRemoveFromSaleOutputFormats(t *testing.T) {
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return singlePlatformAppStoreVersionsResponse(), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
@@ -166,6 +170,8 @@ func TestPricingAvailabilityRemoveFromSaleNoOp(t *testing.T) {
 
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return singlePlatformAppStoreVersionsResponse(), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
@@ -207,6 +213,8 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 	var patches atomic.Int32
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return singlePlatformAppStoreVersionsResponse(), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
@@ -276,6 +284,8 @@ func TestPricingAvailabilityRemoveFromSaleFinalReadbackIncludesInitiallyUnavaila
 	var territoryReads atomic.Int32
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return singlePlatformAppStoreVersionsResponse(), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
@@ -325,4 +335,161 @@ func territoryAvailabilityResponse(t *testing.T, states map[string]bool) *http.R
 		t.Fatalf("marshal territory response: %v", err)
 	}
 	return jsonHTTPResponse(http.StatusOK, string(body))
+}
+
+func singlePlatformAppStoreVersionsResponse() *http.Response {
+	return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-ios","attributes":{"platform":"IOS","versionString":"1.0","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2026-01-01T00:00:00Z"}}],"links":{}}`)
+}
+
+func multiPlatformAppStoreVersionsResponse() *http.Response {
+	return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-ios","attributes":{"platform":"IOS","versionString":"4.1.0","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2026-07-14T00:00:00Z"}},{"type":"appStoreVersions","id":"ver-vision","attributes":{"platform":"VISION_OS","versionString":"1.3.1","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2024-07-06T00:00:00Z"}}],"links":{}}`)
+}
+
+func TestPricingAvailabilityRemoveFromSaleRequiresAllPlatformsWhenMultiplePlatformsLive(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var patches atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return multiPlatformAppStoreVersionsResponse(), nil
+		case req.Method == http.MethodPatch:
+			patches.Add(1)
+			return nil, fmt.Errorf("unexpected PATCH: %s", req.URL.String())
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := rootcmd.Run([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}, "1.2.3"); code != rootcmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+		}
+	})
+	if got := patches.Load(); got != 0 {
+		t.Fatalf("PATCH count = %d, want 0", got)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	for _, want := range []string{"IOS 4.1.0", "VISION_OS 1.3.1", "--all-platforms", "App Store Connect support"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr missing %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var mu sync.Mutex
+	states := map[string]bool{"USA": true, "FRA": false}
+	var patches atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return multiPlatformAppStoreVersionsResponse(), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
+			mu.Lock()
+			defer mu.Unlock()
+			return territoryAvailabilityResponse(t, states), nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
+			patches.Add(1)
+			mu.Lock()
+			states["USA"] = false
+			mu.Unlock()
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm", "--all-platforms", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if got := patches.Load(); got != 1 {
+		t.Fatalf("PATCH count = %d, want 1", got)
+	}
+	var result struct {
+		Status                  string `json:"status"`
+		RemovedPlatformListings []struct {
+			Platform      string `json:"platform"`
+			VersionString string `json:"versionString"`
+			Live          bool   `json:"live"`
+		} `json:"removedPlatformListings"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if result.Status != "removedFromSale" {
+		t.Fatalf("status = %q, want removedFromSale", result.Status)
+	}
+	if len(result.RemovedPlatformListings) != 2 {
+		t.Fatalf("removedPlatformListings = %d, want 2", len(result.RemovedPlatformListings))
+	}
+	if result.RemovedPlatformListings[0].Platform != "IOS" || result.RemovedPlatformListings[1].Platform != "VISION_OS" {
+		t.Fatalf("unexpected platform order: %+v", result.RemovedPlatformListings)
+	}
+}
+
+func TestPricingAvailabilityPlatformsPrefersLiveListingOverNewerNonLive(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-rejected","attributes":{"platform":"IOS","versionString":"2.2.1","appStoreState":"REJECTED","appVersionState":"REJECTED","createdDate":"2026-02-01T00:00:00Z"}},{"type":"appStoreVersions","id":"ver-live","attributes":{"platform":"IOS","versionString":"2.2.0","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2025-09-29T00:00:00Z"}},{"type":"appStoreVersions","id":"ver-mac","attributes":{"platform":"MAC_OS","versionString":"1.0","appStoreState":"PREPARE_FOR_SUBMISSION","appVersionState":"PREPARE_FOR_SUBMISSION","createdDate":"2025-01-01T00:00:00Z"}}],"links":{}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "platforms", "--app", "app-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	var result struct {
+		AppID     string `json:"appId"`
+		Platforms []struct {
+			Platform      string `json:"platform"`
+			VersionString string `json:"versionString"`
+			State         string `json:"state"`
+			Live          bool   `json:"live"`
+		} `json:"platforms"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Platforms) != 2 {
+		t.Fatalf("platforms = %d, want 2", len(result.Platforms))
+	}
+	ios := result.Platforms[0]
+	if ios.Platform != "IOS" || ios.VersionString != "2.2.0" || !ios.Live || ios.State != "READY_FOR_DISTRIBUTION" {
+		t.Fatalf("unexpected iOS listing: %+v", ios)
+	}
+	mac := result.Platforms[1]
+	if mac.Platform != "MAC_OS" || mac.VersionString != "1.0" || mac.Live {
+		t.Fatalf("unexpected macOS listing: %+v", mac)
+	}
 }

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -262,6 +262,9 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 		UpdatedTerritories             int      `json:"updatedTerritories"`
 		VerifiedUnavailableTerritories int      `json:"verifiedUnavailableTerritories"`
 		FailedTerritories              []string `json:"failedTerritories"`
+		RemovedPlatformListings        []struct {
+			Platform string `json:"platform"`
+		} `json:"removedPlatformListings"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("decode partial-failure result %q: %v", stdout, err)
@@ -273,6 +276,9 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 		len(result.FailedTerritories) != 1 ||
 		result.FailedTerritories[0] != "FRA" {
 		t.Fatalf("unexpected partial-failure result: %+v", result)
+	}
+	if len(result.RemovedPlatformListings) != 0 {
+		t.Fatalf("partial failure claimed removed platform listings: %+v", result.RemovedPlatformListings)
 	}
 }
 

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -348,7 +348,7 @@ func singlePlatformAppStoreVersionsResponse() *http.Response {
 }
 
 func multiPlatformAppStoreVersionsResponse() *http.Response {
-	return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-ios","attributes":{"platform":"IOS","versionString":"4.1.0","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2026-07-14T00:00:00Z"}},{"type":"appStoreVersions","id":"ver-vision","attributes":{"platform":"VISION_OS","versionString":"1.3.1","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2024-07-06T00:00:00Z"}}],"links":{}}`)
+	return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"ver-ios","attributes":{"platform":"IOS","versionString":"4.1.0","appStoreState":"READY_FOR_SALE","appVersionState":"READY_FOR_DISTRIBUTION","createdDate":"2026-07-14T00:00:00Z"}},{"type":"appStoreVersions","id":"ver-vision","attributes":{"platform":"VISION_OS","versionString":"1.3.1","appStoreState":"PREORDER_READY_FOR_SALE","createdDate":"2024-07-06T00:00:00Z"}}],"links":{}}`)
 }
 
 func TestPricingAvailabilityRemoveFromSaleRequiresAllPlatformsWhenMultiplePlatformsLive(t *testing.T) {

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -381,6 +381,44 @@ func TestPricingAvailabilityRemoveFromSaleRequiresAllPlatformsWhenMultiplePlatfo
 	}
 }
 
+func TestPricingAvailabilityRemoveFromSaleFailsClosedWhenPlatformsCannotBeVerified(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	var requests atomic.Int32
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appStoreVersions" {
+			return jsonHTTPResponse(http.StatusForbidden, `{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden"}]}`), nil
+		}
+		return nil, fmt.Errorf("unexpected request after failed platform verification: %s %s", req.Method, req.URL.String())
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"pricing", "availability", "remove-from-sale", "--app", "app-1", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if err == nil {
+			t.Fatal("expected platform verification failure")
+		}
+		for _, want := range []string{"could not verify live platform listings", "--all-platforms", "Forbidden"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected no stdout before mutation, got %q", stdout)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want only the failed platform lookup", got)
+	}
+}
+
 func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T) {
 	setupAuth(t)
 	originalTransport := http.DefaultTransport

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -611,6 +611,7 @@ Examples:
 			PricingAvailabilityCreateCommand(),
 			PricingAvailabilityTerritoryAvailabilitiesCommand(),
 			PricingAvailabilitySetCommand(),
+			PricingAvailabilityPlatformsCommand(),
 			PricingAvailabilityRemoveFromSaleCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -869,6 +870,13 @@ Note:
   App Store Connect.`,
 		ErrorPrefix:                      "pricing availability edit",
 		IncludeAvailableInNewTerritories: true,
+	})
+}
+
+// PricingAvailabilityPlatformsCommand returns the platforms subcommand.
+func PricingAvailabilityPlatformsCommand() *ffcli.Command {
+	return shared.NewAvailabilityPlatformsCommand(shared.AvailabilityPlatformsCommandConfig{
+		ClientFactory: pricingAvailabilityClientFactory,
 	})
 }
 

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -45,6 +45,7 @@ Examples:
   asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true
   asc pricing availability edit --app "123456789" --all-territories --available true
+  asc pricing availability platforms --app "123456789"
   asc pricing availability remove-from-sale --app "123456789" --confirm
   asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -603,6 +604,7 @@ Examples:
   asc pricing availability create --app "123456789" --territory "USA,GBR,DEU" --available true --available-in-new-territories true
   asc pricing availability edit --app "123456789" --territory "US,France,DEU" --available true
   asc pricing availability edit --app "123456789" --all-territories --available true
+  asc pricing availability platforms --app "123456789"
   asc pricing availability remove-from-sale --app "123456789" --confirm
   asc pricing availability territory-availabilities --availability "AVAILABILITY_ID"`,
 		UsageFunc: shared.DefaultUsageFunc,

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -877,9 +877,53 @@ Note:
 
 // PricingAvailabilityPlatformsCommand returns the platforms subcommand.
 func PricingAvailabilityPlatformsCommand() *ffcli.Command {
-	return shared.NewAvailabilityPlatformsCommand(shared.AvailabilityPlatformsCommandConfig{
-		ClientFactory: pricingAvailabilityClientFactory,
-	})
+	fs := flag.NewFlagSet("pricing availability platforms", flag.ExitOnError)
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "platforms",
+		ShortUsage: "asc pricing availability platforms --app \"APP_ID\"",
+		ShortHelp:  "[experimental] Summarize each platform's App Store listing.",
+		LongHelp: `[experimental] Summarize each platform's App Store listing.
+
+This command is experimental.
+
+Shows one row per platform: the live listing when one exists, otherwise the
+newest version and its state. Availability is app-wide — every platform
+listing shares one availability record — so removing an app from sale removes
+every live platform at once. Use this command to preview that blast radius
+before "asc pricing availability remove-from-sale".
+
+Examples:
+  asc pricing availability platforms --app "123456789"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("pricing availability platforms does not accept positional arguments")
+			}
+			resolvedAppID := shared.ResolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return shared.MissingRequiredUsageError("--app")
+			}
+			client, err := pricingAvailabilityClientFactory()
+			if err != nil {
+				return fmt.Errorf("pricing availability platforms: %w", err)
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			listings, err := shared.FetchAvailabilityPlatformListings(requestCtx, client, resolvedAppID)
+			if err != nil {
+				return fmt.Errorf("pricing availability platforms: %w", err)
+			}
+
+			result := &asc.AvailabilityPlatformsResult{AppID: resolvedAppID, Platforms: listings}
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
+		},
+	}
 }
 
 // PricingAvailabilityRemoveFromSaleCommand returns the remove-from-sale subcommand.

--- a/internal/cli/pricing/pricing_test.go
+++ b/internal/cli/pricing/pricing_test.go
@@ -381,6 +381,35 @@ func TestPricingAvailabilityCommand_RegistersRemoveFromSale(t *testing.T) {
 	t.Fatal("expected pricing availability remove-from-sale to be registered")
 }
 
+func TestPricingAvailabilityCommand_RegistersPlatforms(t *testing.T) {
+	cmd := PricingAvailabilityCommand()
+
+	for _, subcommand := range cmd.Subcommands {
+		if subcommand.Name == "platforms" {
+			if !strings.HasPrefix(subcommand.ShortHelp, "[experimental]") || !strings.HasPrefix(subcommand.LongHelp, "[experimental]") {
+				t.Fatalf("expected platforms command to enter through the experimental tier, got ShortHelp=%q LongHelp=%q", subcommand.ShortHelp, subcommand.LongHelp)
+			}
+			if !strings.Contains(cmd.LongHelp, `pricing availability platforms --app "123456789"`) {
+				t.Fatalf("expected availability help to mention platforms, got %q", cmd.LongHelp)
+			}
+			return
+		}
+	}
+
+	t.Fatal("expected pricing availability platforms to be registered")
+}
+
+func TestPricingAvailabilityRemoveFromSaleCommand_AllPlatformsIsExperimental(t *testing.T) {
+	command := PricingAvailabilityRemoveFromSaleCommand()
+	allPlatforms := command.FlagSet.Lookup("all-platforms")
+	if allPlatforms == nil {
+		t.Fatal("expected --all-platforms flag")
+	}
+	if !strings.HasPrefix(allPlatforms.Usage, "[experimental] ") {
+		t.Fatalf("--all-platforms usage = %q, want experimental lifecycle label", allPlatforms.Usage)
+	}
+}
+
 func TestPricingAvailabilityRemoveFromSaleCommand_MissingConfirmBeforeAuth(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 	called := false

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -512,7 +512,10 @@ func availabilityListingState(attributes asc.AppStoreVersionAttributes) string {
 }
 
 func availabilityListingIsLive(attributes asc.AppStoreVersionAttributes) bool {
-	return attributes.AppStoreState == "READY_FOR_SALE" || attributes.AppVersionState == "READY_FOR_DISTRIBUTION"
+	return attributes.AppStoreState == "READY_FOR_SALE" ||
+		attributes.AppStoreState == "PREORDER_READY_FOR_SALE" ||
+		attributes.AppVersionState == "READY_FOR_DISTRIBUTION" ||
+		attributes.AppVersionState == "PREORDER_READY_FOR_SALE"
 }
 
 func contextWithAvailabilityTimeout(ctx context.Context, allTerritories bool) (context.Context, context.CancelFunc) {

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -43,15 +43,36 @@ type AvailabilityRemoveFromSaleCommandConfig struct {
 
 // AvailabilityRemoveFromSaleResult summarizes a verified remove-from-sale operation.
 type AvailabilityRemoveFromSaleResult struct {
-	AppID                          string   `json:"appId"`
-	AvailabilityID                 string   `json:"availabilityId"`
-	Status                         string   `json:"status"`
-	AvailableInNewTerritories      bool     `json:"availableInNewTerritories"`
-	TotalTerritories               int      `json:"totalTerritories"`
-	UpdatedTerritories             int      `json:"updatedTerritories"`
-	AlreadyUnavailableTerritories  int      `json:"alreadyUnavailableTerritories"`
-	VerifiedUnavailableTerritories int      `json:"verifiedUnavailableTerritories"`
-	FailedTerritories              []string `json:"failedTerritories"`
+	AppID                          string                        `json:"appId"`
+	AvailabilityID                 string                        `json:"availabilityId"`
+	Status                         string                        `json:"status"`
+	AvailableInNewTerritories      bool                          `json:"availableInNewTerritories"`
+	TotalTerritories               int                           `json:"totalTerritories"`
+	UpdatedTerritories             int                           `json:"updatedTerritories"`
+	AlreadyUnavailableTerritories  int                           `json:"alreadyUnavailableTerritories"`
+	VerifiedUnavailableTerritories int                           `json:"verifiedUnavailableTerritories"`
+	FailedTerritories              []string                      `json:"failedTerritories"`
+	RemovedPlatformListings        []AvailabilityPlatformListing `json:"removedPlatformListings,omitempty"`
+}
+
+// AvailabilityPlatformListing summarizes the newest App Store version for one platform.
+type AvailabilityPlatformListing struct {
+	Platform      string `json:"platform"`
+	VersionString string `json:"versionString"`
+	State         string `json:"state"`
+	Live          bool   `json:"live"`
+	CreatedDate   string `json:"createdDate,omitempty"`
+}
+
+// AvailabilityPlatformsCommandConfig configures the platforms command.
+type AvailabilityPlatformsCommandConfig struct {
+	ClientFactory func() (*asc.Client, error)
+}
+
+// AvailabilityPlatformsResult summarizes per-platform App Store listings for an app.
+type AvailabilityPlatformsResult struct {
+	AppID     string                        `json:"appId"`
+	Platforms []AvailabilityPlatformListing `json:"platforms"`
 }
 
 // NewAvailabilitySetCommand builds a shared availability set command.
@@ -140,6 +161,7 @@ func NewAvailabilityRemoveFromSaleCommand(config AvailabilityRemoveFromSaleComma
 	fs := flag.NewFlagSet("pricing availability remove-from-sale", flag.ExitOnError)
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
 	confirm := fs.Bool("confirm", false, "Confirm removal from sale in all current territories")
+	allPlatforms := fs.Bool("all-platforms", false, "Acknowledge removal of every live platform listing (required when more than one platform is live)")
 	output := BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -152,6 +174,15 @@ This command uses the public App Store Connect API. It makes every existing
 territory unavailable and verifies the final state. It does not delete the app
 record, and it preserves the existing availableInNewTerritories policy because
 Apple does not expose an update operation for that setting.
+
+Removal is always app-wide: every platform listing (iOS, macOS, tvOS,
+visionOS) shares one availability record, and Apple does not support removing
+a single platform from sale through the public API, the internal web API, or
+the App Store Connect UI. When more than one platform has a live listing this
+command lists them and requires --all-platforms as an extra acknowledgement.
+To remove only one platform's listing, file an App Store Connect support
+request instead. Preview the blast radius first with
+"asc pricing availability platforms".
 
 Examples:
   asc pricing availability remove-from-sale --app "123456789" --confirm`,
@@ -180,6 +211,21 @@ Examples:
 
 			requestCtx, cancel := contextWithAvailabilityTimeout(ctx, true)
 			defer cancel()
+
+			liveListings, listingsErr := fetchLiveAvailabilityPlatformListings(requestCtx, client, resolvedAppID)
+			if listingsErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not verify live platform listings: %v\n", listingsErr)
+			} else if len(liveListings) > 0 {
+				fmt.Fprintf(os.Stderr, "Removal is app-wide; %d live platform listing(s) leave sale together:\n", len(liveListings))
+				for _, listing := range liveListings {
+					fmt.Fprintf(os.Stderr, "  %s %s (%s)\n", listing.Platform, listing.VersionString, listing.State)
+				}
+				if len(liveListings) > 1 && !*allPlatforms {
+					fmt.Fprintln(os.Stderr, "Error: --all-platforms is required because more than one platform is live. Apple does not support removing a single platform from sale; to remove one platform listing, file an App Store Connect support request.")
+					return MissingRequiredUsageError("--all-platforms")
+				}
+			}
+
 			_, summary, updateErr := executeTerritoryAvailabilityUpdate(requestCtx, client, availabilityUpdateRequest{
 				AppID:          resolvedAppID,
 				AllTerritories: true,
@@ -204,6 +250,7 @@ Examples:
 				AlreadyUnavailableTerritories:  summary.SkippedTerritories,
 				VerifiedUnavailableTerritories: summary.VerifiedTerritories,
 				FailedTerritories:              append([]string{}, summary.FailedTerritories...),
+				RemovedPlatformListings:        liveListings,
 			}
 			if updateErr != nil {
 				fmt.Fprintf(
@@ -423,6 +470,172 @@ func renderAvailabilityRemoveFromSaleResult(result AvailabilityRemoveFromSaleRes
 		return
 	}
 	asc.RenderTable(headers, rows)
+}
+
+// NewAvailabilityPlatformsCommand builds a command that summarizes each
+// platform's App Store listing for an app.
+func NewAvailabilityPlatformsCommand(config AvailabilityPlatformsCommandConfig) *ffcli.Command {
+	fs := flag.NewFlagSet("pricing availability platforms", flag.ExitOnError)
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	output := BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "platforms",
+		ShortUsage: "asc pricing availability platforms --app \"APP_ID\"",
+		ShortHelp:  "Summarize each platform's App Store listing.",
+		LongHelp: `Summarize each platform's App Store listing.
+
+Shows one row per platform: the live listing when one exists, otherwise the
+newest version and its state. Availability is app-wide — every platform
+listing shares one availability record — so removing an app from sale removes
+every live platform at once. Use this command to preview that blast radius
+before "asc pricing availability remove-from-sale".
+
+Examples:
+  asc pricing availability platforms --app "123456789"`,
+		FlagSet:   fs,
+		UsageFunc: DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return UsageError("pricing availability platforms does not accept positional arguments")
+			}
+			resolvedAppID := resolveAppID(*appID)
+			if resolvedAppID == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return MissingRequiredUsageError("--app")
+			}
+			if config.ClientFactory == nil {
+				return fmt.Errorf("pricing availability platforms: client factory is not configured")
+			}
+			client, err := config.ClientFactory()
+			if err != nil {
+				return fmt.Errorf("pricing availability platforms: %w", err)
+			}
+
+			requestCtx, cancel := contextWithTimeout(ctx)
+			defer cancel()
+			listings, err := fetchAvailabilityPlatformListings(requestCtx, client, resolvedAppID)
+			if err != nil {
+				return fmt.Errorf("pricing availability platforms: %w", err)
+			}
+
+			result := AvailabilityPlatformsResult{AppID: resolvedAppID, Platforms: listings}
+			return PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error {
+					renderAvailabilityPlatformsResult(result, false)
+					return nil
+				},
+				func() error {
+					renderAvailabilityPlatformsResult(result, true)
+					return nil
+				},
+			)
+		},
+	}
+}
+
+func renderAvailabilityPlatformsResult(result AvailabilityPlatformsResult, markdown bool) {
+	headers := []string{"Platform", "Version", "State", "Live", "Created"}
+	rows := make([][]string, 0, len(result.Platforms))
+	for _, listing := range result.Platforms {
+		rows = append(rows, []string{
+			listing.Platform,
+			listing.VersionString,
+			listing.State,
+			fmt.Sprintf("%t", listing.Live),
+			listing.CreatedDate,
+		})
+	}
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return
+	}
+	asc.RenderTable(headers, rows)
+}
+
+// fetchAvailabilityPlatformListings returns one listing per platform: the
+// newest live version when one exists, otherwise the newest version overall.
+func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]AvailabilityPlatformListing, error) {
+	newestLive := map[string]AvailabilityPlatformListing{}
+	newestAny := map[string]AvailabilityPlatformListing{}
+	order := []string{}
+	next := ""
+	for {
+		opts := []asc.AppStoreVersionsOption{asc.WithAppStoreVersionsLimit(200)}
+		if next != "" {
+			opts = append(opts, asc.WithAppStoreVersionsNextURL(next))
+		}
+		resp, err := client.GetAppStoreVersions(ctx, appID, opts...)
+		if err != nil {
+			return nil, err
+		}
+		for _, version := range resp.Data {
+			platform := string(version.Attributes.Platform)
+			if platform == "" {
+				continue
+			}
+			listing := AvailabilityPlatformListing{
+				Platform:      platform,
+				VersionString: version.Attributes.VersionString,
+				State:         availabilityListingState(version.Attributes),
+				Live:          availabilityListingIsLive(version.Attributes),
+				CreatedDate:   version.Attributes.CreatedDate,
+			}
+			if _, seen := newestAny[platform]; !seen {
+				order = append(order, platform)
+			}
+			if current, seen := newestAny[platform]; !seen || listing.CreatedDate > current.CreatedDate {
+				newestAny[platform] = listing
+			}
+			if listing.Live {
+				if current, seen := newestLive[platform]; !seen || listing.CreatedDate > current.CreatedDate {
+					newestLive[platform] = listing
+				}
+			}
+		}
+		next = strings.TrimSpace(resp.Links.Next)
+		if next == "" {
+			break
+		}
+	}
+	listings := make([]AvailabilityPlatformListing, 0, len(order))
+	for _, platform := range order {
+		if live, ok := newestLive[platform]; ok {
+			listings = append(listings, live)
+			continue
+		}
+		listings = append(listings, newestAny[platform])
+	}
+	return listings, nil
+}
+
+// fetchLiveAvailabilityPlatformListings returns only platforms with a live listing.
+func fetchLiveAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]AvailabilityPlatformListing, error) {
+	listings, err := fetchAvailabilityPlatformListings(ctx, client, appID)
+	if err != nil {
+		return nil, err
+	}
+	live := make([]AvailabilityPlatformListing, 0, len(listings))
+	for _, listing := range listings {
+		if listing.Live {
+			live = append(live, listing)
+		}
+	}
+	return live, nil
+}
+
+func availabilityListingState(attributes asc.AppStoreVersionAttributes) string {
+	if attributes.AppVersionState != "" {
+		return attributes.AppVersionState
+	}
+	return attributes.AppStoreState
+}
+
+func availabilityListingIsLive(attributes asc.AppStoreVersionAttributes) bool {
+	return attributes.AppStoreState == "READY_FOR_SALE" || attributes.AppVersionState == "READY_FOR_DISTRIBUTION"
 }
 
 func contextWithAvailabilityTimeout(ctx context.Context, allTerritories bool) (context.Context, context.CancelFunc) {

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -41,38 +41,9 @@ type AvailabilityRemoveFromSaleCommandConfig struct {
 	ClientFactory func() (*asc.Client, error)
 }
 
-// AvailabilityRemoveFromSaleResult summarizes a verified remove-from-sale operation.
-type AvailabilityRemoveFromSaleResult struct {
-	AppID                          string                        `json:"appId"`
-	AvailabilityID                 string                        `json:"availabilityId"`
-	Status                         string                        `json:"status"`
-	AvailableInNewTerritories      bool                          `json:"availableInNewTerritories"`
-	TotalTerritories               int                           `json:"totalTerritories"`
-	UpdatedTerritories             int                           `json:"updatedTerritories"`
-	AlreadyUnavailableTerritories  int                           `json:"alreadyUnavailableTerritories"`
-	VerifiedUnavailableTerritories int                           `json:"verifiedUnavailableTerritories"`
-	FailedTerritories              []string                      `json:"failedTerritories"`
-	RemovedPlatformListings        []AvailabilityPlatformListing `json:"removedPlatformListings,omitempty"`
-}
-
-// AvailabilityPlatformListing summarizes the newest App Store version for one platform.
-type AvailabilityPlatformListing struct {
-	Platform      string `json:"platform"`
-	VersionString string `json:"versionString"`
-	State         string `json:"state"`
-	Live          bool   `json:"live"`
-	CreatedDate   string `json:"createdDate,omitempty"`
-}
-
 // AvailabilityPlatformsCommandConfig configures the platforms command.
 type AvailabilityPlatformsCommandConfig struct {
 	ClientFactory func() (*asc.Client, error)
-}
-
-// AvailabilityPlatformsResult summarizes per-platform App Store listings for an app.
-type AvailabilityPlatformsResult struct {
-	AppID     string                        `json:"appId"`
-	Platforms []AvailabilityPlatformListing `json:"platforms"`
 }
 
 // NewAvailabilitySetCommand builds a shared availability set command.
@@ -161,7 +132,7 @@ func NewAvailabilityRemoveFromSaleCommand(config AvailabilityRemoveFromSaleComma
 	fs := flag.NewFlagSet("pricing availability remove-from-sale", flag.ExitOnError)
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
 	confirm := fs.Bool("confirm", false, "Confirm removal from sale in all current territories")
-	allPlatforms := fs.Bool("all-platforms", false, "Acknowledge removal of every live platform listing (required when more than one platform is live)")
+	allPlatforms := fs.Bool("all-platforms", false, "[experimental] Acknowledge removal of every live platform listing (required when more than one platform is live)")
 	output := BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -180,6 +151,8 @@ visionOS) shares one availability record, and Apple does not support removing
 a single platform from sale through the public API, the internal web API, or
 the App Store Connect UI. When more than one platform has a live listing this
 command lists them and requires --all-platforms as an extra acknowledgement.
+If platform listings cannot be verified, the command fails closed unless
+--all-platforms explicitly acknowledges the unknown app-wide blast radius.
 To remove only one platform's listing, file an App Store Connect support
 request instead. Preview the blast radius first with
 "asc pricing availability platforms".
@@ -214,7 +187,10 @@ Examples:
 
 			liveListings, listingsErr := fetchLiveAvailabilityPlatformListings(requestCtx, client, resolvedAppID)
 			if listingsErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: could not verify live platform listings: %v\n", listingsErr)
+				if !*allPlatforms {
+					return fmt.Errorf("pricing availability remove-from-sale: could not verify live platform listings; retry or pass --all-platforms to acknowledge the unknown app-wide blast radius: %w", listingsErr)
+				}
+				fmt.Fprintf(os.Stderr, "Warning: could not verify live platform listings; proceeding because --all-platforms acknowledges the unknown app-wide blast radius: %v\n", listingsErr)
 			} else if len(liveListings) > 0 {
 				fmt.Fprintf(os.Stderr, "Removal is app-wide; %d live platform listing(s) leave sale together:\n", len(liveListings))
 				for _, listing := range liveListings {
@@ -240,7 +216,7 @@ Examples:
 			if updateErr != nil {
 				status = "partialFailure"
 			}
-			result := AvailabilityRemoveFromSaleResult{
+			result := &asc.AvailabilityRemoveFromSaleResult{
 				AppID:                          resolvedAppID,
 				AvailabilityID:                 summary.AvailabilityID,
 				Status:                         status,
@@ -273,19 +249,7 @@ Examples:
 			if result.AvailableInNewTerritories {
 				fmt.Fprintln(os.Stderr, "Warning: Apple may automatically enable future App Store territories under the preserved policy.")
 			}
-			renderErr := PrintOutputWithRenderers(
-				result,
-				*output.Output,
-				*output.Pretty,
-				func() error {
-					renderAvailabilityRemoveFromSaleResult(result, false)
-					return nil
-				},
-				func() error {
-					renderAvailabilityRemoveFromSaleResult(result, true)
-					return nil
-				},
-			)
+			renderErr := PrintOutput(result, *output.Output, *output.Pretty)
 			return errors.Join(updateErr, renderErr)
 		},
 	}
@@ -452,26 +416,6 @@ func executeTerritoryAvailabilityUpdate(ctx context.Context, client *asc.Client,
 	return resp, summary, nil
 }
 
-func renderAvailabilityRemoveFromSaleResult(result AvailabilityRemoveFromSaleResult, markdown bool) {
-	headers := []string{"Field", "Value"}
-	rows := [][]string{
-		{"App ID", result.AppID},
-		{"Availability ID", result.AvailabilityID},
-		{"Status", result.Status},
-		{"Available in new territories", fmt.Sprintf("%t", result.AvailableInNewTerritories)},
-		{"Total territories", fmt.Sprintf("%d", result.TotalTerritories)},
-		{"Updated territories", fmt.Sprintf("%d", result.UpdatedTerritories)},
-		{"Already unavailable", fmt.Sprintf("%d", result.AlreadyUnavailableTerritories)},
-		{"Verified unavailable", fmt.Sprintf("%d", result.VerifiedUnavailableTerritories)},
-		{"Failed territories", strings.Join(result.FailedTerritories, ", ")},
-	}
-	if markdown {
-		asc.RenderMarkdown(headers, rows)
-		return
-	}
-	asc.RenderTable(headers, rows)
-}
-
 // NewAvailabilityPlatformsCommand builds a command that summarizes each
 // platform's App Store listing for an app.
 func NewAvailabilityPlatformsCommand(config AvailabilityPlatformsCommandConfig) *ffcli.Command {
@@ -482,8 +426,10 @@ func NewAvailabilityPlatformsCommand(config AvailabilityPlatformsCommandConfig) 
 	return &ffcli.Command{
 		Name:       "platforms",
 		ShortUsage: "asc pricing availability platforms --app \"APP_ID\"",
-		ShortHelp:  "Summarize each platform's App Store listing.",
-		LongHelp: `Summarize each platform's App Store listing.
+		ShortHelp:  "[experimental] Summarize each platform's App Store listing.",
+		LongHelp: `[experimental] Summarize each platform's App Store listing.
+
+This command is experimental.
 
 Shows one row per platform: the live listing when one exists, otherwise the
 newest version and its state. Availability is app-wide — every platform
@@ -519,48 +465,17 @@ Examples:
 				return fmt.Errorf("pricing availability platforms: %w", err)
 			}
 
-			result := AvailabilityPlatformsResult{AppID: resolvedAppID, Platforms: listings}
-			return PrintOutputWithRenderers(
-				result,
-				*output.Output,
-				*output.Pretty,
-				func() error {
-					renderAvailabilityPlatformsResult(result, false)
-					return nil
-				},
-				func() error {
-					renderAvailabilityPlatformsResult(result, true)
-					return nil
-				},
-			)
+			result := &asc.AvailabilityPlatformsResult{AppID: resolvedAppID, Platforms: listings}
+			return PrintOutput(result, *output.Output, *output.Pretty)
 		},
 	}
 }
 
-func renderAvailabilityPlatformsResult(result AvailabilityPlatformsResult, markdown bool) {
-	headers := []string{"Platform", "Version", "State", "Live", "Created"}
-	rows := make([][]string, 0, len(result.Platforms))
-	for _, listing := range result.Platforms {
-		rows = append(rows, []string{
-			listing.Platform,
-			listing.VersionString,
-			listing.State,
-			fmt.Sprintf("%t", listing.Live),
-			listing.CreatedDate,
-		})
-	}
-	if markdown {
-		asc.RenderMarkdown(headers, rows)
-		return
-	}
-	asc.RenderTable(headers, rows)
-}
-
 // fetchAvailabilityPlatformListings returns one listing per platform: the
 // newest live version when one exists, otherwise the newest version overall.
-func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]AvailabilityPlatformListing, error) {
-	newestLive := map[string]AvailabilityPlatformListing{}
-	newestAny := map[string]AvailabilityPlatformListing{}
+func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]asc.AvailabilityPlatformListing, error) {
+	newestLive := map[string]asc.AvailabilityPlatformListing{}
+	newestAny := map[string]asc.AvailabilityPlatformListing{}
 	order := []string{}
 	next := ""
 	for {
@@ -577,7 +492,7 @@ func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, 
 			if platform == "" {
 				continue
 			}
-			listing := AvailabilityPlatformListing{
+			listing := asc.AvailabilityPlatformListing{
 				Platform:      platform,
 				VersionString: version.Attributes.VersionString,
 				State:         availabilityListingState(version.Attributes),
@@ -587,11 +502,11 @@ func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, 
 			if _, seen := newestAny[platform]; !seen {
 				order = append(order, platform)
 			}
-			if current, seen := newestAny[platform]; !seen || listing.CreatedDate > current.CreatedDate {
+			if current, seen := newestAny[platform]; !seen || availabilityListingIsNewer(listing, current) {
 				newestAny[platform] = listing
 			}
 			if listing.Live {
-				if current, seen := newestLive[platform]; !seen || listing.CreatedDate > current.CreatedDate {
+				if current, seen := newestLive[platform]; !seen || availabilityListingIsNewer(listing, current) {
 					newestLive[platform] = listing
 				}
 			}
@@ -601,7 +516,7 @@ func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, 
 			break
 		}
 	}
-	listings := make([]AvailabilityPlatformListing, 0, len(order))
+	listings := make([]asc.AvailabilityPlatformListing, 0, len(order))
 	for _, platform := range order {
 		if live, ok := newestLive[platform]; ok {
 			listings = append(listings, live)
@@ -612,13 +527,31 @@ func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, 
 	return listings, nil
 }
 
+func availabilityListingIsNewer(candidate, current asc.AvailabilityPlatformListing) bool {
+	candidateTime, candidateValid := parseAvailabilityCreatedDate(candidate.CreatedDate)
+	currentTime, currentValid := parseAvailabilityCreatedDate(current.CreatedDate)
+	switch {
+	case candidateValid && !currentValid:
+		return true
+	case !candidateValid:
+		return false
+	default:
+		return candidateTime.After(currentTime)
+	}
+}
+
+func parseAvailabilityCreatedDate(value string) (time.Time, bool) {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	return parsed, err == nil
+}
+
 // fetchLiveAvailabilityPlatformListings returns only platforms with a live listing.
-func fetchLiveAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]AvailabilityPlatformListing, error) {
+func fetchLiveAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]asc.AvailabilityPlatformListing, error) {
 	listings, err := fetchAvailabilityPlatformListings(ctx, client, appID)
 	if err != nil {
 		return nil, err
 	}
-	live := make([]AvailabilityPlatformListing, 0, len(listings))
+	live := make([]asc.AvailabilityPlatformListing, 0, len(listings))
 	for _, listing := range listings {
 		if listing.Live {
 			live = append(live, listing)

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -41,11 +41,6 @@ type AvailabilityRemoveFromSaleCommandConfig struct {
 	ClientFactory func() (*asc.Client, error)
 }
 
-// AvailabilityPlatformsCommandConfig configures the platforms command.
-type AvailabilityPlatformsCommandConfig struct {
-	ClientFactory func() (*asc.Client, error)
-}
-
 // NewAvailabilitySetCommand builds a shared availability set command.
 func NewAvailabilitySetCommand(config AvailabilitySetCommandConfig) *ffcli.Command {
 	fs := flag.NewFlagSet(config.FlagSetName, flag.ExitOnError)
@@ -216,6 +211,10 @@ Examples:
 			if updateErr != nil {
 				status = "partialFailure"
 			}
+			removedPlatformListings := liveListings
+			if updateErr != nil {
+				removedPlatformListings = nil
+			}
 			result := &asc.AvailabilityRemoveFromSaleResult{
 				AppID:                          resolvedAppID,
 				AvailabilityID:                 summary.AvailabilityID,
@@ -226,7 +225,7 @@ Examples:
 				AlreadyUnavailableTerritories:  summary.SkippedTerritories,
 				VerifiedUnavailableTerritories: summary.VerifiedTerritories,
 				FailedTerritories:              append([]string{}, summary.FailedTerritories...),
-				RemovedPlatformListings:        liveListings,
+				RemovedPlatformListings:        removedPlatformListings,
 			}
 			if updateErr != nil {
 				fmt.Fprintf(
@@ -416,64 +415,9 @@ func executeTerritoryAvailabilityUpdate(ctx context.Context, client *asc.Client,
 	return resp, summary, nil
 }
 
-// NewAvailabilityPlatformsCommand builds a command that summarizes each
-// platform's App Store listing for an app.
-func NewAvailabilityPlatformsCommand(config AvailabilityPlatformsCommandConfig) *ffcli.Command {
-	fs := flag.NewFlagSet("pricing availability platforms", flag.ExitOnError)
-	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
-	output := BindOutputFlags(fs)
-
-	return &ffcli.Command{
-		Name:       "platforms",
-		ShortUsage: "asc pricing availability platforms --app \"APP_ID\"",
-		ShortHelp:  "[experimental] Summarize each platform's App Store listing.",
-		LongHelp: `[experimental] Summarize each platform's App Store listing.
-
-This command is experimental.
-
-Shows one row per platform: the live listing when one exists, otherwise the
-newest version and its state. Availability is app-wide — every platform
-listing shares one availability record — so removing an app from sale removes
-every live platform at once. Use this command to preview that blast radius
-before "asc pricing availability remove-from-sale".
-
-Examples:
-  asc pricing availability platforms --app "123456789"`,
-		FlagSet:   fs,
-		UsageFunc: DefaultUsageFunc,
-		Exec: func(ctx context.Context, args []string) error {
-			if len(args) > 0 {
-				return UsageError("pricing availability platforms does not accept positional arguments")
-			}
-			resolvedAppID := resolveAppID(*appID)
-			if resolvedAppID == "" {
-				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
-				return MissingRequiredUsageError("--app")
-			}
-			if config.ClientFactory == nil {
-				return fmt.Errorf("pricing availability platforms: client factory is not configured")
-			}
-			client, err := config.ClientFactory()
-			if err != nil {
-				return fmt.Errorf("pricing availability platforms: %w", err)
-			}
-
-			requestCtx, cancel := contextWithTimeout(ctx)
-			defer cancel()
-			listings, err := fetchAvailabilityPlatformListings(requestCtx, client, resolvedAppID)
-			if err != nil {
-				return fmt.Errorf("pricing availability platforms: %w", err)
-			}
-
-			result := &asc.AvailabilityPlatformsResult{AppID: resolvedAppID, Platforms: listings}
-			return PrintOutput(result, *output.Output, *output.Pretty)
-		},
-	}
-}
-
-// fetchAvailabilityPlatformListings returns one listing per platform: the
+// FetchAvailabilityPlatformListings returns one listing per platform: the
 // newest live version when one exists, otherwise the newest version overall.
-func fetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]asc.AvailabilityPlatformListing, error) {
+func FetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]asc.AvailabilityPlatformListing, error) {
 	newestLive := map[string]asc.AvailabilityPlatformListing{}
 	newestAny := map[string]asc.AvailabilityPlatformListing{}
 	order := []string{}
@@ -547,7 +491,7 @@ func parseAvailabilityCreatedDate(value string) (time.Time, bool) {
 
 // fetchLiveAvailabilityPlatformListings returns only platforms with a live listing.
 func fetchLiveAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]asc.AvailabilityPlatformListing, error) {
-	listings, err := fetchAvailabilityPlatformListings(ctx, client, appID)
+	listings, err := FetchAvailabilityPlatformListings(ctx, client, appID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/shared/availability_command.go
+++ b/internal/cli/shared/availability_command.go
@@ -181,7 +181,10 @@ Examples:
 			defer cancel()
 
 			liveListings, listingsErr := fetchLiveAvailabilityPlatformListings(requestCtx, client, resolvedAppID)
+			platformListingsVerified := listingsErr == nil
+			platformListingsVerificationError := ""
 			if listingsErr != nil {
+				platformListingsVerificationError = strings.TrimSpace(listingsErr.Error())
 				if !*allPlatforms {
 					return fmt.Errorf("pricing availability remove-from-sale: could not verify live platform listings; retry or pass --all-platforms to acknowledge the unknown app-wide blast radius: %w", listingsErr)
 				}
@@ -216,16 +219,18 @@ Examples:
 				removedPlatformListings = nil
 			}
 			result := &asc.AvailabilityRemoveFromSaleResult{
-				AppID:                          resolvedAppID,
-				AvailabilityID:                 summary.AvailabilityID,
-				Status:                         status,
-				AvailableInNewTerritories:      summary.AvailableInNewTerritories,
-				TotalTerritories:               summary.TotalTerritories,
-				UpdatedTerritories:             summary.UpdatedTerritories,
-				AlreadyUnavailableTerritories:  summary.SkippedTerritories,
-				VerifiedUnavailableTerritories: summary.VerifiedTerritories,
-				FailedTerritories:              append([]string{}, summary.FailedTerritories...),
-				RemovedPlatformListings:        removedPlatformListings,
+				AppID:                             resolvedAppID,
+				AvailabilityID:                    summary.AvailabilityID,
+				Status:                            status,
+				AvailableInNewTerritories:         summary.AvailableInNewTerritories,
+				TotalTerritories:                  summary.TotalTerritories,
+				UpdatedTerritories:                summary.UpdatedTerritories,
+				AlreadyUnavailableTerritories:     summary.SkippedTerritories,
+				VerifiedUnavailableTerritories:    summary.VerifiedTerritories,
+				FailedTerritories:                 append([]string{}, summary.FailedTerritories...),
+				PlatformListingsVerified:          platformListingsVerified,
+				PlatformListingsVerificationError: platformListingsVerificationError,
+				RemovedPlatformListings:           removedPlatformListings,
 			}
 			if updateErr != nil {
 				fmt.Fprintf(
@@ -420,6 +425,7 @@ func executeTerritoryAvailabilityUpdate(ctx context.Context, client *asc.Client,
 func FetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, appID string) ([]asc.AvailabilityPlatformListing, error) {
 	newestLive := map[string]asc.AvailabilityPlatformListing{}
 	newestAny := map[string]asc.AvailabilityPlatformListing{}
+	platformStateKnown := map[string]bool{}
 	order := []string{}
 	next := ""
 	for {
@@ -436,15 +442,21 @@ func FetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, 
 			if platform == "" {
 				continue
 			}
+			state, live, stateKnown := availabilityListingStatus(version.Attributes)
 			listing := asc.AvailabilityPlatformListing{
 				Platform:      platform,
 				VersionString: version.Attributes.VersionString,
-				State:         availabilityListingState(version.Attributes),
-				Live:          availabilityListingIsLive(version.Attributes),
+				State:         state,
+				Live:          live,
+				StateKnown:    stateKnown,
 				CreatedDate:   version.Attributes.CreatedDate,
 			}
 			if _, seen := newestAny[platform]; !seen {
 				order = append(order, platform)
+				platformStateKnown[platform] = true
+			}
+			if !listing.StateKnown {
+				platformStateKnown[platform] = false
 			}
 			if current, seen := newestAny[platform]; !seen || availabilityListingIsNewer(listing, current) {
 				newestAny[platform] = listing
@@ -463,10 +475,13 @@ func FetchAvailabilityPlatformListings(ctx context.Context, client *asc.Client, 
 	listings := make([]asc.AvailabilityPlatformListing, 0, len(order))
 	for _, platform := range order {
 		if live, ok := newestLive[platform]; ok {
+			live.StateKnown = live.StateKnown && platformStateKnown[platform]
 			listings = append(listings, live)
 			continue
 		}
-		listings = append(listings, newestAny[platform])
+		listing := newestAny[platform]
+		listing.StateKnown = listing.StateKnown && platformStateKnown[platform]
+		listings = append(listings, listing)
 	}
 	return listings, nil
 }
@@ -496,26 +511,59 @@ func fetchLiveAvailabilityPlatformListings(ctx context.Context, client *asc.Clie
 		return nil, err
 	}
 	live := make([]asc.AvailabilityPlatformListing, 0, len(listings))
+	unverifiable := make([]string, 0)
 	for _, listing := range listings {
+		if !listing.StateKnown {
+			state := strings.TrimSpace(listing.State)
+			if state == "" {
+				state = "<missing>"
+			}
+			unverifiable = append(unverifiable, fmt.Sprintf("%s %s (%s)", listing.Platform, listing.VersionString, state))
+			continue
+		}
 		if listing.Live {
 			live = append(live, listing)
 		}
+	}
+	if len(unverifiable) > 0 {
+		sort.Strings(unverifiable)
+		return nil, fmt.Errorf("platform listing states are unverifiable: %s", strings.Join(unverifiable, "; "))
 	}
 	return live, nil
 }
 
 func availabilityListingState(attributes asc.AppStoreVersionAttributes) string {
 	if attributes.AppVersionState != "" {
-		return attributes.AppVersionState
+		return strings.TrimSpace(attributes.AppVersionState)
 	}
-	return attributes.AppStoreState
+	return strings.TrimSpace(attributes.AppStoreState)
 }
 
-func availabilityListingIsLive(attributes asc.AppStoreVersionAttributes) bool {
-	return attributes.AppStoreState == "READY_FOR_SALE" ||
-		attributes.AppStoreState == "PREORDER_READY_FOR_SALE" ||
-		attributes.AppVersionState == "READY_FOR_DISTRIBUTION" ||
-		attributes.AppVersionState == "PREORDER_READY_FOR_SALE"
+func availabilityListingStatus(attributes asc.AppStoreVersionAttributes) (string, bool, bool) {
+	appStoreState := strings.TrimSpace(attributes.AppStoreState)
+	appVersionState := strings.TrimSpace(attributes.AppVersionState)
+	state := availabilityListingState(attributes)
+	if appStoreState == "" && appVersionState == "" {
+		return state, false, false
+	}
+
+	stateKnown := true
+	for _, candidate := range []string{appStoreState, appVersionState} {
+		if candidate == "" {
+			continue
+		}
+		if _, ok := appStoreVersionStates[strings.ToUpper(candidate)]; !ok {
+			stateKnown = false
+		}
+	}
+
+	appStoreStateUpper := strings.ToUpper(appStoreState)
+	appVersionStateUpper := strings.ToUpper(appVersionState)
+	live := appStoreStateUpper == "READY_FOR_SALE" ||
+		appStoreStateUpper == "PREORDER_READY_FOR_SALE" ||
+		appVersionStateUpper == "READY_FOR_DISTRIBUTION" ||
+		appVersionStateUpper == "PREORDER_READY_FOR_SALE"
+	return state, live, stateKnown
 }
 
 func contextWithAvailabilityTimeout(ctx context.Context, allTerritories bool) (context.Context, context.CancelFunc) {

--- a/internal/cli/shared/availability_command_test.go
+++ b/internal/cli/shared/availability_command_test.go
@@ -125,3 +125,39 @@ func TestContextWithAvailabilityTimeout_SingleTerritoryUsesStandardTimeout(t *te
 		t.Fatalf("expected standard timeout near 12s from ASC_TIMEOUT, got %v", got)
 	}
 }
+
+func TestAvailabilityListingIsNewerUsesChronologicalTime(t *testing.T) {
+	listing := func(createdDate string) asc.AvailabilityPlatformListing {
+		return asc.AvailabilityPlatformListing{CreatedDate: createdDate}
+	}
+
+	for _, test := range []struct {
+		name      string
+		candidate string
+		current   string
+		want      bool
+	}{
+		{
+			name:      "offset that sorts later but occurred earlier",
+			candidate: "2026-01-01T00:00:00+02:00",
+			current:   "2025-12-31T23:30:00Z",
+			want:      false,
+		},
+		{
+			name:      "offset that sorts earlier but occurred later",
+			candidate: "2025-12-31T23:30:00Z",
+			current:   "2026-01-01T00:00:00+02:00",
+			want:      true,
+		},
+		{name: "valid replaces invalid", candidate: "2026-01-01T00:00:00Z", current: "not-a-date", want: true},
+		{name: "invalid does not replace valid", candidate: "not-a-date", current: "2026-01-01T00:00:00Z", want: false},
+		{name: "empty does not replace valid", candidate: "", current: "2026-01-01T00:00:00Z", want: false},
+		{name: "first invalid remains deterministic", candidate: "also-invalid", current: "not-a-date", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := availabilityListingIsNewer(listing(test.candidate), listing(test.current)); got != test.want {
+				t.Fatalf("availabilityListingIsNewer(%q, %q) = %t, want %t", test.candidate, test.current, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/cli/shared/availability_command_test.go
+++ b/internal/cli/shared/availability_command_test.go
@@ -161,3 +161,55 @@ func TestAvailabilityListingIsNewerUsesChronologicalTime(t *testing.T) {
 		})
 	}
 }
+
+func TestAvailabilityListingStatusRequiresRecognizedVersionStates(t *testing.T) {
+	tests := []struct {
+		name           string
+		attributes     asc.AppStoreVersionAttributes
+		wantState      string
+		wantLive       bool
+		wantStateKnown bool
+	}{
+		{
+			name:           "missing states",
+			attributes:     asc.AppStoreVersionAttributes{},
+			wantStateKnown: false,
+		},
+		{
+			name: "unknown app store state",
+			attributes: asc.AppStoreVersionAttributes{
+				AppStoreState: "FUTURE_SALE_STATE",
+			},
+			wantState:      "FUTURE_SALE_STATE",
+			wantStateKnown: false,
+		},
+		{
+			name: "known app version preorder state",
+			attributes: asc.AppStoreVersionAttributes{
+				AppVersionState: "PREORDER_READY_FOR_SALE",
+			},
+			wantState:      "PREORDER_READY_FOR_SALE",
+			wantLive:       true,
+			wantStateKnown: true,
+		},
+		{
+			name: "known live state with unknown companion state",
+			attributes: asc.AppStoreVersionAttributes{
+				AppStoreState:   "READY_FOR_SALE",
+				AppVersionState: "FUTURE_DISTRIBUTION_STATE",
+			},
+			wantState:      "FUTURE_DISTRIBUTION_STATE",
+			wantLive:       true,
+			wantStateKnown: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state, live, stateKnown := availabilityListingStatus(test.attributes)
+			if state != test.wantState || live != test.wantLive || stateKnown != test.wantStateKnown {
+				t.Fatalf("availabilityListingStatus() = (%q, %t, %t), want (%q, %t, %t)", state, live, stateKnown, test.wantState, test.wantLive, test.wantStateKnown)
+			}
+		})
+	}
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -363,6 +363,7 @@ var knownFailureParameters = map[string]struct{}{
 	"agreement-text":                    {},
 	"all":                               {},
 	"all-apps":                          {},
+	"all-platforms":                     {},
 	"android-package-name":              {},
 	"app":                               {},
 	"app-clip-id":                       {},


### PR DESCRIPTION
## Summary
- **New `asc pricing availability platforms --app X`** — one row per platform showing the live listing when one exists, otherwise the newest version and its state (prefers a live 2.2.0 over a newer rejected 2.2.1). Previews the blast radius of `remove-from-sale`.
- **Platform guard on `remove-from-sale`** — fetches live platform listings first, prints what leaves sale together, and when more than one platform is live refuses without a new `--all-platforms` acknowledgement, steering single-platform intent to an App Store Connect support request. JSON output gains `removedPlatformListings`, `platformListingsVerified`, and `platformListingsVerificationError`. Unknown or missing platform states now fail closed; `--all-platforms` is the explicit override and the receipt records when discovery was not verified.
- Registers `all-platforms` in the telemetry failure-parameter allowlist (contract test).

## Why
Availability is app-scoped: iOS/macOS/tvOS/visionOS listings share one `appAvailabilities` record. Verified empirically (Aug 2026, live multi-platform app): the ASC web UI's "Remove App From Sale" dialog is app-wide with no platform choice, and the internal iris endpoint (`iris/v2/appAvailabilities`) is identical to the public v2 resource — no platform dimension exists anywhere. Without this guard, `remove-from-sale --confirm` on an app with an ancient secondary platform listing silently takes the live primary platform down with it.

## Verification
- `ASC_BYPASS_KEYCHAIN=1 make test` passes (the telemetry contract test caught the new usage literal; allowlisted).
- `make format`, `make lint`, `make generate-command-docs` clean; 5 existing remove-from-sale tests updated for the new listings fetch, 3 new tests (multi-platform refusal with zero PATCHes, `--all-platforms` acknowledged path, live-over-newer-non-live preference).
- Live read-only smoke against two real multi-platform apps renders correct tables and both would now trip the guard.
- `make check-docs` passes on the repaired exact head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental `platforms` command to list app platforms and relevant live versions.
  * Added support for removing availability across all live platforms with explicit confirmation.
  * Availability results now include affected platforms, versions, states, territory counts, verification status, and failures.
  * Added structured table and field-based output for availability results.

* **Bug Fixes**
  * Improved live-version selection, including preorder-ready versions and chronological date comparisons.
  * Unverifiable platform states now fail safely without making changes.
  * Partial removals no longer report platforms as removed when territory updates fail.
  * Unverified listings remain visible after removal attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->