### PR TITLE
docs(cli): teach the discovery loop on the root help screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ generate-command-docs:
 .PHONY: check-command-docs
 check-command-docs:
 	@echo "$(BLUE)Checking command docs sync...$(NC)"
+	python3 ./scripts/test_generate_command_docs.py
 	python3 ./scripts/generate-command-docs.py --check
 	python3 ./scripts/check-commands-docs.py
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,23 @@ import (
 
 var versionRequested bool
 
+// rootGettingStartedSamples teaches the discovery loop on the first help
+// screen: find the right command, verify credentials, locate an app, then
+// inspect it. Every sample is a copy-paste-valid long-form invocation, and
+// placeholders stay bare uppercase so shells do not read them as redirection.
+const rootGettingStartedSamples = `  asc search "upload a build"    # find the right command (JSON, with examples)
+  asc auth doctor                # check credentials before the first API call
+  asc apps list --output table   # list your apps and their IDs
+  asc status --app APP_ID        # one-screen release overview for one app
+
+  Add --help to any command; replace placeholders like APP_ID with real values.`
+
+// rootLongHelp renders the GETTING STARTED block shown between USAGE and the
+// grouped command listing.
+func rootLongHelp() string {
+	return shared.Bold("GETTING STARTED") + "\n" + rootGettingStartedSamples
+}
+
 // RootCommand returns the root command
 func RootCommand(version string) *ffcli.Command {
 	catalog := registry.NewCatalog(version)
@@ -51,7 +68,7 @@ func newRootCommand(version string, subcommands []*ffcli.Command) *ffcli.Command
 		Name:        "asc",
 		ShortUsage:  "asc <subcommand> [flags]",
 		ShortHelp:   "asc is a fast, lightweight CLI for App Store Connect from Rork.",
-		LongHelp:    "",
+		LongHelp:    rootLongHelp(),
 		FlagSet:     flag.NewFlagSet("asc", flag.ExitOnError),
 		UsageFunc:   RootUsageFunc,
 		Subcommands: subcommands,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,10 +21,14 @@ var versionRequested bool
 // screen: find the right command, diagnose credentials, locate an app, then
 // inspect it. Every sample is a copy-paste-valid long-form invocation, and
 // placeholders stay bare uppercase so shells do not read them as redirection.
-const rootGettingStartedSamples = `  asc search "upload a build" --output json   # find the command, with examples
-  asc auth doctor                             # diagnose local auth configuration
-  asc apps list --output table                # list your apps and their IDs
-  asc status --app APP_ID                     # one-screen release overview
+const rootGettingStartedSamples = `  Find the command, with examples:
+    asc search "upload a build" --output json
+  Diagnose local auth configuration:
+    asc auth doctor
+  List your apps and their IDs:
+    asc apps list --output table
+  Show a one-screen release overview:
+    asc status --app APP_ID
 
   Add --help to any command; replace placeholders like APP_ID with real values.`
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ const rootGettingStartedSamples = `  Find the command, with examples:
   Diagnose local auth configuration:
     asc auth doctor
   List your apps and their IDs:
-    asc apps list --output table
+    asc apps list --paginate --output table
   Show a one-screen release overview:
     asc status --app APP_ID
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,10 +21,10 @@ var versionRequested bool
 // screen: find the right command, verify credentials, locate an app, then
 // inspect it. Every sample is a copy-paste-valid long-form invocation, and
 // placeholders stay bare uppercase so shells do not read them as redirection.
-const rootGettingStartedSamples = `  asc search "upload a build"    # find the right command (JSON, with examples)
-  asc auth doctor                # check credentials before the first API call
-  asc apps list --output table   # list your apps and their IDs
-  asc status --app APP_ID        # one-screen release overview for one app
+const rootGettingStartedSamples = `  asc search "upload a build" --output json   # find the command, with examples
+  asc auth doctor                             # verify credentials up front
+  asc apps list --output table                # list your apps and their IDs
+  asc status --app APP_ID                     # one-screen release overview
 
   Add --help to any command; replace placeholders like APP_ID with real values.`
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,11 +18,11 @@ import (
 var versionRequested bool
 
 // rootGettingStartedSamples teaches the discovery loop on the first help
-// screen: find the right command, validate credentials, locate an app, then
+// screen: find the right command, diagnose credentials, locate an app, then
 // inspect it. Every sample is a copy-paste-valid long-form invocation, and
 // placeholders stay bare uppercase so shells do not read them as redirection.
 const rootGettingStartedSamples = `  asc search "upload a build" --output json   # find the command, with examples
-  asc auth status --validate                  # validate credentials up front
+  asc auth doctor                             # diagnose local auth configuration
   asc apps list --output table                # list your apps and their IDs
   asc status --app APP_ID                     # one-screen release overview
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,11 +18,11 @@ import (
 var versionRequested bool
 
 // rootGettingStartedSamples teaches the discovery loop on the first help
-// screen: find the right command, verify credentials, locate an app, then
+// screen: find the right command, validate credentials, locate an app, then
 // inspect it. Every sample is a copy-paste-valid long-form invocation, and
 // placeholders stay bare uppercase so shells do not read them as redirection.
 const rootGettingStartedSamples = `  asc search "upload a build" --output json   # find the command, with examples
-  asc auth doctor                             # verify credentials up front
+  asc auth status --validate                  # validate credentials up front
   asc apps list --output table                # list your apps and their IDs
   asc status --app APP_ID                     # one-screen release overview
 

--- a/cmd/root_getting_started_test.go
+++ b/cmd/root_getting_started_test.go
@@ -21,8 +21,30 @@ var wantGettingStartedInvocations = []string{
 
 func TestRootHelpDoesNotOverstateAuthDoctorNetworkValidation(t *testing.T) {
 	block := gettingStartedBlock(t)
-	if !strings.Contains(block, "asc auth doctor") || !strings.Contains(block, "diagnose local auth configuration") {
+	if !strings.Contains(block, "Diagnose local auth configuration:\n    asc auth doctor") {
 		t.Fatalf("getting-started auth step must describe local diagnosis accurately:\n%s", block)
+	}
+	lower := strings.ToLower(block)
+	for _, unsupportedClaim := range []string{
+		"validate network",
+		"validates network",
+		"network validation",
+		"validate app store connect",
+		"validates app store connect",
+		"app store connect access",
+	} {
+		if strings.Contains(lower, unsupportedClaim) {
+			t.Fatalf("getting-started auth step must not claim %q:\n%s", unsupportedClaim, block)
+		}
+	}
+}
+
+func TestRootHelpGettingStartedSamplesHaveNoInlineShellComments(t *testing.T) {
+	for _, line := range strings.Split(gettingStartedBlock(t), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "asc ") && strings.Contains(trimmed, "#") {
+			t.Fatalf("pasteable sample has a shell-specific inline comment: %q", trimmed)
+		}
 	}
 }
 
@@ -157,17 +179,13 @@ func gettingStartedBlock(t *testing.T) string {
 	return rest[:end]
 }
 
-// gettingStartedInvocations extracts the `asc ...` sample lines from the block,
-// dropping trailing `#` annotations.
+// gettingStartedInvocations extracts the `asc ...` sample lines from the block.
 func gettingStartedInvocations(block string) []string {
 	invocations := make([]string, 0, 4)
 	for _, line := range strings.Split(block, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if !strings.HasPrefix(trimmed, "asc ") {
 			continue
-		}
-		if comment := strings.Index(trimmed, "#"); comment >= 0 {
-			trimmed = strings.TrimSpace(trimmed[:comment])
 		}
 		invocations = append(invocations, trimmed)
 	}

--- a/cmd/root_getting_started_test.go
+++ b/cmd/root_getting_started_test.go
@@ -13,7 +13,7 @@ var ansiEscapePattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
 // wantGettingStartedInvocations pins the copy-paste invocations that teach the
 // discovery loop on the first screen of `asc --help`.
 var wantGettingStartedInvocations = []string{
-	`asc search "upload a build"`,
+	`asc search "upload a build" --output json`,
 	"asc auth doctor",
 	"asc apps list --output table",
 	"asc status --app APP_ID",

--- a/cmd/root_getting_started_test.go
+++ b/cmd/root_getting_started_test.go
@@ -14,9 +14,16 @@ var ansiEscapePattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
 // discovery loop on the first screen of `asc --help`.
 var wantGettingStartedInvocations = []string{
 	`asc search "upload a build" --output json`,
-	"asc auth status --validate",
+	"asc auth doctor",
 	"asc apps list --output table",
 	"asc status --app APP_ID",
+}
+
+func TestRootHelpDoesNotOverstateAuthDoctorNetworkValidation(t *testing.T) {
+	block := gettingStartedBlock(t)
+	if !strings.Contains(block, "asc auth doctor") || !strings.Contains(block, "diagnose local auth configuration") {
+		t.Fatalf("getting-started auth step must describe local diagnosis accurately:\n%s", block)
+	}
 }
 
 func TestRootHelpRendersGettingStartedBlock(t *testing.T) {

--- a/cmd/root_getting_started_test.go
+++ b/cmd/root_getting_started_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+var ansiEscapePattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// wantGettingStartedInvocations pins the copy-paste invocations that teach the
+// discovery loop on the first screen of `asc --help`.
+var wantGettingStartedInvocations = []string{
+	`asc search "upload a build"`,
+	"asc auth doctor",
+	"asc apps list --output table",
+	"asc status --app APP_ID",
+}
+
+func TestRootHelpRendersGettingStartedBlock(t *testing.T) {
+	usage := stripANSIEscapes(rootUsageText(t))
+
+	headerIndex := strings.Index(usage, "\nGETTING STARTED\n")
+	if headerIndex < 0 {
+		t.Fatalf("root help is missing a GETTING STARTED block:\n%s", usage)
+	}
+
+	usageIndex := strings.Index(usage, "\nUSAGE\n")
+	if usageIndex < 0 || usageIndex > headerIndex {
+		t.Fatalf("GETTING STARTED block must render after USAGE:\n%s", usage)
+	}
+
+	groupIndex := strings.Index(usage, "GETTING STARTED COMMANDS")
+	if groupIndex < 0 || headerIndex > groupIndex {
+		t.Fatalf("GETTING STARTED block must render before the command groups:\n%s", usage)
+	}
+
+	for _, invocation := range wantGettingStartedInvocations {
+		if !strings.Contains(usage, "  "+invocation+" ") && !strings.Contains(usage, "  "+invocation+"\n") {
+			t.Errorf("root help is missing getting-started invocation %q", invocation)
+		}
+	}
+}
+
+func TestRootHelpGettingStartedUsesBarePlaceholders(t *testing.T) {
+	block := gettingStartedBlock(t)
+	if strings.ContainsAny(block, "<>") {
+		t.Errorf("getting-started block must use bare placeholders like APP_ID, not shell redirection characters:\n%s", block)
+	}
+}
+
+// TestRootHelpGettingStartedInvocationsResolve mechanically walks every
+// advertised invocation against the real command tree so the first screen can
+// never advertise a command path or flag that does not exist.
+func TestRootHelpGettingStartedInvocationsResolve(t *testing.T) {
+	root := RootCommand("test")
+	invocations := gettingStartedInvocations(gettingStartedBlock(t))
+	if len(invocations) < 3 {
+		t.Fatalf("expected at least 3 getting-started invocations, got %d", len(invocations))
+	}
+
+	for _, invocation := range invocations {
+		t.Run(invocation, func(t *testing.T) {
+			assertInvocationResolves(t, root, invocation)
+		})
+	}
+}
+
+func assertInvocationResolves(t *testing.T, root *ffcli.Command, invocation string) {
+	t.Helper()
+
+	tokens := splitInvocationTokens(invocation)
+	if len(tokens) == 0 || tokens[0] != "asc" {
+		t.Fatalf("invocation %q must start with asc", invocation)
+	}
+
+	bareWord := regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	current := root
+	index := 1
+	for index < len(tokens) && len(current.Subcommands) > 0 {
+		token := tokens[index]
+		if !bareWord.MatchString(token) {
+			break
+		}
+		sub := findDirectSubcommand(current, token)
+		if sub == nil {
+			t.Fatalf("invocation %q references unknown command %q", invocation, strings.Join(tokens[:index+1], " "))
+		}
+		current = sub
+		index++
+	}
+
+	if current == root {
+		t.Fatalf("invocation %q does not resolve to a subcommand", invocation)
+	}
+	if current.Exec == nil {
+		t.Fatalf("invocation %q resolves to %q, which is not runnable", invocation, current.Name)
+	}
+
+	for _, token := range tokens[index:] {
+		if !strings.HasPrefix(token, "--") {
+			continue
+		}
+		name := strings.TrimPrefix(token, "--")
+		if equals := strings.Index(name, "="); equals >= 0 {
+			name = name[:equals]
+		}
+		if flagLookup(current, name) == nil && flagLookup(root, name) == nil {
+			t.Fatalf("invocation %q uses unknown flag --%s for %q", invocation, name, current.Name)
+		}
+	}
+}
+
+func flagLookup(cmd *ffcli.Command, name string) any {
+	if cmd == nil || cmd.FlagSet == nil {
+		return nil
+	}
+	if f := cmd.FlagSet.Lookup(name); f != nil {
+		return f
+	}
+	return nil
+}
+
+func rootUsageText(t *testing.T) string {
+	t.Helper()
+	root := RootCommand("test")
+	if root.UsageFunc == nil {
+		t.Fatal("root command has no UsageFunc")
+	}
+	return root.UsageFunc(root)
+}
+
+// gettingStartedBlock returns the GETTING STARTED section of the rendered root
+// help, without ANSI styling.
+func gettingStartedBlock(t *testing.T) string {
+	t.Helper()
+
+	usage := stripANSIEscapes(rootUsageText(t))
+	start := strings.Index(usage, "\nGETTING STARTED\n")
+	if start < 0 {
+		t.Fatalf("root help is missing a GETTING STARTED block:\n%s", usage)
+	}
+	rest := usage[start+1:]
+	end := strings.Index(rest, "GETTING STARTED COMMANDS")
+	if end < 0 {
+		t.Fatalf("root help is missing the GETTING STARTED COMMANDS group:\n%s", usage)
+	}
+	return rest[:end]
+}
+
+// gettingStartedInvocations extracts the `asc ...` sample lines from the block,
+// dropping trailing `#` annotations.
+func gettingStartedInvocations(block string) []string {
+	invocations := make([]string, 0, 4)
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "asc ") {
+			continue
+		}
+		if comment := strings.Index(trimmed, "#"); comment >= 0 {
+			trimmed = strings.TrimSpace(trimmed[:comment])
+		}
+		invocations = append(invocations, trimmed)
+	}
+	return invocations
+}
+
+// splitInvocationTokens splits a shell-style invocation, keeping double-quoted
+// arguments as single tokens.
+func splitInvocationTokens(invocation string) []string {
+	tokens := make([]string, 0, 8)
+	var current strings.Builder
+	quoted := false
+	flush := func() {
+		if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+	for _, r := range invocation {
+		switch {
+		case r == '"':
+			quoted = !quoted
+			current.WriteRune(r)
+		case r == ' ' && !quoted:
+			flush()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	flush()
+	return tokens
+}
+
+func stripANSIEscapes(s string) string {
+	return ansiEscapePattern.ReplaceAllString(s, "")
+}

--- a/cmd/root_getting_started_test.go
+++ b/cmd/root_getting_started_test.go
@@ -15,7 +15,7 @@ var ansiEscapePattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
 var wantGettingStartedInvocations = []string{
 	`asc search "upload a build" --output json`,
 	"asc auth doctor",
-	"asc apps list --output table",
+	"asc apps list --paginate --output table",
 	"asc status --app APP_ID",
 }
 

--- a/cmd/root_getting_started_test.go
+++ b/cmd/root_getting_started_test.go
@@ -14,7 +14,7 @@ var ansiEscapePattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
 // discovery loop on the first screen of `asc --help`.
 var wantGettingStartedInvocations = []string{
 	`asc search "upload a build" --output json`,
-	"asc auth doctor",
+	"asc auth status --validate",
 	"asc apps list --output table",
 	"asc status --app APP_ID",
 }

--- a/scripts/generate-command-docs.py
+++ b/scripts/generate-command-docs.py
@@ -48,13 +48,18 @@ def parse_help(help_text: str) -> tuple[str, list[tuple[str, str]], list[tuple[s
     current_group_index: int | None = None
 
     for line in help_text.splitlines():
-        # Only the USAGE section defines the usage pattern; sample invocations
-        # elsewhere in the help text must not overwrite it.
-        if in_usage and line.startswith("  asc "):
-            usage = line.strip()
-            in_usage = False
-
         stripped = line.strip()
+
+        # Only the USAGE section defines the usage pattern; sample invocations
+        # elsewhere in the help text must not overwrite it. Any unindented
+        # heading ends the section, even one this parser does not model.
+        if in_usage:
+            if line.startswith("  asc "):
+                usage = stripped
+                in_usage = False
+            elif stripped and not line.startswith(" "):
+                in_usage = False
+
         if stripped == "USAGE":
             in_usage = True
             in_flags = False

--- a/scripts/generate-command-docs.py
+++ b/scripts/generate-command-docs.py
@@ -44,20 +44,31 @@ def parse_help(help_text: str) -> tuple[str, list[tuple[str, str]], list[tuple[s
     groups: list[tuple[str, list[tuple[str, str]]]] = []
 
     in_flags = False
+    in_usage = False
     current_group_index: int | None = None
 
     for line in help_text.splitlines():
-        if line.startswith("  asc "):
+        # Only the USAGE section defines the usage pattern; sample invocations
+        # elsewhere in the help text must not overwrite it.
+        if in_usage and line.startswith("  asc "):
             usage = line.strip()
+            in_usage = False
 
         stripped = line.strip()
+        if stripped == "USAGE":
+            in_usage = True
+            in_flags = False
+            current_group_index = None
+            continue
         if stripped == "FLAGS":
+            in_usage = False
             in_flags = True
             current_group_index = None
             continue
 
         group_match = re.match(r"^([A-Z0-9 &/-]+) COMMANDS$", stripped)
         if group_match:
+            in_usage = False
             in_flags = False
             groups.append((group_match.group(0), []))
             current_group_index = len(groups) - 1

--- a/scripts/test_generate_command_docs.py
+++ b/scripts/test_generate_command_docs.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("generate-command-docs.py")
+SPEC = importlib.util.spec_from_file_location("generate_command_docs", MODULE_PATH)
+assert SPEC and SPEC.loader
+generate_command_docs = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generate_command_docs)
+
+
+HELP_WITH_SAMPLES = """DESCRIPTION
+  asc is a fast, lightweight CLI for App Store Connect from Rork.
+
+USAGE
+  asc <subcommand> [flags]
+
+GETTING STARTED
+  asc search "upload a build" --output json   # find the command
+  asc status --app APP_ID                     # release overview
+
+UTILITY COMMANDS
+  search:  Search asc commands and examples.
+
+FLAGS
+  --debug  Enable debug logging to stderr
+"""
+
+
+class ParseHelpTests(unittest.TestCase):
+    def test_usage_comes_from_the_usage_section(self) -> None:
+        usage, _, _ = generate_command_docs.parse_help(HELP_WITH_SAMPLES)
+        self.assertEqual(usage, "asc <subcommand> [flags]")
+
+    def test_sample_invocations_do_not_become_the_usage_pattern(self) -> None:
+        # An unindented heading ends the USAGE section, so samples rendered
+        # under it cannot be mistaken for the usage pattern even when the
+        # USAGE section itself carries no recognizable invocation.
+        help_text = HELP_WITH_SAMPLES.replace("  asc <subcommand> [flags]\n", "")
+        usage, _, _ = generate_command_docs.parse_help(help_text)
+        self.assertEqual(usage, "asc <subcommand> [flags]")
+
+    def test_groups_and_flags_still_parse(self) -> None:
+        _, flags, groups = generate_command_docs.parse_help(HELP_WITH_SAMPLES)
+        self.assertEqual(flags, [("--debug", "Enable debug logging to stderr")])
+        self.assertEqual(
+            groups,
+            [("UTILITY COMMANDS", [("search", "Search asc commands and examples.")])],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`asc --help` opened straight into 60+ commands across eleven category headings. There was no sample invocation anywhere on the first screen, and no signal that `asc search` — the CLI's own command-discovery tool, which returns JSON with runnable examples — even exists. It sat unremarked at position three of UTILITY COMMANDS, near the bottom.

An agent's first screen should teach the loop, not just enumerate the surface.

## Change

A short GETTING STARTED block in the root LongHelp, rendered between USAGE and the command groups:

```
GETTING STARTED
  Find the command, with examples:
    asc search "upload a build" --output json
  Diagnose local auth configuration:
    asc auth doctor
  List your apps and their IDs:
    asc apps list --paginate --output table
  Show a one-screen release overview:
    asc status --app APP_ID

  Add --help to any command; replace placeholders like APP_ID with real values.
```

These four invocations form a practical loop: search the local command catalog for runnable examples, diagnose local auth configuration, list every app page, then inspect one app. `asc auth doctor` diagnoses local storage, profiles, key material, and environment state; it does not validate network access or App Store Connect credentials. The sample has no inline shell comments, so each `asc ...` line remains a standalone command in Unix shells and Windows Command Prompt. The search sample pins `--output json` because `asc search` binds a TTY-aware output default, and the table renderer omits the `examples` field the annotation promises. The apps sample pins `--paginate` so operators can find IDs on later pages. Placeholders are bare uppercase (`APP_ID`) rather than angle-bracketed, since `<` and `>` are shell redirection operators.

All existing DESCRIPTION, USAGE, grouped command, and flag sections remain unchanged; this PR adds the GETTING STARTED block.

## Generator fix

`scripts/generate-command-docs.py` took the *last* help line starting with two spaces and `asc ` as the usage pattern. Any sample invocation rendered after USAGE could silently replace the documented usage pattern in `docs/COMMANDS.md`. The capture is now bound to the USAGE section, and any subsequent unindented heading ends usage mode before samples are considered. `docs/COMMANDS.md` regenerates byte-identical, so no doc churn ships here.

Committed first so every commit on the branch is independently green. The USAGE section now also ends at any unindented heading, not just the two headings the parser models, so a sample under an unmodelled heading cannot slip through either. `scripts/test_generate_command_docs.py` covers `parse_help` and runs as part of `check-command-docs`; it fails against both the original parser and the first, narrower fix.

## Tests

`cmd/root_getting_started_test.go`:

- `TestRootHelpDoesNotOverstateAuthDoctorNetworkValidation` — pins the local-diagnosis wording and rejects claims that `asc auth doctor` validates network or App Store Connect access.
- `TestRootHelpGettingStartedSamplesHaveNoInlineShellComments` — keeps each advertised command free of shell-specific inline comments.
- `TestRootHelpRendersGettingStartedBlock` — pins the block's presence, its position (after USAGE, before the command groups), and each advertised invocation.
- `TestRootHelpGettingStartedUsesBarePlaceholders` — fails if `<` or `>` reappear in the block.
- `TestRootHelpGettingStartedInvocationsResolve` — parses the invocations back out of the *rendered* help and mechanically walks each one against the live command tree: every bare path segment must resolve to a real subcommand, the leaf must be runnable (`Exec != nil`), and every `--flag` must exist on the resolved command's FlagSet or the root FlagSet.

The resolution guard was verified non-vacuous: seeding `asc auth doktor` and `--appz` makes it fail with `references unknown command "asc auth doktor"` and `uses unknown flag --appz for "status"`. Because it reads the rendered help rather than a hardcoded list, it also covers any invocation a future edit adds to the block.

## Verification

- `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` — all green (103 packages, no failures, no flakes hit).
- `asc search "upload a build" --output json` and `asc auth doctor` executed against the built binary; both exit 0.
- `asc apps list --paginate --output table` executed as a read-only app discovery call, and `asc status --app APP_ID` rejected the placeholder during app lookup rather than argument parsing, confirming the advertised flag path.

## Follow-up owned elsewhere

`asc search` results carry a verbose `matched` array (18 entries for a two-word query, largely `query:`/`command:`/`summary:` restatements of the same token). Trimming it would tighten the payload an agent reads right after the first screen. Deliberately not touched here — `internal/cli/search/` is under active work in #2107.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a “GETTING STARTED” section to command-line help with copy-ready examples for discovering commands, diagnosing authentication, listing apps, and checking status.
  - Improved generated command documentation so usage information is extracted accurately.

- **Bug Fixes**
  - Prevented sample commands from being mistaken for usage lines.
  - Added validation to keep documented commands and flags aligned with the available command-line interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
