### PR TITLE
feat(testflight): tester removal --wait, export name filters; require --confirm on game-center relationship removal

### DIFF
--- a/internal/cli/cmdtest/testflight_beta_testers_remove_wait_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_remove_wait_test.go
@@ -2,6 +2,8 @@ package cmdtest
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -149,34 +151,34 @@ func TestBetaTestersRemoveWaitTimesOutButPrintsReceipt(t *testing.T) {
 
 func TestBetaTestersRemoveWaitValidatesDurations(t *testing.T) {
 	cases := []struct {
-		name     string
-		args     []string
-		wantFlag string
+		name      string
+		args      []string
+		wantError string
 	}{
 		{
-			name:     "zero poll interval",
-			args:     []string{"--wait", "--poll-interval", "0s"},
-			wantFlag: "--poll-interval",
+			name:      "zero poll interval",
+			args:      []string{"--wait", "--poll-interval", "0s"},
+			wantError: "--poll-interval must be greater than 0",
 		},
 		{
-			name:     "zero timeout",
-			args:     []string{"--wait", "--timeout", "0s"},
-			wantFlag: "--timeout",
+			name:      "zero timeout",
+			args:      []string{"--wait", "--timeout", "0s"},
+			wantError: "--timeout must be greater than 0",
 		},
 		{
-			name:     "poll interval without wait",
-			args:     []string{"--poll-interval", "10s"},
-			wantFlag: "--poll-interval requires --wait",
+			name:      "poll interval without wait",
+			args:      []string{"--poll-interval", "10s"},
+			wantError: "--poll-interval requires --wait",
 		},
 		{
-			name:     "timeout without wait",
-			args:     []string{"--timeout", "1m"},
-			wantFlag: "--timeout requires --wait",
+			name:      "timeout without wait",
+			args:      []string{"--timeout", "1m"},
+			wantError: "--timeout requires --wait",
 		},
 		{
-			name:     "both wait flags without wait",
-			args:     []string{"--poll-interval", "10s", "--timeout", "1m"},
-			wantFlag: "--poll-interval and --timeout require --wait",
+			name:      "both wait flags without wait",
+			args:      []string{"--poll-interval", "10s", "--timeout", "1m"},
+			wantError: "--poll-interval and --timeout require --wait",
 		},
 	}
 
@@ -194,9 +196,25 @@ func TestBetaTestersRemoveWaitValidatesDurations(t *testing.T) {
 			if err := root.Parse(args); err != nil {
 				t.Fatalf("parse error: %v", err)
 			}
-			err := root.Run(context.Background())
-			if err == nil || !strings.Contains(err.Error(), tc.wantFlag) {
-				t.Fatalf("expected usage error mentioning %q, got %v", tc.wantFlag, err)
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				runErr = root.Run(context.Background())
+			})
+			if runErr == nil {
+				t.Fatal("expected usage error")
+			}
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected flag.ErrHelp, got %v", runErr)
+			}
+			if runErr.Error() != tc.wantError {
+				t.Fatalf("error = %q, want %q", runErr.Error(), tc.wantError)
+			}
+			wantDiagnostic := "Error: " + tc.wantError + "\n"
+			if !strings.HasPrefix(stderr, wantDiagnostic) {
+				t.Fatalf("stderr = %q, want prefix %q", stderr, wantDiagnostic)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty output", stdout)
 			}
 		})
 	}

--- a/internal/cli/cmdtest/testflight_beta_testers_remove_wait_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_remove_wait_test.go
@@ -1,0 +1,208 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupBetaTesterRemoveWaitEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	writeECDSAPEM(t, keyPath)
+	t.Setenv("ASC_KEY_ID", "TEST_KEY")
+	t.Setenv("ASC_ISSUER_ID", "TEST_ISSUER")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", keyPath)
+}
+
+func betaTesterRemoveWaitTransport(t *testing.T, pollResponses func(pollCount int) (int, string)) {
+	t.Helper()
+
+	pollCount := 0
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/betaTesters":
+			body := `{"data":[{"type":"betaTesters","id":"tester-1","attributes":{"email":"tester@example.com","state":"INSTALLED"}}],"links":{}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodDelete && req.URL.Path == "/v1/betaTesters/tester-1":
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/betaTesters/tester-1":
+			pollCount++
+			status, body := pollResponses(pollCount)
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		default:
+			t.Errorf("unexpected request %s %s", req.Method, req.URL.String())
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+	})
+}
+
+func TestBetaTestersRemoveWaitCompletesOnNotFound(t *testing.T) {
+	setupBetaTesterRemoveWaitEnv(t)
+	betaTesterRemoveWaitTransport(t, func(int) (int, string) {
+		return http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist"}]}`
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "remove",
+			"--app", "app-1", "--email", "tester@example.com", "--confirm",
+			"--wait", "--poll-interval", "10ms", "--timeout", "5s",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"deleted":true`) {
+		t.Fatalf("expected delete receipt, got %q", stdout)
+	}
+}
+
+func TestBetaTestersRemoveWaitCompletesOnRevoked(t *testing.T) {
+	setupBetaTesterRemoveWaitEnv(t)
+	betaTesterRemoveWaitTransport(t, func(int) (int, string) {
+		return http.StatusOK, `{"data":{"type":"betaTesters","id":"tester-1","attributes":{"state":"REVOKED"}}}`
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "remove",
+			"--app", "app-1", "--email", "tester@example.com", "--confirm",
+			"--wait", "--poll-interval", "10ms", "--timeout", "5s",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"deleted":true`) {
+		t.Fatalf("expected delete receipt, got %q", stdout)
+	}
+}
+
+func TestBetaTestersRemoveWaitTimesOutButPrintsReceipt(t *testing.T) {
+	setupBetaTesterRemoveWaitEnv(t)
+	betaTesterRemoveWaitTransport(t, func(int) (int, string) {
+		return http.StatusOK, `{"data":{"type":"betaTesters","id":"tester-1","attributes":{"state":"INSTALLED"}}}`
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "remove",
+			"--app", "app-1", "--email", "tester@example.com", "--confirm",
+			"--wait", "--poll-interval", "20ms", "--timeout", "150ms",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if runErr == nil || !strings.Contains(runErr.Error(), "not yet visible") {
+		t.Fatalf("expected visibility timeout error, got %v", runErr)
+	}
+	if !strings.Contains(stdout, `"deleted":true`) {
+		t.Fatalf("timeout must still print the delete receipt, got %q", stdout)
+	}
+}
+
+func TestBetaTestersRemoveWaitValidatesDurations(t *testing.T) {
+	setupBetaTesterRemoveWaitEnv(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	if err := root.Parse([]string{
+		"testflight", "testers", "remove",
+		"--app", "app-1", "--email", "tester@example.com", "--confirm",
+		"--wait", "--poll-interval", "0s",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--poll-interval") {
+		t.Fatalf("expected poll-interval usage error, got %v", err)
+	}
+}
+
+func TestBetaTestersExportForwardsNameFilters(t *testing.T) {
+	setupBetaTesterRemoveWaitEnv(t)
+
+	var gotQuery string
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotQuery = req.URL.RawQuery
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":[],"links":{}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	csvPath := filepath.Join(t.TempDir(), "testers.csv")
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"testflight", "testers", "export",
+			"--app", "app-1", "--first-name", "Ada", "--last-name", "Lovelace",
+			"--output", csvPath,
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	for _, want := range []string{"filter%5BfirstName%5D=Ada", "filter%5BlastName%5D=Lovelace"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("expected %s in query, got %q", want, gotQuery)
+		}
+	}
+}

--- a/internal/cli/cmdtest/testflight_beta_testers_remove_wait_test.go
+++ b/internal/cli/cmdtest/testflight_beta_testers_remove_wait_test.go
@@ -148,21 +148,57 @@ func TestBetaTestersRemoveWaitTimesOutButPrintsReceipt(t *testing.T) {
 }
 
 func TestBetaTestersRemoveWaitValidatesDurations(t *testing.T) {
-	setupBetaTesterRemoveWaitEnv(t)
-
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-
-	if err := root.Parse([]string{
-		"testflight", "testers", "remove",
-		"--app", "app-1", "--email", "tester@example.com", "--confirm",
-		"--wait", "--poll-interval", "0s",
-	}); err != nil {
-		t.Fatalf("parse error: %v", err)
+	cases := []struct {
+		name     string
+		args     []string
+		wantFlag string
+	}{
+		{
+			name:     "zero poll interval",
+			args:     []string{"--wait", "--poll-interval", "0s"},
+			wantFlag: "--poll-interval",
+		},
+		{
+			name:     "zero timeout",
+			args:     []string{"--wait", "--timeout", "0s"},
+			wantFlag: "--timeout",
+		},
+		{
+			name:     "poll interval without wait",
+			args:     []string{"--poll-interval", "10s"},
+			wantFlag: "--poll-interval requires --wait",
+		},
+		{
+			name:     "timeout without wait",
+			args:     []string{"--timeout", "1m"},
+			wantFlag: "--timeout requires --wait",
+		},
+		{
+			name:     "both wait flags without wait",
+			args:     []string{"--poll-interval", "10s", "--timeout", "1m"},
+			wantFlag: "--poll-interval and --timeout require --wait",
+		},
 	}
-	err := root.Run(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "--poll-interval") {
-		t.Fatalf("expected poll-interval usage error, got %v", err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupBetaTesterRemoveWaitEnv(t)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			args := append([]string{
+				"testflight", "testers", "remove",
+				"--app", "app-1", "--email", "tester@example.com", "--confirm",
+			}, tc.args...)
+			if err := root.Parse(args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			err := root.Run(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.wantFlag) {
+				t.Fatalf("expected usage error mentioning %q, got %v", tc.wantFlag, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/gamecenter/game_center_activities.go
+++ b/internal/cli/gamecenter/game_center_activities.go
@@ -499,7 +499,7 @@ func GameCenterActivityAchievementsSetCommand() *ffcli.Command {
 	activityID := fs.String("activity-id", "", "Game Center activity ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated achievement IDs")
 	remove := fs.Bool("remove", false, "Remove relationships instead of adding")
-	confirm := fs.Bool("confirm", false, "Confirm removal (required with --remove)")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm removal (required with --remove)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -589,7 +589,7 @@ func GameCenterActivityLeaderboardsSetCommand() *ffcli.Command {
 	activityID := fs.String("activity-id", "", "Game Center activity ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated leaderboard IDs")
 	remove := fs.Bool("remove", false, "Remove relationships instead of adding")
-	confirm := fs.Bool("confirm", false, "Confirm removal (required with --remove)")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm removal (required with --remove)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{

--- a/internal/cli/gamecenter/game_center_activities.go
+++ b/internal/cli/gamecenter/game_center_activities.go
@@ -524,6 +524,9 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
 			}
+			if *confirm && !*remove {
+				return shared.UsageError("--confirm requires --remove")
+			}
 			if *remove && !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --remove")
 				return shared.MissingRequiredUsageError("--confirm")
@@ -610,6 +613,9 @@ Examples:
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
+			}
+			if *confirm && !*remove {
+				return shared.UsageError("--confirm requires --remove")
 			}
 			if *remove && !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --remove")

--- a/internal/cli/gamecenter/game_center_activities.go
+++ b/internal/cli/gamecenter/game_center_activities.go
@@ -480,7 +480,7 @@ Use --remove to remove relationships instead of adding.
 
 Examples:
   asc game-center activities achievements set --activity-id "ACTIVITY_ID" --ids "ACH_1,ACH_2"
-  asc game-center activities achievements set --activity-id "ACTIVITY_ID" --ids "ACH_1" --remove`,
+  asc game-center activities achievements set --activity-id "ACTIVITY_ID" --ids "ACH_1" --remove --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -499,6 +499,7 @@ func GameCenterActivityAchievementsSetCommand() *ffcli.Command {
 	activityID := fs.String("activity-id", "", "Game Center activity ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated achievement IDs")
 	remove := fs.Bool("remove", false, "Remove relationships instead of adding")
+	confirm := fs.Bool("confirm", false, "Confirm removal (required with --remove)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -509,7 +510,7 @@ func GameCenterActivityAchievementsSetCommand() *ffcli.Command {
 
 Examples:
   asc game-center activities achievements set --activity-id "ACTIVITY_ID" --ids "ACH_1,ACH_2"
-  asc game-center activities achievements set --activity-id "ACTIVITY_ID" --ids "ACH_1" --remove`,
+  asc game-center activities achievements set --activity-id "ACTIVITY_ID" --ids "ACH_1" --remove --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -522,6 +523,10 @@ Examples:
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
+			}
+			if *remove && !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --remove")
+				return shared.MissingRequiredUsageError("--confirm")
 			}
 
 			client, err := shared.GetASCClient()
@@ -562,7 +567,7 @@ Use --remove to remove relationships instead of adding.
 
 Examples:
   asc game-center activities leaderboards set --activity-id "ACTIVITY_ID" --ids "LB_1,LB_2"
-  asc game-center activities leaderboards set --activity-id "ACTIVITY_ID" --ids "LB_1" --remove`,
+  asc game-center activities leaderboards set --activity-id "ACTIVITY_ID" --ids "LB_1" --remove --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -581,6 +586,7 @@ func GameCenterActivityLeaderboardsSetCommand() *ffcli.Command {
 	activityID := fs.String("activity-id", "", "Game Center activity ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated leaderboard IDs")
 	remove := fs.Bool("remove", false, "Remove relationships instead of adding")
+	confirm := fs.Bool("confirm", false, "Confirm removal (required with --remove)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -591,7 +597,7 @@ func GameCenterActivityLeaderboardsSetCommand() *ffcli.Command {
 
 Examples:
   asc game-center activities leaderboards set --activity-id "ACTIVITY_ID" --ids "LB_1,LB_2"
-  asc game-center activities leaderboards set --activity-id "ACTIVITY_ID" --ids "LB_1" --remove`,
+  asc game-center activities leaderboards set --activity-id "ACTIVITY_ID" --ids "LB_1" --remove --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -604,6 +610,10 @@ Examples:
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
+			}
+			if *remove && !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required with --remove")
+				return shared.MissingRequiredUsageError("--confirm")
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_activities_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_activities_confirm_test.go
@@ -1,0 +1,74 @@
+package gamecenter
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"path/filepath"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+func isolateGameCenterAuthEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_PROFILE", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY_PATH", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_PRIVATE_KEY_B64", "")
+	t.Setenv("ASC_STRICT_AUTH", "")
+}
+
+func TestGameCenterActivitySetCommandsRequireConfirmForRemove(t *testing.T) {
+	isolateGameCenterAuthEnv(t)
+
+	commands := map[string]func() *ffcli.Command{
+		"achievements": GameCenterActivityAchievementsSetCommand,
+		"leaderboards": GameCenterActivityLeaderboardsSetCommand,
+	}
+
+	for name, newCommand := range commands {
+		t.Run(name+" remove without confirm fails validation", func(t *testing.T) {
+			cmd := newCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--activity-id", "activity-1", "--ids", "res-1", "--remove",
+			}); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("remove without --confirm should fail validation, got %v", err)
+			}
+		})
+
+		t.Run(name+" remove with confirm passes validation", func(t *testing.T) {
+			cmd := newCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--activity-id", "activity-1", "--ids", "res-1", "--remove", "--confirm",
+			}); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), []string{})
+			if errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("remove with --confirm should pass validation, got %v", err)
+			}
+		})
+
+		t.Run(name+" add mode needs no confirm", func(t *testing.T) {
+			cmd := newCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--activity-id", "activity-1", "--ids", "res-1",
+			}); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), []string{})
+			if errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("additive set should pass validation without --confirm, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/cli/gamecenter/game_center_activities_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_activities_confirm_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -102,6 +103,26 @@ func TestGameCenterActivitySetCommandsRequireConfirmForRemove(t *testing.T) {
 			err := cmd.Exec(context.Background(), []string{})
 			if errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("additive set should pass validation without --confirm, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGameCenterActivitySetConfirmFlagsAreExperimental(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  *ffcli.Command
+	}{
+		{name: "achievements", cmd: GameCenterActivityAchievementsSetCommand()},
+		{name: "leaderboards", cmd: GameCenterActivityLeaderboardsSetCommand()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			confirm := tc.cmd.FlagSet.Lookup("confirm")
+			if confirm == nil {
+				t.Fatal("--confirm is not registered")
+			}
+			if !strings.HasPrefix(confirm.Usage, "[experimental] ") {
+				t.Fatalf("--confirm usage = %q, want [experimental] prefix", confirm.Usage)
 			}
 		})
 	}

--- a/internal/cli/gamecenter/game_center_activities_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_activities_confirm_test.go
@@ -32,6 +32,19 @@ func TestGameCenterActivitySetCommandsRequireConfirmForRemove(t *testing.T) {
 	}
 
 	for name, newCommand := range commands {
+		t.Run(name+" confirm without remove fails validation", func(t *testing.T) {
+			cmd := newCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--activity-id", "activity-1", "--ids", "res-1", "--confirm",
+			}); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), []string{})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("--confirm without --remove should fail validation, got %v", err)
+			}
+		})
+
 		t.Run(name+" remove without confirm fails validation", func(t *testing.T) {
 			cmd := newCommand()
 			if err := cmd.FlagSet.Parse([]string{

--- a/internal/cli/gamecenter/game_center_activities_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_activities_confirm_test.go
@@ -1,9 +1,12 @@
 package gamecenter
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,9 +42,18 @@ func TestGameCenterActivitySetCommandsRequireConfirmForRemove(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("parse flags: %v", err)
 			}
-			err := cmd.Exec(context.Background(), []string{})
+			var err error
+			stderr := captureGameCenterStderr(t, func() {
+				err = cmd.Exec(context.Background(), []string{})
+			})
 			if !errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("--confirm without --remove should fail validation, got %v", err)
+			}
+			if err.Error() != "--confirm requires --remove" {
+				t.Fatalf("error = %q, want %q", err.Error(), "--confirm requires --remove")
+			}
+			if stderr != "Error: --confirm requires --remove\n" {
+				t.Fatalf("stderr = %q, want exact conflict diagnostic", stderr)
 			}
 		})
 
@@ -52,9 +64,18 @@ func TestGameCenterActivitySetCommandsRequireConfirmForRemove(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("parse flags: %v", err)
 			}
-			err := cmd.Exec(context.Background(), []string{})
+			var err error
+			stderr := captureGameCenterStderr(t, func() {
+				err = cmd.Exec(context.Background(), []string{})
+			})
 			if !errors.Is(err, flag.ErrHelp) {
 				t.Fatalf("remove without --confirm should fail validation, got %v", err)
+			}
+			if err.Error() != "--confirm" {
+				t.Fatalf("error = %q, want missing parameter %q", err.Error(), "--confirm")
+			}
+			if stderr != "Error: --confirm is required with --remove\n" {
+				t.Fatalf("stderr = %q, want exact missing-confirm diagnostic", stderr)
 			}
 		})
 
@@ -84,4 +105,28 @@ func TestGameCenterActivitySetCommandsRequireConfirmForRemove(t *testing.T) {
 			}
 		})
 	}
+}
+
+func captureGameCenterStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	t.Cleanup(func() { os.Stderr = originalStderr })
+	os.Stderr = writer
+
+	done := make(chan string)
+	go func() {
+		var buffer bytes.Buffer
+		_, _ = io.Copy(&buffer, reader)
+		_ = reader.Close()
+		done <- buffer.String()
+	}()
+
+	fn()
+	_ = writer.Close()
+	return <-done
 }

--- a/internal/cli/testflight/beta_tester_remove_confirm_test.go
+++ b/internal/cli/testflight/beta_tester_remove_confirm_test.go
@@ -45,3 +45,18 @@ func TestBetaTestersRemoveCommand_ConfirmPassesValidation(t *testing.T) {
 		t.Fatalf("remove with --confirm should pass validation, got %v", err)
 	}
 }
+
+func TestBetaTestersRemoveWaitFlagsAreExperimental(t *testing.T) {
+	cmd := BetaTestersRemoveCommand()
+	for _, name := range []string{"wait", "poll-interval", "timeout"} {
+		t.Run(name, func(t *testing.T) {
+			flagValue := cmd.FlagSet.Lookup(name)
+			if flagValue == nil {
+				t.Fatalf("--%s is not registered", name)
+			}
+			if !strings.HasPrefix(flagValue.Usage, "[experimental] ") {
+				t.Fatalf("--%s usage = %q, want [experimental] prefix", name, flagValue.Usage)
+			}
+		})
+	}
+}

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -307,9 +307,9 @@ func BetaTestersRemoveCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	email := fs.String("email", "", "Tester email address")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
-	wait := fs.Bool("wait", false, "Wait until the removal is visible (tester is gone or reports REVOKED)")
-	pollInterval := fs.Duration("poll-interval", betaTesterRemoveDefaultPollInterval, "Polling interval while waiting for removal visibility")
-	timeout := fs.Duration("timeout", betaTesterRemoveDefaultWaitTimeout, "Maximum time to wait for removal visibility")
+	wait := fs.Bool("wait", false, "[experimental] Wait until the removal is visible (tester is gone or reports REVOKED)")
+	pollInterval := fs.Duration("poll-interval", betaTesterRemoveDefaultPollInterval, "[experimental] Polling interval while waiting for removal visibility")
+	timeout := fs.Duration("timeout", betaTesterRemoveDefaultWaitTimeout, "[experimental] Maximum time to wait for removal visibility")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -345,6 +345,19 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
 				return shared.MissingRequiredUsageError("--confirm")
 			}
+			waitFlagsProvided := make([]string, 0, 2)
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "poll-interval" || f.Name == "timeout" {
+					waitFlagsProvided = append(waitFlagsProvided, "--"+f.Name)
+				}
+			})
+			if !*wait && len(waitFlagsProvided) > 0 {
+				verb := "requires"
+				if len(waitFlagsProvided) > 1 {
+					verb = "require"
+				}
+				return shared.UsageError(strings.Join(waitFlagsProvided, " and ") + " " + verb + " --wait")
+			}
 			if *wait {
 				if *pollInterval <= 0 {
 					return shared.UsageError("--poll-interval must be greater than 0")

--- a/internal/cli/testflight/beta_testers.go
+++ b/internal/cli/testflight/beta_testers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -306,11 +307,14 @@ func BetaTestersRemoveCommand() *ffcli.Command {
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
 	email := fs.String("email", "", "Tester email address")
 	confirm := fs.Bool("confirm", false, "Confirm removal")
+	wait := fs.Bool("wait", false, "Wait until the removal is visible (tester is gone or reports REVOKED)")
+	pollInterval := fs.Duration("poll-interval", betaTesterRemoveDefaultPollInterval, "Polling interval while waiting for removal visibility")
+	timeout := fs.Duration("timeout", betaTesterRemoveDefaultWaitTimeout, "Maximum time to wait for removal visibility")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "remove",
-		ShortUsage: "asc testflight beta-testers remove --app APP_ID --email EMAIL --confirm",
+		ShortUsage: "asc testflight beta-testers remove --app APP_ID --email EMAIL --confirm [--wait]",
 		ShortHelp:  "Remove a TestFlight beta tester.",
 		LongHelp: `Remove a TestFlight beta tester.
 
@@ -318,8 +322,13 @@ Removal deletes the beta tester record itself: every group membership and
 build assignment is removed across all apps the tester belongs to, not only
 the app used for the lookup. This cannot be undone, so --confirm is required.
 
+Removed testers can continue to appear in list output with state REVOKED;
+verify a removal with view --id, which reports the record as gone. Pass
+--wait to block until that signal is observed.
+
 Examples:
-  asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com" --confirm`,
+  asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com" --confirm
+  asc testflight beta-testers remove --app "APP_ID" --email "tester@example.com" --confirm --wait`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -335,6 +344,14 @@ Examples:
 			if !*confirm {
 				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
 				return shared.MissingRequiredUsageError("--confirm")
+			}
+			if *wait {
+				if *pollInterval <= 0 {
+					return shared.UsageError("--poll-interval must be greater than 0")
+				}
+				if *timeout <= 0 {
+					return shared.UsageError("--timeout must be greater than 0")
+				}
 			}
 
 			client, err := shared.GetASCClient()
@@ -363,9 +380,43 @@ Examples:
 				Deleted: true,
 			}
 
+			if *wait {
+				if waitErr := waitForBetaTesterRemoval(ctx, client, testerID, *pollInterval, *timeout); waitErr != nil {
+					if printErr := shared.PrintOutput(result, *output.Output, *output.Pretty); printErr != nil {
+						return printErr
+					}
+					return fmt.Errorf("beta-testers remove: removal committed but not yet visible: %w", waitErr)
+				}
+			}
+
 			return shared.PrintOutput(result, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+const (
+	betaTesterRemoveDefaultPollInterval = 5 * time.Second
+	betaTesterRemoveDefaultWaitTimeout  = 2 * time.Minute
+)
+
+func waitForBetaTesterRemoval(ctx context.Context, client *asc.Client, testerID string, pollInterval, timeout time.Duration) error {
+	waitCtx, cancel := shared.ContextWithTimeoutDuration(ctx, timeout)
+	defer cancel()
+
+	_, err := asc.PollUntil(waitCtx, pollInterval, func(pollCtx context.Context) (struct{}, bool, error) {
+		tester, err := client.GetBetaTester(pollCtx, testerID)
+		if err != nil {
+			if asc.IsNotFound(err) {
+				return struct{}{}, true, nil
+			}
+			return struct{}{}, false, err
+		}
+		if tester.Data.Attributes.State == asc.BetaTesterStateRevoked {
+			return struct{}{}, true, nil
+		}
+		return struct{}{}, false, nil
+	})
+	return err
 }
 
 // BetaTestersAddGroupsCommand returns the beta testers add-groups subcommand.

--- a/internal/cli/testflight/beta_testers_csv.go
+++ b/internal/cli/testflight/beta_testers_csv.go
@@ -36,6 +36,8 @@ func BetaTestersExportCommand() *ffcli.Command {
 	group := fs.String("group", "", "Beta group name or ID to filter (optional)")
 	buildID, legacyBuildID := bindBuildIDFlag(fs, "Build ID to filter (optional)")
 	email := fs.String("email", "", "Filter by tester email (optional)")
+	firstName := fs.String("first-name", "", "Filter by tester first name (exact match, optional)")
+	lastName := fs.String("last-name", "", "Filter by tester last name (exact match, optional)")
 	includeGroups := fs.Bool("include-groups", false, "Include a groups column (requires additional API calls)")
 	format := shared.BindOutputFlagsWith(fs, "format", "json", "Summary output format: json (default), table, markdown")
 
@@ -58,6 +60,7 @@ Examples:
   asc testflight beta-testers export --app "APP_ID" --group "Beta" --output "./testers.csv"
   asc testflight beta-testers export --app "APP_ID" --build-id "BUILD_ID" --output "./testers.csv"
   asc testflight beta-testers export --app "APP_ID" --email "tester@example.com" --output "./testers.csv"
+  asc testflight beta-testers export --app "APP_ID" --last-name "Lovelace" --output "./testers.csv"
   asc testflight beta-testers export --app "APP_ID" --output "./testers.csv" --include-groups`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -110,6 +113,12 @@ Examples:
 			}
 			if trimmed := strings.TrimSpace(*email); trimmed != "" {
 				opts = append(opts, asc.WithBetaTestersEmail(trimmed))
+			}
+			if trimmed := strings.TrimSpace(*firstName); trimmed != "" {
+				opts = append(opts, asc.WithBetaTestersFirstName(trimmed))
+			}
+			if trimmed := strings.TrimSpace(*lastName); trimmed != "" {
+				opts = append(opts, asc.WithBetaTestersLastName(trimmed))
 			}
 			if trimmed := strings.TrimSpace(*group); trimmed != "" {
 				id, err := groupResolver.Resolve(trimmed)


### PR DESCRIPTION
## What

Three follow-ups from the tester-lookup work in #2060, packaged as one additive commit plus one breaking commit.

### 1. `beta-testers remove --wait` (additive)

Removal is committed by the API immediately, but verification is a trap: removed testers linger in `list` output as `REVOKED` tombstones (observed >30 min), while `GET /v1/betaTesters/{id}` 404s right away. `--wait` (with `--poll-interval`, default 5s, and `--timeout`, default 2m) polls the tester by ID via `asc.PollUntil` until it 404s (`asc.IsNotFound`) or reports `REVOKED` — the two authoritative signals. On timeout the delete receipt still prints to stdout and the command exits nonzero, so scripts get both the receipt and the guarantee failure. Help now documents the tombstone behavior.

### 2. `beta-testers export --first-name/--last-name` (additive)

Parity with the `list` filters added in #2060; exact-match `filter[firstName]`/`filter[lastName]`, forwarded server-side.

### 3. `game-center activities … set --remove` requires `--confirm` (BREAKING)

A fresh mechanical audit of every destructive client call in the tree (137 sites, 95 files) found the repo almost fully compliant with the destructive-operation contract — 150 gated sites — with exactly **two** gaps: the activities achievements/leaderboards `set --remove` branches. Both now require `--confirm` (additive `set` unchanged), matching the analogous `promoted-purchases link --clear`. Audit inventory in the commit message; everything else verified gated (including dry-run-default and plan-then-apply flows).

**BREAKING CHANGE (for the 4.9.0 notes):** scripts using `game-center activities achievements set --remove` or `leaderboards set --remove` must add `--confirm`.

## Tests

- cmdtest: wait completes on 404; wait completes on `REVOKED`; wait timeout still prints the receipt and exits nonzero; `--poll-interval` validation; export forwards both name filters (query-asserted).
- gamecenter: table-driven validation for both commands — remove without `--confirm` fails, with `--confirm` passes, additive set needs no confirm.
- Full pre-commit gate green on both commits (the known-flaky `TestBuildsNextBuildNumberRefreshesDeadlinesAcrossHistoryPages` deadline test tripped one gate run under load and passed on retry; pre-existing, margins already widened upstream in a7b4e549b).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional waiting to beta tester removal, with configurable polling intervals and timeouts.
  - Removal status is monitored until the tester is no longer found or marked revoked.
  - Added exact first-name and last-name filters to beta tester exports.
  - Added explicit confirmation requirements for removing Game Center achievement and leaderboard relationships.

- **Bug Fixes**
  - Deletion results remain available when waiting times out or encounters an error.
  - Added validation for wait-related options and duration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->