### PR TITLE
apps wall: add Ring Widget

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1321,6 +1321,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/52/db/cc/52dbcc8f-c4aa-2cf0-36f9-bdeacf943fd7/AppIcon-0-1x_U007epad-0-11-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Ring Widget",
+    "link": "https://apps.apple.com/us/app/ring-widget/id1663323988?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f9/a4/20/f9a420ea-1b6b-83f4-25b5-488aef5a11db/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Ripple News - AI Personal News",
     "link": "https://apps.apple.com/us/app/ripple-news-ai-personal-news/id6758356024?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/19/33/17/193317c5-5112-6151-9fd9-5b98ac41b52d/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Ring Widget` to the Wall of Apps

## Entry

- App ID: 1663323988
- App: Ring Widget
- Link: https://apps.apple.com/us/app/ring-widget/id1663323988?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Ring Widget app to the applications list, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->