### PR TITLE
fix(web): sanitize Bundle ID patch attributes

### DIFF
--- a/internal/web/developer_app_groups.go
+++ b/internal/web/developer_app_groups.go
@@ -385,9 +385,9 @@ func buildDeveloperAppGroupAssignmentPatchRequest(current developerBundleIDRespo
 		updated = append(updated, capability)
 	}
 
-	relationship, err := json.Marshal(developerResourceRelationship{Data: updated})
+	relationship, err := marshalDeveloperBundleIDCapabilitiesForPatch(updated)
 	if err != nil {
-		return developerBundleIDPatchRequest{}, false, fmt.Errorf("failed to build Bundle ID capability relationships: %w", err)
+		return developerBundleIDPatchRequest{}, false, err
 	}
 	relationships := cloneRawMessageMap(current.Data.Relationships)
 	if relationships == nil {

--- a/internal/web/developer_app_groups_test.go
+++ b/internal/web/developer_app_groups_test.go
@@ -242,8 +242,8 @@ func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
 				t.Fatalf("unexpected bundle read %s %s", request.Method, request.URL.String())
 			}
 			return developerPortalTestResponse(http.StatusOK, `{
-				"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app","platform":"IOS"},"relationships":{"bundleIdCapabilities":{"data":[{"type":"bundleIdCapabilities","id":"push-1"}]}}},
-				"included":[{"type":"bundleIdCapabilities","id":"push-1","attributes":{"enabled":true,"settings":[]},"relationships":{"capability":{"data":{"type":"capabilities","id":"PUSH_NOTIFICATIONS"}}}}]
+				"data":{"id":"bundle-1","type":"bundleIds","attributes":{"name":"Example","identifier":"com.example.app","platform":"IOS","permissions":{"delete":true,"edit":true},"~permissions.delete":true,"~permissions.edit":true},"relationships":{"bundleIdCapabilities":{"data":[{"type":"bundleIdCapabilities","id":"push-1"}]}}},
+				"included":[{"type":"bundleIdCapabilities","id":"push-1","attributes":{"enabled":true,"settings":[],"ownerType":"BUNDLE","editable":true,"inputs":[],"responseId":"response-1"},"relationships":{"capability":{"data":{"type":"capabilities","id":"PUSH_NOTIFICATIONS"}}}}]
 			}`, nil), nil
 		case 3:
 			if request.URL.Path != "/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action" {
@@ -284,8 +284,17 @@ func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
 	if err := json.Unmarshal(patchBody, &payload); err != nil {
 		t.Fatalf("decode patch: %v; body=%s", err, patchBody)
 	}
-	if payload.Data.Attributes == nil || !strings.Contains(string(payload.Data.Attributes), `"teamId":"TEAM123456"`) {
-		t.Fatalf("team and existing attributes not preserved: %s", payload.Data.Attributes)
+	var bundleAttributes map[string]json.RawMessage
+	if err := json.Unmarshal(payload.Data.Attributes, &bundleAttributes); err != nil {
+		t.Fatalf("decode Bundle ID attributes: %v", err)
+	}
+	if string(bundleAttributes["teamId"]) != `"TEAM123456"` || string(bundleAttributes["identifier"]) != `"com.example.app"` {
+		t.Fatalf("team and writable attributes not preserved: %s", payload.Data.Attributes)
+	}
+	for _, key := range []string{"permissions", "~permissions.delete", "~permissions.edit"} {
+		if _, ok := bundleAttributes[key]; ok {
+			t.Fatalf("read-only Bundle ID attribute %q was sent in PATCH: %s", key, payload.Data.Attributes)
+		}
 	}
 	var capabilities developerResourceRelationship
 	if err := json.Unmarshal(payload.Data.Relationships["bundleIdCapabilities"], &capabilities); err != nil {
@@ -293,6 +302,16 @@ func TestAssignDeveloperAppGroupPreservesBundleGraph(t *testing.T) {
 	}
 	if len(capabilities.Data) != 2 {
 		t.Fatalf("capability count = %d, want existing plus APP_GROUPS", len(capabilities.Data))
+	}
+	var existingAttributes map[string]json.RawMessage
+	if err := json.Unmarshal(capabilities.Data[0].Attributes, &existingAttributes); err != nil {
+		t.Fatalf("decode existing capability attributes: %v", err)
+	}
+	if len(existingAttributes) != 2 || string(existingAttributes["enabled"]) != "true" || string(existingAttributes["settings"]) != "[]" {
+		t.Fatalf("PATCH contained read-only capability attributes: %s", capabilities.Data[0].Attributes)
+	}
+	if _, ok := capabilities.Data[0].Relationships["capability"]; !ok {
+		t.Fatalf("existing capability relationship was not preserved: %+v", capabilities.Data[0].Relationships)
 	}
 	appGroupsCapability := capabilities.Data[1]
 	if capability, err := developerBundleIDCapabilityID(appGroupsCapability); err != nil || capability != "APP_GROUPS" {

--- a/internal/web/developer_bundle_ids.go
+++ b/internal/web/developer_bundle_ids.go
@@ -384,9 +384,9 @@ func buildDeveloperBundleIDCapabilityPatchRequest(current developerBundleIDRespo
 		updated = append(updated, newDeveloperBundleIDCapability(req.Capability))
 	}
 
-	relationshipBody, err := json.Marshal(developerResourceRelationship{Data: updated})
+	relationshipBody, err := marshalDeveloperBundleIDCapabilitiesForPatch(updated)
 	if err != nil {
-		return developerBundleIDPatchRequest{}, false, fmt.Errorf("failed to build Bundle ID capability relationships: %w", err)
+		return developerBundleIDPatchRequest{}, false, err
 	}
 	relationships := cloneRawMessageMap(current.Data.Relationships)
 	if relationships == nil {
@@ -412,6 +412,11 @@ func addDeveloperPortalTeamID(payload developerBundleIDPatchRequest, teamID stri
 	if attributes == nil {
 		attributes = make(map[string]json.RawMessage)
 	}
+	for key := range attributes {
+		if key == "permissions" || strings.HasPrefix(key, "~permissions.") {
+			delete(attributes, key)
+		}
+	}
 	encodedTeamID, err := json.Marshal(strings.TrimSpace(teamID))
 	if err != nil {
 		return payload, fmt.Errorf("failed to encode Developer Portal team: %w", err)
@@ -423,6 +428,35 @@ func addDeveloperPortalTeamID(payload developerBundleIDPatchRequest, teamID stri
 	}
 	payload.Data.Attributes = encodedAttributes
 	return payload, nil
+}
+
+func marshalDeveloperBundleIDCapabilitiesForPatch(capabilities []developerResource) (json.RawMessage, error) {
+	for index := range capabilities {
+		if len(capabilities[index].Attributes) == 0 {
+			continue
+		}
+		var attributes map[string]json.RawMessage
+		if err := json.Unmarshal(capabilities[index].Attributes, &attributes); err != nil {
+			return nil, fmt.Errorf("failed to parse Bundle ID capability %q attributes for patch: %w", capabilities[index].ID, err)
+		}
+		writable := make(map[string]json.RawMessage, 2)
+		for _, key := range []string{"enabled", "settings"} {
+			if value, ok := attributes[key]; ok {
+				writable[key] = append(json.RawMessage(nil), value...)
+			}
+		}
+		encoded, err := json.Marshal(writable)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode Bundle ID capability %q attributes for patch: %w", capabilities[index].ID, err)
+		}
+		capabilities[index].Attributes = encoded
+	}
+
+	encoded, err := json.Marshal(developerResourceRelationship{Data: capabilities})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Bundle ID capability relationships: %w", err)
+	}
+	return encoded, nil
 }
 
 func developerBundleIDCapabilities(current developerBundleIDResponse) ([]developerResource, error) {

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -63,55 +63,48 @@ func TestEnsureDeveloperPortalSessionRejectsDifferentPortRedirect(t *testing.T) 
 }
 
 func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *testing.T) {
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatalf("cookiejar.New() error: %v", err)
-	}
-
 	var patchBody []byte
+	var err error
 	requestCount := 0
-	client := &Client{
-		httpClient: &http.Client{
-			Jar: jar,
-			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-				requestCount++
-				for _, header := range []string{"Accept", "Content-Type", "Referer", "User-Agent", "X-Requested-With"} {
-					if strings.TrimSpace(r.Header.Get(header)) == "" {
-						t.Fatalf("request %d missing %s header", requestCount, header)
-					}
-				}
+	handler := func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		for _, header := range []string{"Accept", "Content-Type", "Referer", "User-Agent", "X-Requested-With"} {
+			if strings.TrimSpace(r.Header.Get(header)) == "" {
+				t.Fatalf("request %d missing %s header", requestCount, header)
+			}
+		}
 
-				switch requestCount {
-				case 1:
-					if r.Method != http.MethodPost || r.URL.Path != "/services-account/QH65B2/account/listTeams.action" {
-						t.Fatalf("unexpected bootstrap request %s %s", r.Method, r.URL.String())
-					}
-					return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": []string{"bootstrap-csrf"}, "csrf_ts": []string{"bootstrap-ts"}}), nil
-				case 2:
-					if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/capabilities" {
-						t.Fatalf("unexpected metadata request %s %s", r.Method, r.URL.String())
-					}
-					if got := r.Header.Get("X-HTTP-Method-Override"); got != http.MethodGet {
-						t.Fatalf("metadata method override = %q", got)
-					}
-					proxy := decodeDeveloperPortalProxyReadRequest(t, r)
-					if proxy.TeamID != "TEAM123456" {
-						t.Fatalf("metadata teamId = %q", proxy.TeamID)
-					}
-					query, err := url.ParseQuery(proxy.URLEncodedQueryParams)
-					if err != nil {
-						t.Fatalf("metadata query: %v", err)
-					}
-					if got := query.Get("filter[capabilityType]"); got != "capability,service" {
-						t.Fatalf("filter[capabilityType] = %q", got)
-					}
-					if got := query.Get("filter[includeRequestable]"); got != "true" {
-						t.Fatalf("filter[includeRequestable] = %q", got)
-					}
-					if r.Header.Get("csrf") != "bootstrap-csrf" || r.Header.Get("csrf_ts") != "bootstrap-ts" {
-						t.Fatalf("metadata request missing bootstrap CSRF headers")
-					}
-					return developerPortalTestResponse(http.StatusOK, `{
+		switch requestCount {
+		case 1:
+			if r.Method != http.MethodPost || r.URL.Path != "/services-account/QH65B2/account/listTeams.action" {
+				t.Fatalf("unexpected bootstrap request %s %s", r.Method, r.URL.String())
+			}
+			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": []string{"bootstrap-csrf"}, "csrf_ts": []string{"bootstrap-ts"}}), nil
+		case 2:
+			if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/capabilities" {
+				t.Fatalf("unexpected metadata request %s %s", r.Method, r.URL.String())
+			}
+			if got := r.Header.Get("X-HTTP-Method-Override"); got != http.MethodGet {
+				t.Fatalf("metadata method override = %q", got)
+			}
+			proxy := decodeDeveloperPortalProxyReadRequest(t, r)
+			if proxy.TeamID != "TEAM123456" {
+				t.Fatalf("metadata teamId = %q", proxy.TeamID)
+			}
+			query, err := url.ParseQuery(proxy.URLEncodedQueryParams)
+			if err != nil {
+				t.Fatalf("metadata query: %v", err)
+			}
+			if got := query.Get("filter[capabilityType]"); got != "capability,service" {
+				t.Fatalf("filter[capabilityType] = %q", got)
+			}
+			if got := query.Get("filter[includeRequestable]"); got != "true" {
+				t.Fatalf("filter[includeRequestable] = %q", got)
+			}
+			if r.Header.Get("csrf") != "bootstrap-csrf" || r.Header.Get("csrf_ts") != "bootstrap-ts" {
+				t.Fatalf("metadata request missing bootstrap CSRF headers")
+			}
+			return developerPortalTestResponse(http.StatusOK, `{
 						"data":[{
 							"type":"capabilities",
 							"id":"PRIVATE_CLOUD_COMPUTE",
@@ -124,33 +117,33 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 							}
 						}]
 					}`, http.Header{"csrf": []string{"secret-csrf"}, "csrf_ts": []string{"secret-ts"}}), nil
-				case 3:
-					if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
-						t.Fatalf("unexpected bundle request %s %s", r.Method, r.URL.String())
-					}
-					if got := r.Header.Get("X-HTTP-Method-Override"); got != http.MethodGet {
-						t.Fatalf("bundle method override = %q", got)
-					}
-					proxy := decodeDeveloperPortalProxyReadRequest(t, r)
-					query, err := url.ParseQuery(proxy.URLEncodedQueryParams)
-					if err != nil {
-						t.Fatalf("bundle query: %v", err)
-					}
-					if got := query.Get("fields[bundleIds]"); got != "name,identifier,platform,seedId,wildcard,~permissions.delete,~permissions.edit" {
-						t.Fatalf("fields[bundleIds] = %q", got)
-					}
-					include := query.Get("include")
-					for _, relationship := range []string{
-						"bundleIdCapabilities",
-						"bundleIdCapabilities.capability",
-						"bundleIdCapabilities.appGroups",
-						"bundleIdCapabilities.cloudContainers",
-					} {
-						if !strings.Contains(include, relationship) {
-							t.Fatalf("include missing %q: %q", relationship, include)
-						}
-					}
-					return developerPortalTestResponse(http.StatusOK, `{
+		case 3:
+			if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
+				t.Fatalf("unexpected bundle request %s %s", r.Method, r.URL.String())
+			}
+			if got := r.Header.Get("X-HTTP-Method-Override"); got != http.MethodGet {
+				t.Fatalf("bundle method override = %q", got)
+			}
+			proxy := decodeDeveloperPortalProxyReadRequest(t, r)
+			query, err := url.ParseQuery(proxy.URLEncodedQueryParams)
+			if err != nil {
+				t.Fatalf("bundle query: %v", err)
+			}
+			if got := query.Get("fields[bundleIds]"); got != "name,identifier,platform,seedId,wildcard,~permissions.delete,~permissions.edit" {
+				t.Fatalf("fields[bundleIds] = %q", got)
+			}
+			include := query.Get("include")
+			for _, relationship := range []string{
+				"bundleIdCapabilities",
+				"bundleIdCapabilities.capability",
+				"bundleIdCapabilities.appGroups",
+				"bundleIdCapabilities.cloudContainers",
+			} {
+				if !strings.Contains(include, relationship) {
+					t.Fatalf("include missing %q: %q", relationship, include)
+				}
+			}
+			return developerPortalTestResponse(http.StatusOK, `{
 						"data":{
 							"id":"bundle-1",
 							"type":"bundleIds",
@@ -183,24 +176,52 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 							}
 						}]
 					}`, nil), nil
-				case 4:
-					if r.Method != http.MethodPatch || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
-						t.Fatalf("unexpected patch request %s %s", r.Method, r.URL.String())
-					}
-					if r.Header.Get("csrf") != "secret-csrf" || r.Header.Get("csrf_ts") != "secret-ts" {
-						t.Fatalf("missing CSRF headers")
-					}
-					patchBody, err = io.ReadAll(r.Body)
-					if err != nil {
-						t.Fatalf("ReadAll() error: %v", err)
-					}
-					return developerPortalTestResponse(http.StatusOK, `{"data":{"type":"bundleIds","id":"bundle-1"}}`, nil), nil
-				default:
-					t.Fatalf("unexpected request %d: %s %s", requestCount, r.Method, r.URL.String())
-					return nil, nil
-				}
-			}),
-		},
+		case 4:
+			if r.Method != http.MethodPatch || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
+				t.Fatalf("unexpected patch request %s %s", r.Method, r.URL.String())
+			}
+			if r.Header.Get("csrf") != "secret-csrf" || r.Header.Get("csrf_ts") != "secret-ts" {
+				t.Fatalf("missing CSRF headers")
+			}
+			patchBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll() error: %v", err)
+			}
+			return developerPortalTestResponse(http.StatusOK, `{"data":{"type":"bundleIds","id":"bundle-1"}}`, nil), nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requestCount, r.Method, r.URL.String())
+			return nil, nil
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		response, err := handler(request)
+		if err != nil {
+			t.Errorf("test Developer Portal handler: %v", err)
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if response == nil {
+			t.Error("test Developer Portal handler returned a nil response")
+			http.Error(writer, "missing test response", http.StatusInternalServerError)
+			return
+		}
+		for name, values := range response.Header {
+			for _, value := range values {
+				writer.Header().Add(name, value)
+			}
+		}
+		writer.WriteHeader(response.StatusCode)
+		if response.Body != nil {
+			defer func() { _ = response.Body.Close() }()
+			if _, err := io.Copy(writer, response.Body); err != nil {
+				t.Errorf("write test Developer Portal response: %v", err)
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := &Client{
+		httpClient:         server.Client(),
+		developerPortalURL: server.URL,
 	}
 
 	result, err := client.EnableDeveloperBundleIDCapability(context.Background(), DeveloperBundleIDCapabilityEnableRequest{
@@ -263,6 +284,18 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 	}
 	if len(existing.Attributes) != 2 {
 		t.Fatalf("PATCH contained read-only capability attributes: %+v", existing.Attributes)
+	}
+	settings, ok := existing.Attributes["settings"].([]any)
+	if !ok {
+		t.Fatalf("PATCH omitted or changed existing capability settings: %+v", existing.Attributes)
+	}
+	encodedSettings, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatalf("encode existing capability settings: %v", err)
+	}
+	const wantSettings = `[{"key":"ICLOUD_VERSION","options":[{"enabled":true,"key":"XCODE_6"}]}]`
+	if string(encodedSettings) != wantSettings {
+		t.Fatalf("PATCH changed existing capability settings: got %s, want %s", encodedSettings, wantSettings)
 	}
 	if _, ok := existing.Relationships["appGroups"]; !ok {
 		t.Fatalf("existing appGroups relationship was not preserved: %+v", existing.Relationships)

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -66,7 +66,7 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 	var patchBody []byte
 	var err error
 	requestCount := 0
-	handler := func(r *http.Request) (*http.Response, error) {
+	handler := func(r *http.Request) *http.Response {
 		requestCount++
 		for _, header := range []string{"Accept", "Content-Type", "Referer", "User-Agent", "X-Requested-With"} {
 			if strings.TrimSpace(r.Header.Get(header)) == "" {
@@ -79,7 +79,7 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 			if r.Method != http.MethodPost || r.URL.Path != "/services-account/QH65B2/account/listTeams.action" {
 				t.Fatalf("unexpected bootstrap request %s %s", r.Method, r.URL.String())
 			}
-			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": []string{"bootstrap-csrf"}, "csrf_ts": []string{"bootstrap-ts"}}), nil
+			return developerPortalTestResponse(http.StatusOK, developerPortalTeamsFixture(), http.Header{"csrf": []string{"bootstrap-csrf"}, "csrf_ts": []string{"bootstrap-ts"}})
 		case 2:
 			if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/capabilities" {
 				t.Fatalf("unexpected metadata request %s %s", r.Method, r.URL.String())
@@ -116,7 +116,7 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 								"canRequestFromPortal":false
 							}
 						}]
-					}`, http.Header{"csrf": []string{"secret-csrf"}, "csrf_ts": []string{"secret-ts"}}), nil
+					}`, http.Header{"csrf": []string{"secret-csrf"}, "csrf_ts": []string{"secret-ts"}})
 		case 3:
 			if r.Method != http.MethodPost || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
 				t.Fatalf("unexpected bundle request %s %s", r.Method, r.URL.String())
@@ -175,7 +175,7 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 								"cloudContainers":{"data":[{"type":"cloudContainers","id":"cloud-1"}]}
 							}
 						}]
-					}`, nil), nil
+					}`, nil)
 		case 4:
 			if r.Method != http.MethodPatch || r.URL.Path != "/services-account/v1/bundleIds/bundle-1" {
 				t.Fatalf("unexpected patch request %s %s", r.Method, r.URL.String())
@@ -187,19 +187,14 @@ func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *te
 			if err != nil {
 				t.Fatalf("ReadAll() error: %v", err)
 			}
-			return developerPortalTestResponse(http.StatusOK, `{"data":{"type":"bundleIds","id":"bundle-1"}}`, nil), nil
+			return developerPortalTestResponse(http.StatusOK, `{"data":{"type":"bundleIds","id":"bundle-1"}}`, nil)
 		default:
 			t.Fatalf("unexpected request %d: %s %s", requestCount, r.Method, r.URL.String())
-			return nil, nil
+			return nil
 		}
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		response, err := handler(request)
-		if err != nil {
-			t.Errorf("test Developer Portal handler: %v", err)
-			http.Error(writer, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		response := handler(request)
 		if response == nil {
 			t.Error("test Developer Portal handler returned a nil response")
 			http.Error(writer, "missing test response", http.StatusInternalServerError)

--- a/internal/web/developer_bundle_ids_test.go
+++ b/internal/web/developer_bundle_ids_test.go
@@ -62,7 +62,7 @@ func TestEnsureDeveloperPortalSessionRejectsDifferentPortRedirect(t *testing.T) 
 	}
 }
 
-func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
+func TestEnableDeveloperBundleIDCapabilityPreservesWritablePayloadAndGraph(t *testing.T) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		t.Fatalf("cookiejar.New() error: %v", err)
@@ -175,7 +175,7 @@ func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 						"included":[{
 							"type":"bundleIdCapabilities",
 							"id":"icloud-1",
-							"attributes":{"enabled":true,"settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]},
+							"attributes":{"enabled":true,"settings":[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}],"ownerType":"BUNDLE","editable":true,"inputs":[],"responseId":"response-1"},
 							"relationships":{
 								"capability":{"data":{"type":"capabilities","id":"ICLOUD"}},
 								"appGroups":{"data":[{"type":"appGroups","id":"group-1"}]},
@@ -231,8 +231,13 @@ func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 	if payload.Data.ID != "bundle-1" || payload.Data.Type != "bundleIds" {
 		t.Fatalf("unexpected resource identity: %+v", payload.Data)
 	}
-	if payload.Data.Attributes["platform"] != "IOS" || payload.Data.Attributes["seedId"] != "TEAMID" || payload.Data.Attributes["~permissions.edit"] != true {
-		t.Fatalf("bundle attributes were not preserved: %+v", payload.Data.Attributes)
+	if payload.Data.Attributes["platform"] != "IOS" || payload.Data.Attributes["seedId"] != "TEAMID" {
+		t.Fatalf("writable Bundle ID attributes were not preserved: %+v", payload.Data.Attributes)
+	}
+	for _, key := range []string{"permissions", "~permissions.delete", "~permissions.edit"} {
+		if _, ok := payload.Data.Attributes[key]; ok {
+			t.Fatalf("read-only Bundle ID attribute %q was sent in PATCH: %+v", key, payload.Data.Attributes)
+		}
 	}
 	if payload.Data.Attributes["teamId"] != "TEAM123456" {
 		t.Fatalf("Developer Portal teamId = %v", payload.Data.Attributes["teamId"])
@@ -255,6 +260,9 @@ func TestEnableDeveloperBundleIDCapabilityPreservesFullPayload(t *testing.T) {
 	existing := capabilityRelationship.Data[0]
 	if existing.ID != "icloud-1" || existing.Attributes["enabled"] != true {
 		t.Fatalf("existing capability changed: %+v", existing)
+	}
+	if len(existing.Attributes) != 2 {
+		t.Fatalf("PATCH contained read-only capability attributes: %+v", existing.Attributes)
 	}
 	if _, ok := existing.Relationships["appGroups"]; !ok {
 		t.Fatalf("existing appGroups relationship was not preserved: %+v", existing.Relationships)
@@ -481,8 +489,11 @@ func TestEnableDeveloperBundleIDCapabilityUpdatesDisabledTargetOnce(t *testing.T
 	if err := json.Unmarshal(caps[0].Attributes, &attributes); err != nil {
 		t.Fatalf("decode attributes: %v", err)
 	}
-	if attributes["enabled"] != true || attributes["portalOwned"] != "keep" {
-		t.Fatalf("target attributes not preserved: %+v", attributes)
+	if attributes["enabled"] != true {
+		t.Fatalf("target enabled state not updated: %+v", attributes)
+	}
+	if _, ok := attributes["portalOwned"]; ok {
+		t.Fatalf("read-only target attribute was sent in PATCH: %+v", attributes)
 	}
 	settings, ok := attributes["settings"].([]any)
 	if !ok || len(settings) != 1 {


### PR DESCRIPTION
## Summary

- remove Developer Portal read-only permission attributes from Bundle ID PATCH payloads
- serialize only the writable `enabled` and `settings` capability attributes while preserving the complete capability relationship graph
- cover App Group assignment and the shared capability-enable path with live-shaped HTTP regression fixtures

## Why

The Developer Portal GET representation includes response-only Bundle ID and capability attributes. Sending that representation back unchanged causes `web app-groups assign` to fail with `409 ENTITY_ERROR.ATTRIBUTE.UNKNOWN`.

This keeps the existing read-modify-write graph behavior, but narrows only the attributes written back. The public CLI shape, output, and exit behavior are unchanged.

## Verification

- RED: `TestAssignDeveloperAppGroupPreservesBundleGraph` failed because `permissions` was present in the outgoing PATCH
- GREEN: focused App Group regression test
- `go test ./internal/web -count=1`
- `make format`
- `make check-docs`
- `make lint`
- `make build` (binary written outside the checkout)
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary `asc web app-groups assign --help`

The issue's minimized live payload already confirmed that omitting these response-only fields is accepted by Developer Portal. This change did not perform another live mutation.

Fixes #2136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bundle ID capability updates by preserving writable settings and enabled states.
  * Prevented read-only and permission-related fields from being included in update requests.
  * Preserved existing capability relationships when assigning apps to groups.
  * Improved handling of disabled capabilities during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->