### PR TITLE
fix(system-status): accept completed incidents

### DIFF
--- a/internal/cli/systemstatus/system_status.go
+++ b/internal/cli/systemstatus/system_status.go
@@ -270,7 +270,7 @@ func statusEventActive(event statusFeedEvent) (bool, error) {
 		return strings.TrimSpace(event.EndDate) == "" && event.EpochEndDate == nil, nil
 	case strings.EqualFold(status, "ongoing"):
 		return true, nil
-	case strings.EqualFold(status, "resolved"):
+	case strings.EqualFold(status, "resolved"), strings.EqualFold(status, "completed"):
 		return false, nil
 	default:
 		return false, fmt.Errorf("unknown eventStatus %q", status)

--- a/internal/cli/systemstatus/system_status_test.go
+++ b/internal/cli/systemstatus/system_status_test.go
@@ -428,6 +428,16 @@ func TestDecodeDeveloperSystemStatusFeedShapes(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "completed event",
+			body: []byte(`{"services":[{"serviceName":"App Store Connect","events":[{"messageId":"2000005610","eventStatus":"completed","startDate":"08/20/2026 05:00 PDT","endDate":"08/20/2026 06:00 PDT","epochStartDate":1787227200000,"epochEndDate":1787230800000}]}]}`),
+			assert: func(t *testing.T, report *asc.DeveloperSystemStatusReport) {
+				service := report.Services[0]
+				if service.Status != "operational" || service.Events[0].Active {
+					t.Fatalf("completed service = %#v, want inactive operational event", service)
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- accept Apple's observed `completed` system-status event state as terminal/inactive
- preserve completed incidents in output without marking their service as affected
- add a realistic regression fixture from Apple's current App Store Connect maintenance event

Closes #2145

## Why

Apple's public Developer System Status feed currently contains message `2000005610` with `eventStatus: "completed"`. The parser only accepted `ongoing` and `resolved`, so decoding failed before `--service` filtering and made every `asc system-status` query unusable while that event remained in the feed.

The fix remains strict for unknown future states: only the observed terminal state is added. It does not infer state from end timestamps or discard unrecognized events.

## Verification

- RED: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/systemstatus -run 'TestDecodeDeveloperSystemStatusFeedShapes/completed_event' -count=1`
  - failed with `unknown eventStatus "completed"`
- GREEN: focused regression and full `internal/cli/systemstatus` package
- black-box: `ASC_BYPASS_KEYCHAIN=1 go test ./cmd -run 'SystemStatus' -count=1`
- build: `go build -o /tmp/asc-system-status-completed .`
- live read-only check against Apple's official feed:
  - `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-system-status-completed system-status --service TestFlight --output json` exited 0 with empty stderr
  - message `2000005610` remained present with `eventStatus: "completed"` and `active: false`
- repository gate:
  - `make format`
  - `make check-docs`
  - `make lint`
  - `ASC_BYPASS_KEYCHAIN=1 make test`
