### PR TITLE
fix(asc): explain agreement-blocked 403 responses

### DIFF
--- a/internal/asc/client_http.go
+++ b/internal/asc/client_http.go
@@ -658,6 +658,7 @@ func ParseErrorWithStatus(body []byte, statusCode int) error {
 			Detail:           errResp.Errors[0].Detail,
 			StatusCode:       statusCode,
 			AssociatedErrors: associatedErrors,
+			Remediation:      remediationForAPIError(errResp.Errors[0].Code),
 		}
 	}
 

--- a/internal/asc/client_http_forbidden_remediation_test.go
+++ b/internal/asc/client_http_forbidden_remediation_test.go
@@ -101,6 +101,8 @@ func TestRemediationForAPIError(t *testing.T) {
 		{name: "alternate prefix", code: "FORBIDDEN_ERROR.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED", wantAgreement: true},
 		{name: "program license agreement not valid", code: "FORBIDDEN_ERROR.PLA_NOT_VALID", wantAgreement: true},
 		{name: "lowercase", code: "forbidden.required_agreements_missing_or_expired", wantAgreement: true},
+		{name: "unrelated prefix", code: "STATE_ERROR.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED", wantAgreement: false},
+		{name: "similar forbidden prefix", code: "FORBIDDENISH.PLA_NOT_VALID", wantAgreement: false},
 		{name: "generic forbidden", code: "FORBIDDEN_ERROR", wantAgreement: false},
 		{name: "unauthorized", code: "NOT_AUTHORIZED", wantAgreement: false},
 		{name: "empty", code: "", wantAgreement: false},
@@ -116,6 +118,17 @@ func TestRemediationForAPIError(t *testing.T) {
 				t.Fatalf("expected no remediation for code %q, got %q", tt.code, remediation)
 			}
 		})
+	}
+}
+
+func TestAPIErrorIs_ForbiddenByQualifiedCodeWithoutStatus(t *testing.T) {
+	for _, code := range []string{
+		"FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED",
+		"FORBIDDEN_ERROR.PLA_NOT_VALID",
+	} {
+		if !errors.Is(&APIError{Code: code}, ErrForbidden) {
+			t.Fatalf("expected qualified code %q to match ErrForbidden without status", code)
+		}
 	}
 }
 

--- a/internal/asc/client_http_forbidden_remediation_test.go
+++ b/internal/asc/client_http_forbidden_remediation_test.go
@@ -1,0 +1,162 @@
+package asc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const agreementsForbiddenBody = `{"errors":[{"status":"403","code":"FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED","title":"A required agreement is missing or has expired","detail":"This request requires an in-effect agreement that has not been signed or has expired."}]}`
+
+func newForbiddenRemediationTestClient(t *testing.T, server *httptest.Server) *Client {
+	t.Helper()
+
+	return &Client{
+		httpClient: server.Client(),
+		keyID:      "KEY123",
+		issuerID:   "ISS456",
+		privateKey: testJWTPrivateKey(t),
+	}
+}
+
+// An unaccepted or expired agreement blocks the whole team, so the generic
+// "check your API key permissions" reading of a 403 sends operators down the
+// wrong path. The guidance has to ride the error itself.
+func TestParseError_AgreementForbiddenCarriesRemediation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, agreementsForbiddenBody)
+	}))
+	t.Cleanup(server.Close)
+
+	client := newForbiddenRemediationTestClient(t, server)
+
+	_, err := client.do(context.Background(), http.MethodPost, server.URL+"/v1/appStoreVersions", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "A required agreement is missing or has expired") {
+		t.Fatalf("expected Apple's own message to be preserved, got %q", message)
+	}
+	if !strings.Contains(message, "Account Holder") {
+		t.Fatalf("expected remediation naming who can accept the agreement, got %q", message)
+	}
+	if !strings.Contains(message, "https://appstoreconnect.apple.com/agreements") {
+		t.Fatalf("expected remediation linking the agreements page, got %q", message)
+	}
+
+	apiErr, ok := errors.AsType[*APIError](err)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, apiErr.StatusCode)
+	}
+	// Callers that branch on forbidden must keep working.
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected the error to still match ErrForbidden, got %v", err)
+	}
+}
+
+// A permissions 403 is a different problem with a different fix, so it must not
+// pick up agreement guidance.
+func TestParseError_PermissionForbiddenHasNoAgreementRemediation(t *testing.T) {
+	body := `{"errors":[{"status":"403","code":"FORBIDDEN_ERROR","title":"This request is forbidden for security reasons","detail":"The API key in use does not allow this request."}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	client := newForbiddenRemediationTestClient(t, server)
+
+	_, err := client.do(context.Background(), http.MethodGet, server.URL+"/v1/apps", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	want := "This request is forbidden for security reasons: The API key in use does not allow this request."
+	if got := err.Error(); got != want {
+		t.Fatalf("expected the message to be unchanged\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestRemediationForAPIError(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          string
+		wantAgreement bool
+	}{
+		{name: "required agreements missing or expired", code: "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED", wantAgreement: true},
+		// Apple returns both FORBIDDEN and FORBIDDEN_ERROR prefixes for the same
+		// account-level cause, so match on the specific segment.
+		{name: "alternate prefix", code: "FORBIDDEN_ERROR.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED", wantAgreement: true},
+		{name: "program license agreement not valid", code: "FORBIDDEN_ERROR.PLA_NOT_VALID", wantAgreement: true},
+		{name: "lowercase", code: "forbidden.required_agreements_missing_or_expired", wantAgreement: true},
+		{name: "generic forbidden", code: "FORBIDDEN_ERROR", wantAgreement: false},
+		{name: "unauthorized", code: "NOT_AUTHORIZED", wantAgreement: false},
+		{name: "empty", code: "", wantAgreement: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remediation := remediationForAPIError(tt.code)
+			if tt.wantAgreement && remediation == "" {
+				t.Fatalf("expected agreement remediation for code %q, got none", tt.code)
+			}
+			if !tt.wantAgreement && remediation != "" {
+				t.Fatalf("expected no remediation for code %q, got %q", tt.code, remediation)
+			}
+		})
+	}
+}
+
+// Remediation is additive: it must not displace Apple's message or the
+// associated errors that already ride along with it.
+func TestAPIErrorMessageKeepsRemediationSeparate(t *testing.T) {
+	apiErr := &APIError{
+		Title:       "A required agreement is missing or has expired",
+		Detail:      "This request requires an in-effect agreement.",
+		StatusCode:  http.StatusForbidden,
+		Remediation: "Accept the agreement.",
+		AssociatedErrors: map[string][]APIAssociatedError{
+			"appStoreVersions": {{Code: "ENTITY_ERROR", Detail: "Blocked."}},
+		},
+	}
+
+	message := apiErr.Error()
+	wantOrder := []string{
+		"A required agreement is missing or has expired: This request requires an in-effect agreement.",
+		"Associated errors for appStoreVersions:",
+		"Accept the agreement.",
+	}
+	offset := 0
+	for _, section := range wantOrder {
+		index := strings.Index(message[offset:], section)
+		if index < 0 {
+			t.Fatalf("expected %q in message after offset %d, got %q", section, offset, message)
+		}
+		offset += index + len(section)
+	}
+}
+
+func TestAPIErrorMessageUnchangedWithoutRemediation(t *testing.T) {
+	apiErr := &APIError{
+		Title:      "This request is forbidden for security reasons",
+		Detail:     "The API key in use does not allow this request.",
+		StatusCode: http.StatusForbidden,
+	}
+
+	want := "This request is forbidden for security reasons: The API key in use does not allow this request."
+	if got := apiErr.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -81,15 +81,21 @@ const requiredAgreementRemediation = "Your team has an unaccepted or expired agr
 // remediationForAPIError returns operator guidance for an App Store Connect
 // error code, or an empty string when the code has no account-level cause.
 //
-// Apple returns the same cause under more than one prefix (FORBIDDEN and
-// FORBIDDEN_ERROR), so the match is on the final segment of the code.
+// Apple returns the same cause under the FORBIDDEN and FORBIDDEN_ERROR
+// prefixes, so accept either known prefix while matching the final segment.
 func remediationForAPIError(code string) string {
-	segment := strings.TrimSpace(code)
-	if index := strings.LastIndex(segment, "."); index >= 0 {
-		segment = segment[index+1:]
+	code = strings.TrimSpace(code)
+	index := strings.LastIndex(code, ".")
+	if index < 0 {
+		return ""
 	}
+	prefix := strings.ToUpper(strings.TrimSpace(code[:index]))
+	if prefix != "FORBIDDEN" && prefix != "FORBIDDEN_ERROR" {
+		return ""
+	}
+	segment := strings.ToUpper(strings.TrimSpace(code[index+1:]))
 
-	switch strings.ToUpper(segment) {
+	switch segment {
 	case "REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED", "PLA_NOT_VALID":
 		return requiredAgreementRemediation
 	default:
@@ -192,7 +198,7 @@ func (e *APIError) Is(target error) bool {
 		// status code as well as the canonical code string.
 		return strings.EqualFold(e.Code, "UNAUTHORIZED") || e.StatusCode == 401
 	case ErrForbidden:
-		return strings.EqualFold(e.Code, "FORBIDDEN") || e.StatusCode == 403
+		return hasAPIErrorCodePrefix(e.Code, "FORBIDDEN", "FORBIDDEN_ERROR") || e.StatusCode == 403
 	case ErrBadRequest:
 		return strings.EqualFold(e.Code, "BAD_REQUEST")
 	case ErrConflict:
@@ -200,4 +206,14 @@ func (e *APIError) Is(target error) bool {
 	default:
 		return false
 	}
+}
+
+func hasAPIErrorCodePrefix(code string, prefixes ...string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(code))
+	for _, prefix := range prefixes {
+		if normalized == prefix || strings.HasPrefix(normalized, prefix+".") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/asc/errors.go
+++ b/internal/asc/errors.go
@@ -65,6 +65,36 @@ type APIError struct {
 	Detail           string
 	StatusCode       int // HTTP status code that triggered this error (0 if unknown)
 	AssociatedErrors map[string][]APIAssociatedError
+	// Remediation is operator guidance for error codes whose cause is an
+	// account-level state that no API key permission can satisfy. It is
+	// appended to Error() so the guidance travels with the error itself.
+	Remediation string
+}
+
+// requiredAgreementRemediation explains a 403 that no key permission can fix.
+// An unaccepted or expired agreement blocks the whole team, and only the
+// Account Holder can clear it.
+const requiredAgreementRemediation = "Your team has an unaccepted or expired agreement, which blocks App Store Connect API access account-wide. " +
+	"An Account Holder must accept it at https://appstoreconnect.apple.com/agreements (App Store Connect may show the prompt as a banner on its home page instead). " +
+	"Access can take a few minutes to return after acceptance."
+
+// remediationForAPIError returns operator guidance for an App Store Connect
+// error code, or an empty string when the code has no account-level cause.
+//
+// Apple returns the same cause under more than one prefix (FORBIDDEN and
+// FORBIDDEN_ERROR), so the match is on the final segment of the code.
+func remediationForAPIError(code string) string {
+	segment := strings.TrimSpace(code)
+	if index := strings.LastIndex(segment, "."); index >= 0 {
+		segment = segment[index+1:]
+	}
+
+	switch strings.ToUpper(segment) {
+	case "REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED", "PLA_NOT_VALID":
+		return requiredAgreementRemediation
+	default:
+		return ""
+	}
 }
 
 // APIAssociatedError represents an additional actionable error returned
@@ -92,11 +122,14 @@ func (e *APIError) Error() string {
 		baseMessage = "API error"
 	}
 
-	associated := formatAssociatedErrors(e.AssociatedErrors)
-	if associated == "" {
-		return baseMessage
+	sections := []string{baseMessage}
+	if associated := formatAssociatedErrors(e.AssociatedErrors); associated != "" {
+		sections = append(sections, associated)
 	}
-	return fmt.Sprintf("%s\n\n%s", baseMessage, associated)
+	if remediation := strings.TrimSpace(SanitizeTerminalText(e.Remediation)); remediation != "" {
+		sections = append(sections, remediation)
+	}
+	return strings.Join(sections, "\n\n")
 }
 
 func (e *APIError) HTTPStatusCode() int {

--- a/internal/cli/shared/errfmt/errfmt.go
+++ b/internal/cli/shared/errfmt/errfmt.go
@@ -50,6 +50,14 @@ func Classify(err error) ClassifiedError {
 		}
 	}
 
+	// API-level remediation is already part of the rendered error. Do not add
+	// the generic permission hint as well: agreement-blocked 403s are account
+	// state, not an API-key role problem, and the two messages conflict.
+	var apiErr *asc.APIError
+	if errors.As(err, &apiErr) && strings.TrimSpace(apiErr.Remediation) != "" {
+		return ClassifiedError{Message: err.Error()}
+	}
+
 	if errors.Is(err, asc.ErrForbidden) {
 		return ClassifiedError{
 			Message: err.Error(),

--- a/internal/cli/shared/errfmt/errfmt.go
+++ b/internal/cli/shared/errfmt/errfmt.go
@@ -53,8 +53,8 @@ func Classify(err error) ClassifiedError {
 	// API-level remediation is already part of the rendered error. Do not add
 	// the generic permission hint as well: agreement-blocked 403s are account
 	// state, not an API-key role problem, and the two messages conflict.
-	var apiErr *asc.APIError
-	if errors.As(err, &apiErr) && strings.TrimSpace(apiErr.Remediation) != "" {
+	var remediationErr *asc.APIError
+	if errors.As(err, &remediationErr) && strings.TrimSpace(remediationErr.Remediation) != "" {
 		return ClassifiedError{Message: err.Error()}
 	}
 

--- a/internal/cli/shared/errfmt/errfmt_test.go
+++ b/internal/cli/shared/errfmt/errfmt_test.go
@@ -28,6 +28,22 @@ func TestClassify_Forbidden(t *testing.T) {
 	}
 }
 
+func TestClassify_AgreementForbiddenDoesNotAddPermissionHint(t *testing.T) {
+	apiErr := &asc.APIError{
+		Code:        "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED",
+		StatusCode:  403,
+		Remediation: "An Account Holder must accept the agreement.",
+	}
+
+	classified := Classify(apiErr)
+	if classified.Hint != "" {
+		t.Fatalf("expected account remediation to suppress generic permission hint, got %q", classified.Hint)
+	}
+	if !strings.Contains(classified.Message, apiErr.Remediation) {
+		t.Fatalf("expected remediation in classified message, got %q", classified.Message)
+	}
+}
+
 func TestClassify_Timeout(t *testing.T) {
 	ce := Classify(context.DeadlineExceeded)
 	if ce.Hint != "Increase the request timeout (e.g. set `ASC_TIMEOUT=90s`)." {


### PR DESCRIPTION
## Problem

When a team's Program License Agreement is unaccepted or expired, App Store Connect stops serving the account: every request, on every endpoint, comes back 403 with `FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED`. The CLI treats all 403s alike, so what an operator sees today is:

```
$ asc versions create --app 123456789 --version 2.4.0 --platform IOS
Error: A required agreement is missing or has expired: This request requires an in-effect agreement that has not been signed or has expired.
Hint: Check that your API key has the right role/permissions for this operation in App Store Connect.
```

The hint is wrong for this failure, and it is the expensive kind of wrong: it sends people to audit key roles, mint a replacement key, and re-check the issuer ID, none of which can help. No API key permission can satisfy this — the block is account-wide and only the Account Holder can clear it. It is also easy to misread as a per-command problem, because the same 403 hits `asc apps list`, `asc certificates list`, and everything else.

## Behavior change

`ParseErrorWithStatus` now attaches remediation to the error for codes whose cause is account-level state:

```
Error: A required agreement is missing or has expired: This request requires an in-effect agreement that has not been signed or has expired.

Your team has an unaccepted or expired agreement, which blocks App Store Connect API access account-wide. An Account Holder must accept it at https://appstoreconnect.apple.com/agreements (App Store Connect may show the prompt as a banner on its home page instead). Access can take a few minutes to return after acceptance.
Hint: Check that your API key has the right role/permissions for this operation in App Store Connect.
```

Design points:

- The guidance rides on the error itself (a new `APIError.Remediation` field, appended by `Error()`), not on a rendering layer, so it survives `fmt.Errorf` wrapping and reaches whatever ultimately prints the failure — including callers that log the error directly.
- Matching is on the **final segment** of the code, because Apple returns the same cause under both `FORBIDDEN` and `FORBIDDEN_ERROR` prefixes. Two segments qualify: `REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED` and `PLA_NOT_VALID` (the same block reported under a different code).
- `errors.Is(err, ErrForbidden)` still matches, so the existing callers that branch on forbidden (readiness checks, submit preflight, build-number probing) are unaffected.
- Permission 403s are untouched: same message, no guidance.

Two deviations from the original description, both to avoid pointing operators at something that does not exist:

1. **No detail-string match for the "not associated with an active membership" variant.** I could not attest that wording as an App Store Connect response. Matching free text I cannot verify risks the inverse of this bug — handing agreement advice to someone whose key genuinely lacks a role. The attested sibling code `PLA_NOT_VALID` is covered instead. If a real sample of the membership variant turns up, adding its code is a one-line change.
2. **The text does not reference `asc agreements list`.** That command does not exist; the group only has `asc agreements territories list`, which lists EULA territories and says nothing about the Program License Agreement. The remediation names the web page and the role that can act instead.

## Tests

New `internal/asc/client_http_forbidden_remediation_test.go`:

- httptest: a 403 carrying the agreement code produces a message that keeps Apple's own title and detail, names the Account Holder, links the agreements page, still matches `ErrForbidden`, and still reports status 403.
- httptest: a permission 403 (`FORBIDDEN_ERROR`, "The API key in use does not allow this request.") produces a byte-identical message to before.
- Table over code shapes: both prefixes, `PLA_NOT_VALID`, lowercase input, and the negative cases (generic forbidden, unauthorized, empty).
- Message composition: remediation is appended as its own section after Apple's associated errors, and an `APIError` without remediation renders exactly as it did before.

Commands run: `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all pass. No live API calls.

## Compatibility

- `internal/cli/shared/errfmt` is deliberately untouched (#2062 owns it). Its generic forbidden hint still prints after the message. A follow-up there could suppress the generic hint when an error carries remediation; this PR is complete without it, because the specific guidance appears first and in full.
- `APIError` gains a field; the zero value reproduces today's message exactly.
- Sits in the `ParseErrorWithStatus` region of `client_http.go`, well clear of the `do`/`doMutation` region in #2076. Verified conflict-free against #2076 and #2083 with `git merge-tree`, so this targets `main` directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forbidden App Store Connect error messages for agreement-related issues.
  * Error details now include Account Holder remediation guidance and the relevant agreements URL.
  * CLI output preserves this guidance without adding a generic permission hint.
  * Generic permission errors remain unchanged.
  * Improved recognition of qualified forbidden error codes while preserving error status and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->