### PR TITLE
test: add shared off-test-goroutine assertion helper and convert the concurrency-sensitive suites

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -60,6 +60,37 @@ func TestSomething(t *testing.T) {
 - For JSON assertions, unmarshal and assert fields (not `strings.Contains`)
 - For renderer/output assertions, avoid token-only checks when structure matters; include header or formatting assertions for representative cases
 
+### Assertions Outside the Test Goroutine
+
+`t.Fatal`, `t.Fatalf`, and `t.FailNow` may only be called from the goroutine running the test. Inside an `httptest` handler they skip the response write and leave the client under test waiting; inside a worker goroutine or an injected dependency stub they terminate that goroutine before it can send its result, so the test deadlocks instead of failing and the real failure is buried in a timeout dump.
+
+Use `internal/handlertest` instead. It records the failure with `Errorf`, which is safe from any goroutine, and returns a value the fixture hands back so the code under test unwinds normally:
+
+```go
+fixture := handlertest.New(t)
+
+// RoundTrippers, dependency stubs, and worker goroutines return the error.
+transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+    return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL)
+})
+
+// httptest handlers cannot return, so answer with a 500 and stop.
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+    fixture.Respond(w, "unexpected request: %s %s", req.Method, req.URL.Path)
+}))
+
+// Fixture builders that must return a response answer with a 500 body.
+func territoryResponse(fixture *handlertest.Asserter, payload any) *http.Response {
+    body, err := json.Marshal(payload)
+    if err != nil {
+        return fixture.Response("marshal territory response: %v", err)
+    }
+    return jsonHTTPResponse(http.StatusOK, string(body))
+}
+```
+
+`Errorf` renders with `fmt.Errorf`, so `%w` keeps wrapping the operand and still prints readably in the test log. Keep using `t.Fatal` for setup that runs on the test goroutine.
+
 ### CLI Tests
 
 - Add CLI-level tests for command output/parsing

--- a/internal/cli/cmdtest/pricing_availability_edit_territory_test.go
+++ b/internal/cli/cmdtest/pricing_availability_edit_territory_test.go
@@ -10,10 +10,13 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
 )
 
 func TestPricingAvailabilityEditNormalizesTerritories(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -42,8 +45,7 @@ func TestPricingAvailabilityEditNormalizesTerritories(t *testing.T) {
 			patchedMu.Unlock()
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"patched","attributes":{"available":true}}}`), nil
 		default:
-			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -80,6 +82,7 @@ func TestPricingAvailabilityEditNormalizesTerritories(t *testing.T) {
 
 func TestPricingAvailabilityEditSkipsNoOpWithoutNewTerritoriesGuard(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -98,11 +101,9 @@ func TestPricingAvailabilityEditSkipsNoOpWithoutNewTerritoriesGuard(t *testing.T
 			}`), nil
 		case req.Method == http.MethodPatch:
 			patches.Add(1)
-			t.Errorf("no-op territory should not be patched: %s", req.URL.Path)
-			return nil, fmt.Errorf("unexpected PATCH %s", req.URL.Path)
+			return nil, fixture.Errorf("no-op territory should not be patched: %s", req.URL.Path)
 		default:
-			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -136,6 +137,7 @@ func TestPricingAvailabilityEditSkipsNoOpWithoutNewTerritoriesGuard(t *testing.T
 
 func TestPricingAvailabilityEditRejectsMismatchedNewTerritoriesGuardBeforeTerritoryRead(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -148,15 +150,12 @@ func TestPricingAvailabilityEditRejectsMismatchedNewTerritoriesGuardBeforeTerrit
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":true}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
 			territoryReads.Add(1)
-			t.Errorf("policy mismatch should fail before territory reads")
-			return nil, fmt.Errorf("unexpected territory availability read")
+			return nil, fixture.Errorf("policy mismatch should fail before territory reads")
 		case req.Method == http.MethodPatch:
 			patches.Add(1)
-			t.Errorf("policy mismatch should not patch %s", req.URL.Path)
-			return nil, fmt.Errorf("unexpected PATCH %s", req.URL.Path)
+			return nil, fixture.Errorf("policy mismatch should not patch %s", req.URL.Path)
 		default:
-			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -192,6 +191,7 @@ func TestPricingAvailabilityEditRejectsMismatchedNewTerritoriesGuardBeforeTerrit
 
 func TestPricingAvailabilityEditContinuesAfterFailureAndVerifiesFinalState(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -216,7 +216,7 @@ func TestPricingAvailabilityEditContinuesAfterFailureAndVerifiesFinalState(t *te
 		}
 		body, err := json.Marshal(map[string]any{"data": data, "links": map[string]string{"next": ""}})
 		if err != nil {
-			t.Fatalf("marshal territory response: %v", err)
+			return fixture.Response("marshal territory response: %v", err)
 		}
 		return jsonHTTPResponse(http.StatusOK, string(body))
 	}
@@ -240,8 +240,7 @@ func TestPricingAvailabilityEditContinuesAfterFailureAndVerifiesFinalState(t *te
 			}
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"patched","attributes":{"available":true}}}`), nil
 		default:
-			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 

--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -3,7 +3,6 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -12,10 +11,12 @@ import (
 	"testing"
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
 )
 
 func TestPricingAvailabilityRemoveFromSaleUpdatesAndVerifiesTerritories(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -31,7 +32,7 @@ func TestPricingAvailabilityRemoveFromSaleUpdatesAndVerifiesTerritories(t *testi
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
 			mu.Lock()
 			defer mu.Unlock()
-			return territoryAvailabilityResponse(t, states), nil
+			return territoryAvailabilityResponse(fixture, states), nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
 			var payload struct {
 				Data struct {
@@ -42,12 +43,10 @@ func TestPricingAvailabilityRemoveFromSaleUpdatesAndVerifiesTerritories(t *testi
 				} `json:"data"`
 			}
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-				t.Errorf("decode PATCH: %v", err)
-				return nil, fmt.Errorf("decode PATCH: %w", err)
+				return nil, fixture.Errorf("decode PATCH: %w", err)
 			}
 			if payload.Data.ID != "ta-usa" || payload.Data.Attributes.Available == nil || *payload.Data.Attributes.Available {
-				t.Errorf("unexpected PATCH payload: %+v", payload)
-				return nil, fmt.Errorf("unexpected PATCH payload")
+				return nil, fixture.Errorf("unexpected PATCH payload: %+v", payload)
 			}
 			patches.Add(1)
 			mu.Lock()
@@ -55,8 +54,7 @@ func TestPricingAvailabilityRemoveFromSaleUpdatesAndVerifiesTerritories(t *testi
 			mu.Unlock()
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
 		default:
-			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -118,6 +116,8 @@ func TestPricingAvailabilityRemoveFromSaleRequiresConfirmWithUsageExit(t *testin
 
 func TestPricingAvailabilityRemoveFromSaleOutputFormats(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
+
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -125,9 +125,9 @@ func TestPricingAvailabilityRemoveFromSaleOutputFormats(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
-			return territoryAvailabilityResponse(t, map[string]bool{"USA": false, "FRA": false}), nil
+			return territoryAvailabilityResponse(fixture, map[string]bool{"USA": false, "FRA": false}), nil
 		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -159,6 +159,7 @@ func TestPricingAvailabilityRemoveFromSaleOutputFormats(t *testing.T) {
 
 func TestPricingAvailabilityRemoveFromSaleNoOp(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -169,12 +170,12 @@ func TestPricingAvailabilityRemoveFromSaleNoOp(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
-			return territoryAvailabilityResponse(t, map[string]bool{"USA": false, "FRA": false}), nil
+			return territoryAvailabilityResponse(fixture, map[string]bool{"USA": false, "FRA": false}), nil
 		case req.Method == http.MethodPatch:
 			patches.Add(1)
-			return nil, fmt.Errorf("unexpected PATCH %s", req.URL.Path)
+			return nil, fixture.Errorf("no-op availability should not be patched: %s", req.URL.Path)
 		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -198,6 +199,7 @@ func TestPricingAvailabilityRemoveFromSaleNoOp(t *testing.T) {
 
 func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -212,7 +214,7 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
 			mu.Lock()
 			defer mu.Unlock()
-			return territoryAvailabilityResponse(t, states), nil
+			return territoryAvailabilityResponse(fixture, states), nil
 		case req.Method == http.MethodPatch && strings.HasPrefix(req.URL.Path, "/v1/territoryAvailabilities/ta-"):
 			patches.Add(1)
 			territory := strings.ToUpper(strings.TrimPrefix(req.URL.Path, "/v1/territoryAvailabilities/ta-"))
@@ -224,7 +226,7 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 			mu.Unlock()
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
 		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -270,6 +272,7 @@ func TestPricingAvailabilityRemoveFromSaleContinuesAfterPartialFailure(t *testin
 
 func TestPricingAvailabilityRemoveFromSaleFinalReadbackIncludesInitiallyUnavailableTerritories(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
@@ -280,13 +283,13 @@ func TestPricingAvailabilityRemoveFromSaleFinalReadbackIncludesInitiallyUnavaila
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
 			if territoryReads.Add(1) == 1 {
-				return territoryAvailabilityResponse(t, map[string]bool{"USA": true, "FRA": false}), nil
+				return territoryAvailabilityResponse(fixture, map[string]bool{"USA": true, "FRA": false}), nil
 			}
-			return territoryAvailabilityResponse(t, map[string]bool{"USA": false, "FRA": true}), nil
+			return territoryAvailabilityResponse(fixture, map[string]bool{"USA": false, "FRA": true}), nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil
 		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}
 	})
 
@@ -306,8 +309,7 @@ func TestPricingAvailabilityRemoveFromSaleFinalReadbackIncludesInitiallyUnavaila
 	})
 }
 
-func territoryAvailabilityResponse(t *testing.T, states map[string]bool) *http.Response {
-	t.Helper()
+func territoryAvailabilityResponse(fixture *handlertest.Asserter, states map[string]bool) *http.Response {
 	territories := []string{"USA", "FRA"}
 	data := make([]map[string]any, 0, len(territories))
 	for _, territory := range territories {
@@ -322,7 +324,7 @@ func territoryAvailabilityResponse(t *testing.T, states map[string]bool) *http.R
 	}
 	body, err := json.Marshal(map[string]any{"data": data, "links": map[string]string{"next": ""}})
 	if err != nil {
-		t.Fatalf("marshal territory response: %v", err)
+		return fixture.Response("marshal territory response: %v", err)
 	}
 	return jsonHTTPResponse(http.StatusOK, string(body))
 }

--- a/internal/cli/distribute/orchestration_test.go
+++ b/internal/cli/distribute/orchestration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/signing"
 	core "github.com/rudrankriyam/App-Store-Connect-CLI/internal/distribution"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
 	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 )
 
@@ -1390,6 +1391,10 @@ func TestExecuteDistributionApplySamePlanReturnsSameRunWithoutRepeatingStages(t 
 }
 
 func TestConcurrentApplyInitializesOnlyAfterReadingStateUnderRunLock(t *testing.T) {
+	// executeDistributionApply runs on a worker goroutine below, so these
+	// dependency stubs must report and return instead of calling t.Fatal:
+	// terminating the worker would leave the test blocked on done forever.
+	fixture := handlertest.New(t)
 	plan := validPersistedDistributionPlan(t)
 	deps := validApplyDistributionOrchestrationDependencies(t, plan)
 	runID := deterministicDistributionRunID(plan)
@@ -1409,12 +1414,10 @@ func TestConcurrentApplyInitializesOnlyAfterReadingStateUnderRunLock(t *testing.
 	}
 	deps.readRun = func(string, string) (persistedDistributionRunState, error) { return completed, nil }
 	deps.writeRun = func(string, persistedDistributionRunState) error {
-		t.Fatal("stale creator overwrote completed state")
-		return nil
+		return fixture.Errorf("stale creator overwrote completed state")
 	}
 	deps.reconcileApply = func(context.Context, signing.ReconcileApplyOptions) (signing.ReconcileReceiptView, error) {
-		t.Fatal("stale creator repeated reconciliation")
-		return signing.ReconcileReceiptView{}, nil
+		return signing.ReconcileReceiptView{}, fixture.Errorf("stale creator repeated reconciliation")
 	}
 	deps.readReceipt = func(string, string) (persistedDistributionReceipt, error) {
 		return validPersistedDistributionReceipt(completed), nil

--- a/internal/cli/validate/concurrency_test.go
+++ b/internal/cli/validate/concurrency_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
 )
 
 type requestConcurrencyTracker struct {
@@ -118,6 +119,7 @@ func TestBuildReadinessReport_OverlapsSixIndependentReadGroups(t *testing.T) {
 	}
 	serialDelay := slowDelay + 5*shortDelay
 
+	fixture := handlertest.New(t)
 	tracker := &requestConcurrencyTracker{}
 	var mu sync.Mutex
 	requestCounts := make(map[string]int)
@@ -164,8 +166,7 @@ func TestBuildReadinessReport_OverlapsSixIndependentReadGroups(t *testing.T) {
 			"/v1/apps/app-1/inAppPurchasesV2":
 			fmt.Fprint(w, `{"data":[]}`)
 		default:
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST","detail":%q}]}`, req.URL.Path)
+			fixture.Respond(w, "unexpected request: %s", req.URL.Path)
 		}
 	}))
 	t.Cleanup(server.Close)

--- a/internal/cli/validate/subscription_fetch_test.go
+++ b/internal/cli/validate/subscription_fetch_test.go
@@ -7,10 +7,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
 )
 
 func TestFetchSubscriptions_BoundsGroupAndMetadataFanOutAndSortsDeterministically(t *testing.T) {
 	const delay = 50 * time.Millisecond
+	fixture := handlertest.New(t)
 	tracker := &requestConcurrencyTracker{}
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Path == "/v1/apps/app-1/subscriptionGroups" {
@@ -41,7 +44,7 @@ func TestFetchSubscriptions_BoundsGroupAndMetadataFanOutAndSortsDeterministicall
 			strings.HasSuffix(req.URL.Path, "/winBackOffers"):
 			return buildsJSONResponse(http.StatusOK, `{"data":[]}`)
 		default:
-			return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST"}]}`)
+			return fixture.Response("unexpected request: %s", req.URL.Path), nil
 		}
 	}))
 
@@ -69,27 +72,27 @@ func TestFetchSubscriptions_BoundsGroupAndMetadataFanOutAndSortsDeterministicall
 }
 
 func TestFetchSubscriptionPlanAvailabilitiesPaginatesPlansAndTerritories(t *testing.T) {
+	fixture := handlertest.New(t)
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.URL.Path == "/v1/subscriptions/sub-1/planAvailabilities" && req.URL.Query().Get("cursor") == "next":
 			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-monthly","attributes":{"planType":"MONTHLY","availableInNewTerritories":false}}]}`)
 		case req.URL.Path == "/v1/subscriptions/sub-1/planAvailabilities":
 			if got := req.URL.Query().Get("limit"); got != "200" {
-				t.Fatalf("expected plan limit=200, got %q", got)
+				return nil, fixture.Errorf("expected plan limit=200, got %q", got)
 			}
 			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"subscriptionPlanAvailabilities","id":"plan-upfront","attributes":{"planType":"UPFRONT","availableInNewTerritories":true}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptions/sub-1/planAvailabilities?cursor=next"}}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-upfront/relationships/availableTerritories" && req.URL.Query().Get("cursor") == "next":
 			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"territories","id":"CAN"}]}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-upfront/relationships/availableTerritories":
 			if got := req.URL.Query().Get("limit"); got != "200" {
-				t.Fatalf("expected territory limit=200, got %q", got)
+				return nil, fixture.Errorf("expected territory limit=200, got %q", got)
 			}
 			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/subscriptionPlanAvailabilities/plan-upfront/relationships/availableTerritories?cursor=next"}}`)
 		case req.URL.Path == "/v1/subscriptionPlanAvailabilities/plan-monthly/relationships/availableTerritories":
 			return buildsJSONResponse(http.StatusOK, `{"data":[]}`)
 		default:
-			t.Fatalf("unexpected request: %s", req.URL.String())
-			return nil, nil
+			return nil, fixture.Errorf("unexpected request: %s", req.URL.String())
 		}
 	}))
 
@@ -126,6 +129,7 @@ func TestFetchSubscriptionPlanAvailabilitiesPreservesUnverifiedFallback(t *testi
 }
 
 func TestFetchSubscriptionAvailabilityTerritoriesNormalizesTerritoryIDs(t *testing.T) {
+	fixture := handlertest.New(t)
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
 		case "/v1/subscriptions/sub-1/subscriptionAvailability":
@@ -133,8 +137,7 @@ func TestFetchSubscriptionAvailabilityTerritoriesNormalizesTerritoryIDs(t *testi
 		case "/v1/subscriptionAvailabilities/availability-1/availableTerritories":
 			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"territories","id":" can "},{"type":"territories","id":"fra"}]}`)
 		default:
-			t.Fatalf("unexpected request: %s", req.URL.String())
-			return nil, nil
+			return nil, fixture.Errorf("unexpected request: %s", req.URL.String())
 		}
 	}))
 
@@ -151,21 +154,22 @@ func TestFetchSubscriptionAvailabilityTerritoriesNormalizesTerritoryIDs(t *testi
 }
 
 func TestFetchSubscriptionPriceTerritories_DeduplicatesAndSortsTerritories(t *testing.T) {
+	fixture := handlertest.New(t)
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet {
 			return buildsJSONResponse(http.StatusMethodNotAllowed, `{"errors":[{"status":"405"}]}`)
 		}
 		if req.URL.Path != "/v1/subscriptions/sub-1/prices" {
-			t.Fatalf("expected subscription prices path, got %q", req.URL.Path)
+			return nil, fixture.Errorf("expected subscription prices path, got %q", req.URL.Path)
 		}
 		if got := req.URL.Query().Get("include"); got != "territory" {
-			t.Fatalf("expected include=territory query, got %q", got)
+			return nil, fixture.Errorf("expected include=territory query, got %q", got)
 		}
 		if got := req.URL.Query().Get("limit"); got != "200" {
-			t.Fatalf("expected limit=200 query, got %q", got)
+			return nil, fixture.Errorf("expected limit=200 query, got %q", got)
 		}
 		if got := req.URL.Query().Get("filter[planType]"); got != "UPFRONT" {
-			t.Fatalf("expected filter[planType]=UPFRONT query, got %q", got)
+			return nil, fixture.Errorf("expected filter[planType]=UPFRONT query, got %q", got)
 		}
 		return buildsJSONResponse(http.StatusOK, `{
 			"data": [
@@ -289,9 +293,10 @@ func TestFetchSubscriptionReviewScreenshot_ReportsAssetDeliveryState(t *testing.
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			fixture := handlertest.New(t)
 			client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				if got := req.URL.Query().Get("fields[subscriptionAppStoreReviewScreenshots]"); got != "assetDeliveryState" {
-					t.Fatalf("expected assetDeliveryState field request, got %q", got)
+					return nil, fixture.Errorf("expected assetDeliveryState field request, got %q", got)
 				}
 				attributes := `{}`
 				if test.state != "" {

--- a/internal/handlertest/handlertest.go
+++ b/internal/handlertest/handlertest.go
@@ -1,0 +1,147 @@
+// Package handlertest reports test-fixture assertion failures raised by code
+// that does not run on the goroutine running the test: httptest handlers,
+// RoundTrippers, injected dependency stubs, and worker goroutines.
+//
+// t.Fatal, t.Fatalf, and t.FailNow may only be called from the goroutine
+// running the test. Calling them from an httptest handler skips the response
+// write and leaves the client under test waiting for a reply that never
+// arrives. Calling them from a worker goroutine terminates that goroutine
+// before it can send its result, so the test deadlocks on the channel or wait
+// group instead of failing, and the package eventually panics on the test
+// timeout with the original failure buried in the dump.
+//
+// An Asserter records the failure with Errorf, which is safe from any
+// goroutine, and returns a value the fixture can hand back to its caller, so
+// the code under test observes a deterministic failure and unwinds normally.
+package handlertest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	assertionCode  = "TEST_FIXTURE_ASSERTION"
+	assertionTitle = "test fixture assertion failed"
+)
+
+// reporter is the subset of testing.TB an Asserter needs. It exists so the
+// package can test its own reporting behavior; testing.TB cannot be
+// implemented outside the testing package.
+type reporter interface {
+	Helper()
+	Errorf(format string, args ...any)
+}
+
+// Asserter reports fixture failures from off-test-goroutine code.
+type Asserter struct {
+	reporter reporter
+}
+
+// New returns an Asserter that reports failures to tb.
+func New(tb testing.TB) *Asserter {
+	tb.Helper()
+	return &Asserter{reporter: tb}
+}
+
+// Errorf records a failure and returns an error carrying the same message.
+//
+// Use it wherever the fixture can hand an error back to the code under test:
+// a RoundTripper, an injected dependency stub, or a worker goroutine that
+// reports through a channel. The message is rendered with fmt.Errorf, so %w
+// keeps wrapping the operand and still prints readably in the test log.
+//
+//	return nil, fixture.Errorf("unexpected request: %s %s", req.Method, req.URL)
+func (a *Asserter) Errorf(format string, args ...any) error {
+	a.reporter.Helper()
+
+	err := fmt.Errorf(format, args...)
+	a.reporter.Errorf("%s", err.Error())
+	return err
+}
+
+// Respond records a failure and writes an HTTP 500 JSON error body to w.
+//
+// Use it from httptest handlers, which cannot return an error. The client
+// under test receives a complete response instead of blocking until its own
+// timeout, and the recorded failure fails the test.
+//
+//	default:
+//	    fixture.Respond(w, "unexpected request: %s %s", req.Method, req.URL.Path)
+//	    return
+func (a *Asserter) Respond(w http.ResponseWriter, format string, args ...any) {
+	a.reporter.Helper()
+
+	body := a.record(format, args...)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = io.WriteString(w, body)
+}
+
+// Response records a failure and returns a synthetic HTTP 500 JSON response.
+//
+// Use it from fixture helpers that must return an *http.Response and have no
+// way to signal an error, such as a response builder called from inside a
+// RoundTripper.
+//
+//	body, err := json.Marshal(payload)
+//	if err != nil {
+//	    return fixture.Response("marshal territory response: %v", err)
+//	}
+func (a *Asserter) Response(format string, args ...any) *http.Response {
+	a.reporter.Helper()
+
+	body := a.record(format, args...)
+	return &http.Response{
+		Status:        fmt.Sprintf("%d %s", http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)),
+		StatusCode:    http.StatusInternalServerError,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+// record reports the formatted message and returns the JSON error body that
+// carries it to the client under test.
+func (a *Asserter) record(format string, args ...any) string {
+	a.reporter.Helper()
+
+	message := fmt.Errorf(format, args...).Error()
+	a.reporter.Errorf("%s", message)
+	return errorBody(message)
+}
+
+// errorObject mirrors one entry of an App Store Connect error envelope so the
+// client under test decodes a fixture failure the same way it decodes a real
+// API failure.
+type errorObject struct {
+	Status string `json:"status"`
+	Code   string `json:"code"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+}
+
+type errorEnvelope struct {
+	Errors []errorObject `json:"errors"`
+}
+
+func errorBody(message string) string {
+	encoded, err := json.Marshal(errorEnvelope{Errors: []errorObject{{
+		Status: strconv.Itoa(http.StatusInternalServerError),
+		Code:   assertionCode,
+		Title:  assertionTitle,
+		Detail: message,
+	}}})
+	if err != nil {
+		return fmt.Sprintf(`{"errors":[{"status":"500","code":%q,"title":%q}]}`, assertionCode, assertionTitle)
+	}
+	return string(encoded)
+}

--- a/internal/handlertest/handlertest_test.go
+++ b/internal/handlertest/handlertest_test.go
@@ -1,0 +1,220 @@
+package handlertest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// clientDeadline bounds every request in this package so a regression that
+// reintroduces the hang fails the test instead of running until the package
+// timeout.
+const clientDeadline = 5 * time.Second
+
+// fakeReporter records what an Asserter reports without failing the enclosing
+// test. testing.TB cannot be implemented outside the testing package, which is
+// why Asserter holds the narrower reporter interface.
+type fakeReporter struct {
+	mu       sync.Mutex
+	messages []string
+	helpers  int
+}
+
+func (r *fakeReporter) Helper() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.helpers++
+}
+
+func (r *fakeReporter) Errorf(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.messages = append(r.messages, fmt.Sprintf(format, args...))
+}
+
+func (r *fakeReporter) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]string(nil), r.messages...)
+}
+
+func newFakeAsserter() (*Asserter, *fakeReporter) {
+	recorder := &fakeReporter{}
+	return &Asserter{reporter: recorder}, recorder
+}
+
+func TestNewReportsThroughTheTestItself(t *testing.T) {
+	fixture := New(t)
+	if fixture.reporter != reporter(t) {
+		t.Fatalf("New() bound %#v, want the test passed to it", fixture.reporter)
+	}
+}
+
+func TestRespondFailsTheTestAndDeliversFiveHundredWithoutHanging(t *testing.T) {
+	fixture, recorder := newFakeAsserter()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		fixture.Respond(w, "unexpected request: %s %s", req.Method, req.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), clientDeadline)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/v1/unexpected", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	started := time.Now()
+	response, err := server.Client().Do(request)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("client did not receive a response from a failing handler: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if elapsed >= clientDeadline {
+		t.Fatalf("failing handler took %s to answer; the client must not wait on an assertion", elapsed)
+	}
+	if response.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusInternalServerError)
+	}
+	if got := response.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type = %q, want application/json", got)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var envelope errorEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode body %q: %v", body, err)
+	}
+	if len(envelope.Errors) != 1 {
+		t.Fatalf("error envelope = %+v, want exactly one error", envelope)
+	}
+	if envelope.Errors[0].Status != "500" || envelope.Errors[0].Code != assertionCode {
+		t.Fatalf("error object = %+v", envelope.Errors[0])
+	}
+	if envelope.Errors[0].Detail != "unexpected request: GET /v1/unexpected" {
+		t.Fatalf("error detail = %q", envelope.Errors[0].Detail)
+	}
+
+	messages := recorder.snapshot()
+	if len(messages) != 1 || messages[0] != "unexpected request: GET /v1/unexpected" {
+		t.Fatalf("reported messages = %#v, want the formatted assertion exactly once", messages)
+	}
+}
+
+func TestErrorfReportsAndLetsAWorkerGoroutineReturn(t *testing.T) {
+	fixture, recorder := newFakeAsserter()
+
+	// Models the shape that deadlocks with t.Fatal: a worker that must send its
+	// result before the test can proceed.
+	results := make(chan error, 1)
+	go func() {
+		results <- fixture.Errorf("stale creator overwrote completed state")
+	}()
+
+	select {
+	case err := <-results:
+		if err == nil || err.Error() != "stale creator overwrote completed state" {
+			t.Fatalf("worker error = %v", err)
+		}
+	case <-time.After(clientDeadline):
+		t.Fatal("worker goroutine never reported; Errorf must not terminate the caller")
+	}
+
+	messages := recorder.snapshot()
+	if len(messages) != 1 || messages[0] != "stale creator overwrote completed state" {
+		t.Fatalf("reported messages = %#v", messages)
+	}
+}
+
+func TestErrorfKeepsWrappedOperandsReadableAndUnwrappable(t *testing.T) {
+	fixture, recorder := newFakeAsserter()
+	cause := errors.New("unexpected EOF")
+
+	err := fixture.Errorf("decode PATCH: %w", cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("errors.Is(%v, cause) = false, want true", err)
+	}
+	if err.Error() != "decode PATCH: unexpected EOF" {
+		t.Fatalf("error = %q", err.Error())
+	}
+
+	messages := recorder.snapshot()
+	if len(messages) != 1 || messages[0] != "decode PATCH: unexpected EOF" {
+		t.Fatalf("reported messages = %#v, want the wrapped operand rendered readably", messages)
+	}
+}
+
+func TestResponseReportsAndReachesTheClientThroughARoundTripper(t *testing.T) {
+	fixture, recorder := newFakeAsserter()
+
+	client := &http.Client{
+		Timeout: clientDeadline,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return fixture.Response("marshal territory response: %v", io.ErrUnexpectedEOF), nil
+		}),
+	}
+
+	response, err := client.Get("https://api.appstoreconnect.apple.com/v1/apps/app-1")
+	if err != nil {
+		t.Fatalf("client did not receive a response from a failing fixture: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusInternalServerError)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(body), "marshal territory response: unexpected EOF") {
+		t.Fatalf("body = %s", body)
+	}
+
+	messages := recorder.snapshot()
+	if len(messages) != 1 || messages[0] != "marshal territory response: unexpected EOF" {
+		t.Fatalf("reported messages = %#v", messages)
+	}
+}
+
+func TestReportersAreCalledOnceForEveryAssertion(t *testing.T) {
+	fixture, recorder := newFakeAsserter()
+
+	_ = fixture.Errorf("first")
+	fixture.Respond(httptest.NewRecorder(), "second")
+	_ = fixture.Response("third")
+
+	messages := recorder.snapshot()
+	want := []string{"first", "second", "third"}
+	if len(messages) != len(want) {
+		t.Fatalf("reported messages = %#v, want %#v", messages, want)
+	}
+	for index, message := range want {
+		if messages[index] != message {
+			t.Fatalf("message %d = %q, want %q", index, messages[index], message)
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## Why

Three consecutive review rounds flagged the same defect class: `t.Fatal` / `t.Fatalf` called from code that does not run on the goroutine running the test.

- #2053 and #2055 (`pricing availability edit`, `remove-from-sale`) — RoundTrippers driven by the territory worker pool.
- #2057 (ads search optimization) — httptest handlers; that thread asked for a shared repo-wide helper instead of another isolated fix.

The agreed fix each time was `t.Errorf` plus an explicit return. The helper was never built, so the idiom has been re-derived by hand, inconsistently, in every round.

`t.Fatal` runs `runtime.Goexit` on whichever goroutine calls it. Inside an httptest handler that skips the response write and leaves the client under test waiting for a reply that never arrives. Inside a worker goroutine it kills the worker before it can send its result, so the test blocks on a channel or wait group until the package timeout panics, with the real assertion buried in the goroutine dump.

Measured on `TestConcurrentApplyInitializesOnlyAfterReadingStateUnderRunLock`, forcing its `writeRun` guard to fire:

| stub reports with | result |
| --- | --- |
| `t.Fatal` (before) | `panic: test timed out after 20s`, no assertion message |
| `handlertest` (after) | `--- FAIL (0.00s)` naming both the violated guard and the run error it produced |

## What this adds

`internal/handlertest`: one `Asserter`, bound with `handlertest.New(t)`, covering the three shapes the hazard takes.

| method | for | returns |
| --- | --- | --- |
| `Errorf(format, args...)` | RoundTrippers, dependency stubs, worker goroutines | `error` carrying the same message |
| `Respond(w, format, args...)` | httptest handlers, which cannot return | writes HTTP 500 + JSON error envelope |
| `Response(format, args...)` | fixture builders that must hand back a response | synthetic HTTP 500 `*http.Response` |

Each records once with `Errorf`, which is safe from any goroutine, and hands the caller a value so the code under test observes a deterministic failure and unwinds normally. Messages render through `fmt.Errorf`, so `%w` keeps wrapping the operand and still prints readably in the test log — that collapses the `t.Errorf(...)` + duplicated `fmt.Errorf(...)` pairs the previous PRs had to write by hand into a single call with one message.

`internal/handlertest/handlertest_test.go` proves the semantics: a deliberately failing handler answers a real client with a 500 inside a bounded deadline (a hang fails the test rather than running to the package timeout), the envelope carries the assertion detail, a failing stub lets its worker goroutine return through its channel, and every path reports exactly once. `testing.TB` cannot be implemented outside `testing`, so `Asserter` holds a narrow `reporter` interface and the tests inject a recorder that captures reports without failing the run.

`docs/TESTING.md` documents the convention so the next reviewer can point at it.

## Blast radius, measured

AST pass over the whole tree (`go/parser`), counting `t.Fatal`, `t.Fatalf`, and `t.FailNow` lexically inside a func literal whose signature is `func(http.ResponseWriter, *http.Request)` or `func(*http.Request) (*http.Response, error)`:

- **4,290 call sites across 344 files** at this branch's HEAD (4,299 across 345 before this PR).
- 485 in handler literals, 3,805 in RoundTripper literals, 0 directly inside `go func() {}` bodies.
- Concentration: `internal/cli/cmdtest` 3,472 sites / 254 files, `internal/web` 273 / 19, `internal/cli/web` 74 / 10, `internal/cli/apps` 68 / 2, `internal/cli/publish` 66 / 5, `internal/cli/assets` 59 / 6, `internal/cli/shared` 50 / 5.
- An earlier coarse regex estimated ~169 files; the real file count is about double.

That number is a ceiling on the pattern, not on the hazard. A Fatal in a RoundTripper only deadlocks when the code under test issues that request off the test goroutine; most of the 3,805 are sequential fixtures where Fatal is merely ugly. It also misses two indirect classes the lexical scan cannot see, both present in this batch: fixture helpers called from inside a RoundTripper, and injected dependency stubs invoked on a worker goroutine.

**Deliberately not a mass rewrite.** This converts the sharp subset — suites whose production code fans out — and leaves the rest for follow-ups now that the helper and the documented convention exist.

## Converted in this batch

| file | why it is sharp | change |
| --- | --- | --- |
| `internal/cli/cmdtest/pricing_availability_edit_territory_test.go` | `updateTerritoryAvailabilityTargets` patches from a worker pool | 7 `t.Errorf` + duplicated `fmt.Errorf` pairs collapsed; 1 `t.Fatalf` in the response builder called from the transport |
| `internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go` | same worker pool | 3 pairs collapsed; 1 `t.Fatalf` in `territoryAvailabilityResponse`; 4 silent unexpected-request guards now report |
| `internal/cli/validate/subscription_fetch_test.go` | readiness drives these fetches from bounded workers | 9 RoundTripper `t.Fatalf` converted, two of which returned `(nil, nil)` after the Fatal — a nil response handed to the client if it ever ran on |
| `internal/cli/validate/concurrency_test.go` | httptest handler serving a six-way concurrent read fan-out | unexpected-request default answered 500 without failing the test; now reports through `Respond` |
| `internal/cli/distribute/orchestration_test.go` | `executeDistributionApply` runs on a worker goroutine | 2 stub `t.Fatal` calls — the hang measured above |

13 `t.Fatal`/`t.Fatalf` removed from off-test-goroutine code, 10 report/return pairs collapsed, 7 previously silent guards now name their cause.

## Not converted

- `internal/cli/ads/search_optimization_test.go` — open PR #2071 owns the file; next batch, after it lands.
- Everything else in the survey. The concentration in `internal/cli/cmdtest`, `internal/web`, and `internal/cli/web` is the natural next sweep, prioritised by whether the command under test fans out.

## Behavior

Mechanism only, not assertions. Every converted test still fails on exactly the conditions it failed on before — the fixture now reports and answers instead of terminating its goroutine. Where a Fatal guarded an unrecoverable fixture error (a marshal failure, an unexpected request), the replacement still fails the test and additionally propagates a deterministic error or 500 to the code under test, so the outer assertion fails too rather than hanging.

The seven previously silent guards are the one place strictness increases: they returned an error or a 500 without recording anything, so an unexpected request could only surface indirectly. Each converted suite was re-run to confirm it stays green, which also confirms none of them currently hits those branches.

## Verification

- `make build`, `make format`, `make check-docs`, `GOLANGCI_LINT_TIMEOUT="10m --allow-parallel-runners" make lint` (0 issues), `ASC_BYPASS_KEYCHAIN=1 make test` — full suite green.
- `go test ./internal/cli/validate ./internal/cli/cmdtest -run TestPricingAvailability -race -count=2` green.
- RED proof per suite: broke a pricing fixture path deliberately — failed in 0.02s at the fixture line with the request that violated it, no hang.
- No live API calls; `ASC_BYPASS_KEYCHAIN=1` throughout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for safely reporting failures from concurrent test routines.
  * Documented helper usage for transport errors, handlers, HTTP responses, and wrapped errors.

* **Tests**
  * Improved concurrent test reliability by preventing premature goroutine termination and hangs.
  * Added comprehensive coverage for failure reporting, HTTP 500 responses, formatted errors, and wrapped errors.
  * Updated existing tests to use consistent failure-handling helpers without changing their scenarios or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->