### PR TITLE
fix(xcode-cloud): include artifacts from every run action

### DIFF
--- a/internal/cli/cmdtest/xcode_cloud_action_resource_run_id_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_action_resource_run_id_test.go
@@ -90,7 +90,7 @@ func TestXcodeCloudIssuesListAggregatesIssuesFromRunID(t *testing.T) {
 	}
 }
 
-func TestXcodeCloudArtifactsListAggregatesArchiveActionsFromRunID(t *testing.T) {
+func TestXcodeCloudArtifactsListAggregatesAllActionsFromRunID(t *testing.T) {
 	setupAuth(t)
 
 	originalTransport := http.DefaultTransport
@@ -129,8 +129,21 @@ func TestXcodeCloudArtifactsListAggregatesArchiveActionsFromRunID(t *testing.T) 
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			}, nil
 		case 3:
-			if req.Method != http.MethodGet || req.URL.Path != "/v1/ciBuildActions/act-3/artifacts" {
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/ciBuildActions/act-2/artifacts" {
 				t.Fatalf("unexpected third request: %s %s", req.Method, req.URL.String())
+			}
+			if req.URL.Query().Get("limit") != "200" {
+				t.Fatalf("expected limit=200, got %q", req.URL.Query().Get("limit"))
+			}
+			body := `{"data":[{"type":"ciArtifacts","id":"test-log-bundle","attributes":{"fileType":"LOG_BUNDLE"}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		case 4:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/ciBuildActions/act-3/artifacts" {
+				t.Fatalf("unexpected fourth request: %s %s", req.Method, req.URL.String())
 			}
 			if req.URL.Query().Get("limit") != "200" {
 				t.Fatalf("expected limit=200, got %q", req.URL.Query().Get("limit"))
@@ -168,8 +181,11 @@ func TestXcodeCloudArtifactsListAggregatesArchiveActionsFromRunID(t *testing.T) 
 	if !strings.Contains(stdout, `"id":"artifact-2"`) {
 		t.Fatalf("expected second artifact output, got %q", stdout)
 	}
-	if callCount != 3 {
-		t.Fatalf("expected 3 requests, got %d", callCount)
+	if !strings.Contains(stdout, `"id":"test-log-bundle"`) {
+		t.Fatalf("expected test action log bundle output, got %q", stdout)
+	}
+	if callCount != 4 {
+		t.Fatalf("expected 4 requests, got %d", callCount)
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_action_resources_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_action_resources_helpers.go
@@ -502,14 +502,14 @@ func aggregateXcodeCloudArtifactsFromRun(ctx context.Context, client *asc.Client
 		return nil, err
 	}
 
-	archiveActionIDs := matchingBuildActionIDsByType(actions, "ARCHIVE")
-	if len(archiveActionIDs) == 0 {
-		return nil, shared.UsageErrorf("no ARCHIVE build actions found for --run-id %q", runID)
-	}
-
 	combined := &asc.CiArtifactsResponse{Data: make([]asc.CiArtifactResource, 0)}
 	remaining := limit
-	for _, actionID := range archiveActionIDs {
+	for _, action := range actions {
+		actionID := strings.TrimSpace(action.ID)
+		if actionID == "" {
+			continue
+		}
+
 		pageLimit := remaining
 		if paginate {
 			pageLimit = 200

--- a/internal/cli/xcodecloud/xcode_cloud_artifacts.go
+++ b/internal/cli/xcodecloud/xcode_cloud_artifacts.go
@@ -48,7 +48,7 @@ func XcodeCloudArtifactsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	actionID := fs.String("action-id", "", "Build action ID to list artifacts for")
-	runID := fs.String("run-id", "", "Build run ID to resolve a single action from")
+	runID := fs.String("run-id", "", "Build run ID to aggregate artifacts across all actions")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -57,8 +57,8 @@ func XcodeCloudArtifactsListCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "list",
 		ShortUsage: "asc xcode-cloud artifacts list [flags]",
-		ShortHelp:  "List artifacts for a build action.",
-		LongHelp: `List artifacts for a build action.
+		ShortHelp:  "List artifacts for a build action or build run.",
+		LongHelp: `List artifacts for a build action or across all actions in a build run.
 
 Examples:
   asc xcode-cloud artifacts list --action-id "ACTION_ID"


### PR DESCRIPTION
## What changed

`asc xcode-cloud artifacts list --run-id` now queries artifacts for every action in the run. The old helper filtered to `ARCHIVE`, which hid log and result bundles attached to BUILD, TEST, or ANALYZE actions.

The JSON envelope and existing `--action-id` path stay unchanged; run-wide output can now contain artifacts that the command previously omitted.

## Tests

- Added a regression case with a TEST action `LOG_BUNDLE`
- Ran formatting, command/docs checks, lint, and the complete test suite with `ASC_BYPASS_KEYCHAIN=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artifact listings for a build run now include artifacts from all available build actions, not only archive actions.
  * Added support for retrieving artifact outputs and log bundles from additional action types.

* **Documentation**
  * Updated `--run-id` help text to clarify that artifacts are aggregated across all actions in a build run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->