### PR TITLE
feat(age-rating): audit subcommand for September 2026 social-media responses

### DIFF
--- a/internal/asc/app_info_resolution.go
+++ b/internal/asc/app_info_resolution.go
@@ -75,9 +75,24 @@ func (c *Client) ResolveCurrentAppInfoIDForApp(ctx context.Context, appID string
 		return "", fmt.Errorf("appID is required")
 	}
 
-	appInfos, err := c.GetAppInfos(ctx, appID, WithAppInfoFields([]string{"state"}))
+	firstPage, err := c.GetAppInfos(
+		ctx,
+		appID,
+		WithAppInfoFields([]string{"state"}),
+		WithAppInfosLimit(200),
+	)
 	if err != nil {
 		return "", err
+	}
+	allPages, err := PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
+		return c.GetAppInfos(ctx, appID, WithAppInfosNextURL(nextURL))
+	})
+	if err != nil {
+		return "", err
+	}
+	appInfos, ok := allPages.(*AppInfosResponse)
+	if !ok {
+		return "", fmt.Errorf("unexpected app info pagination response %T", allPages)
 	}
 	return resolveCurrentAppInfoID(appID, appInfos.Data)
 }

--- a/internal/asc/app_info_resolution.go
+++ b/internal/asc/app_info_resolution.go
@@ -68,11 +68,11 @@ type AppInfoCandidate struct {
 	State string
 }
 
-// ResolveCurrentAppInfoIDForApp resolves the single non-historical app info for an app.
-func (c *Client) ResolveCurrentAppInfoIDForApp(ctx context.Context, appID string) (string, error) {
+// ListAppInfoCandidatesForApp lists every app info candidate for an app.
+func (c *Client) ListAppInfoCandidatesForApp(ctx context.Context, appID string) ([]AppInfoCandidate, error) {
 	appID = strings.TrimSpace(appID)
 	if appID == "" {
-		return "", fmt.Errorf("appID is required")
+		return nil, fmt.Errorf("appID is required")
 	}
 
 	firstPage, err := c.GetAppInfos(
@@ -82,33 +82,41 @@ func (c *Client) ResolveCurrentAppInfoIDForApp(ctx context.Context, appID string
 		WithAppInfosLimit(200),
 	)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	allPages, err := PaginateAll(ctx, firstPage, func(ctx context.Context, nextURL string) (PaginatedResponse, error) {
 		return c.GetAppInfos(ctx, appID, WithAppInfosNextURL(nextURL))
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	appInfos, ok := allPages.(*AppInfosResponse)
 	if !ok {
-		return "", fmt.Errorf("unexpected app info pagination response %T", allPages)
+		return nil, fmt.Errorf("unexpected app info pagination response %T", allPages)
 	}
-	return resolveCurrentAppInfoID(appID, appInfos.Data)
+	return AppInfoCandidates(appInfos.Data), nil
+}
+
+// ResolveCurrentAppInfoIDForApp resolves the single non-historical app info for an app.
+func (c *Client) ResolveCurrentAppInfoIDForApp(ctx context.Context, appID string) (string, error) {
+	candidates, err := c.ListAppInfoCandidatesForApp(ctx, appID)
+	if err != nil {
+		return "", err
+	}
+	return resolveCurrentAppInfoIDFromCandidates(appID, candidates)
 }
 
 func resolveCurrentAppInfoID(appID string, appInfos []Resource[AppInfoAttributes]) (string, error) {
 	if len(appInfos) == 0 {
 		return "", fmt.Errorf("no app info found for app %q", appID)
 	}
+	return resolveCurrentAppInfoIDFromCandidates(appID, AppInfoCandidates(appInfos))
+}
 
-	candidates := AppInfoCandidates(appInfos)
-	current := make([]AppInfoCandidate, 0, len(candidates))
-	for _, candidate := range candidates {
-		if strings.EqualFold(candidate.State, "REPLACED_WITH_NEW_INFO") {
-			continue
-		}
-		current = append(current, candidate)
+func resolveCurrentAppInfoIDFromCandidates(appID string, candidates []AppInfoCandidate) (string, error) {
+	current := CurrentAppInfoCandidates(candidates)
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("no app info found for app %q", appID)
 	}
 	if len(current) == 1 && current[0].ID != "" {
 		return current[0].ID, nil
@@ -129,6 +137,18 @@ func resolveCurrentAppInfoID(appID string, appInfos []Resource[AppInfoAttributes
 		formatted,
 		appID,
 	)
+}
+
+// CurrentAppInfoCandidates excludes historical app info records.
+func CurrentAppInfoCandidates(candidates []AppInfoCandidate) []AppInfoCandidate {
+	current := make([]AppInfoCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.State, "REPLACED_WITH_NEW_INFO") {
+			continue
+		}
+		current = append(current, candidate)
+	}
+	return current
 }
 
 // ResolveAppInfoIDForAppStoreVersion resolves the app info backing a version-scoped workflow.

--- a/internal/asc/app_info_resolution.go
+++ b/internal/asc/app_info_resolution.go
@@ -68,6 +68,54 @@ type AppInfoCandidate struct {
 	State string
 }
 
+// ResolveCurrentAppInfoIDForApp resolves the single non-historical app info for an app.
+func (c *Client) ResolveCurrentAppInfoIDForApp(ctx context.Context, appID string) (string, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return "", fmt.Errorf("appID is required")
+	}
+
+	appInfos, err := c.GetAppInfos(ctx, appID, WithAppInfoFields([]string{"state"}))
+	if err != nil {
+		return "", err
+	}
+	return resolveCurrentAppInfoID(appID, appInfos.Data)
+}
+
+func resolveCurrentAppInfoID(appID string, appInfos []Resource[AppInfoAttributes]) (string, error) {
+	if len(appInfos) == 0 {
+		return "", fmt.Errorf("no app info found for app %q", appID)
+	}
+
+	candidates := AppInfoCandidates(appInfos)
+	current := make([]AppInfoCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.State, "REPLACED_WITH_NEW_INFO") {
+			continue
+		}
+		current = append(current, candidate)
+	}
+	if len(current) == 1 && current[0].ID != "" {
+		return current[0].ID, nil
+	}
+
+	formatted := FormatAppInfoCandidates(candidates)
+	if len(current) == 0 {
+		return "", fmt.Errorf(
+			"no current app info found for app %q (%s); run `asc apps info list --app %q` to inspect candidates",
+			appID,
+			formatted,
+			appID,
+		)
+	}
+	return "", fmt.Errorf(
+		"multiple current app infos found for app %q (%s); run `asc apps info list --app %q` to inspect candidates",
+		appID,
+		formatted,
+		appID,
+	)
+}
+
 // ResolveAppInfoIDForAppStoreVersion resolves the app info backing a version-scoped workflow.
 func (c *Client) ResolveAppInfoIDForAppStoreVersion(ctx context.Context, versionID string) (string, error) {
 	versionID = strings.TrimSpace(versionID)

--- a/internal/asc/app_info_resolution_test.go
+++ b/internal/asc/app_info_resolution_test.go
@@ -1,6 +1,60 @@
 package asc
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveCurrentAppInfoID(t *testing.T) {
+	tests := []struct {
+		name     string
+		appInfos []Resource[AppInfoAttributes]
+		wantID   string
+		wantErr  string
+	}{
+		{
+			name: "selects the only non-historical app info",
+			appInfos: []Resource[AppInfoAttributes]{
+				{ID: "info-old", Attributes: AppInfoAttributes{"state": "REPLACED_WITH_NEW_INFO"}},
+				{ID: "info-current", Attributes: AppInfoAttributes{"state": "READY_FOR_DISTRIBUTION"}},
+			},
+			wantID: "info-current",
+		},
+		{
+			name: "rejects ambiguous current app infos",
+			appInfos: []Resource[AppInfoAttributes]{
+				{ID: "info-one", Attributes: AppInfoAttributes{"state": "READY_FOR_REVIEW"}},
+				{ID: "info-two", Attributes: AppInfoAttributes{"state": "PREPARE_FOR_SUBMISSION"}},
+			},
+			wantErr: "multiple current app infos found",
+		},
+		{
+			name: "rejects all-historical app infos",
+			appInfos: []Resource[AppInfoAttributes]{
+				{ID: "info-old", Attributes: AppInfoAttributes{"state": "REPLACED_WITH_NEW_INFO"}},
+			},
+			wantErr: "no current app info found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveCurrentAppInfoID("app-1", tt.appInfos)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveCurrentAppInfoID() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveCurrentAppInfoID() error = %v", err)
+			}
+			if got != tt.wantID {
+				t.Fatalf("resolveCurrentAppInfoID() = %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}
 
 func TestAutoResolveAppInfoIDByVersionState(t *testing.T) {
 	tests := []struct {

--- a/internal/asc/app_info_resolution_test.go
+++ b/internal/asc/app_info_resolution_test.go
@@ -1,6 +1,8 @@
 package asc
 
 import (
+	"context"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -51,6 +53,61 @@ func TestResolveCurrentAppInfoID(t *testing.T) {
 			}
 			if got != tt.wantID {
 				t.Fatalf("resolveCurrentAppInfoID() = %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestResolveCurrentAppInfoIDForAppFollowsEveryPage(t *testing.T) {
+	tests := []struct {
+		name       string
+		firstPage  string
+		secondPage string
+		wantID     string
+		wantErr    string
+	}{
+		{
+			name:       "finds current app info on the second page",
+			firstPage:  `{"data":[{"type":"appInfos","id":"info-old","attributes":{"state":"REPLACED_WITH_NEW_INFO"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps/app-1/appInfos?cursor=next"}}`,
+			secondPage: `{"data":[{"type":"appInfos","id":"info-current","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`,
+			wantID:     "info-current",
+		},
+		{
+			name:       "detects current candidates split across pages",
+			firstPage:  `{"data":[{"type":"appInfos","id":"info-one","attributes":{"state":"READY_FOR_REVIEW"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps/app-1/appInfos?cursor=next"}}`,
+			secondPage: `{"data":[{"type":"appInfos","id":"info-two","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}],"links":{}}`,
+			wantErr:    "multiple current app infos found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requests := make([]string, 0, 2)
+			client := newTestClient(t, func(req *http.Request) {
+				requests = append(requests, req.URL.String())
+			}, jsonResponse(http.StatusOK, test.firstPage), jsonResponse(http.StatusOK, test.secondPage))
+
+			got, err := client.ResolveCurrentAppInfoIDForApp(context.Background(), "app-1")
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("ResolveCurrentAppInfoIDForApp() error = %v, want containing %q", err, test.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ResolveCurrentAppInfoIDForApp() error = %v", err)
+				}
+				if got != test.wantID {
+					t.Fatalf("ResolveCurrentAppInfoIDForApp() = %q, want %q", got, test.wantID)
+				}
+			}
+			if len(requests) != 2 {
+				t.Fatalf("requests = %v, want two pages", requests)
+			}
+			if !strings.Contains(requests[0], "limit=200") || !strings.Contains(requests[0], "fields%5BappInfos%5D=state") {
+				t.Fatalf("first request = %q, want maximum page size and state field", requests[0])
+			}
+			if !strings.Contains(requests[1], "cursor=next") {
+				t.Fatalf("second request = %q, want continuation URL", requests[1])
 			}
 		})
 	}

--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -1728,7 +1728,12 @@ func (c *Client) GetAppInfos(ctx context.Context, appID string, opts ...AppInfoO
 	}
 
 	path := fmt.Sprintf("/v1/apps/%s/appInfos", appID)
-	if queryString := buildAppInfoQuery(query); queryString != "" {
+	if query.nextURL != "" {
+		if err := validateNextURL(query.nextURL); err != nil {
+			return nil, fmt.Errorf("appInfos: %w", err)
+		}
+		path = query.nextURL
+	} else if queryString := buildAppInfoQuery(query); queryString != "" {
 		path += "?" + queryString
 	}
 	data, err := c.do(ctx, "GET", path, nil)

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -134,6 +134,14 @@ func TestListEndpoints_UseNextURL(t *testing.T) {
 			},
 		},
 		{
+			name: "GetAppInfos",
+			next: "https://api.appstoreconnect.apple.com/v1/apps/app-1/appInfos?cursor=abc",
+			call: func(c *Client, next string) error {
+				_, err := c.GetAppInfos(ctx, "app-1", WithAppInfosNextURL(next))
+				return err
+			},
+		},
+		{
 			name: "GetAppTags",
 			next: "https://api.appstoreconnect.apple.com/v1/apps/123/appTags?cursor=abc",
 			call: func(c *Client, next string) error {

--- a/internal/asc/client_query_versions.go
+++ b/internal/asc/client_query_versions.go
@@ -67,6 +67,7 @@ type appInfoLocalizationsQuery struct {
 }
 
 type appInfoQuery struct {
+	listQuery
 	fields                     []string
 	ageRatingDeclarationFields []string
 	include                    []string
@@ -264,6 +265,7 @@ func buildAppInfoQuery(query *appInfoQuery) string {
 	addCSV(values, "fields[appInfos]", fields)
 	addCSV(values, "fields[ageRatingDeclarations]", query.ageRatingDeclarationFields)
 	addCSV(values, "include", include)
+	addLimit(values, query.limit)
 	if query.localizationsLimit > 0 {
 		values.Set("limit[appInfoLocalizations]", strconv.Itoa(query.localizationsLimit))
 	}
@@ -827,6 +829,24 @@ func WithAppInfoLocalizationsInclude(include []string) AppInfoLocalizationsOptio
 func WithAppInfoFields(fields []string) AppInfoOption {
 	return func(q *appInfoQuery) {
 		q.fields = normalizeList(fields)
+	}
+}
+
+// WithAppInfosLimit sets the maximum number of app info records to return.
+func WithAppInfosLimit(limit int) AppInfoOption {
+	return func(q *appInfoQuery) {
+		if limit > 0 {
+			q.limit = limit
+		}
+	}
+}
+
+// WithAppInfosNextURL uses an app info continuation URL directly.
+func WithAppInfosNextURL(next string) AppInfoOption {
+	return func(q *appInfoQuery) {
+		if strings.TrimSpace(next) != "" {
+			q.nextURL = strings.TrimSpace(next)
+		}
 	}
 }
 

--- a/internal/asc/output_age_rating_audit.go
+++ b/internal/asc/output_age_rating_audit.go
@@ -15,6 +15,7 @@ type AgeRatingAuditRow struct {
 	SocialMedia              string   `json:"socialMedia"`
 	SocialMediaAgeRestricted string   `json:"socialMediaAgeRestricted"`
 	MessagingAndChat         string   `json:"messagingAndChat"`
+	UserGeneratedContent     string   `json:"userGeneratedContent"`
 	AgeAssurance             string   `json:"ageAssurance"`
 	MissingResponses         []string `json:"missingResponses"`
 	Ready                    bool     `json:"ready"`
@@ -30,7 +31,7 @@ type AgeRatingAuditResult struct {
 }
 
 func ageRatingAuditResultRows(result *AgeRatingAuditResult) ([]string, [][]string) {
-	headers := []string{"App ID", "App Info ID", "State", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
+	headers := []string{"App ID", "App Info ID", "State", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "User Generated Content", "Age Assurance", "Ready", "Missing"}
 	rows := make([][]string, 0, len(result.Apps))
 	for _, row := range result.Apps {
 		missing := strings.Join(row.MissingResponses, ", ")
@@ -45,6 +46,7 @@ func ageRatingAuditResultRows(result *AgeRatingAuditResult) ([]string, [][]strin
 			row.SocialMedia,
 			row.SocialMediaAgeRestricted,
 			row.MessagingAndChat,
+			row.UserGeneratedContent,
 			row.AgeAssurance,
 			strconv.FormatBool(row.Ready),
 			missing,

--- a/internal/asc/output_age_rating_audit.go
+++ b/internal/asc/output_age_rating_audit.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 )
 
-// AgeRatingAuditRow reports one app's social-media capability responses.
+// AgeRatingAuditRow reports one active app info's social-media capability responses.
 type AgeRatingAuditRow struct {
 	AppID                    string   `json:"appId"`
+	AppInfoID                string   `json:"appInfoId,omitempty"`
+	AppInfoState             string   `json:"appInfoState,omitempty"`
 	Name                     string   `json:"name,omitempty"`
 	BundleID                 string   `json:"bundleId,omitempty"`
 	SocialMedia              string   `json:"socialMedia"`
@@ -19,7 +21,7 @@ type AgeRatingAuditRow struct {
 	Error                    string   `json:"error,omitempty"`
 }
 
-// AgeRatingAuditResult summarizes social-media capability readiness per app.
+// AgeRatingAuditResult summarizes social-media capability readiness per active app info.
 type AgeRatingAuditResult struct {
 	Apps         []AgeRatingAuditRow `json:"apps"`
 	ReadyCount   int                 `json:"readyCount"`
@@ -28,7 +30,7 @@ type AgeRatingAuditResult struct {
 }
 
 func ageRatingAuditResultRows(result *AgeRatingAuditResult) ([]string, [][]string) {
-	headers := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
+	headers := []string{"App ID", "App Info ID", "State", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
 	rows := make([][]string, 0, len(result.Apps))
 	for _, row := range result.Apps {
 		missing := strings.Join(row.MissingResponses, ", ")
@@ -37,6 +39,8 @@ func ageRatingAuditResultRows(result *AgeRatingAuditResult) ([]string, [][]strin
 		}
 		rows = append(rows, []string{
 			row.AppID,
+			row.AppInfoID,
+			row.AppInfoState,
 			row.Name,
 			row.SocialMedia,
 			row.SocialMediaAgeRestricted,

--- a/internal/asc/output_age_rating_audit.go
+++ b/internal/asc/output_age_rating_audit.go
@@ -1,6 +1,9 @@
 package asc
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // AgeRatingAuditRow reports one app's social-media capability responses.
 type AgeRatingAuditRow struct {
@@ -25,7 +28,7 @@ type AgeRatingAuditResult struct {
 }
 
 func ageRatingAuditResultRows(result *AgeRatingAuditResult) ([]string, [][]string) {
-	headers := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Missing"}
+	headers := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
 	rows := make([][]string, 0, len(result.Apps))
 	for _, row := range result.Apps {
 		missing := strings.Join(row.MissingResponses, ", ")
@@ -39,6 +42,7 @@ func ageRatingAuditResultRows(result *AgeRatingAuditResult) ([]string, [][]strin
 			row.SocialMediaAgeRestricted,
 			row.MessagingAndChat,
 			row.AgeAssurance,
+			strconv.FormatBool(row.Ready),
 			missing,
 		})
 	}

--- a/internal/asc/output_age_rating_audit.go
+++ b/internal/asc/output_age_rating_audit.go
@@ -1,0 +1,46 @@
+package asc
+
+import "strings"
+
+// AgeRatingAuditRow reports one app's social-media capability responses.
+type AgeRatingAuditRow struct {
+	AppID                    string   `json:"appId"`
+	Name                     string   `json:"name,omitempty"`
+	BundleID                 string   `json:"bundleId,omitempty"`
+	SocialMedia              string   `json:"socialMedia"`
+	SocialMediaAgeRestricted string   `json:"socialMediaAgeRestricted"`
+	MessagingAndChat         string   `json:"messagingAndChat"`
+	AgeAssurance             string   `json:"ageAssurance"`
+	MissingResponses         []string `json:"missingResponses"`
+	Ready                    bool     `json:"ready"`
+	Error                    string   `json:"error,omitempty"`
+}
+
+// AgeRatingAuditResult summarizes social-media capability readiness per app.
+type AgeRatingAuditResult struct {
+	Apps         []AgeRatingAuditRow `json:"apps"`
+	ReadyCount   int                 `json:"readyCount"`
+	MissingCount int                 `json:"missingCount"`
+	ErrorCount   int                 `json:"errorCount"`
+}
+
+func ageRatingAuditResultRows(result *AgeRatingAuditResult) ([]string, [][]string) {
+	headers := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Missing"}
+	rows := make([][]string, 0, len(result.Apps))
+	for _, row := range result.Apps {
+		missing := strings.Join(row.MissingResponses, ", ")
+		if row.Error != "" {
+			missing = "error: " + row.Error
+		}
+		rows = append(rows, []string{
+			row.AppID,
+			row.Name,
+			row.SocialMedia,
+			row.SocialMediaAgeRestricted,
+			row.MessagingAndChat,
+			row.AgeAssurance,
+			missing,
+		})
+	}
+	return headers, rows
+}

--- a/internal/asc/output_age_rating_test.go
+++ b/internal/asc/output_age_rating_test.go
@@ -39,20 +39,22 @@ func TestAgeRatingAuditResultRows(t *testing.T) {
 				SocialMedia:              "true",
 				SocialMediaAgeRestricted: "true",
 				MessagingAndChat:         "false",
+				UserGeneratedContent:     "true",
 				AgeAssurance:             "true",
 				Ready:                    true,
 			},
 			{
-				AppID:            "app-2",
-				Name:             "Broken App",
-				MissingResponses: []string{"socialMedia", "messagingAndChat"},
-				Error:            "request failed",
+				AppID:                "app-2",
+				Name:                 "Broken App",
+				UserGeneratedContent: "-",
+				MissingResponses:     []string{"socialMedia", "messagingAndChat"},
+				Error:                "request failed",
 			},
 		},
 	}
 
 	headers, rows := ageRatingAuditResultRows(result)
-	wantHeaders := []string{"App ID", "App Info ID", "State", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
+	wantHeaders := []string{"App ID", "App Info ID", "State", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "User Generated Content", "Age Assurance", "Ready", "Missing"}
 	if !reflect.DeepEqual(headers, wantHeaders) {
 		t.Fatalf("headers = %#v, want %#v", headers, wantHeaders)
 	}
@@ -65,16 +67,25 @@ func TestAgeRatingAuditResultRows(t *testing.T) {
 	if got := rows[0][2]; got != "READY_FOR_DISTRIBUTION" {
 		t.Fatalf("state column = %q, want READY_FOR_DISTRIBUTION", got)
 	}
+	if got := rows[0][7]; got != "true" {
+		t.Fatalf("user-generated content column = %q, want true", got)
+	}
 	if got := rows[0][8]; got != "true" {
+		t.Fatalf("age assurance column = %q, want true", got)
+	}
+	if got := rows[0][9]; got != "true" {
 		t.Fatalf("ready column = %q, want true", got)
 	}
-	if got := rows[0][9]; got != "" {
+	if got := rows[0][10]; got != "" {
 		t.Fatalf("ready missing column = %q, want empty", got)
 	}
-	if got := rows[1][8]; got != "false" {
+	if got := rows[1][9]; got != "false" {
 		t.Fatalf("error ready column = %q, want false", got)
 	}
-	if got := rows[1][9]; got != "error: request failed" {
+	if got := rows[1][7]; got != "-" {
+		t.Fatalf("error user-generated content column = %q, want -", got)
+	}
+	if got := rows[1][10]; got != "error: request failed" {
 		t.Fatalf("error missing column = %q, want error detail", got)
 	}
 	ensureOutputRegistryPopulated()

--- a/internal/asc/output_age_rating_test.go
+++ b/internal/asc/output_age_rating_test.go
@@ -33,6 +33,8 @@ func TestAgeRatingAuditResultRows(t *testing.T) {
 		Apps: []AgeRatingAuditRow{
 			{
 				AppID:                    "app-1",
+				AppInfoID:                "info-1",
+				AppInfoState:             "READY_FOR_DISTRIBUTION",
 				Name:                     "Ready App",
 				SocialMedia:              "true",
 				SocialMediaAgeRestricted: "true",
@@ -50,23 +52,29 @@ func TestAgeRatingAuditResultRows(t *testing.T) {
 	}
 
 	headers, rows := ageRatingAuditResultRows(result)
-	wantHeaders := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
+	wantHeaders := []string{"App ID", "App Info ID", "State", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
 	if !reflect.DeepEqual(headers, wantHeaders) {
 		t.Fatalf("headers = %#v, want %#v", headers, wantHeaders)
 	}
 	if len(rows) != 2 {
 		t.Fatalf("rows = %#v, want 2 rows", rows)
 	}
-	if got := rows[0][6]; got != "true" {
+	if got := rows[0][1]; got != "info-1" {
+		t.Fatalf("app info column = %q, want info-1", got)
+	}
+	if got := rows[0][2]; got != "READY_FOR_DISTRIBUTION" {
+		t.Fatalf("state column = %q, want READY_FOR_DISTRIBUTION", got)
+	}
+	if got := rows[0][8]; got != "true" {
 		t.Fatalf("ready column = %q, want true", got)
 	}
-	if got := rows[0][7]; got != "" {
+	if got := rows[0][9]; got != "" {
 		t.Fatalf("ready missing column = %q, want empty", got)
 	}
-	if got := rows[1][6]; got != "false" {
+	if got := rows[1][8]; got != "false" {
 		t.Fatalf("error ready column = %q, want false", got)
 	}
-	if got := rows[1][7]; got != "error: request failed" {
+	if got := rows[1][9]; got != "error: request failed" {
 		t.Fatalf("error missing column = %q, want error detail", got)
 	}
 	ensureOutputRegistryPopulated()

--- a/internal/asc/output_age_rating_test.go
+++ b/internal/asc/output_age_rating_test.go
@@ -1,6 +1,7 @@
 package asc
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -24,5 +25,46 @@ func TestPrintTableAgeRatingIncludesSocialMediaFields(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected table output to contain %q, got %q", want, output)
 		}
+	}
+}
+
+func TestAgeRatingAuditResultRows(t *testing.T) {
+	result := &AgeRatingAuditResult{
+		Apps: []AgeRatingAuditRow{
+			{
+				AppID:                    "app-1",
+				Name:                     "Ready App",
+				SocialMedia:              "true",
+				SocialMediaAgeRestricted: "true",
+				MessagingAndChat:         "false",
+				AgeAssurance:             "true",
+				Ready:                    true,
+			},
+			{
+				AppID:            "app-2",
+				Name:             "Broken App",
+				MissingResponses: []string{"socialMedia", "messagingAndChat"},
+				Error:            "request failed",
+			},
+		},
+	}
+
+	headers, rows := ageRatingAuditResultRows(result)
+	wantHeaders := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Missing"}
+	if !reflect.DeepEqual(headers, wantHeaders) {
+		t.Fatalf("headers = %#v, want %#v", headers, wantHeaders)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %#v, want 2 rows", rows)
+	}
+	if got := rows[0][6]; got != "" {
+		t.Fatalf("ready missing column = %q, want empty", got)
+	}
+	if got := rows[1][6]; got != "error: request failed" {
+		t.Fatalf("error missing column = %q, want error detail", got)
+	}
+	ensureOutputRegistryPopulated()
+	if !isRegistryTypeRegistered(typeForPtr[AgeRatingAuditResult]()) {
+		t.Fatal("AgeRatingAuditResult is not registered with the output renderer")
 	}
 }

--- a/internal/asc/output_age_rating_test.go
+++ b/internal/asc/output_age_rating_test.go
@@ -50,17 +50,23 @@ func TestAgeRatingAuditResultRows(t *testing.T) {
 	}
 
 	headers, rows := ageRatingAuditResultRows(result)
-	wantHeaders := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Missing"}
+	wantHeaders := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Ready", "Missing"}
 	if !reflect.DeepEqual(headers, wantHeaders) {
 		t.Fatalf("headers = %#v, want %#v", headers, wantHeaders)
 	}
 	if len(rows) != 2 {
 		t.Fatalf("rows = %#v, want 2 rows", rows)
 	}
-	if got := rows[0][6]; got != "" {
+	if got := rows[0][6]; got != "true" {
+		t.Fatalf("ready column = %q, want true", got)
+	}
+	if got := rows[0][7]; got != "" {
 		t.Fatalf("ready missing column = %q, want empty", got)
 	}
-	if got := rows[1][6]; got != "error: request failed" {
+	if got := rows[1][6]; got != "false" {
+		t.Fatalf("error ready column = %q, want false", got)
+	}
+	if got := rows[1][7]; got != "error: request failed" {
 		t.Fatalf("error missing column = %q, want error detail", got)
 	}
 	ensureOutputRegistryPopulated()

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -179,6 +179,7 @@ func registerAllOutputRenderers() {
 	registerRowsWithSingleToListAdapter[BetaLicenseAgreementResponse, BetaLicenseAgreementsResponse](betaLicenseAgreementsRows)
 	registerRows(buildBetaNotificationRows)
 	registerRows(ageRatingDeclarationRows)
+	registerRows(ageRatingAuditResultRows)
 	registerRows(accessibilityDeclarationsRows)
 	registerRows(accessibilityDeclarationRows)
 	registerRows(appStoreReviewDetailRows)

--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -77,6 +77,7 @@ Examples:
 		Subcommands: []*ffcli.Command{
 			AgeRatingViewCommand(),
 			AgeRatingEditCommand(),
+			AgeRatingAuditCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp

--- a/internal/cli/agerating/age_rating.go
+++ b/internal/cli/agerating/age_rating.go
@@ -364,16 +364,9 @@ func fetchAgeRatingDeclaration(ctx context.Context, client *asc.Client, appID, a
 	case versionID != "":
 		return client.GetAgeRatingDeclarationForAppStoreVersion(ctx, versionID, opts...)
 	default:
-		appInfos, err := client.GetAppInfos(ctx, appID)
+		appInfoID, err := client.ResolveCurrentAppInfoIDForApp(ctx, appID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get app info: %w", err)
-		}
-		if len(appInfos.Data) == 0 {
-			return nil, fmt.Errorf("no app info found for app %s", appID)
-		}
-		appInfoID := appInfos.Data[0].ID
-		if strings.TrimSpace(appInfoID) == "" {
-			return nil, fmt.Errorf("app info id is empty for app %s", appID)
+			return nil, fmt.Errorf("failed to resolve current app info: %w", err)
 		}
 		return client.GetAgeRatingDeclarationForAppInfo(ctx, appInfoID, opts...)
 	}

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -1,0 +1,289 @@
+package agerating
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const ageRatingAuditWorkers = 5
+
+// AgeRatingAuditRow reports one app's social-media capability responses.
+type AgeRatingAuditRow struct {
+	AppID                    string   `json:"appId"`
+	Name                     string   `json:"name,omitempty"`
+	BundleID                 string   `json:"bundleId,omitempty"`
+	SocialMedia              string   `json:"socialMedia"`
+	SocialMediaAgeRestricted string   `json:"socialMediaAgeRestricted"`
+	MessagingAndChat         string   `json:"messagingAndChat"`
+	AgeAssurance             string   `json:"ageAssurance"`
+	MissingResponses         []string `json:"missingResponses"`
+	Ready                    bool     `json:"ready"`
+	Error                    string   `json:"error,omitempty"`
+}
+
+// AgeRatingAuditResult summarizes social-media capability readiness per app.
+type AgeRatingAuditResult struct {
+	Apps         []AgeRatingAuditRow `json:"apps"`
+	ReadyCount   int                 `json:"readyCount"`
+	MissingCount int                 `json:"missingCount"`
+	ErrorCount   int                 `json:"errorCount"`
+}
+
+// AgeRatingAuditCommand returns the age-rating audit subcommand.
+func AgeRatingAuditCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("age-rating audit", flag.ExitOnError)
+
+	appIDs := shared.BindOnceCSVFlag(fs, "app", "Restrict the audit to specific app IDs (comma-separated; default: every app)")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "audit",
+		ShortUsage: "asc age-rating audit [--app \"APP_ID,APP_ID\"] [flags]",
+		ShortHelp:  "Audit social-media age rating responses across apps.",
+		LongHelp: `Audit social-media age rating responses across apps.
+
+Starting September 2026, Apple requires responses to the social-media
+capability questions in the age rating questionnaire for every new submission
+and app update. This command sweeps apps and reports which declarations still
+have unset responses.
+
+A response counts as missing when:
+  - socialMedia is unset
+  - messagingAndChat is unset
+  - socialMediaAgeRestricted is unset while socialMedia is true
+
+ageAssurance is reported for context but only matters when declaring
+socialMediaAgeRestricted true; use "asc age-rating edit" to fill gaps.
+
+Examples:
+  asc age-rating audit
+  asc age-rating audit --app "123456789,987654321"
+  asc age-rating audit --output table`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("age-rating audit does not accept positional arguments")
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("age-rating audit: %w", err)
+			}
+
+			only := []string{}
+			for _, id := range strings.Split(appIDs.String(), ",") {
+				if trimmed := strings.TrimSpace(id); trimmed != "" {
+					only = append(only, trimmed)
+				}
+			}
+			apps, err := auditTargetApps(ctx, client, only)
+			if err != nil {
+				return fmt.Errorf("age-rating audit: %w", err)
+			}
+			if len(apps) == 0 {
+				return fmt.Errorf("age-rating audit: no apps matched")
+			}
+
+			rows := auditDeclarations(ctx, client, apps)
+
+			result := AgeRatingAuditResult{Apps: rows}
+			for _, row := range rows {
+				switch {
+				case row.Error != "":
+					result.ErrorCount++
+				case row.Ready:
+					result.ReadyCount++
+				default:
+					result.MissingCount++
+				}
+			}
+
+			if result.MissingCount > 0 {
+				fmt.Fprintf(
+					os.Stderr,
+					"%d of %d apps are missing social-media age rating responses; Apple requires them for new submissions and updates starting September 2026.\n",
+					result.MissingCount,
+					len(rows),
+				)
+			} else if result.ErrorCount == 0 {
+				fmt.Fprintf(os.Stderr, "All %d apps have the social-media age rating responses set.\n", len(rows))
+			}
+
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error {
+					renderAgeRatingAuditResult(result, false)
+					return nil
+				},
+				func() error {
+					renderAgeRatingAuditResult(result, true)
+					return nil
+				},
+			)
+		},
+	}
+}
+
+type auditApp struct {
+	id       string
+	name     string
+	bundleID string
+}
+
+func auditTargetApps(ctx context.Context, client *asc.Client, only []string) ([]auditApp, error) {
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+
+	wanted := map[string]bool{}
+	for _, id := range only {
+		wanted[strings.TrimSpace(id)] = true
+	}
+
+	apps := []auditApp{}
+	next := ""
+	for {
+		opts := []asc.AppsOption{asc.WithAppsLimit(200)}
+		if next != "" {
+			opts = append(opts, asc.WithAppsNextURL(next))
+		}
+		resp, err := client.GetApps(requestCtx, opts...)
+		if err != nil {
+			return nil, err
+		}
+		for _, app := range resp.Data {
+			if len(wanted) > 0 && !wanted[app.ID] {
+				continue
+			}
+			apps = append(apps, auditApp{id: app.ID, name: app.Attributes.Name, bundleID: app.Attributes.BundleID})
+		}
+		next = strings.TrimSpace(resp.Links.Next)
+		if next == "" {
+			break
+		}
+	}
+
+	for id := range wanted {
+		if id == "" {
+			continue
+		}
+		found := false
+		for _, app := range apps {
+			if app.id == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			apps = append(apps, auditApp{id: id})
+		}
+	}
+	return apps, nil
+}
+
+func auditDeclarations(ctx context.Context, client *asc.Client, apps []auditApp) []AgeRatingAuditRow {
+	rows := make([]AgeRatingAuditRow, len(apps))
+	jobs := make(chan int)
+
+	var workers sync.WaitGroup
+	workerCount := min(ageRatingAuditWorkers, len(apps))
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				rows[index] = auditDeclaration(ctx, client, apps[index])
+			}
+		}()
+	}
+	for index := range apps {
+		jobs <- index
+	}
+	close(jobs)
+	workers.Wait()
+	return rows
+}
+
+func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) AgeRatingAuditRow {
+	row := AgeRatingAuditRow{
+		AppID:            app.id,
+		Name:             app.name,
+		BundleID:         app.bundleID,
+		MissingResponses: []string{},
+	}
+
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+
+	resp, err := fetchAgeRatingDeclaration(requestCtx, client, app.id, "", "", nil)
+	if err != nil {
+		row.Error = err.Error()
+		row.SocialMedia = "-"
+		row.SocialMediaAgeRestricted = "-"
+		row.MessagingAndChat = "-"
+		row.AgeAssurance = "-"
+		return row
+	}
+
+	attrs := resp.Data.Attributes
+	socialMedia := nullableBoolValue(attrs.SocialMedia)
+	row.SocialMedia = auditBoolStatus(socialMedia)
+	row.SocialMediaAgeRestricted = auditBoolStatus(nullableBoolValue(attrs.SocialMediaAgeRestricted))
+	row.MessagingAndChat = auditBoolStatus(attrs.MessagingAndChat)
+	row.AgeAssurance = auditBoolStatus(attrs.AgeAssurance)
+
+	if socialMedia == nil {
+		row.MissingResponses = append(row.MissingResponses, "socialMedia")
+	}
+	if attrs.MessagingAndChat == nil {
+		row.MissingResponses = append(row.MissingResponses, "messagingAndChat")
+	}
+	if boolIsTrue(socialMedia) && nullableBoolValue(attrs.SocialMediaAgeRestricted) == nil {
+		row.MissingResponses = append(row.MissingResponses, "socialMediaAgeRestricted")
+	}
+	row.Ready = len(row.MissingResponses) == 0
+	return row
+}
+
+func auditBoolStatus(value *bool) string {
+	if value == nil {
+		return "UNSET"
+	}
+	return fmt.Sprintf("%t", *value)
+}
+
+func renderAgeRatingAuditResult(result AgeRatingAuditResult, markdown bool) {
+	headers := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Missing"}
+	rows := make([][]string, 0, len(result.Apps))
+	for _, row := range result.Apps {
+		missing := strings.Join(row.MissingResponses, ", ")
+		if row.Error != "" {
+			missing = "error: " + row.Error
+		}
+		rows = append(rows, []string{
+			row.AppID,
+			row.Name,
+			row.SocialMedia,
+			row.SocialMediaAgeRestricted,
+			row.MessagingAndChat,
+			row.AgeAssurance,
+			missing,
+		})
+	}
+	if markdown {
+		asc.RenderMarkdown(headers, rows)
+		return
+	}
+	asc.RenderTable(headers, rows)
+}

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -35,14 +35,15 @@ This command is experimental.
 Starting September 2026, Apple requires responses to the social-media
 capability questions in the age rating questionnaire for every new submission
 and app update. By default, this command audits the first app page (up to 200
-apps). Pass --paginate to audit every app page, or --app to audit specific IDs.
+apps). Every active AppInfo for each app is audited. Pass --paginate to audit
+every app page, or --app to audit specific IDs.
 
 A response counts as missing when:
   - socialMedia is unset, or false while socialMediaAgeRestricted is true
   - messagingAndChat is unset
   - socialMediaAgeRestricted is unset while socialMedia is true
   - ageAssurance is unset or false while socialMediaAgeRestricted is true
-  - userGeneratedContent is false while socialMedia or socialMediaAgeRestricted is true
+  - userGeneratedContent is unset or false while socialMedia or socialMediaAgeRestricted is true
 
 Use "asc age-rating edit" to fill gaps.
 
@@ -96,12 +97,12 @@ Examples:
 			if result.MissingCount > 0 {
 				fmt.Fprintf(
 					os.Stderr,
-					"%d of %d apps are missing social-media age rating responses; Apple requires them for new submissions and updates starting September 2026.\n",
+					"%d of %d active app info records are missing social-media age rating responses; Apple requires them for new submissions and updates starting September 2026.\n",
 					result.MissingCount,
 					len(rows),
 				)
 			} else if result.ErrorCount == 0 {
-				fmt.Fprintf(os.Stderr, "All %d apps have the social-media age rating responses set.\n", len(rows))
+				fmt.Fprintf(os.Stderr, "All %d active app info records have the social-media age rating responses set.\n", len(rows))
 			}
 			if len(only) == 0 && moreApps {
 				fmt.Fprintln(os.Stderr, "Warning: more apps exist; use --paginate to audit every app.")
@@ -111,11 +112,11 @@ Examples:
 				return err
 			}
 			if result.ErrorCount > 0 {
-				noun := "apps"
+				noun := "app info records"
 				if result.ErrorCount == 1 {
-					noun = "app"
+					noun = "app info record"
 				}
-				err := fmt.Errorf("age-rating audit: %d %s could not be audited; see per-app errors in the output", result.ErrorCount, noun)
+				err := fmt.Errorf("age-rating audit: %d %s could not be audited; see row errors in the output", result.ErrorCount, noun)
 				fmt.Fprintln(os.Stderr, err)
 				return shared.NewReportedError(err)
 			}
@@ -178,7 +179,7 @@ func auditTargetApps(ctx context.Context, client *asc.Client, only []string, pag
 }
 
 func auditDeclarations(ctx context.Context, client *asc.Client, apps []auditApp) []asc.AgeRatingAuditRow {
-	rows := make([]asc.AgeRatingAuditRow, len(apps))
+	rowsByApp := make([][]asc.AgeRatingAuditRow, len(apps))
 	jobs := make(chan int)
 
 	var workers sync.WaitGroup
@@ -188,7 +189,7 @@ func auditDeclarations(ctx context.Context, client *asc.Client, apps []auditApp)
 		go func() {
 			defer workers.Done()
 			for index := range jobs {
-				rows[index] = auditDeclaration(ctx, client, apps[index])
+				rowsByApp[index] = auditAppDeclarations(ctx, client, apps[index])
 			}
 		}()
 	}
@@ -197,12 +198,45 @@ func auditDeclarations(ctx context.Context, client *asc.Client, apps []auditApp)
 	}
 	close(jobs)
 	workers.Wait()
+
+	rows := make([]asc.AgeRatingAuditRow, 0, len(apps))
+	for _, appRows := range rowsByApp {
+		rows = append(rows, appRows...)
+	}
 	return rows
 }
 
-func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) asc.AgeRatingAuditRow {
+func auditAppDeclarations(ctx context.Context, client *asc.Client, app auditApp) []asc.AgeRatingAuditRow {
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	candidates, err := client.ListAppInfoCandidatesForApp(requestCtx, app.id)
+	cancel()
+	if err != nil {
+		return []asc.AgeRatingAuditRow{newAgeRatingAuditErrorRow(app, asc.AppInfoCandidate{}, err)}
+	}
+
+	current := asc.CurrentAppInfoCandidates(candidates)
+	if len(current) == 0 {
+		err := fmt.Errorf(
+			"no current app info found for app %q (%s); run `asc apps info list --app %q` to inspect candidates",
+			app.id,
+			asc.FormatAppInfoCandidates(candidates),
+			app.id,
+		)
+		return []asc.AgeRatingAuditRow{newAgeRatingAuditErrorRow(app, asc.AppInfoCandidate{}, err)}
+	}
+
+	rows := make([]asc.AgeRatingAuditRow, 0, len(current))
+	for _, candidate := range current {
+		rows = append(rows, auditDeclaration(ctx, client, app, candidate))
+	}
+	return rows
+}
+
+func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp, appInfo asc.AppInfoCandidate) asc.AgeRatingAuditRow {
 	row := asc.AgeRatingAuditRow{
 		AppID:            app.id,
+		AppInfoID:        appInfo.ID,
+		AppInfoState:     appInfo.State,
 		Name:             app.name,
 		BundleID:         app.bundleID,
 		MissingResponses: []string{},
@@ -211,14 +245,9 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) asc
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
-	resp, err := fetchAgeRatingDeclaration(requestCtx, client, app.id, "", "", nil)
+	resp, err := fetchAgeRatingDeclaration(requestCtx, client, "", appInfo.ID, "", nil)
 	if err != nil {
-		row.Error = err.Error()
-		row.SocialMedia = "-"
-		row.SocialMediaAgeRestricted = "-"
-		row.MessagingAndChat = "-"
-		row.AgeAssurance = "-"
-		return row
+		return newAgeRatingAuditErrorRow(app, appInfo, err)
 	}
 
 	attrs := resp.Data.Attributes
@@ -249,6 +278,22 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) asc
 	}
 	row.Ready = len(row.MissingResponses) == 0
 	return row
+}
+
+func newAgeRatingAuditErrorRow(app auditApp, appInfo asc.AppInfoCandidate, err error) asc.AgeRatingAuditRow {
+	return asc.AgeRatingAuditRow{
+		AppID:                    app.id,
+		AppInfoID:                appInfo.ID,
+		AppInfoState:             appInfo.State,
+		Name:                     app.name,
+		BundleID:                 app.bundleID,
+		SocialMedia:              "-",
+		SocialMediaAgeRestricted: "-",
+		MessagingAndChat:         "-",
+		AgeAssurance:             "-",
+		MissingResponses:         []string{},
+		Error:                    err.Error(),
+	}
 }
 
 func auditBoolStatus(value *bool) string {

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -20,7 +20,7 @@ const ageRatingAuditWorkers = 5
 func AgeRatingAuditCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("age-rating audit", flag.ExitOnError)
 
-	appIDs := shared.BindOnceCSVFlag(fs, "app", "Restrict the audit to specific app IDs (comma-separated)")
+	appIDs := shared.BindOnceCSVFlag(fs, "app", "[experimental] Restrict the audit to specific app IDs (comma-separated)")
 	paginate := fs.Bool("paginate", false, "[experimental] Fetch all app pages (default: first page only)")
 	output := shared.BindOutputFlags(fs)
 

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -241,7 +241,7 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) asc
 	if boolIsTrue(socialMediaAgeRestricted) && boolIsFalse(socialMedia) {
 		row.MissingResponses = append(row.MissingResponses, "socialMedia")
 	}
-	if (boolIsTrue(socialMedia) || boolIsTrue(socialMediaAgeRestricted)) && boolIsFalse(attrs.UserGeneratedContent) {
+	if (boolIsTrue(socialMedia) || boolIsTrue(socialMediaAgeRestricted)) && !boolIsTrue(attrs.UserGeneratedContent) {
 		row.MissingResponses = append(row.MissingResponses, "userGeneratedContent")
 	}
 	if boolIsTrue(socialMediaAgeRestricted) && !boolIsTrue(attrs.AgeAssurance) {

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -142,6 +142,8 @@ func auditTargetApps(ctx context.Context, client *asc.Client, only []string, pag
 
 	apps := []auditApp{}
 	next := ""
+	seenNext := map[string]struct{}{}
+	page := 1
 	for {
 		opts := []asc.AppsOption{asc.WithAppsLimit(200)}
 		if next != "" {
@@ -161,6 +163,11 @@ func auditTargetApps(ctx context.Context, client *asc.Client, only []string, pag
 		if next == "" || !paginate {
 			break
 		}
+		if _, seen := seenNext[next]; seen {
+			return nil, false, fmt.Errorf("page %d: %w", page+1, asc.ErrRepeatedPaginationURL)
+		}
+		seenNext[next] = struct{}{}
+		page++
 	}
 
 	for _, id := range only {
@@ -256,6 +263,7 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp, app
 	row.SocialMedia = auditBoolStatus(socialMedia)
 	row.SocialMediaAgeRestricted = auditBoolStatus(socialMediaAgeRestricted)
 	row.MessagingAndChat = auditBoolStatus(attrs.MessagingAndChat)
+	row.UserGeneratedContent = auditBoolStatus(attrs.UserGeneratedContent)
 	row.AgeAssurance = auditBoolStatus(attrs.AgeAssurance)
 
 	if socialMedia == nil {
@@ -290,6 +298,7 @@ func newAgeRatingAuditErrorRow(app auditApp, appInfo asc.AppInfoCandidate, err e
 		SocialMedia:              "-",
 		SocialMediaAgeRestricted: "-",
 		MessagingAndChat:         "-",
+		UserGeneratedContent:     "-",
 		AgeAssurance:             "-",
 		MissingResponses:         []string{},
 		Error:                    err.Error(),

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -21,7 +21,7 @@ func AgeRatingAuditCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("age-rating audit", flag.ExitOnError)
 
 	appIDs := shared.BindOnceCSVFlag(fs, "app", "Restrict the audit to specific app IDs (comma-separated)")
-	paginate := fs.Bool("paginate", false, "Fetch all app pages (default: first page only)")
+	paginate := fs.Bool("paginate", false, "[experimental] Fetch all app pages (default: first page only)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -38,7 +38,7 @@ and app update. By default, this command audits the first app page (up to 200
 apps). Pass --paginate to audit every app page, or --app to audit specific IDs.
 
 A response counts as missing when:
-  - socialMedia is unset
+  - socialMedia is unset, or false while socialMediaAgeRestricted is true
   - messagingAndChat is unset
   - socialMediaAgeRestricted is unset while socialMedia is true
   - ageAssurance is unset or false while socialMediaAgeRestricted is true
@@ -106,7 +106,19 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Warning: more apps exist; use --paginate to audit every app.")
 			}
 
-			return shared.PrintOutput(&result, *output.Output, *output.Pretty)
+			if err := shared.PrintOutput(&result, *output.Output, *output.Pretty); err != nil {
+				return err
+			}
+			if result.ErrorCount > 0 {
+				noun := "apps"
+				if result.ErrorCount == 1 {
+					noun = "app"
+				}
+				err := fmt.Errorf("age-rating audit: %d %s could not be audited; see per-app errors in the output", result.ErrorCount, noun)
+				fmt.Fprintln(os.Stderr, err)
+				return shared.NewReportedError(err)
+			}
+			return nil
 		},
 	}
 }
@@ -224,6 +236,9 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) asc
 	}
 	if boolIsTrue(socialMedia) && socialMediaAgeRestricted == nil {
 		row.MissingResponses = append(row.MissingResponses, "socialMediaAgeRestricted")
+	}
+	if boolIsTrue(socialMediaAgeRestricted) && boolIsFalse(socialMedia) {
+		row.MissingResponses = append(row.MissingResponses, "socialMedia")
 	}
 	if boolIsTrue(socialMediaAgeRestricted) && !boolIsTrue(attrs.AgeAssurance) {
 		row.MissingResponses = append(row.MissingResponses, "ageAssurance")

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -16,56 +16,38 @@ import (
 
 const ageRatingAuditWorkers = 5
 
-// AgeRatingAuditRow reports one app's social-media capability responses.
-type AgeRatingAuditRow struct {
-	AppID                    string   `json:"appId"`
-	Name                     string   `json:"name,omitempty"`
-	BundleID                 string   `json:"bundleId,omitempty"`
-	SocialMedia              string   `json:"socialMedia"`
-	SocialMediaAgeRestricted string   `json:"socialMediaAgeRestricted"`
-	MessagingAndChat         string   `json:"messagingAndChat"`
-	AgeAssurance             string   `json:"ageAssurance"`
-	MissingResponses         []string `json:"missingResponses"`
-	Ready                    bool     `json:"ready"`
-	Error                    string   `json:"error,omitempty"`
-}
-
-// AgeRatingAuditResult summarizes social-media capability readiness per app.
-type AgeRatingAuditResult struct {
-	Apps         []AgeRatingAuditRow `json:"apps"`
-	ReadyCount   int                 `json:"readyCount"`
-	MissingCount int                 `json:"missingCount"`
-	ErrorCount   int                 `json:"errorCount"`
-}
-
 // AgeRatingAuditCommand returns the age-rating audit subcommand.
 func AgeRatingAuditCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("age-rating audit", flag.ExitOnError)
 
-	appIDs := shared.BindOnceCSVFlag(fs, "app", "Restrict the audit to specific app IDs (comma-separated; default: every app)")
+	appIDs := shared.BindOnceCSVFlag(fs, "app", "Restrict the audit to specific app IDs (comma-separated)")
+	paginate := fs.Bool("paginate", false, "Fetch all app pages (default: first page only)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "audit",
-		ShortUsage: "asc age-rating audit [--app \"APP_ID,APP_ID\"] [flags]",
-		ShortHelp:  "Audit social-media age rating responses across apps.",
-		LongHelp: `Audit social-media age rating responses across apps.
+		ShortUsage: "asc age-rating audit [--app \"APP_ID,APP_ID\"] [--paginate] [flags]",
+		ShortHelp:  "[experimental] Audit social-media age rating responses across apps.",
+		LongHelp: `[experimental] Audit social-media age rating responses across apps.
+
+This command is experimental.
 
 Starting September 2026, Apple requires responses to the social-media
 capability questions in the age rating questionnaire for every new submission
-and app update. This command sweeps apps and reports which declarations still
-have unset responses.
+and app update. By default, this command audits the first app page (up to 200
+apps). Pass --paginate to audit every app page, or --app to audit specific IDs.
 
 A response counts as missing when:
   - socialMedia is unset
   - messagingAndChat is unset
   - socialMediaAgeRestricted is unset while socialMedia is true
+  - ageAssurance is unset or false while socialMediaAgeRestricted is true
 
-ageAssurance is reported for context but only matters when declaring
-socialMediaAgeRestricted true; use "asc age-rating edit" to fill gaps.
+Use "asc age-rating edit" to fill gaps.
 
 Examples:
   asc age-rating audit
+  asc age-rating audit --paginate
   asc age-rating audit --app "123456789,987654321"
   asc age-rating audit --output table`,
 		FlagSet:   fs,
@@ -75,18 +57,20 @@ Examples:
 				return shared.UsageError("age-rating audit does not accept positional arguments")
 			}
 
+			appProvided := false
+			fs.Visit(func(parsed *flag.Flag) {
+				appProvided = appProvided || parsed.Name == "app"
+			})
+			only := shared.SplitUniqueCSV(appIDs.String())
+			if appProvided && len(only) == 0 {
+				return shared.UsageError("--app must include at least one app ID")
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("age-rating audit: %w", err)
 			}
-
-			only := []string{}
-			for _, id := range strings.Split(appIDs.String(), ",") {
-				if trimmed := strings.TrimSpace(id); trimmed != "" {
-					only = append(only, trimmed)
-				}
-			}
-			apps, err := auditTargetApps(ctx, client, only)
+			apps, moreApps, err := auditTargetApps(ctx, client, only, *paginate)
 			if err != nil {
 				return fmt.Errorf("age-rating audit: %w", err)
 			}
@@ -96,7 +80,7 @@ Examples:
 
 			rows := auditDeclarations(ctx, client, apps)
 
-			result := AgeRatingAuditResult{Apps: rows}
+			result := asc.AgeRatingAuditResult{Apps: rows}
 			for _, row := range rows {
 				switch {
 				case row.Error != "":
@@ -118,20 +102,11 @@ Examples:
 			} else if result.ErrorCount == 0 {
 				fmt.Fprintf(os.Stderr, "All %d apps have the social-media age rating responses set.\n", len(rows))
 			}
+			if len(only) == 0 && moreApps {
+				fmt.Fprintln(os.Stderr, "Warning: more apps exist; use --paginate to audit every app.")
+			}
 
-			return shared.PrintOutputWithRenderers(
-				result,
-				*output.Output,
-				*output.Pretty,
-				func() error {
-					renderAgeRatingAuditResult(result, false)
-					return nil
-				},
-				func() error {
-					renderAgeRatingAuditResult(result, true)
-					return nil
-				},
-			)
+			return shared.PrintOutput(&result, *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -142,7 +117,7 @@ type auditApp struct {
 	bundleID string
 }
 
-func auditTargetApps(ctx context.Context, client *asc.Client, only []string) ([]auditApp, error) {
+func auditTargetApps(ctx context.Context, client *asc.Client, only []string, paginate bool) ([]auditApp, bool, error) {
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
@@ -160,7 +135,7 @@ func auditTargetApps(ctx context.Context, client *asc.Client, only []string) ([]
 		}
 		resp, err := client.GetApps(requestCtx, opts...)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		for _, app := range resp.Data {
 			if len(wanted) > 0 && !wanted[app.ID] {
@@ -169,15 +144,12 @@ func auditTargetApps(ctx context.Context, client *asc.Client, only []string) ([]
 			apps = append(apps, auditApp{id: app.ID, name: app.Attributes.Name, bundleID: app.Attributes.BundleID})
 		}
 		next = strings.TrimSpace(resp.Links.Next)
-		if next == "" {
+		if next == "" || !paginate {
 			break
 		}
 	}
 
-	for id := range wanted {
-		if id == "" {
-			continue
-		}
+	for _, id := range only {
 		found := false
 		for _, app := range apps {
 			if app.id == id {
@@ -189,11 +161,11 @@ func auditTargetApps(ctx context.Context, client *asc.Client, only []string) ([]
 			apps = append(apps, auditApp{id: id})
 		}
 	}
-	return apps, nil
+	return apps, next != "", nil
 }
 
-func auditDeclarations(ctx context.Context, client *asc.Client, apps []auditApp) []AgeRatingAuditRow {
-	rows := make([]AgeRatingAuditRow, len(apps))
+func auditDeclarations(ctx context.Context, client *asc.Client, apps []auditApp) []asc.AgeRatingAuditRow {
+	rows := make([]asc.AgeRatingAuditRow, len(apps))
 	jobs := make(chan int)
 
 	var workers sync.WaitGroup
@@ -215,8 +187,8 @@ func auditDeclarations(ctx context.Context, client *asc.Client, apps []auditApp)
 	return rows
 }
 
-func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) AgeRatingAuditRow {
-	row := AgeRatingAuditRow{
+func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) asc.AgeRatingAuditRow {
+	row := asc.AgeRatingAuditRow{
 		AppID:            app.id,
 		Name:             app.name,
 		BundleID:         app.bundleID,
@@ -238,8 +210,9 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) Age
 
 	attrs := resp.Data.Attributes
 	socialMedia := nullableBoolValue(attrs.SocialMedia)
+	socialMediaAgeRestricted := nullableBoolValue(attrs.SocialMediaAgeRestricted)
 	row.SocialMedia = auditBoolStatus(socialMedia)
-	row.SocialMediaAgeRestricted = auditBoolStatus(nullableBoolValue(attrs.SocialMediaAgeRestricted))
+	row.SocialMediaAgeRestricted = auditBoolStatus(socialMediaAgeRestricted)
 	row.MessagingAndChat = auditBoolStatus(attrs.MessagingAndChat)
 	row.AgeAssurance = auditBoolStatus(attrs.AgeAssurance)
 
@@ -249,8 +222,11 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) Age
 	if attrs.MessagingAndChat == nil {
 		row.MissingResponses = append(row.MissingResponses, "messagingAndChat")
 	}
-	if boolIsTrue(socialMedia) && nullableBoolValue(attrs.SocialMediaAgeRestricted) == nil {
+	if boolIsTrue(socialMedia) && socialMediaAgeRestricted == nil {
 		row.MissingResponses = append(row.MissingResponses, "socialMediaAgeRestricted")
+	}
+	if boolIsTrue(socialMediaAgeRestricted) && !boolIsTrue(attrs.AgeAssurance) {
+		row.MissingResponses = append(row.MissingResponses, "ageAssurance")
 	}
 	row.Ready = len(row.MissingResponses) == 0
 	return row
@@ -261,29 +237,4 @@ func auditBoolStatus(value *bool) string {
 		return "UNSET"
 	}
 	return fmt.Sprintf("%t", *value)
-}
-
-func renderAgeRatingAuditResult(result AgeRatingAuditResult, markdown bool) {
-	headers := []string{"App ID", "Name", "Social Media", "Age Restricted", "Messaging & Chat", "Age Assurance", "Missing"}
-	rows := make([][]string, 0, len(result.Apps))
-	for _, row := range result.Apps {
-		missing := strings.Join(row.MissingResponses, ", ")
-		if row.Error != "" {
-			missing = "error: " + row.Error
-		}
-		rows = append(rows, []string{
-			row.AppID,
-			row.Name,
-			row.SocialMedia,
-			row.SocialMediaAgeRestricted,
-			row.MessagingAndChat,
-			row.AgeAssurance,
-			missing,
-		})
-	}
-	if markdown {
-		asc.RenderMarkdown(headers, rows)
-		return
-	}
-	asc.RenderTable(headers, rows)
 }

--- a/internal/cli/agerating/age_rating_audit.go
+++ b/internal/cli/agerating/age_rating_audit.go
@@ -42,6 +42,7 @@ A response counts as missing when:
   - messagingAndChat is unset
   - socialMediaAgeRestricted is unset while socialMedia is true
   - ageAssurance is unset or false while socialMediaAgeRestricted is true
+  - userGeneratedContent is false while socialMedia or socialMediaAgeRestricted is true
 
 Use "asc age-rating edit" to fill gaps.
 
@@ -239,6 +240,9 @@ func auditDeclaration(ctx context.Context, client *asc.Client, app auditApp) asc
 	}
 	if boolIsTrue(socialMediaAgeRestricted) && boolIsFalse(socialMedia) {
 		row.MissingResponses = append(row.MissingResponses, "socialMedia")
+	}
+	if (boolIsTrue(socialMedia) || boolIsTrue(socialMediaAgeRestricted)) && boolIsFalse(attrs.UserGeneratedContent) {
+		row.MissingResponses = append(row.MissingResponses, "userGeneratedContent")
 	}
 	if boolIsTrue(socialMediaAgeRestricted) && !boolIsTrue(attrs.AgeAssurance) {
 		row.MissingResponses = append(row.MissingResponses, "ageAssurance")

--- a/internal/cli/agerating/age_rating_test.go
+++ b/internal/cli/agerating/age_rating_test.go
@@ -42,13 +42,16 @@ func TestAgeRatingCommandShape(t *testing.T) {
 	}
 }
 
-func TestAgeRatingAuditPaginateFlagIsExperimental(t *testing.T) {
-	flag := AgeRatingAuditCommand().FlagSet.Lookup("paginate")
-	if flag == nil {
-		t.Fatal("expected --paginate flag")
-	}
-	if !strings.HasPrefix(flag.Usage, "[experimental] ") {
-		t.Fatalf("--paginate usage = %q, want [experimental] prefix", flag.Usage)
+func TestAgeRatingAuditFlagsAreExperimental(t *testing.T) {
+	cmd := AgeRatingAuditCommand()
+	for _, name := range []string{"app", "paginate"} {
+		flag := cmd.FlagSet.Lookup(name)
+		if flag == nil {
+			t.Fatalf("expected --%s flag", name)
+		}
+		if !strings.HasPrefix(flag.Usage, "[experimental] ") {
+			t.Fatalf("--%s usage = %q, want [experimental] prefix", name, flag.Usage)
+		}
 	}
 }
 

--- a/internal/cli/agerating/age_rating_test.go
+++ b/internal/cli/agerating/age_rating_test.go
@@ -42,6 +42,16 @@ func TestAgeRatingCommandShape(t *testing.T) {
 	}
 }
 
+func TestAgeRatingAuditPaginateFlagIsExperimental(t *testing.T) {
+	flag := AgeRatingAuditCommand().FlagSet.Lookup("paginate")
+	if flag == nil {
+		t.Fatal("expected --paginate flag")
+	}
+	if !strings.HasPrefix(flag.Usage, "[experimental] ") {
+		t.Fatalf("--paginate usage = %q, want [experimental] prefix", flag.Usage)
+	}
+}
+
 func TestAgeRatingValidationErrors(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 

--- a/internal/cli/agerating/age_rating_test.go
+++ b/internal/cli/agerating/age_rating_test.go
@@ -19,16 +19,17 @@ func TestAgeRatingCommandShape(t *testing.T) {
 	if cmd.Name != "age-rating" {
 		t.Fatalf("unexpected command name: %q", cmd.Name)
 	}
-	if len(cmd.Subcommands) != 2 {
-		t.Fatalf("expected 2 subcommands, got %d", len(cmd.Subcommands))
+	if len(cmd.Subcommands) != 3 {
+		t.Fatalf("expected 3 subcommands, got %d", len(cmd.Subcommands))
 	}
 	if got := AgeRatingCommand(); got == nil {
 		t.Fatal("expected Command wrapper to return command")
 	}
 	usage := cmd.UsageFunc(cmd)
 	for _, visible := range []string{
-		"\n  view  View an age rating declaration.",
-		"\n  edit  Update an age rating declaration.",
+		"\n  view   View an age rating declaration.",
+		"\n  edit   Update an age rating declaration.",
+		"\n  audit  [experimental] Audit social-media age rating responses across apps.",
 	} {
 		if !strings.Contains(usage, visible) {
 			t.Fatalf("expected age-rating help to include canonical verb %q, got %q", strings.TrimSpace(visible), usage)

--- a/internal/cli/cmdtest/age_rating_audit_test.go
+++ b/internal/cli/cmdtest/age_rating_audit_test.go
@@ -239,6 +239,67 @@ func TestAgeRatingAuditRejectsContradictoryRestrictedSocialMedia(t *testing.T) {
 	}
 }
 
+func TestAgeRatingAuditRequiresUserGeneratedContent(t *testing.T) {
+	tests := []struct {
+		name        string
+		attributes  string
+		wantMissing string
+	}{
+		{
+			name:        "social media",
+			attributes:  `"socialMedia":true,"socialMediaAgeRestricted":false,"messagingAndChat":true,"ageAssurance":false,"userGeneratedContent":false`,
+			wantMissing: "userGeneratedContent",
+		},
+		{
+			name:        "age-restricted social media",
+			attributes:  `"socialMedia":false,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":true,"userGeneratedContent":false`,
+			wantMissing: "socialMedia,userGeneratedContent",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+			installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/v1/apps":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1"}],"links":{}}`), nil
+				case "/v1/apps/app-1/appInfos":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`), nil
+				case "/v1/appInfos/info-1/ageRatingDeclaration":
+					return jsonHTTPResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{%s}}}`, test.attributes)), nil
+				default:
+					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+			}))
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, _ := captureOutput(t, func() {
+				if err := root.Parse([]string{"age-rating", "audit", "--output", "json"}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			var result struct {
+				Apps []struct {
+					MissingResponses []string `json:"missingResponses"`
+					Ready            bool     `json:"ready"`
+				} `json:"apps"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+			}
+			if len(result.Apps) != 1 || result.Apps[0].Ready || strings.Join(result.Apps[0].MissingResponses, ",") != test.wantMissing {
+				t.Fatalf("unexpected readiness result: %+v", result.Apps)
+			}
+		})
+	}
+}
+
 func TestAgeRatingAuditReturnsFailureAfterRenderingPerAppErrors(t *testing.T) {
 	setupAuth(t)
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/cli/cmdtest/age_rating_audit_test.go
+++ b/internal/cli/cmdtest/age_rating_audit_test.go
@@ -199,6 +199,81 @@ func TestAgeRatingAuditRequiresAgeAssuranceForRestrictedSocialMedia(t *testing.T
 	}
 }
 
+func TestAgeRatingAuditRejectsContradictoryRestrictedSocialMedia(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1"}],"links":{}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`), nil
+		case "/v1/appInfos/info-1/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":false,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":true}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"age-rating", "audit", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Apps []struct {
+			MissingResponses []string `json:"missingResponses"`
+			Ready            bool     `json:"ready"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Apps) != 1 || result.Apps[0].Ready || strings.Join(result.Apps[0].MissingResponses, ",") != "socialMedia" {
+		t.Fatalf("unexpected readiness result: %+v", result.Apps)
+	}
+}
+
+func TestAgeRatingAuditReturnsFailureAfterRenderingPerAppErrors(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1"}],"links":{}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusForbidden, `{"errors":[{"status":"403","title":"Forbidden"}]}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	}))
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := cmd.Run([]string{"age-rating", "audit", "--output", "json"}, "1.2.3"); code != cmd.ExitError {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitError)
+		}
+	})
+	var result struct {
+		Apps []struct {
+			Error string `json:"error"`
+		} `json:"apps"`
+		ErrorCount int `json:"errorCount"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Apps) != 1 || result.Apps[0].Error == "" || result.ErrorCount != 1 {
+		t.Fatalf("unexpected error result: %+v", result)
+	}
+	if !strings.Contains(stderr, "age-rating audit: 1 app could not be audited") {
+		t.Fatalf("stderr = %q, want partial-audit diagnostic", stderr)
+	}
+}
+
 func TestAgeRatingAuditRejectsExplicitEmptyApp(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_KEY_ID", "")

--- a/internal/cli/cmdtest/age_rating_audit_test.go
+++ b/internal/cli/cmdtest/age_rating_audit_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
 func ageRatingAuditTransport() http.RoundTripper {
@@ -56,10 +58,11 @@ func TestAgeRatingAuditReportsMissingSocialMediaResponses(t *testing.T) {
 
 	var result struct {
 		Apps []struct {
-			AppID            string   `json:"appId"`
-			SocialMedia      string   `json:"socialMedia"`
-			MissingResponses []string `json:"missingResponses"`
-			Ready            bool     `json:"ready"`
+			AppID                string   `json:"appId"`
+			SocialMedia          string   `json:"socialMedia"`
+			UserGeneratedContent string   `json:"userGeneratedContent"`
+			MissingResponses     []string `json:"missingResponses"`
+			Ready                bool     `json:"ready"`
 		} `json:"apps"`
 		ReadyCount   int `json:"readyCount"`
 		MissingCount int `json:"missingCount"`
@@ -72,8 +75,16 @@ func TestAgeRatingAuditReportsMissingSocialMediaResponses(t *testing.T) {
 		t.Fatalf("counts = ready %d missing %d error %d, want 1/2/0", result.ReadyCount, result.MissingCount, result.ErrorCount)
 	}
 	rows := map[string][]string{}
+	userGeneratedContent := map[string]string{}
 	for _, row := range result.Apps {
 		rows[row.AppID] = row.MissingResponses
+		userGeneratedContent[row.AppID] = row.UserGeneratedContent
+	}
+	if got := userGeneratedContent["app-social"]; got != "true" {
+		t.Fatalf("app-social user-generated content = %q, want true", got)
+	}
+	if got := userGeneratedContent["app-unset"]; got != "UNSET" {
+		t.Fatalf("app-unset user-generated content = %q, want UNSET", got)
 	}
 	if len(rows["app-ready"]) != 0 {
 		t.Fatalf("app-ready missing = %v, want none", rows["app-ready"])
@@ -479,5 +490,38 @@ func TestAgeRatingAuditPaginationIsExplicit(t *testing.T) {
 				t.Fatalf("stderr = %q, want pagination warning", stderr)
 			}
 		})
+	}
+}
+
+func TestAgeRatingAuditRejectsRepeatedAppPaginationURL(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_TIMEOUT", "100ms")
+	t.Setenv("ASC_TIMEOUT_SECONDS", "")
+	requests := 0
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps" {
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		requests++
+		if requests > 2 {
+			return nil, fmt.Errorf("pagination loop escaped repeated-link guard")
+		}
+		if req.URL.Query().Get("cursor") == "repeat" {
+			return jsonHTTPResponse(http.StatusOK, `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps?cursor=repeat"}}`), nil
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps?cursor=repeat"}}`), nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"age-rating", "audit", "--paginate", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if !errors.Is(err, asc.ErrRepeatedPaginationURL) {
+		t.Fatalf("run error = %v, want ErrRepeatedPaginationURL", err)
+	}
+	if requests != 2 {
+		t.Fatalf("app requests = %d, want 2 before rejecting repeated link", requests)
 	}
 }

--- a/internal/cli/cmdtest/age_rating_audit_test.go
+++ b/internal/cli/cmdtest/age_rating_audit_test.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func ageRatingAuditTransport() http.RoundTripper {
@@ -114,5 +117,169 @@ func TestAgeRatingAuditAppFilterRestrictsSweep(t *testing.T) {
 	}
 	if len(result.Apps) != 1 || result.Apps[0].AppID != "app-social" || result.Apps[0].Name != "Social App" {
 		t.Fatalf("unexpected filtered rows: %+v", result.Apps)
+	}
+}
+
+func TestAgeRatingAuditSelectsCurrentAppInfo(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1","attributes":{"name":"Current App"}}],"links":{}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-old","attributes":{"state":"REPLACED_WITH_NEW_INFO"}},{"type":"appInfos","id":"info-current","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`), nil
+		case "/v1/appInfos/info-current/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-current","attributes":{"socialMedia":false,"socialMediaAgeRestricted":false,"messagingAndChat":false,"ageAssurance":false}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"age-rating", "audit", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Apps []struct {
+			Ready bool `json:"ready"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Apps) != 1 || !result.Apps[0].Ready {
+		t.Fatalf("unexpected audit result: %+v", result.Apps)
+	}
+}
+
+func TestAgeRatingAuditRequiresAgeAssuranceForRestrictedSocialMedia(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1"}],"links":{}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`), nil
+		case "/v1/appInfos/info-1/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":true,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":false}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"age-rating", "audit", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Apps []struct {
+			MissingResponses []string `json:"missingResponses"`
+			Ready            bool     `json:"ready"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Apps) != 1 || result.Apps[0].Ready || strings.Join(result.Apps[0].MissingResponses, ",") != "ageAssurance" {
+		t.Fatalf("unexpected readiness result: %+v", result.Apps)
+	}
+}
+
+func TestAgeRatingAuditRejectsExplicitEmptyApp(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	}))
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := cmd.Run([]string{"age-rating", "audit", "--app", " , \t"}, "1.2.3"); code != cmd.ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, cmd.ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "--app must include at least one app ID") {
+		t.Fatalf("stderr = %q, want explicit empty --app error", stderr)
+	}
+}
+
+func TestAgeRatingAuditPaginationIsExplicit(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		args           []string
+		wantApps       int
+		wantSecondPage bool
+	}{
+		{name: "first page by default", args: []string{"age-rating", "audit", "--output", "json"}, wantApps: 1},
+		{name: "all pages when requested", args: []string{"age-rating", "audit", "--paginate", "--output", "json"}, wantApps: 2, wantSecondPage: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuth(t)
+			secondPage := false
+			installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.URL.Path == "/v1/apps" && req.URL.Query().Get("cursor") == "next":
+					secondPage = true
+					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-2"}],"links":{}}`), nil
+				case req.URL.Path == "/v1/apps":
+					return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/apps?cursor=next"}}`), nil
+				case strings.HasPrefix(req.URL.Path, "/v1/apps/") && strings.HasSuffix(req.URL.Path, "/appInfos"):
+					appID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/apps/"), "/appInfos")
+					return jsonHTTPResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appInfos","id":"info-%s","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`, appID)), nil
+				case strings.HasPrefix(req.URL.Path, "/v1/appInfos/") && strings.HasSuffix(req.URL.Path, "/ageRatingDeclaration"):
+					return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":false,"socialMediaAgeRestricted":false,"messagingAndChat":false,"ageAssurance":false}}}`), nil
+				default:
+					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+			}))
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(tt.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			var result struct {
+				Apps []json.RawMessage `json:"apps"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+			}
+			if len(result.Apps) != tt.wantApps {
+				t.Fatalf("app count = %d, want %d", len(result.Apps), tt.wantApps)
+			}
+			if secondPage != tt.wantSecondPage {
+				t.Fatalf("second page requested = %t, want %t", secondPage, tt.wantSecondPage)
+			}
+			if !tt.wantSecondPage && !strings.Contains(stderr, "use --paginate to audit every app") {
+				t.Fatalf("stderr = %q, want pagination warning", stderr)
+			}
+		})
 	}
 }

--- a/internal/cli/cmdtest/age_rating_audit_test.go
+++ b/internal/cli/cmdtest/age_rating_audit_test.go
@@ -159,6 +159,58 @@ func TestAgeRatingAuditSelectsCurrentAppInfo(t *testing.T) {
 	}
 }
 
+func TestAgeRatingAuditChecksEveryCurrentAppInfo(t *testing.T) {
+	setupAuth(t)
+	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"apps","id":"app-1","attributes":{"name":"Multi-platform App"}}],"links":{}}`), nil
+		case "/v1/apps/app-1/appInfos":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-ios","attributes":{"state":"READY_FOR_DISTRIBUTION"}},{"type":"appInfos","id":"info-mac","attributes":{"state":"PREPARE_FOR_SUBMISSION"}}],"links":{}}`), nil
+		case "/v1/appInfos/info-ios/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-ios","attributes":{"socialMedia":false,"socialMediaAgeRestricted":false,"messagingAndChat":false,"ageAssurance":false}}}`), nil
+		case "/v1/appInfos/info-mac/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-mac","attributes":{"socialMedia":true,"socialMediaAgeRestricted":false,"messagingAndChat":true,"ageAssurance":false,"userGeneratedContent":true}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"age-rating", "audit", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Apps []struct {
+			AppInfoID    string `json:"appInfoId"`
+			AppInfoState string `json:"appInfoState"`
+			Ready        bool   `json:"ready"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Apps) != 2 {
+		t.Fatalf("audit rows = %+v, want one row per current app info", result.Apps)
+	}
+	want := []struct {
+		id    string
+		state string
+	}{{"info-ios", "READY_FOR_DISTRIBUTION"}, {"info-mac", "PREPARE_FOR_SUBMISSION"}}
+	for i, row := range result.Apps {
+		if row.AppInfoID != want[i].id || row.AppInfoState != want[i].state || !row.Ready {
+			t.Fatalf("audit row %d = %+v, want app info %q in state %q and ready", i, row, want[i].id, want[i].state)
+		}
+	}
+}
+
 func TestAgeRatingAuditRequiresAgeAssuranceForRestrictedSocialMedia(t *testing.T) {
 	setupAuth(t)
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -310,7 +362,7 @@ func TestAgeRatingAuditRequiresUserGeneratedContent(t *testing.T) {
 	}
 }
 
-func TestAgeRatingAuditReturnsFailureAfterRenderingPerAppErrors(t *testing.T) {
+func TestAgeRatingAuditReturnsFailureAfterRenderingRowErrors(t *testing.T) {
 	setupAuth(t)
 	installDefaultTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
@@ -340,7 +392,7 @@ func TestAgeRatingAuditReturnsFailureAfterRenderingPerAppErrors(t *testing.T) {
 	if len(result.Apps) != 1 || result.Apps[0].Error == "" || result.ErrorCount != 1 {
 		t.Fatalf("unexpected error result: %+v", result)
 	}
-	if !strings.Contains(stderr, "age-rating audit: 1 app could not be audited") {
+	if !strings.Contains(stderr, "age-rating audit: 1 app info record could not be audited") {
 		t.Fatalf("stderr = %q, want partial-audit diagnostic", stderr)
 	}
 }

--- a/internal/cli/cmdtest/age_rating_audit_test.go
+++ b/internal/cli/cmdtest/age_rating_audit_test.go
@@ -28,7 +28,7 @@ func ageRatingAuditTransport() http.RoundTripper {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-app-ready/ageRatingDeclaration":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":false,"socialMediaAgeRestricted":false,"messagingAndChat":false,"ageAssurance":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-app-social/ageRatingDeclaration":
-			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-2","attributes":{"socialMedia":true,"messagingAndChat":true,"ageAssurance":true}}}`), nil
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-2","attributes":{"socialMedia":true,"messagingAndChat":true,"ageAssurance":true,"userGeneratedContent":true}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-app-unset/ageRatingDeclaration":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-3","attributes":{}}}`), nil
 		default:
@@ -168,7 +168,7 @@ func TestAgeRatingAuditRequiresAgeAssuranceForRestrictedSocialMedia(t *testing.T
 		case "/v1/apps/app-1/appInfos":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`), nil
 		case "/v1/appInfos/info-1/ageRatingDeclaration":
-			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":true,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":false}}}`), nil
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":true,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":false,"userGeneratedContent":true}}}`), nil
 		default:
 			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
@@ -208,7 +208,7 @@ func TestAgeRatingAuditRejectsContradictoryRestrictedSocialMedia(t *testing.T) {
 		case "/v1/apps/app-1/appInfos":
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"READY_FOR_DISTRIBUTION"}}],"links":{}}`), nil
 		case "/v1/appInfos/info-1/ageRatingDeclaration":
-			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":false,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":true}}}`), nil
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":false,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":true,"userGeneratedContent":true}}}`), nil
 		default:
 			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
@@ -253,6 +253,16 @@ func TestAgeRatingAuditRequiresUserGeneratedContent(t *testing.T) {
 		{
 			name:        "age-restricted social media",
 			attributes:  `"socialMedia":false,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":true,"userGeneratedContent":false`,
+			wantMissing: "socialMedia,userGeneratedContent",
+		},
+		{
+			name:        "social media with user-generated content unset",
+			attributes:  `"socialMedia":true,"socialMediaAgeRestricted":false,"messagingAndChat":true,"ageAssurance":false`,
+			wantMissing: "userGeneratedContent",
+		},
+		{
+			name:        "age-restricted social media with user-generated content unset",
+			attributes:  `"socialMedia":false,"socialMediaAgeRestricted":true,"messagingAndChat":true,"ageAssurance":true`,
 			wantMissing: "socialMedia,userGeneratedContent",
 		},
 	}

--- a/internal/cli/cmdtest/age_rating_audit_test.go
+++ b/internal/cli/cmdtest/age_rating_audit_test.go
@@ -1,0 +1,118 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func ageRatingAuditTransport() http.RoundTripper {
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[
+				{"type":"apps","id":"app-ready","attributes":{"name":"Ready App","bundleId":"com.example.ready"}},
+				{"type":"apps","id":"app-social","attributes":{"name":"Social App","bundleId":"com.example.social"}},
+				{"type":"apps","id":"app-unset","attributes":{"name":"Unset App","bundleId":"com.example.unset"}}
+			],"links":{}}`), nil
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v1/apps/") && strings.HasSuffix(req.URL.Path, "/appInfos"):
+			appID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/apps/"), "/appInfos")
+			return jsonHTTPResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appInfos","id":"info-%s"}],"links":{}}`, appID)), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-app-ready/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-1","attributes":{"socialMedia":false,"socialMediaAgeRestricted":false,"messagingAndChat":false,"ageAssurance":false}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-app-social/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-2","attributes":{"socialMedia":true,"messagingAndChat":true,"ageAssurance":true}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appInfos/info-app-unset/ageRatingDeclaration":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"decl-3","attributes":{}}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+}
+
+func TestAgeRatingAuditReportsMissingSocialMediaResponses(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = ageRatingAuditTransport()
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"age-rating", "audit", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Apps []struct {
+			AppID            string   `json:"appId"`
+			SocialMedia      string   `json:"socialMedia"`
+			MissingResponses []string `json:"missingResponses"`
+			Ready            bool     `json:"ready"`
+		} `json:"apps"`
+		ReadyCount   int `json:"readyCount"`
+		MissingCount int `json:"missingCount"`
+		ErrorCount   int `json:"errorCount"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if result.ReadyCount != 1 || result.MissingCount != 2 || result.ErrorCount != 0 {
+		t.Fatalf("counts = ready %d missing %d error %d, want 1/2/0", result.ReadyCount, result.MissingCount, result.ErrorCount)
+	}
+	rows := map[string][]string{}
+	for _, row := range result.Apps {
+		rows[row.AppID] = row.MissingResponses
+	}
+	if len(rows["app-ready"]) != 0 {
+		t.Fatalf("app-ready missing = %v, want none", rows["app-ready"])
+	}
+	if got := strings.Join(rows["app-social"], ","); got != "socialMediaAgeRestricted" {
+		t.Fatalf("app-social missing = %q, want socialMediaAgeRestricted", got)
+	}
+	if got := strings.Join(rows["app-unset"], ","); got != "socialMedia,messagingAndChat" {
+		t.Fatalf("app-unset missing = %q, want socialMedia,messagingAndChat", got)
+	}
+	if !strings.Contains(stderr, "September 2026") {
+		t.Fatalf("stderr missing deadline notice, got %q", stderr)
+	}
+}
+
+func TestAgeRatingAuditAppFilterRestrictsSweep(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = ageRatingAuditTransport()
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"age-rating", "audit", "--app", "app-social", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		Apps []struct {
+			AppID string `json:"appId"`
+			Name  string `json:"name"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (%q)", err, stdout)
+	}
+	if len(result.Apps) != 1 || result.Apps[0].AppID != "app-social" || result.Apps[0].Name != "Social App" {
+		t.Fatalf("unexpected filtered rows: %+v", result.Apps)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds experimental `asc age-rating audit` for September 2026 social-media questionnaire readiness.
- Audits the first app page by default, all app pages with experimental `--paginate`, or an explicit comma-separated subset with experimental `--app`.
- Discovers AppInfo records across every relationship page, excludes historical replacements, and audits every active record for multi-platform apps.
- Reports `socialMedia`, `messagingAndChat`, `socialMediaAgeRestricted`, and the conditional `ageAssurance` requirement.
- Returns registered table, Markdown, and camelCase JSON output with AppInfo IDs, states, per-record readiness, and ready, missing, and error totals.
- Renders all collected rows but exits nonzero when any AppInfo record could not be audited.

## Behavior
A row is not ready when:
- `socialMedia` is unset, or false while `socialMediaAgeRestricted` is true.
- `messagingAndChat` is unset.
- `socialMediaAgeRestricted` is unset while `socialMedia` is true.
- `ageAssurance` is unset or false while `socialMediaAgeRestricted` is true.
- `userGeneratedContent` is unset or false while either social-media capability is true.

Per-record fetch failures remain visible rows so one inaccessible declaration does not discard the rest of the account audit. The command prints a stderr summary and returns a failure exit code after rendering those rows. Explicitly empty `--app` values are usage errors.

## Verification
- Focused age-rating command, renderer, AppInfo-resolution, pagination, validation, readiness, and partial-failure tests.
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
