### PR TITLE
fix(subscriptions): honor --dry-run for single-territory intro offers

### DIFF
--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -895,6 +895,8 @@ Offer discounted pricing to new subscribers.
 `--all-territories` and prints a migration warning. Use `--all-territories` in
 new scripts; combining both spellings is invalid.
 
+`--dry-run` prints a summary and creates nothing, in either territory mode.
+
 ```bash  theme={null}
 # Create introductory offer
 asc subscriptions offers introductory create \
@@ -916,6 +918,15 @@ asc subscriptions offers introductory create \
 asc subscriptions offers introductory create \
   --subscription-id "SUB_ID" \
   --all-territories \
+  --dry-run \
+  --offer-duration ONE_MONTH \
+  --offer-mode FREE_TRIAL \
+  --number-of-periods 1
+
+# Preview a single-territory introductory offer without mutating ASC
+asc subscriptions offers introductory create \
+  --subscription-id "SUB_ID" \
+  --territory "USA" \
   --dry-run \
   --offer-duration ONE_MONTH \
   --offer-mode FREE_TRIAL \

--- a/commands/subscriptions.mdx
+++ b/commands/subscriptions.mdx
@@ -896,6 +896,9 @@ Offer discounted pricing to new subscribers.
 new scripts; combining both spellings is invalid.
 
 `--dry-run` prints a summary and creates nothing, in either territory mode.
+Single-territory dry runs normalize the territory locally and make no network
+requests; the `subscriptionId` field echoes the selector supplied on the command
+line and `created: 1` is the planned create count, not an existing-offer check.
 
 ```bash  theme={null}
 # Create introductory offer

--- a/docs/design/subscription-introductory-offer-territory-selector.md
+++ b/docs/design/subscription-introductory-offer-territory-selector.md
@@ -38,7 +38,12 @@ schema and has callers outside this command.
 same summary shape. Single-territory mode reports `total: 1` with the resolved
 territory and issues no requests of its own, because the territory is already
 resolved locally and the availability lookup only exists to enumerate territories
-for the bulk path.
+for the bulk path. In this mode the `subscriptionId` summary field echoes the
+selector supplied by the caller; it is not resolved or existence-checked. The
+single planned create is therefore reported as `created: 1` even when an
+existing offer might cause the real create to be rejected. All-territories mode
+retains its existing availability and offer reconciliation reads, so its
+`created` and `skipped` counts remain provider-backed.
 
 ## Compatibility and verification
 

--- a/docs/design/subscription-introductory-offer-territory-selector.md
+++ b/docs/design/subscription-introductory-offer-territory-selector.md
@@ -34,6 +34,12 @@ create requests, summary output, dry-run behavior, and partial-failure handling.
 The lower-level API client remains unchanged because it follows the OpenAPI
 schema and has callers outside this command.
 
+`--dry-run` suppresses the create request in both territory modes and prints the
+same summary shape. Single-territory mode reports `total: 1` with the resolved
+territory and issues no requests of its own, because the territory is already
+resolved locally and the availability lookup only exists to enumerate territories
+for the bulk path.
+
 ## Compatibility and verification
 
 Valid concrete and all-territories invocations keep their existing request and

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -158,6 +158,19 @@ func registerAllOutputRenderers() {
 	})
 	registerRows(winBackOfferDeleteResultRows)
 	registerRows(subscriptionPriceDeleteResultRows)
+	registerDirect(func(v *SubscriptionIntroductoryOfferCreateSummary, render func([]string, [][]string)) error {
+		h, r := subscriptionIntroductoryOfferCreateSummaryRows(v)
+		render(h, r)
+		if len(v.Skips) > 0 {
+			sh, sr := subscriptionIntroductoryOfferCreateSummarySkipRows(v)
+			render(sh, sr)
+		}
+		if len(v.Failures) > 0 {
+			fh, fr := subscriptionIntroductoryOfferCreateSummaryFailureRows(v)
+			render(fh, fr)
+		}
+		return nil
+	})
 	registerRowsErr(offerCodePricesRows)
 	registerRows(appAvailabilityRows)
 	registerRows(territoryAvailabilitiesRows)

--- a/internal/asc/subscriptions_output.go
+++ b/internal/asc/subscriptions_output.go
@@ -23,6 +23,37 @@ type SubscriptionPriceDeleteResult struct {
 	Deleted bool   `json:"deleted"`
 }
 
+// SubscriptionIntroductoryOfferCreateSummary describes a single- or
+// all-territories introductory-offer create operation.
+type SubscriptionIntroductoryOfferCreateSummary struct {
+	SubscriptionID  string                                              `json:"subscriptionId"`
+	AvailabilityID  string                                              `json:"availabilityId,omitempty"`
+	Territory       string                                              `json:"territory,omitempty"`
+	AllTerritories  bool                                                `json:"allTerritories"`
+	DryRun          bool                                                `json:"dryRun"`
+	ContinueOnError bool                                                `json:"continueOnError"`
+	Total           int                                                 `json:"total"`
+	Created         int                                                 `json:"created"`
+	Skipped         int                                                 `json:"skipped"`
+	Failed          int                                                 `json:"failed"`
+	Skips           []SubscriptionIntroductoryOfferCreateSummarySkip    `json:"skips,omitempty"`
+	Failures        []SubscriptionIntroductoryOfferCreateSummaryFailure `json:"failures,omitempty"`
+}
+
+// SubscriptionIntroductoryOfferCreateSummarySkip records an existing offer
+// that was not recreated in an all-territories operation.
+type SubscriptionIntroductoryOfferCreateSummarySkip struct {
+	Territory string `json:"territory"`
+	Reason    string `json:"reason"`
+}
+
+// SubscriptionIntroductoryOfferCreateSummaryFailure records a territory that
+// could not be processed.
+type SubscriptionIntroductoryOfferCreateSummaryFailure struct {
+	Territory string `json:"territory"`
+	Error     string `json:"error"`
+}
+
 func subscriptionGroupsRows(resp *SubscriptionGroupsResponse) ([]string, [][]string) {
 	headers := []string{"ID", "Reference Name"}
 	rows := make([][]string, 0, len(resp.Data))
@@ -179,6 +210,45 @@ func subscriptionPriceDeleteResultRows(result *SubscriptionPriceDeleteResult) ([
 	headers := []string{"ID", "Deleted"}
 	rows := [][]string{{result.ID, fmt.Sprintf("%t", result.Deleted)}}
 	return headers, rows
+}
+
+func subscriptionIntroductoryOfferCreateSummaryRows(summary *SubscriptionIntroductoryOfferCreateSummary) ([]string, [][]string) {
+	headers := []string{"Subscription ID"}
+	row := []string{summary.SubscriptionID}
+	if summary.AvailabilityID != "" {
+		headers = append(headers, "Availability ID")
+		row = append(row, summary.AvailabilityID)
+	}
+	if summary.Territory != "" {
+		headers = append(headers, "Territory")
+		row = append(row, summary.Territory)
+	}
+	headers = append(headers, "Dry Run", "Total", "Created", "Skipped", "Failed")
+	row = append(
+		row,
+		fmt.Sprintf("%t", summary.DryRun),
+		fmt.Sprintf("%d", summary.Total),
+		fmt.Sprintf("%d", summary.Created),
+		fmt.Sprintf("%d", summary.Skipped),
+		fmt.Sprintf("%d", summary.Failed),
+	)
+	return headers, [][]string{row}
+}
+
+func subscriptionIntroductoryOfferCreateSummarySkipRows(summary *SubscriptionIntroductoryOfferCreateSummary) ([]string, [][]string) {
+	rows := make([][]string, 0, len(summary.Skips))
+	for _, skip := range summary.Skips {
+		rows = append(rows, []string{skip.Territory, skip.Reason})
+	}
+	return []string{"Skipped Territory", "Reason"}, rows
+}
+
+func subscriptionIntroductoryOfferCreateSummaryFailureRows(summary *SubscriptionIntroductoryOfferCreateSummary) ([]string, [][]string) {
+	rows := make([][]string, 0, len(summary.Failures))
+	for _, failure := range summary.Failures {
+		rows = append(rows, []string{failure.Territory, failure.Error})
+	}
+	return []string{"Failed Territory", "Error"}, rows
 }
 
 func subscriptionPriceRelationshipIDs(raw json.RawMessage) (string, string, error) {

--- a/internal/asc/subscriptions_output_test.go
+++ b/internal/asc/subscriptions_output_test.go
@@ -84,6 +84,57 @@ func TestPrintMarkdown_SubscriptionPriceDeleteResult(t *testing.T) {
 	}
 }
 
+func TestPrintTable_SubscriptionIntroductoryOfferCreateSummary(t *testing.T) {
+	result := &SubscriptionIntroductoryOfferCreateSummary{
+		SubscriptionID: "sub-1",
+		AvailabilityID: "availability-1",
+		AllTerritories: true,
+		DryRun:         true,
+		Total:          2,
+		Created:        1,
+		Skipped:        1,
+		Failed:         1,
+		Skips: []SubscriptionIntroductoryOfferCreateSummarySkip{{
+			Territory: "USA",
+			Reason:    "already exists",
+		}},
+		Failures: []SubscriptionIntroductoryOfferCreateSummaryFailure{{
+			Territory: "CAN",
+			Error:     "provider rejected request",
+		}},
+	}
+
+	output := captureStdout(t, func() error { return PrintTable(result) })
+	for _, want := range []string{"Availability ID", "availability-1", "Skipped Territory", "USA", "Failed Territory", "provider rejected request"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output, got: %s", want, output)
+		}
+	}
+	if strings.Contains(output, "Territory\n") {
+		t.Fatalf("all-territories summary should not expose a single-territory column: %s", output)
+	}
+}
+
+func TestPrintMarkdown_SubscriptionIntroductoryOfferCreateSummary(t *testing.T) {
+	result := &SubscriptionIntroductoryOfferCreateSummary{
+		SubscriptionID: "sub-1",
+		Territory:      "USA",
+		DryRun:         true,
+		Total:          1,
+		Created:        1,
+	}
+
+	output := captureStdout(t, func() error { return PrintMarkdown(result) })
+	for _, want := range []string{"Subscription ID", "Territory", "USA", "Dry Run", "true"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output, got: %s", want, output)
+		}
+	}
+	if strings.Contains(output, "Availability ID") {
+		t.Fatalf("single-territory summary should not expose availability column: %s", output)
+	}
+}
+
 func TestPrintTable_SubscriptionGracePeriod(t *testing.T) {
 	resp := &SubscriptionGracePeriodResponse{
 		Data: Resource[SubscriptionGracePeriodAttributes]{

--- a/internal/asc/subscriptions_output_test.go
+++ b/internal/asc/subscriptions_output_test.go
@@ -90,7 +90,7 @@ func TestPrintTable_SubscriptionIntroductoryOfferCreateSummary(t *testing.T) {
 		AvailabilityID: "availability-1",
 		AllTerritories: true,
 		DryRun:         true,
-		Total:          2,
+		Total:          3,
 		Created:        1,
 		Skipped:        1,
 		Failed:         1,
@@ -105,7 +105,11 @@ func TestPrintTable_SubscriptionIntroductoryOfferCreateSummary(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() error { return PrintTable(result) })
-	for _, want := range []string{"Availability ID", "availability-1", "Skipped Territory", "USA", "Failed Territory", "provider rejected request"} {
+	for _, want := range []string{
+		"Subscription ID", "sub-1", "Availability ID", "availability-1",
+		"Dry Run", "true", "Total", "3", "Created", "1", "Skipped", "1", "Failed", "1",
+		"Skipped Territory", "USA", "already exists", "Failed Territory", "CAN", "provider rejected request",
+	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected %q in output, got: %s", want, output)
 		}
@@ -125,7 +129,10 @@ func TestPrintMarkdown_SubscriptionIntroductoryOfferCreateSummary(t *testing.T) 
 	}
 
 	output := captureStdout(t, func() error { return PrintMarkdown(result) })
-	for _, want := range []string{"Subscription ID", "Territory", "USA", "Dry Run", "true"} {
+	for _, want := range []string{
+		"Subscription ID", "sub-1", "Territory", "USA", "Dry Run", "true",
+		"Total", "1", "Created", "1", "Skipped", "0", "Failed", "0",
+	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected %q in output, got: %s", want, output)
 		}

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -524,6 +524,74 @@ func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunSkipsSubscrip
 	}
 }
 
+func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunHonorsCanceledContext(t *testing.T) {
+	isolateIntroductoryOfferCreateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("canceled dry-run should not reach the API: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{
+		"subscriptions", "offers", "introductory", "create",
+		"--subscription-id", "8000000001",
+		"--offer-duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--number-of-periods", "1",
+		"--territory", "US",
+		"--dry-run",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Run(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("run error = %v, want context canceled", err)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("expected no output after cancellation, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunRendersRegisteredFormats(t *testing.T) {
+	isolateIntroductoryOfferCreateAuth(t)
+
+	for _, format := range []string{"table", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			stdout, stderr, runErr := runRootCommand(t, []string{
+				"subscriptions", "offers", "introductory", "create",
+				"--subscription-id", "8000000001",
+				"--offer-duration", "ONE_MONTH",
+				"--offer-mode", "FREE_TRIAL",
+				"--number-of-periods", "1",
+				"--territory", "US",
+				"--dry-run",
+				"--output", format,
+			})
+			if runErr != nil {
+				t.Fatalf("run error: %v", runErr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if !strings.Contains(stdout, "Subscription ID") || !strings.Contains(stdout, "USA") {
+				t.Fatalf("expected registered %s output, got %q", format, stdout)
+			}
+		})
+	}
+}
+
 func TestSubscriptionsIntroductoryOffersCreateDeprecatedAllAliasCreatesPerAvailabilityTerritory(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -416,6 +416,68 @@ func TestSubscriptionsIntroductoryOffersCreateAllTerritoriesDryRunSummarizesAvai
 	}
 }
 
+func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunSummarizesResolvedTerritory(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	seen := make([]string, 0, 1)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		seen = append(seen, req.Method+" "+req.URL.Path)
+		t.Fatalf("dry-run should not POST or otherwise reach the API, saw requests: %v", seen)
+		return nil, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var summary struct {
+		SubscriptionID string `json:"subscriptionId"`
+		Territory      string `json:"territory"`
+		AllTerritories bool   `json:"allTerritories"`
+		DryRun         bool   `json:"dryRun"`
+		Total          int    `json:"total"`
+		Created        int    `json:"created"`
+		Skipped        int    `json:"skipped"`
+		Failed         int    `json:"failed"`
+	}
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "offers", "introductory", "create",
+			"--subscription-id", "8000000001",
+			"--offer-duration", "ONE_MONTH",
+			"--offer-mode", "FREE_TRIAL",
+			"--number-of-periods", "1",
+			"--territory", "US",
+			"--dry-run",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.SubscriptionID != "8000000001" || summary.AllTerritories || !summary.DryRun {
+		t.Fatalf("unexpected summary identity: %+v", summary)
+	}
+	if summary.Territory != "USA" {
+		t.Fatalf("expected normalized territory USA, got %+v", summary)
+	}
+	if summary.Total != 1 || summary.Created != 1 || summary.Skipped != 0 || summary.Failed != 0 {
+		t.Fatalf("unexpected summary counts: %+v", summary)
+	}
+}
+
 func TestSubscriptionsIntroductoryOffersCreateDeprecatedAllAliasCreatesPerAvailabilityTerritory(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -478,6 +478,52 @@ func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunSummarizesRes
 	}
 }
 
+func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunSkipsSubscriptionLookup(t *testing.T) {
+	isolateIntroductoryOfferCreateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("single-territory dry-run should not resolve subscription selectors: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	stdout, stderr, runErr := runRootCommand(t, []string{
+		"subscriptions", "offers", "introductory", "create",
+		"--subscription-id", "com.example.monthly",
+		"--app", "app-1",
+		"--offer-duration", "ONE_MONTH",
+		"--offer-mode", "FREE_TRIAL",
+		"--number-of-periods", "1",
+		"--territory", "US",
+		"--dry-run",
+		"--output", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var summary struct {
+		SubscriptionID string `json:"subscriptionId"`
+		Territory      string `json:"territory"`
+		DryRun         bool   `json:"dryRun"`
+		Total          int    `json:"total"`
+		Created        int    `json:"created"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse JSON summary: %v", err)
+	}
+	if summary.SubscriptionID != "com.example.monthly" || summary.Territory != "USA" || !summary.DryRun {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if summary.Total != 1 || summary.Created != 1 {
+		t.Fatalf("unexpected summary counts: %+v", summary)
+	}
+}
+
 func TestSubscriptionsIntroductoryOffersCreateDeprecatedAllAliasCreatesPerAvailabilityTerritory(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
+++ b/internal/cli/cmdtest/subscriptions_introductory_offers_create_test.go
@@ -177,7 +177,7 @@ func isolateIntroductoryOfferCreateAuth(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 	for _, key := range []string{
-		"ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
+		"ASC_APP_ID", "ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
 		"ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_B64", "ASC_STRICT_AUTH",
 	} {
 		t.Setenv(key, "")
@@ -521,6 +521,44 @@ func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunSkipsSubscrip
 	}
 	if summary.Total != 1 || summary.Created != 1 {
 		t.Fatalf("unexpected summary counts: %+v", summary)
+	}
+}
+
+func TestSubscriptionsIntroductoryOffersCreateSingleTerritoryDryRunRequiresAppForLookupSelectors(t *testing.T) {
+	isolateIntroductoryOfferCreateAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("missing app validation must happen before HTTP: %s %s", req.Method, req.URL.Path)
+		return nil, nil
+	})
+
+	for _, selector := range []string{"com.example.monthly", "Monthly Plan"} {
+		t.Run(selector, func(t *testing.T) {
+			stdout, stderr, runErr := runRootCommand(t, []string{
+				"subscriptions", "offers", "introductory", "create",
+				"--subscription-id", selector,
+				"--offer-duration", "ONE_MONTH",
+				"--offer-mode", "FREE_TRIAL",
+				"--number-of-periods", "1",
+				"--territory", "US",
+				"--dry-run",
+				"--output", "json",
+			})
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected usage error, got %v", runErr)
+			}
+			if rootcmd.ExitCodeFromError(runErr) != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", rootcmd.ExitCodeFromError(runErr), rootcmd.ExitUsage)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "Error: --app is required (or set ASC_APP_ID) when --subscription-id is a product ID or name") {
+				t.Fatalf("unexpected stderr: %q", stderr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
+++ b/internal/cli/cmdtest/subscriptions_review_screenshot_recovery_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -581,13 +582,13 @@ func TestSubscriptionsReviewScreenshotCreateDoesNotCommitAfterUploadFailure(t *t
 	}
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	puts := 0
+	var puts atomic.Int32
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/8000000001/appStoreReviewScreenshot":
 			return jsonHTTPResponse(http.StatusOK, subscriptionReviewScreenshotResponseWithOperations("shot-1", filepath.Base(path), int64(len(content)), operations)), nil
 		case req.Method == http.MethodPut && req.URL.Host == "upload.example":
-			puts++
+			puts.Add(1)
 			if req.URL.Path == "/part-2" {
 				return jsonHTTPResponse(http.StatusBadRequest, ``), nil
 			}
@@ -602,8 +603,8 @@ func TestSubscriptionsReviewScreenshotCreateDoesNotCommitAfterUploadFailure(t *t
 	if err == nil || !strings.Contains(err.Error(), "upload request failed") {
 		t.Fatalf("expected upload failure, got %v", err)
 	}
-	if stdout != "" || stderr != "" || puts != 2 {
-		t.Fatalf("unexpected failed upload result: puts=%d stdout=%q stderr=%q", puts, stdout, stderr)
+	if stdout != "" || stderr != "" || puts.Load() != 2 {
+		t.Fatalf("unexpected failed upload result: puts=%d stdout=%q stderr=%q", puts.Load(), stdout, stderr)
 	}
 }
 

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -281,6 +281,7 @@ Examples:
   asc subscriptions offers introductory create --subscription-id "SUB_ID" --territory "USA" --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
   asc subscriptions offers introductory create --subscription-id "SUB_ID" --all-territories --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
   asc subscriptions offers introductory create --subscription-id "SUB_ID" --all-territories --dry-run --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
+  asc subscriptions offers introductory create --subscription-id "SUB_ID" --territory "USA" --dry-run --offer-duration ONE_MONTH --offer-mode FREE_TRIAL --number-of-periods 1
 
 Timeouts:
   An explicit ASC_TIMEOUT caps the full create operation. Without an override, the operation uses a 5m fallback while individual requests retain the standard request timeout.`,
@@ -406,6 +407,16 @@ Timeouts:
 				)
 			}
 
+			if *dryRun {
+				return summarizeSubscriptionIntroductoryOfferCreateDryRun(
+					id,
+					territoryID,
+					*continueOnError,
+					*output.Output,
+					*output.Pretty,
+				)
+			}
+
 			requestCtx, cancel := shared.ContextWithTimeout(operationCtx)
 			defer cancel()
 
@@ -433,6 +444,7 @@ func subscriptionIntroductoryOfferSelectorUsageError(kind shared.UsageErrorKind,
 type subscriptionIntroductoryOfferCreateBulkSummary struct {
 	SubscriptionID  string                                                  `json:"subscriptionId"`
 	AvailabilityID  string                                                  `json:"availabilityId,omitempty"`
+	Territory       string                                                  `json:"territory,omitempty"`
 	AllTerritories  bool                                                    `json:"allTerritories"`
 	DryRun          bool                                                    `json:"dryRun"`
 	ContinueOnError bool                                                    `json:"continueOnError"`
@@ -452,6 +464,37 @@ type subscriptionIntroductoryOfferCreateBulkSummarySkip struct {
 type subscriptionIntroductoryOfferCreateBulkSummaryFailure struct {
 	Territory string `json:"territory"`
 	Error     string `json:"error"`
+}
+
+// summarizeSubscriptionIntroductoryOfferCreateDryRun reports what a single-territory
+// create would do, using the same summary shape as the all-territories path so both
+// dry runs read alike. It performs no requests: the territory is already resolved
+// locally, and the availability lookup the bulk path needs to enumerate territories
+// would be wasted work here.
+func summarizeSubscriptionIntroductoryOfferCreateDryRun(
+	subscriptionID string,
+	territoryID string,
+	continueOnError bool,
+	output string,
+	pretty bool,
+) error {
+	summary := &subscriptionIntroductoryOfferCreateBulkSummary{
+		SubscriptionID:  subscriptionID,
+		Territory:       territoryID,
+		AllTerritories:  false,
+		DryRun:          true,
+		ContinueOnError: continueOnError,
+		Total:           1,
+		Created:         1,
+	}
+
+	return shared.PrintOutputWithRenderers(
+		summary,
+		output,
+		pretty,
+		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, false) },
+		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, true) },
+	)
 }
 
 func createSubscriptionIntroductoryOffersForAllTerritories(
@@ -704,18 +747,29 @@ func renderSubscriptionIntroductoryOfferCreateBulkSummary(summary *subscriptionI
 		render = asc.RenderMarkdown
 	}
 
-	render(
-		[]string{"Subscription ID", "Availability ID", "Dry Run", "Total", "Created", "Skipped", "Failed"},
-		[][]string{{
-			summary.SubscriptionID,
-			summary.AvailabilityID,
-			fmt.Sprintf("%t", summary.DryRun),
-			fmt.Sprintf("%d", summary.Total),
-			fmt.Sprintf("%d", summary.Created),
-			fmt.Sprintf("%d", summary.Skipped),
-			fmt.Sprintf("%d", summary.Failed),
-		}},
+	// Mirror the summary's omitempty JSON fields: a column only appears when the
+	// path that produced the summary actually fills it in.
+	headers := []string{"Subscription ID"}
+	row := []string{summary.SubscriptionID}
+	if summary.AvailabilityID != "" {
+		headers = append(headers, "Availability ID")
+		row = append(row, summary.AvailabilityID)
+	}
+	if summary.Territory != "" {
+		headers = append(headers, "Territory")
+		row = append(row, summary.Territory)
+	}
+	headers = append(headers, "Dry Run", "Total", "Created", "Skipped", "Failed")
+	row = append(
+		row,
+		fmt.Sprintf("%t", summary.DryRun),
+		fmt.Sprintf("%d", summary.Total),
+		fmt.Sprintf("%d", summary.Created),
+		fmt.Sprintf("%d", summary.Skipped),
+		fmt.Sprintf("%d", summary.Failed),
 	)
+
+	render(headers, [][]string{row})
 
 	if len(summary.Skips) > 0 {
 		rows := make([][]string, 0, len(summary.Skips))

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -267,7 +267,7 @@ func SubscriptionsIntroductoryOffersCreateCommand() *ffcli.Command {
 	territory := fs.String("territory", "", "Territory for the offer (accepts alpha-2, alpha-3, or exact English country name; required unless --all-territories)")
 	allTerritories := fs.Bool("all-territories", false, "Create introductory offers for all current subscription availability territories")
 	pricePoint := fs.String("price-point", "", "Subscription price point ID")
-	dryRun := fs.Bool("dry-run", false, "Resolve territories and print summary without creating offers")
+	dryRun := fs.Bool("dry-run", false, "Print a summary without creating offers; single-territory mode makes no network requests")
 	continueOnError := fs.Bool("continue-on-error", true, "Continue creating offers after a territory fails")
 	output := shared.BindOutputFlags(fs)
 
@@ -370,6 +370,9 @@ Timeouts:
 			}
 
 			if *dryRun && !useAllTerritories {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				return summarizeSubscriptionIntroductoryOfferCreateDryRun(
 					id,
 					territoryID,
@@ -441,30 +444,11 @@ func subscriptionIntroductoryOfferSelectorUsageError(kind shared.UsageErrorKind,
 	return shared.NewReportedUsageError(kind, message)
 }
 
-type subscriptionIntroductoryOfferCreateBulkSummary struct {
-	SubscriptionID  string                                                  `json:"subscriptionId"`
-	AvailabilityID  string                                                  `json:"availabilityId,omitempty"`
-	Territory       string                                                  `json:"territory,omitempty"`
-	AllTerritories  bool                                                    `json:"allTerritories"`
-	DryRun          bool                                                    `json:"dryRun"`
-	ContinueOnError bool                                                    `json:"continueOnError"`
-	Total           int                                                     `json:"total"`
-	Created         int                                                     `json:"created"`
-	Skipped         int                                                     `json:"skipped"`
-	Failed          int                                                     `json:"failed"`
-	Skips           []subscriptionIntroductoryOfferCreateBulkSummarySkip    `json:"skips,omitempty"`
-	Failures        []subscriptionIntroductoryOfferCreateBulkSummaryFailure `json:"failures,omitempty"`
-}
-
-type subscriptionIntroductoryOfferCreateBulkSummarySkip struct {
-	Territory string `json:"territory"`
-	Reason    string `json:"reason"`
-}
-
-type subscriptionIntroductoryOfferCreateBulkSummaryFailure struct {
-	Territory string `json:"territory"`
-	Error     string `json:"error"`
-}
+type (
+	subscriptionIntroductoryOfferCreateBulkSummary        = asc.SubscriptionIntroductoryOfferCreateSummary
+	subscriptionIntroductoryOfferCreateBulkSummarySkip    = asc.SubscriptionIntroductoryOfferCreateSummarySkip
+	subscriptionIntroductoryOfferCreateBulkSummaryFailure = asc.SubscriptionIntroductoryOfferCreateSummaryFailure
+)
 
 // summarizeSubscriptionIntroductoryOfferCreateDryRun reports what a single-territory
 // create would do, using the same summary shape as the all-territories path so both
@@ -488,13 +472,7 @@ func summarizeSubscriptionIntroductoryOfferCreateDryRun(
 		Created:         1,
 	}
 
-	return shared.PrintOutputWithRenderers(
-		summary,
-		output,
-		pretty,
-		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, false) },
-		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, true) },
-	)
+	return shared.PrintOutput(summary, output, pretty)
 }
 
 func createSubscriptionIntroductoryOffersForAllTerritories(
@@ -562,13 +540,7 @@ func createSubscriptionIntroductoryOffersForAllTerritories(
 		summary.Created++
 	}
 
-	if err := shared.PrintOutputWithRenderers(
-		summary,
-		output,
-		pretty,
-		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, false) },
-		func() error { return renderSubscriptionIntroductoryOfferCreateBulkSummary(summary, true) },
-	); err != nil {
+	if err := shared.PrintOutput(summary, output, pretty); err != nil {
 		return err
 	}
 	if operationErr != nil {
@@ -735,59 +707,6 @@ func appendSubscriptionIntroductoryOfferCreateBulkFailure(summary *subscriptionI
 		Territory: territoryID,
 		Error:     err.Error(),
 	})
-}
-
-func renderSubscriptionIntroductoryOfferCreateBulkSummary(summary *subscriptionIntroductoryOfferCreateBulkSummary, markdown bool) error {
-	if summary == nil {
-		return fmt.Errorf("summary is nil")
-	}
-
-	render := asc.RenderTable
-	if markdown {
-		render = asc.RenderMarkdown
-	}
-
-	// Mirror the summary's omitempty JSON fields: a column only appears when the
-	// path that produced the summary actually fills it in.
-	headers := []string{"Subscription ID"}
-	row := []string{summary.SubscriptionID}
-	if summary.AvailabilityID != "" {
-		headers = append(headers, "Availability ID")
-		row = append(row, summary.AvailabilityID)
-	}
-	if summary.Territory != "" {
-		headers = append(headers, "Territory")
-		row = append(row, summary.Territory)
-	}
-	headers = append(headers, "Dry Run", "Total", "Created", "Skipped", "Failed")
-	row = append(
-		row,
-		fmt.Sprintf("%t", summary.DryRun),
-		fmt.Sprintf("%d", summary.Total),
-		fmt.Sprintf("%d", summary.Created),
-		fmt.Sprintf("%d", summary.Skipped),
-		fmt.Sprintf("%d", summary.Failed),
-	)
-
-	render(headers, [][]string{row})
-
-	if len(summary.Skips) > 0 {
-		rows := make([][]string, 0, len(summary.Skips))
-		for _, skip := range summary.Skips {
-			rows = append(rows, []string{skip.Territory, skip.Reason})
-		}
-		render([]string{"Skipped Territory", "Reason"}, rows)
-	}
-
-	if len(summary.Failures) > 0 {
-		rows := make([][]string, 0, len(summary.Failures))
-		for _, failure := range summary.Failures {
-			rows = append(rows, []string{failure.Territory, failure.Error})
-		}
-		render([]string{"Failed Territory", "Error"}, rows)
-	}
-
-	return nil
 }
 
 func pluralizeIntroductoryOfferCreateTerritories(n int) string {

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -444,12 +444,6 @@ func subscriptionIntroductoryOfferSelectorUsageError(kind shared.UsageErrorKind,
 	return shared.NewReportedUsageError(kind, message)
 }
 
-type (
-	subscriptionIntroductoryOfferCreateBulkSummary        = asc.SubscriptionIntroductoryOfferCreateSummary
-	subscriptionIntroductoryOfferCreateBulkSummarySkip    = asc.SubscriptionIntroductoryOfferCreateSummarySkip
-	subscriptionIntroductoryOfferCreateBulkSummaryFailure = asc.SubscriptionIntroductoryOfferCreateSummaryFailure
-)
-
 // summarizeSubscriptionIntroductoryOfferCreateDryRun reports what a single-territory
 // create would do, using the same summary shape as the all-territories path so both
 // dry runs read alike. It performs no requests: the territory is already resolved
@@ -462,7 +456,7 @@ func summarizeSubscriptionIntroductoryOfferCreateDryRun(
 	output string,
 	pretty bool,
 ) error {
-	summary := &subscriptionIntroductoryOfferCreateBulkSummary{
+	summary := &asc.SubscriptionIntroductoryOfferCreateSummary{
 		SubscriptionID:  subscriptionID,
 		Territory:       territoryID,
 		AllTerritories:  false,
@@ -495,7 +489,7 @@ func createSubscriptionIntroductoryOffersForAllTerritories(
 		return fmt.Errorf("subscriptions introductory-offers create: %w", err)
 	}
 
-	summary := &subscriptionIntroductoryOfferCreateBulkSummary{
+	summary := &asc.SubscriptionIntroductoryOfferCreateSummary{
 		SubscriptionID:  subscriptionID,
 		AvailabilityID:  availabilityID,
 		AllTerritories:  true,
@@ -687,23 +681,23 @@ func introductoryOfferTerritoryIDFromEncodedID(id string) string {
 	return territoryID
 }
 
-func appendSubscriptionIntroductoryOfferCreateBulkSkip(summary *subscriptionIntroductoryOfferCreateBulkSummary, territoryID, reason string) {
+func appendSubscriptionIntroductoryOfferCreateBulkSkip(summary *asc.SubscriptionIntroductoryOfferCreateSummary, territoryID, reason string) {
 	if summary == nil {
 		return
 	}
 	summary.Skipped++
-	summary.Skips = append(summary.Skips, subscriptionIntroductoryOfferCreateBulkSummarySkip{
+	summary.Skips = append(summary.Skips, asc.SubscriptionIntroductoryOfferCreateSummarySkip{
 		Territory: territoryID,
 		Reason:    reason,
 	})
 }
 
-func appendSubscriptionIntroductoryOfferCreateBulkFailure(summary *subscriptionIntroductoryOfferCreateBulkSummary, territoryID string, err error) {
+func appendSubscriptionIntroductoryOfferCreateBulkFailure(summary *asc.SubscriptionIntroductoryOfferCreateSummary, territoryID string, err error) {
 	if summary == nil || err == nil {
 		return
 	}
 	summary.Failed++
-	summary.Failures = append(summary.Failures, subscriptionIntroductoryOfferCreateBulkSummaryFailure{
+	summary.Failures = append(summary.Failures, asc.SubscriptionIntroductoryOfferCreateSummaryFailure{
 		Territory: territoryID,
 		Error:     err.Error(),
 	})

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -369,6 +369,10 @@ Timeouts:
 				}
 			}
 
+			if err := shared.RequireAppForStableSelector(shared.ResolveAppID(*appID), id, "--subscription-id"); err != nil {
+				return err
+			}
+
 			if *dryRun && !useAllTerritories {
 				if err := ctx.Err(); err != nil {
 					return err

--- a/internal/cli/subscriptions/introductory_offers.go
+++ b/internal/cli/subscriptions/introductory_offers.go
@@ -369,6 +369,16 @@ Timeouts:
 				}
 			}
 
+			if *dryRun && !useAllTerritories {
+				return summarizeSubscriptionIntroductoryOfferCreateDryRun(
+					id,
+					territoryID,
+					*continueOnError,
+					*output.Output,
+					*output.Pretty,
+				)
+			}
+
 			client, err := shared.GetASCClient()
 			if err != nil {
 				return fmt.Errorf("subscriptions introductory-offers create: %w", err)
@@ -401,16 +411,6 @@ Timeouts:
 					id,
 					attrs,
 					*dryRun,
-					*continueOnError,
-					*output.Output,
-					*output.Pretty,
-				)
-			}
-
-			if *dryRun {
-				return summarizeSubscriptionIntroductoryOfferCreateDryRun(
-					id,
-					territoryID,
 					*continueOnError,
 					*output.Output,
 					*output.Pretty,


### PR DESCRIPTION
## Summary

Fixes #2138 by making `--dry-run` effective for single-territory introductory-offer creation.

- Single-territory dry runs validate and normalize local inputs, then print the existing summary shape without creating an offer or making any network request.
- All-territories behavior remains unchanged: it resolves the subscription, reads availability and existing offers, and reports provider-backed `created`/`skipped` counts without POSTing when `--dry-run` is set.
- The computed summary is now an exported `internal/asc` output type with a registered table/Markdown renderer, preserving the JSON/table/Markdown output contract.
- A canceled context stops the local dry run before output.

For single-territory dry runs, `subscriptionId` echoes the selector supplied by the caller because selector resolution is intentionally skipped; `territory` is normalized locally. `created: 1` is the planned create count and is not an existing-offer check. Use the all-territories mode when provider-backed reconciliation is needed.

## Validation

- RED/GREEN regression for product/name selectors with `--app`: zero HTTP requests.
- RED/GREEN regression for canceled contexts: no output and `context.Canceled`.
- JSON, table, and Markdown rendering tests through the central output registry.
- Full `ASC_BYPASS_KEYCHAIN=1 go test ./...`.
- `make format`, `make check-docs`, `make lint`, and `make build`.
- No live App Store Connect mutation or API request was performed for the single-territory dry-run path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dry-run support for introductory-offer creation in single-territory mode.
  - Preview runs avoid resource creation and network requests while showing the resolved territory and summary results.
  - Added consistent summary output across table, Markdown, and JSON formats, including created, skipped, and failed territories.
  - All-territories previews retain availability checks and reconciliation counts.

- **Documentation**
  - Documented dry-run behavior for single-territory and all-territories workflows.
  - Added a single-territory dry-run command example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->