### PR TITLE
feat(xcode-cloud): add build run doctor

### DIFF
--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -483,6 +483,7 @@ func registerAllOutputRenderers() {
 	registerRows(signingFetchResultRows)
 	registerRows(xcodeCloudRunResultRows)
 	registerRows(xcodeCloudStatusResultRows)
+	registerDirect(xcodeCloudDoctorResultTables)
 	registerRowsWithSingleToListAdapter[CiProductResponse, CiProductsResponse](ciProductsRows)
 	registerRowsWithSingleToListAdapter[CiWorkflowResponse, CiWorkflowsResponse](ciWorkflowsRows)
 	registerRowsWithSingleToListAdapter[ScmProviderResponse, ScmProvidersResponse](scmProvidersRows)

--- a/internal/asc/output_xcode_cloud_doctor.go
+++ b/internal/asc/output_xcode_cloud_doctor.go
@@ -68,14 +68,15 @@ type XcodeCloudDoctorCoverageWarning struct {
 
 // XcodeCloudDoctorLogBundle records inspection results for a log bundle.
 type XcodeCloudDoctorLogBundle struct {
-	ArtifactID   string                          `json:"artifactId"`
-	ActionID     string                          `json:"actionId"`
-	FileName     string                          `json:"fileName,omitempty"`
-	FileSize     int                             `json:"fileSize,omitempty"`
-	Inspected    bool                            `json:"inspected"`
-	SavedPath    string                          `json:"savedPath,omitempty"`
-	ExportStatus string                          `json:"exportStatus,omitempty"`
-	Diagnostics  []XcodeCloudDoctorLogDiagnostic `json:"diagnostics"`
+	ArtifactID           string                          `json:"artifactId"`
+	ActionID             string                          `json:"actionId"`
+	FileName             string                          `json:"fileName,omitempty"`
+	FileSize             int                             `json:"fileSize,omitempty"`
+	Inspected            bool                            `json:"inspected"`
+	SavedPath            string                          `json:"savedPath,omitempty"`
+	ExportStatus         string                          `json:"exportStatus,omitempty"`
+	Diagnostics          []XcodeCloudDoctorLogDiagnostic `json:"diagnostics"`
+	DiagnosticsTruncated bool                            `json:"diagnosticsTruncated,omitempty"`
 }
 
 // XcodeCloudDoctorLogDiagnostic is an App Store import diagnostic extracted from a log bundle.
@@ -166,6 +167,7 @@ func xcodeCloudDoctorResultTables(result *XcodeCloudDoctorResult, render func([]
 			strconv.FormatBool(bundle.Inspected),
 			xcodeCloudDoctorOrNA(bundle.ExportStatus),
 			strings.Join(codes, ","),
+			strconv.FormatBool(bundle.DiagnosticsTruncated),
 			bundle.SavedPath,
 		})
 		for _, diagnostic := range bundle.Diagnostics {
@@ -178,7 +180,7 @@ func xcodeCloudDoctorResultTables(result *XcodeCloudDoctorResult, render func([]
 			})
 		}
 	}
-	render([]string{"Log bundles action ID", "Artifact ID", "Inspected", "Export status", "Diagnostics", "Saved path"}, logRows)
+	render([]string{"Log bundles action ID", "Artifact ID", "Inspected", "Export status", "Diagnostics", "Diagnostics truncated", "Saved path"}, logRows)
 	render([]string{"Log diagnostics action ID", "Artifact ID", "Code", "Message", "Source file"}, diagnosticRows)
 
 	coverageRows := make([][]string, 0, len(result.CoverageWarnings))

--- a/internal/asc/output_xcode_cloud_doctor.go
+++ b/internal/asc/output_xcode_cloud_doctor.go
@@ -154,6 +154,7 @@ func xcodeCloudDoctorResultTables(result *XcodeCloudDoctorResult, render func([]
 	render([]string{"Artifacts action ID", "ID", "Type", "Name", "Bytes"}, artifactRows)
 
 	logRows := make([][]string, 0, len(result.LogBundles))
+	diagnosticRows := make([][]string, 0)
 	for _, bundle := range result.LogBundles {
 		codes := make([]string, 0, len(bundle.Diagnostics))
 		for _, diagnostic := range bundle.Diagnostics {
@@ -167,8 +168,18 @@ func xcodeCloudDoctorResultTables(result *XcodeCloudDoctorResult, render func([]
 			strings.Join(codes, ","),
 			bundle.SavedPath,
 		})
+		for _, diagnostic := range bundle.Diagnostics {
+			diagnosticRows = append(diagnosticRows, []string{
+				bundle.ActionID,
+				bundle.ArtifactID,
+				diagnostic.Code,
+				diagnostic.Message,
+				diagnostic.SourceFile,
+			})
+		}
 	}
 	render([]string{"Log bundles action ID", "Artifact ID", "Inspected", "Export status", "Diagnostics", "Saved path"}, logRows)
+	render([]string{"Log diagnostics action ID", "Artifact ID", "Code", "Message", "Source file"}, diagnosticRows)
 
 	coverageRows := make([][]string, 0, len(result.CoverageWarnings))
 	for _, warning := range result.CoverageWarnings {

--- a/internal/asc/output_xcode_cloud_doctor.go
+++ b/internal/asc/output_xcode_cloud_doctor.go
@@ -21,6 +21,7 @@ type XcodeCloudDoctorResult struct {
 type XcodeCloudDoctorSummary struct {
 	TotalActions        int `json:"totalActions"`
 	FailedActions       int `json:"failedActions"`
+	CanceledActions     int `json:"canceledActions"`
 	SkippedActions      int `json:"skippedActions"`
 	Errors              int `json:"errors"`
 	Warnings            int `json:"warnings"`
@@ -104,6 +105,7 @@ func xcodeCloudDoctorResultTables(result *XcodeCloudDoctorResult, render func([]
 		{"completionStatus", xcodeCloudDoctorOrNA(run.CompletionStatus)},
 		{"totalActions", strconv.Itoa(result.Summary.TotalActions)},
 		{"failedActions", strconv.Itoa(result.Summary.FailedActions)},
+		{"canceledActions", strconv.Itoa(result.Summary.CanceledActions)},
 		{"skippedActions", strconv.Itoa(result.Summary.SkippedActions)},
 		{"errors", strconv.Itoa(result.Summary.Errors)},
 		{"warnings", strconv.Itoa(result.Summary.Warnings)},

--- a/internal/asc/output_xcode_cloud_doctor.go
+++ b/internal/asc/output_xcode_cloud_doctor.go
@@ -1,0 +1,185 @@
+package asc
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// XcodeCloudDoctorResult is the computed diagnosis for an Xcode Cloud build run.
+type XcodeCloudDoctorResult struct {
+	Run              *XcodeCloudStatusResult           `json:"run"`
+	Summary          XcodeCloudDoctorSummary           `json:"summary"`
+	Actions          []XcodeCloudDoctorAction          `json:"actions"`
+	LogBundles       []XcodeCloudDoctorLogBundle       `json:"logBundles"`
+	CoverageWarnings []XcodeCloudDoctorCoverageWarning `json:"coverageWarnings"`
+	Conclusion       string                            `json:"conclusion"`
+	NextAction       string                            `json:"nextAction"`
+}
+
+// XcodeCloudDoctorSummary contains aggregate counts for a doctor report.
+type XcodeCloudDoctorSummary struct {
+	TotalActions        int `json:"totalActions"`
+	FailedActions       int `json:"failedActions"`
+	SkippedActions      int `json:"skippedActions"`
+	Errors              int `json:"errors"`
+	Warnings            int `json:"warnings"`
+	Artifacts           int `json:"artifacts"`
+	LogBundles          int `json:"logBundles"`
+	LogBundlesInspected int `json:"logBundlesInspected"`
+}
+
+// XcodeCloudDoctorAction contains the issues and artifacts for one build action.
+type XcodeCloudDoctorAction struct {
+	ID                string                     `json:"id"`
+	Name              string                     `json:"name,omitempty"`
+	ActionType        string                     `json:"actionType,omitempty"`
+	ExecutionProgress string                     `json:"executionProgress,omitempty"`
+	CompletionStatus  string                     `json:"completionStatus,omitempty"`
+	IsRequiredToPass  *bool                      `json:"isRequiredToPass,omitempty"`
+	Issues            []XcodeCloudDoctorIssue    `json:"issues"`
+	Artifacts         []XcodeCloudDoctorArtifact `json:"artifacts"`
+}
+
+// XcodeCloudDoctorIssue is an issue reported for a build action.
+type XcodeCloudDoctorIssue struct {
+	ID         string        `json:"id"`
+	IssueType  string        `json:"issueType,omitempty"`
+	Category   string        `json:"category,omitempty"`
+	Message    string        `json:"message,omitempty"`
+	FileSource *FileLocation `json:"fileSource,omitempty"`
+}
+
+// XcodeCloudDoctorArtifact is an artifact produced by a build action.
+type XcodeCloudDoctorArtifact struct {
+	ID       string `json:"id"`
+	FileType string `json:"fileType,omitempty"`
+	FileName string `json:"fileName,omitempty"`
+	FileSize int    `json:"fileSize,omitempty"`
+}
+
+// XcodeCloudDoctorCoverageWarning explains a diagnostic coverage limitation.
+type XcodeCloudDoctorCoverageWarning struct {
+	ID          string `json:"id"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation"`
+}
+
+// XcodeCloudDoctorLogBundle records inspection results for a log bundle.
+type XcodeCloudDoctorLogBundle struct {
+	ArtifactID   string                          `json:"artifactId"`
+	ActionID     string                          `json:"actionId"`
+	FileName     string                          `json:"fileName,omitempty"`
+	FileSize     int                             `json:"fileSize,omitempty"`
+	Inspected    bool                            `json:"inspected"`
+	SavedPath    string                          `json:"savedPath,omitempty"`
+	ExportStatus string                          `json:"exportStatus,omitempty"`
+	Diagnostics  []XcodeCloudDoctorLogDiagnostic `json:"diagnostics"`
+}
+
+// XcodeCloudDoctorLogDiagnostic is an App Store import diagnostic extracted from a log bundle.
+type XcodeCloudDoctorLogDiagnostic struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	SourceFile string `json:"sourceFile,omitempty"`
+}
+
+func xcodeCloudDoctorResultTables(result *XcodeCloudDoctorResult, render func([]string, [][]string)) error {
+	if result == nil {
+		result = &XcodeCloudDoctorResult{}
+	}
+	run := result.Run
+	if run == nil {
+		run = &XcodeCloudStatusResult{}
+	}
+
+	buildNumber := "n/a"
+	if run.BuildNumber > 0 {
+		buildNumber = strconv.Itoa(run.BuildNumber)
+	}
+	render([]string{"Summary field", "Summary value"}, [][]string{
+		{"runId", run.BuildRunID},
+		{"buildNumber", buildNumber},
+		{"executionProgress", xcodeCloudDoctorOrNA(run.ExecutionProgress)},
+		{"completionStatus", xcodeCloudDoctorOrNA(run.CompletionStatus)},
+		{"totalActions", strconv.Itoa(result.Summary.TotalActions)},
+		{"failedActions", strconv.Itoa(result.Summary.FailedActions)},
+		{"skippedActions", strconv.Itoa(result.Summary.SkippedActions)},
+		{"errors", strconv.Itoa(result.Summary.Errors)},
+		{"warnings", strconv.Itoa(result.Summary.Warnings)},
+		{"artifacts", strconv.Itoa(result.Summary.Artifacts)},
+		{"logBundles", strconv.Itoa(result.Summary.LogBundles)},
+		{"logBundlesInspected", strconv.Itoa(result.Summary.LogBundlesInspected)},
+		{"conclusion", result.Conclusion},
+		{"nextAction", result.NextAction},
+	})
+
+	actionRows := make([][]string, 0, len(result.Actions))
+	issueRows := make([][]string, 0, result.Summary.Errors+result.Summary.Warnings)
+	artifactRows := make([][]string, 0, result.Summary.Artifacts)
+	for _, action := range result.Actions {
+		actionRows = append(actionRows, []string{
+			action.ID,
+			action.Name,
+			action.ActionType,
+			action.ExecutionProgress,
+			action.CompletionStatus,
+			strconv.Itoa(len(action.Issues)),
+			strconv.Itoa(len(action.Artifacts)),
+		})
+		for _, issue := range action.Issues {
+			location := ""
+			if issue.FileSource != nil {
+				location = issue.FileSource.Path
+				if issue.FileSource.LineNumber > 0 {
+					location = fmt.Sprintf("%s:%d", location, issue.FileSource.LineNumber)
+				}
+			}
+			issueRows = append(issueRows, []string{action.ID, issue.IssueType, issue.Category, issue.Message, location})
+		}
+		for _, artifact := range action.Artifacts {
+			artifactRows = append(artifactRows, []string{
+				action.ID,
+				artifact.ID,
+				artifact.FileType,
+				artifact.FileName,
+				strconv.Itoa(artifact.FileSize),
+			})
+		}
+	}
+	render([]string{"Actions ID", "Name", "Type", "Progress", "Status", "Issues", "Artifacts"}, actionRows)
+	render([]string{"Issues action ID", "Type", "Category", "Message", "Location"}, issueRows)
+	render([]string{"Artifacts action ID", "ID", "Type", "Name", "Bytes"}, artifactRows)
+
+	logRows := make([][]string, 0, len(result.LogBundles))
+	for _, bundle := range result.LogBundles {
+		codes := make([]string, 0, len(bundle.Diagnostics))
+		for _, diagnostic := range bundle.Diagnostics {
+			codes = append(codes, diagnostic.Code)
+		}
+		logRows = append(logRows, []string{
+			bundle.ActionID,
+			bundle.ArtifactID,
+			strconv.FormatBool(bundle.Inspected),
+			xcodeCloudDoctorOrNA(bundle.ExportStatus),
+			strings.Join(codes, ","),
+			bundle.SavedPath,
+		})
+	}
+	render([]string{"Log bundles action ID", "Artifact ID", "Inspected", "Export status", "Diagnostics", "Saved path"}, logRows)
+
+	coverageRows := make([][]string, 0, len(result.CoverageWarnings))
+	for _, warning := range result.CoverageWarnings {
+		coverageRows = append(coverageRows, []string{warning.ID, warning.Message, warning.Remediation})
+	}
+	render([]string{"Coverage warning ID", "Message", "Remediation"}, coverageRows)
+	return nil
+}
+
+func xcodeCloudDoctorOrNA(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "n/a"
+	}
+	return value
+}

--- a/internal/asc/xcode_cloud_test.go
+++ b/internal/asc/xcode_cloud_test.go
@@ -82,6 +82,35 @@ func TestPrintTable_XcodeCloudRunResult(t *testing.T) {
 	}
 }
 
+func TestPrintTable_XcodeCloudDoctorResultUsesRegisteredRenderer(t *testing.T) {
+	result := &XcodeCloudDoctorResult{
+		Run: &XcodeCloudStatusResult{
+			BuildRunID:        "run-92",
+			BuildNumber:       92,
+			ExecutionProgress: "COMPLETE",
+			CompletionStatus:  "FAILED",
+		},
+		Summary: XcodeCloudDoctorSummary{TotalActions: 1, FailedActions: 1},
+		Actions: []XcodeCloudDoctorAction{{
+			ID:               "action-1",
+			Name:             "Archive - iOS",
+			CompletionStatus: "FAILED",
+		}},
+		Conclusion: "The Xcode Cloud build run failed.",
+		NextAction: "Resolve the reported issues.",
+	}
+
+	output := captureXcodeCloudStdout(t, func() error {
+		return PrintTable(result)
+	})
+
+	for _, expected := range []string{"Summary field", "run-92", "Actions ID", "action-1", "Archive - iOS"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("registered doctor renderer output missing %q: %s", expected, output)
+		}
+	}
+}
+
 func TestPrintMarkdown_XcodeCloudRunResult(t *testing.T) {
 	result := &XcodeCloudRunResult{
 		BuildRunID:        "run-123",

--- a/internal/asc/xcode_cloud_test.go
+++ b/internal/asc/xcode_cloud_test.go
@@ -96,6 +96,16 @@ func TestPrintTable_XcodeCloudDoctorResultUsesRegisteredRenderer(t *testing.T) {
 			Name:             "Archive - iOS",
 			CompletionStatus: "FAILED",
 		}},
+		LogBundles: []XcodeCloudDoctorLogBundle{{
+			ArtifactID: "log-1",
+			ActionID:   "action-1",
+			Inspected:  true,
+			Diagnostics: []XcodeCloudDoctorLogDiagnostic{{
+				Code:       "ITMS-90478",
+				Message:    "Invalid Version",
+				SourceFile: "IDEDistribution.standard.log",
+			}},
+		}},
 		Conclusion: "The Xcode Cloud build run failed.",
 		NextAction: "Resolve the reported issues.",
 	}
@@ -104,7 +114,7 @@ func TestPrintTable_XcodeCloudDoctorResultUsesRegisteredRenderer(t *testing.T) {
 		return PrintTable(result)
 	})
 
-	for _, expected := range []string{"Summary field", "run-92", "Actions ID", "action-1", "Archive - iOS"} {
+	for _, expected := range []string{"Summary field", "run-92", "Actions ID", "action-1", "Archive - iOS", "Log diagnostics action ID", "ITMS-90478", "Invalid Version", "IDEDistribution.standard.log"} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("registered doctor renderer output missing %q: %s", expected, output)
 		}

--- a/internal/asc/xcode_cloud_test.go
+++ b/internal/asc/xcode_cloud_test.go
@@ -97,9 +97,10 @@ func TestPrintTable_XcodeCloudDoctorResultUsesRegisteredRenderer(t *testing.T) {
 			CompletionStatus: "FAILED",
 		}},
 		LogBundles: []XcodeCloudDoctorLogBundle{{
-			ArtifactID: "log-1",
-			ActionID:   "action-1",
-			Inspected:  true,
+			ArtifactID:           "log-1",
+			ActionID:             "action-1",
+			Inspected:            true,
+			DiagnosticsTruncated: true,
 			Diagnostics: []XcodeCloudDoctorLogDiagnostic{{
 				Code:       "ITMS-90478",
 				Message:    "Invalid Version",
@@ -114,7 +115,7 @@ func TestPrintTable_XcodeCloudDoctorResultUsesRegisteredRenderer(t *testing.T) {
 		return PrintTable(result)
 	})
 
-	for _, expected := range []string{"Summary field", "run-92", "Actions ID", "action-1", "Archive - iOS", "Log diagnostics action ID", "ITMS-90478", "Invalid Version", "IDEDistribution.standard.log"} {
+	for _, expected := range []string{"Summary field", "run-92", "Actions ID", "action-1", "Archive - iOS", "Diagnostics truncated", "Log diagnostics action ID", "ITMS-90478", "Invalid Version", "IDEDistribution.standard.log"} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("registered doctor renderer output missing %q: %s", expected, output)
 		}

--- a/internal/cli/cmdtest/xcode_cloud_doctor_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_doctor_test.go
@@ -148,6 +148,27 @@ func TestXcodeCloudDoctorRequiresRunID(t *testing.T) {
 	}
 }
 
+func TestXcodeCloudDoctorHelpMarksNewSurfaceExperimental(t *testing.T) {
+	root := RootCommand("1.2.3")
+	doctor := findCommand(root, "xcode-cloud", "doctor")
+	if doctor == nil {
+		t.Fatal("xcode-cloud doctor command is not registered")
+	}
+	if !strings.HasPrefix(doctor.ShortHelp, "[experimental]") {
+		t.Fatalf("ShortHelp = %q, want experimental lifecycle label", doctor.ShortHelp)
+	}
+
+	for _, name := range []string{"run-id", "wait", "poll-interval", "timeout", "skip-logs", "save-logs"} {
+		flagValue := doctor.FlagSet.Lookup(name)
+		if flagValue == nil {
+			t.Fatalf("flag --%s is not registered", name)
+		}
+		if !strings.HasPrefix(flagValue.Usage, "[experimental] ") {
+			t.Fatalf("--%s usage = %q, want experimental lifecycle label", name, flagValue.Usage)
+		}
+	}
+}
+
 func TestXcodeCloudDoctorSavesLogBundleWithoutOverwriting(t *testing.T) {
 	setupAuth(t)
 
@@ -333,7 +354,7 @@ func TestXcodeCloudDoctorWaitsForTerminalRunAndRendersTable(t *testing.T) {
 	if runRequests != 2 {
 		t.Fatalf("run requests = %d, want 2", runRequests)
 	}
-	for _, expected := range []string{"SUMMARY", "completionStatus", "FAILED", "ACTIONS", "Xcode Cloud build run failed"} {
+	for _, expected := range []string{"Summary field", "completionStatus", "FAILED", "Actions ID", "Xcode Cloud build run failed"} {
 		if !strings.Contains(stdout, expected) {
 			t.Fatalf("table output missing %q: %s", expected, stdout)
 		}

--- a/internal/cli/cmdtest/xcode_cloud_doctor_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_doctor_test.go
@@ -1,0 +1,427 @@
+package cmdtest
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestXcodeCloudDoctorReportsFailedRunAndInspectsLogBundle(t *testing.T) {
+	setupAuth(t)
+
+	logBundle := buildXcodeCloudLogBundle(t, "Export/IDEDistribution.standard.log", strings.Join([]string{
+		"Exported Presset to: /Volumes/workspace/appstoreexport",
+		"** EXPORT SUCCEEDED **",
+		"error: ITMS-90478: Invalid Version - Choose a different version number.",
+	}, "\n"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	requests := make(map[string]int)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests[req.URL.Path]++
+		var body string
+		switch req.URL.Path {
+		case "/v1/ciBuildRuns/run-1":
+			body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"number":92,"executionProgress":"COMPLETE","completionStatus":"FAILED"},"relationships":{"workflow":{"data":{"type":"ciWorkflows","id":"workflow-1"}}}}}`
+		case "/v1/ciBuildRuns/run-1/actions":
+			body = `{"data":[{"type":"ciBuildActions","id":"action-1","attributes":{"name":"Archive - iOS","actionType":"ARCHIVE","executionProgress":"COMPLETE","completionStatus":"FAILED"}}]}`
+		case "/v1/ciBuildActions/action-1/issues":
+			body = `{"data":[{"type":"ciIssues","id":"issue-1","attributes":{"issueType":"ERROR","category":"Prepare Build for App Store Connect","message":"Preparing build for App Store Connect failed"}}]}`
+		case "/v1/ciBuildActions/action-1/artifacts":
+			body = `{"data":[{"type":"ciArtifacts","id":"log-1","attributes":{"fileType":"LOG_BUNDLE","fileName":"Build 92 Logs.zip","fileSize":512}}]}`
+		case "/v1/ciArtifacts/log-1":
+			body = `{"data":{"type":"ciArtifacts","id":"log-1","attributes":{"fileType":"LOG_BUNDLE","fileName":"Build 92 Logs.zip","fileSize":512,"downloadUrl":"https://appstoreconnect.apple.com/logs/log-1.zip"}}}`
+		case "/logs/log-1.zip":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(logBundle)),
+				Header:     http.Header{"Content-Type": []string{"application/zip"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "doctor", "--run-id", "run-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result struct {
+		Run struct {
+			BuildRunID       string `json:"buildRunId"`
+			CompletionStatus string `json:"completionStatus"`
+		} `json:"run"`
+		Summary struct {
+			FailedActions int `json:"failedActions"`
+		} `json:"summary"`
+		LogBundles []struct {
+			ArtifactID   string `json:"artifactId"`
+			Inspected    bool   `json:"inspected"`
+			ExportStatus string `json:"exportStatus"`
+			Diagnostics  []struct {
+				Code string `json:"code"`
+			} `json:"diagnostics"`
+		} `json:"logBundles"`
+		Conclusion string `json:"conclusion"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output %q: %v", stdout, err)
+	}
+	if result.Run.BuildRunID != "run-1" || result.Run.CompletionStatus != "FAILED" {
+		t.Fatalf("unexpected run result: %+v", result.Run)
+	}
+	if result.Summary.FailedActions != 1 {
+		t.Fatalf("failedActions = %d, want 1", result.Summary.FailedActions)
+	}
+	if len(result.LogBundles) != 1 || result.LogBundles[0].ArtifactID != "log-1" || !result.LogBundles[0].Inspected {
+		t.Fatalf("unexpected log bundle result: %+v", result.LogBundles)
+	}
+	if result.LogBundles[0].ExportStatus != "SUCCEEDED" {
+		t.Fatalf("exportStatus = %q, want SUCCEEDED", result.LogBundles[0].ExportStatus)
+	}
+	if len(result.LogBundles[0].Diagnostics) != 1 || result.LogBundles[0].Diagnostics[0].Code != "ITMS-90478" {
+		t.Fatalf("unexpected diagnostics: %+v", result.LogBundles[0].Diagnostics)
+	}
+	if !strings.Contains(result.Conclusion, "App Store import diagnostics") {
+		t.Fatalf("unexpected conclusion %q", result.Conclusion)
+	}
+	for _, path := range []string{
+		"/v1/ciBuildRuns/run-1",
+		"/v1/ciBuildRuns/run-1/actions",
+		"/v1/ciBuildActions/action-1/issues",
+		"/v1/ciBuildActions/action-1/artifacts",
+		"/v1/ciArtifacts/log-1",
+		"/logs/log-1.zip",
+	} {
+		if requests[path] != 1 {
+			t.Fatalf("request count for %s = %d, want 1", path, requests[path])
+		}
+	}
+}
+
+func TestXcodeCloudDoctorRequiresRunID(t *testing.T) {
+	setupAuth(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "doctor"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "--run-id is required") {
+		t.Fatalf("expected required flag error, got %q", stderr)
+	}
+}
+
+func TestXcodeCloudDoctorSavesLogBundleWithoutOverwriting(t *testing.T) {
+	setupAuth(t)
+
+	logBundle := buildXcodeCloudLogBundle(t, "Export/export.log", "** EXPORT FAILED **\nerror: ITMS-90062: Invalid bundle")
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.URL.Path {
+		case "/v1/ciBuildRuns/run-1":
+			body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"executionProgress":"COMPLETE","completionStatus":"FAILED"}}}`
+		case "/v1/ciBuildRuns/run-1/actions":
+			body = `{"data":[{"type":"ciBuildActions","id":"action-1","attributes":{"actionType":"ARCHIVE","executionProgress":"COMPLETE","completionStatus":"FAILED"}}]}`
+		case "/v1/ciBuildActions/action-1/issues":
+			body = `{"data":[]}`
+		case "/v1/ciBuildActions/action-1/artifacts":
+			body = `{"data":[{"type":"ciArtifacts","id":"log-1","attributes":{"fileType":"LOG_BUNDLE","fileName":"Build 92 Logs.zip","fileSize":512}}]}`
+		case "/v1/ciArtifacts/log-1":
+			body = `{"data":{"type":"ciArtifacts","id":"log-1","attributes":{"downloadUrl":"https://appstoreconnect.apple.com/logs/log-1.zip"}}}`
+		case "/logs/log-1.zip":
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(logBundle))}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	saveDir := t.TempDir()
+	runDoctor := func() error {
+		root := RootCommand("1.2.3")
+		root.FlagSet.SetOutput(io.Discard)
+		if err := root.Parse([]string{"xcode-cloud", "doctor", "--run-id", "run-1", "--save-logs", saveDir, "--output", "json"}); err != nil {
+			return err
+		}
+		return root.Run(context.Background())
+	}
+
+	var firstRunErr error
+	captureOutput(t, func() {
+		firstRunErr = runDoctor()
+	})
+	if firstRunErr != nil {
+		t.Fatalf("first doctor run error: %v", firstRunErr)
+	}
+	entries, err := os.ReadDir(saveDir)
+	if err != nil {
+		t.Fatalf("read save directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("saved entries = %d, want 1", len(entries))
+	}
+	saved, err := os.ReadFile(saveDir + string(os.PathSeparator) + entries[0].Name())
+	if err != nil {
+		t.Fatalf("read saved log bundle: %v", err)
+	}
+	if !bytes.Equal(saved, logBundle) {
+		t.Fatal("saved log bundle does not match download")
+	}
+	var secondRunErr error
+	captureOutput(t, func() {
+		secondRunErr = runDoctor()
+	})
+	if secondRunErr == nil || !strings.Contains(secondRunErr.Error(), "exist") {
+		t.Fatalf("second doctor run error = %v, want existing-file refusal", secondRunErr)
+	}
+}
+
+func TestXcodeCloudDoctorSuccessfulRunDoesNotDownloadLogs(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	requestedArtifactDetail := false
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.URL.Path {
+		case "/v1/ciBuildRuns/run-1":
+			body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"executionProgress":"COMPLETE","completionStatus":"SUCCEEDED"}}}`
+		case "/v1/ciBuildRuns/run-1/actions":
+			body = `{"data":[{"type":"ciBuildActions","id":"action-1","attributes":{"actionType":"ARCHIVE","executionProgress":"COMPLETE","completionStatus":"SUCCEEDED"}}]}`
+		case "/v1/ciBuildActions/action-1/issues":
+			body = `{"data":[]}`
+		case "/v1/ciBuildActions/action-1/artifacts":
+			body = `{"data":[{"type":"ciArtifacts","id":"log-1","attributes":{"fileType":"LOG_BUNDLE"}}]}`
+		case "/v1/ciArtifacts/log-1":
+			requestedArtifactDetail = true
+			t.Fatalf("successful run should not download log bundle")
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "doctor", "--run-id", "run-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestedArtifactDetail {
+		t.Fatal("successful run requested artifact details")
+	}
+	var result struct {
+		Summary struct {
+			LogBundles          int `json:"logBundles"`
+			LogBundlesInspected int `json:"logBundlesInspected"`
+		} `json:"summary"`
+		Conclusion string `json:"conclusion"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if result.Summary.LogBundles != 1 || result.Summary.LogBundlesInspected != 0 {
+		t.Fatalf("unexpected summary: %+v", result.Summary)
+	}
+	if !strings.Contains(result.Conclusion, "completed successfully") {
+		t.Fatalf("unexpected conclusion %q", result.Conclusion)
+	}
+}
+
+func TestXcodeCloudDoctorWaitsForTerminalRunAndRendersTable(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	runRequests := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.URL.Path {
+		case "/v1/ciBuildRuns/run-1":
+			runRequests++
+			if runRequests == 1 {
+				body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"executionProgress":"RUNNING"}}}`
+			} else {
+				body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"executionProgress":"COMPLETE","completionStatus":"FAILED"}}}`
+			}
+		case "/v1/ciBuildRuns/run-1/actions":
+			body = `{"data":[]}`
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "doctor", "--run-id", "run-1", "--wait", "--poll-interval", "1ms", "--output", "table"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if runRequests != 2 {
+		t.Fatalf("run requests = %d, want 2", runRequests)
+	}
+	for _, expected := range []string{"SUMMARY", "completionStatus", "FAILED", "ACTIONS", "Xcode Cloud build run failed"} {
+		if !strings.Contains(stdout, expected) {
+			t.Fatalf("table output missing %q: %s", expected, stdout)
+		}
+	}
+}
+
+func TestXcodeCloudDoctorRejectsPollIntervalWithoutWait(t *testing.T) {
+	setupAuth(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "doctor", "--run-id", "run-1", "--poll-interval", "1s"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "--poll-interval requires --wait") {
+		t.Fatalf("expected poll interval validation, got %q", stderr)
+	}
+}
+
+func TestXcodeCloudDoctorReportsRunAPIError(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/ciBuildRuns/run-1" {
+			t.Fatalf("unexpected request: %s", req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"status":"500","code":"SERVER_ERROR","title":"Unavailable"}]}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"xcode-cloud", "doctor", "--run-id", "run-1"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "xcode-cloud doctor") {
+		t.Fatalf("run error = %v, want doctor API error", err)
+	}
+}
+
+func TestXcodeCloudDoctorRejectsSaveLogsWithSkipLogs(t *testing.T) {
+	setupAuth(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "doctor", "--run-id", "run-1", "--save-logs", t.TempDir(), "--skip-logs"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected ErrHelp, got %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "--save-logs and --skip-logs are mutually exclusive") {
+		t.Fatalf("expected conflicting flag error, got %q", stderr)
+	}
+}
+
+func buildXcodeCloudLogBundle(t *testing.T, name, content string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	archive := zip.NewWriter(&buffer)
+	file, err := archive.Create(name)
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := io.WriteString(file, content); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buffer.Bytes()
+}

--- a/internal/cli/cmdtest/xcode_cloud_doctor_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_doctor_test.go
@@ -234,11 +234,23 @@ func TestXcodeCloudDoctorSavesLogBundleWithoutOverwriting(t *testing.T) {
 		t.Fatal("saved log bundle does not match download")
 	}
 	var secondRunErr error
-	captureOutput(t, func() {
+	secondStdout, _ := captureOutput(t, func() {
 		secondRunErr = runDoctor()
 	})
-	if secondRunErr == nil || !strings.Contains(secondRunErr.Error(), "exist") {
-		t.Fatalf("second doctor run error = %v, want existing-file refusal", secondRunErr)
+	if secondRunErr != nil {
+		t.Fatalf("second doctor run error = %v, want completed report", secondRunErr)
+	}
+	var secondResult struct {
+		CoverageWarnings []struct {
+			ID      string `json:"id"`
+			Message string `json:"message"`
+		} `json:"coverageWarnings"`
+	}
+	if err := json.Unmarshal([]byte(secondStdout), &secondResult); err != nil {
+		t.Fatalf("decode second doctor output %q: %v", secondStdout, err)
+	}
+	if len(secondResult.CoverageWarnings) != 1 || secondResult.CoverageWarnings[0].ID != "log_bundle_inspection_failed" || !strings.Contains(secondResult.CoverageWarnings[0].Message, "exist") {
+		t.Fatalf("second doctor warnings = %+v, want existing-file coverage warning", secondResult.CoverageWarnings)
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -46,12 +46,14 @@ Examples:
   asc xcode-cloud run --source-run-id "BUILD_RUN_ID" --clean
   asc xcode-cloud run --app "APP_ID" --workflow "Deploy" --branch "main" --wait
   asc xcode-cloud status --run-id "BUILD_RUN_ID"
-  asc xcode-cloud status --run-id "BUILD_RUN_ID" --wait`,
+  asc xcode-cloud status --run-id "BUILD_RUN_ID" --wait
+  asc xcode-cloud doctor --run-id "BUILD_RUN_ID" --wait`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			XcodeCloudRunCommand(),
 			XcodeCloudStatusCommand(),
+			XcodeCloudDoctorCommand(),
 			XcodeCloudProductsCommand(),
 			XcodeCloudWorkflowsCommand(),
 			XcodeCloudScmCommand(),

--- a/internal/cli/xcodecloud/xcode_cloud_action_resources_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_action_resources_helpers.go
@@ -361,12 +361,20 @@ func resolveSingleBuildActionIDForRun(ctx context.Context, client *asc.Client, r
 }
 
 func listBuildActionsForRun(ctx context.Context, client *asc.Client, runID string) ([]asc.CiBuildActionResource, error) {
+	actions, err := listBuildActionsForRunAllowEmpty(ctx, client, runID)
+	if err != nil {
+		return nil, err
+	}
+	if len(actions) == 0 {
+		return nil, shared.UsageErrorf("no build actions found for --run-id %q", runID)
+	}
+	return actions, nil
+}
+
+func listBuildActionsForRunAllowEmpty(ctx context.Context, client *asc.Client, runID string) ([]asc.CiBuildActionResource, error) {
 	resp, err := client.GetCiBuildActions(ctx, runID, asc.WithCiBuildActionsLimit(200))
 	if err != nil {
 		return nil, fmt.Errorf("resolve build actions for run %q: %w", runID, err)
-	}
-	if len(resp.Data) == 0 {
-		return nil, shared.UsageErrorf("no build actions found for --run-id %q", runID)
 	}
 	if strings.TrimSpace(resp.Links.Next) == "" {
 		return resp.Data, nil
@@ -383,10 +391,6 @@ func listBuildActionsForRun(ctx context.Context, client *asc.Client, runID strin
 	if !ok {
 		return nil, fmt.Errorf("resolve build actions for run %q: unexpected response type %T", runID, allPages)
 	}
-	if len(allActions.Data) == 0 {
-		return nil, shared.UsageErrorf("no build actions found for --run-id %q", runID)
-	}
-
 	return allActions.Data, nil
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -145,7 +145,7 @@ func diagnoseXcodeCloudRun(ctx context.Context, client *asc.Client, runID string
 	}
 
 	summarizeXcodeCloudDoctorResult(result)
-	if options.SkipLogs && result.Summary.LogBundles > 0 && doctorRunFailed(result) {
+	if options.SkipLogs && doctorFailedActionLogBundleCount(result) > 0 && doctorRunFailed(result) {
 		result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
 			ID:          "log_bundle_inspection_skipped",
 			Message:     "Log bundle inspection was disabled with --skip-logs.",
@@ -274,8 +274,10 @@ func summarizeXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	result.Summary.TotalActions = len(result.Actions)
 	for _, action := range result.Actions {
 		switch strings.ToUpper(strings.TrimSpace(action.CompletionStatus)) {
-		case "FAILED", "ERRORED", "CANCELED":
+		case "FAILED", "ERRORED":
 			result.Summary.FailedActions++
+		case "CANCELED":
+			result.Summary.CanceledActions++
 		case "SKIPPED":
 			result.Summary.SkippedActions++
 		}
@@ -297,13 +299,13 @@ func summarizeXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 }
 
 func shouldInspectDoctorLogs(result *asc.XcodeCloudDoctorResult, options xcodeCloudDoctorOptions) bool {
-	if options.SkipLogs || result.Summary.LogBundles == 0 {
+	if options.SkipLogs || result == nil {
 		return false
 	}
 	if strings.TrimSpace(options.SaveLogs) != "" {
-		return true
+		return result.Summary.LogBundles > 0
 	}
-	return doctorRunFailed(result)
+	return doctorRunFailed(result) && doctorFailedActionLogBundleCount(result) > 0
 }
 
 func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
@@ -331,6 +333,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 
 	hasImportDiagnostic := false
 	hasSuccessfulExport := false
+	failedActionLogBundles := doctorFailedActionLogBundleCount(result)
 	for _, bundle := range result.LogBundles {
 		if bundle.ExportStatus == "SUCCEEDED" {
 			hasSuccessfulExport = true
@@ -348,7 +351,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 		if hasSuccessfulExport {
 			result.Conclusion = "The archive export succeeded, but Xcode Cloud reported a later failure without an ITMS-level import diagnostic."
 			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
-		} else if result.Summary.LogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
+		} else if failedActionLogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
 			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure, but its available log bundles were not inspected."
 			result.NextAction = "Re-run without --skip-logs, then check App Store Connect if the logs still contain no import detail."
 		} else {
@@ -367,7 +370,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 		return
 	}
 
-	if result.Summary.LogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
+	if failedActionLogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
 		result.Conclusion = "The Xcode Cloud build run failed, but its available log bundles were not inspected."
 		result.NextAction = "Re-run without --skip-logs or download the listed log bundle artifacts for inspection."
 	} else if result.Summary.Errors > 0 {
@@ -377,6 +380,24 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 		result.Conclusion = "The Xcode Cloud build run failed without a more specific diagnostic."
 		result.NextAction = "Review the available issues and artifacts in the report."
 	}
+}
+
+func doctorFailedActionLogBundleCount(result *asc.XcodeCloudDoctorResult) int {
+	if result == nil {
+		return 0
+	}
+	count := 0
+	for _, action := range result.Actions {
+		if !isFailedDoctorAction(action.CompletionStatus) {
+			continue
+		}
+		for _, artifact := range action.Artifacts {
+			if strings.EqualFold(strings.TrimSpace(artifact.FileType), "LOG_BUNDLE") {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 func doctorRunFailed(result *asc.XcodeCloudDoctorResult) bool {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -22,76 +22,23 @@ type xcodeCloudDoctorOptions struct {
 	SaveLogs     string
 }
 
-type xcodeCloudDoctorResult struct {
-	Run              *asc.XcodeCloudStatusResult       `json:"run"`
-	Summary          xcodeCloudDoctorSummary           `json:"summary"`
-	Actions          []xcodeCloudDoctorAction          `json:"actions"`
-	LogBundles       []xcodeCloudDoctorLogBundle       `json:"logBundles"`
-	CoverageWarnings []xcodeCloudDoctorCoverageWarning `json:"coverageWarnings"`
-	Conclusion       string                            `json:"conclusion"`
-	NextAction       string                            `json:"nextAction"`
-}
-
-type xcodeCloudDoctorSummary struct {
-	TotalActions        int `json:"totalActions"`
-	FailedActions       int `json:"failedActions"`
-	SkippedActions      int `json:"skippedActions"`
-	Errors              int `json:"errors"`
-	Warnings            int `json:"warnings"`
-	Artifacts           int `json:"artifacts"`
-	LogBundles          int `json:"logBundles"`
-	LogBundlesInspected int `json:"logBundlesInspected"`
-}
-
-type xcodeCloudDoctorAction struct {
-	ID                string                     `json:"id"`
-	Name              string                     `json:"name,omitempty"`
-	ActionType        string                     `json:"actionType,omitempty"`
-	ExecutionProgress string                     `json:"executionProgress,omitempty"`
-	CompletionStatus  string                     `json:"completionStatus,omitempty"`
-	IsRequiredToPass  *bool                      `json:"isRequiredToPass,omitempty"`
-	Issues            []xcodeCloudDoctorIssue    `json:"issues"`
-	Artifacts         []xcodeCloudDoctorArtifact `json:"artifacts"`
-}
-
-type xcodeCloudDoctorIssue struct {
-	ID         string            `json:"id"`
-	IssueType  string            `json:"issueType,omitempty"`
-	Category   string            `json:"category,omitempty"`
-	Message    string            `json:"message,omitempty"`
-	FileSource *asc.FileLocation `json:"fileSource,omitempty"`
-}
-
-type xcodeCloudDoctorArtifact struct {
-	ID       string `json:"id"`
-	FileType string `json:"fileType,omitempty"`
-	FileName string `json:"fileName,omitempty"`
-	FileSize int    `json:"fileSize,omitempty"`
-}
-
-type xcodeCloudDoctorCoverageWarning struct {
-	ID          string `json:"id"`
-	Message     string `json:"message"`
-	Remediation string `json:"remediation"`
-}
-
 // XcodeCloudDoctorCommand returns the xcode-cloud doctor subcommand.
 func XcodeCloudDoctorCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("doctor", flag.ExitOnError)
 
-	runID := fs.String("run-id", "", "Build run ID to diagnose")
-	wait := fs.Bool("wait", false, "Wait for the build run to complete before diagnosing it")
-	pollInterval := fs.Duration("poll-interval", 10*time.Second, "Poll interval when waiting")
-	timeout := fs.Duration("timeout", 0, "Timeout for Xcode Cloud requests (0 = use ASC_TIMEOUT or 30m default)")
-	skipLogs := fs.Bool("skip-logs", false, "Skip automatic inspection of failed-action log bundles")
-	saveLogs := fs.String("save-logs", "", "Directory in which to retain inspected log bundles")
+	runID := fs.String("run-id", "", "[experimental] Build run ID to diagnose")
+	wait := fs.Bool("wait", false, "[experimental] Wait for the build run to complete before diagnosing it")
+	pollInterval := fs.Duration("poll-interval", 10*time.Second, "[experimental] Poll interval when waiting")
+	timeout := fs.Duration("timeout", 0, "[experimental] Timeout for Xcode Cloud requests (0 = use ASC_TIMEOUT or 30m default)")
+	skipLogs := fs.Bool("skip-logs", false, "[experimental] Skip automatic inspection of failed-action log bundles")
+	saveLogs := fs.String("save-logs", "", "[experimental] Directory in which to retain inspected log bundles")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "doctor",
 		ShortUsage: "asc xcode-cloud doctor --run-id \"BUILD_RUN_ID\" [flags]",
-		ShortHelp:  "Diagnose an Xcode Cloud build run and inspect failure logs.",
-		LongHelp: `Diagnose an Xcode Cloud build run.
+		ShortHelp:  "[experimental] Diagnose an Xcode Cloud build run and inspect failure logs.",
+		LongHelp: `[experimental] Diagnose an Xcode Cloud build run.
 
 The command combines run status, actions, issues, and artifacts into one report.
 For failed runs, it inspects failed-action LOG_BUNDLE artifacts in memory and
@@ -164,7 +111,7 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 	return set
 }
 
-func diagnoseXcodeCloudRun(ctx context.Context, client *asc.Client, runID string, options xcodeCloudDoctorOptions) (*xcodeCloudDoctorResult, error) {
+func diagnoseXcodeCloudRun(ctx context.Context, client *asc.Client, runID string, options xcodeCloudDoctorOptions) (*asc.XcodeCloudDoctorResult, error) {
 	var (
 		run *asc.CiBuildRunResponse
 		err error
@@ -183,11 +130,11 @@ func diagnoseXcodeCloudRun(ctx context.Context, client *asc.Client, runID string
 		return nil, err
 	}
 
-	result := &xcodeCloudDoctorResult{
+	result := &asc.XcodeCloudDoctorResult{
 		Run:              buildStatusResult(run),
-		Actions:          make([]xcodeCloudDoctorAction, 0, len(actions)),
-		LogBundles:       make([]xcodeCloudDoctorLogBundle, 0),
-		CoverageWarnings: make([]xcodeCloudDoctorCoverageWarning, 0),
+		Actions:          make([]asc.XcodeCloudDoctorAction, 0, len(actions)),
+		LogBundles:       make([]asc.XcodeCloudDoctorLogBundle, 0),
+		CoverageWarnings: make([]asc.XcodeCloudDoctorCoverageWarning, 0),
 	}
 	for _, action := range actions {
 		actionResult, err := diagnoseXcodeCloudAction(ctx, client, action)
@@ -199,7 +146,7 @@ func diagnoseXcodeCloudRun(ctx context.Context, client *asc.Client, runID string
 
 	summarizeXcodeCloudDoctorResult(result)
 	if options.SkipLogs && result.Summary.LogBundles > 0 && doctorRunFailed(result) {
-		result.CoverageWarnings = append(result.CoverageWarnings, xcodeCloudDoctorCoverageWarning{
+		result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
 			ID:          "log_bundle_inspection_skipped",
 			Message:     "Log bundle inspection was disabled with --skip-logs.",
 			Remediation: "Re-run without --skip-logs to inspect failed-action log bundles.",
@@ -236,17 +183,17 @@ func waitForBuildRunForDoctor(ctx context.Context, client *asc.Client, runID str
 	return run, nil
 }
 
-func diagnoseXcodeCloudAction(ctx context.Context, client *asc.Client, action asc.CiBuildActionResource) (xcodeCloudDoctorAction, error) {
+func diagnoseXcodeCloudAction(ctx context.Context, client *asc.Client, action asc.CiBuildActionResource) (asc.XcodeCloudDoctorAction, error) {
 	actionID := strings.TrimSpace(action.ID)
-	result := xcodeCloudDoctorAction{
+	result := asc.XcodeCloudDoctorAction{
 		ID:                actionID,
 		Name:              action.Attributes.Name,
 		ActionType:        action.Attributes.ActionType,
 		ExecutionProgress: string(action.Attributes.ExecutionProgress),
 		CompletionStatus:  string(action.Attributes.CompletionStatus),
 		IsRequiredToPass:  action.Attributes.IsRequiredToPass,
-		Issues:            make([]xcodeCloudDoctorIssue, 0),
-		Artifacts:         make([]xcodeCloudDoctorArtifact, 0),
+		Issues:            make([]asc.XcodeCloudDoctorIssue, 0),
+		Artifacts:         make([]asc.XcodeCloudDoctorArtifact, 0),
 	}
 	if actionID == "" {
 		return result, nil
@@ -257,7 +204,7 @@ func diagnoseXcodeCloudAction(ctx context.Context, client *asc.Client, action as
 		return result, fmt.Errorf("list issues for action %q: %w", actionID, err)
 	}
 	for _, issue := range issues {
-		result.Issues = append(result.Issues, xcodeCloudDoctorIssue{
+		result.Issues = append(result.Issues, asc.XcodeCloudDoctorIssue{
 			ID:         issue.ID,
 			IssueType:  issue.Attributes.IssueType,
 			Category:   issue.Attributes.Category,
@@ -271,7 +218,7 @@ func diagnoseXcodeCloudAction(ctx context.Context, client *asc.Client, action as
 		return result, fmt.Errorf("list artifacts for action %q: %w", actionID, err)
 	}
 	for _, artifact := range artifacts {
-		result.Artifacts = append(result.Artifacts, xcodeCloudDoctorArtifact{
+		result.Artifacts = append(result.Artifacts, asc.XcodeCloudDoctorArtifact{
 			ID:       artifact.ID,
 			FileType: artifact.Attributes.FileType,
 			FileName: artifact.Attributes.FileName,
@@ -323,7 +270,7 @@ func listAllXcodeCloudActionArtifacts(ctx context.Context, client *asc.Client, a
 	return allArtifacts.Data, nil
 }
 
-func summarizeXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
+func summarizeXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	result.Summary.TotalActions = len(result.Actions)
 	for _, action := range result.Actions {
 		switch strings.ToUpper(strings.TrimSpace(action.CompletionStatus)) {
@@ -349,7 +296,7 @@ func summarizeXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
 	}
 }
 
-func shouldInspectDoctorLogs(result *xcodeCloudDoctorResult, options xcodeCloudDoctorOptions) bool {
+func shouldInspectDoctorLogs(result *asc.XcodeCloudDoctorResult, options xcodeCloudDoctorOptions) bool {
 	if options.SkipLogs || result.Summary.LogBundles == 0 {
 		return false
 	}
@@ -360,7 +307,7 @@ func shouldInspectDoctorLogs(result *xcodeCloudDoctorResult, options xcodeCloudD
 		asc.IsBuildRunComplete(asc.CiBuildRunExecutionProgress(result.Run.ExecutionProgress))
 }
 
-func finishXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
+func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	status := strings.ToUpper(strings.TrimSpace(result.Run.CompletionStatus))
 	if !strings.EqualFold(result.Run.ExecutionProgress, string(asc.CiBuildRunExecutionProgressComplete)) {
 		result.Conclusion = "The Xcode Cloud build run is not complete."
@@ -370,6 +317,16 @@ func finishXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
 	if status == string(asc.CiBuildRunCompletionStatusSucceeded) {
 		result.Conclusion = "The Xcode Cloud build run completed successfully."
 		result.NextAction = "No corrective action is required."
+		return
+	}
+	if status == string(asc.CiBuildRunCompletionStatusCanceled) {
+		result.Conclusion = "The Xcode Cloud build run was canceled."
+		result.NextAction = "Review the cancellation reason and start a new build run when ready."
+		return
+	}
+	if status == string(asc.CiBuildRunCompletionStatusSkipped) {
+		result.Conclusion = "The Xcode Cloud build run was skipped."
+		result.NextAction = "Review the workflow conditions and action results to determine why the run was skipped."
 		return
 	}
 
@@ -403,7 +360,7 @@ func finishXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
 		if result.Summary.LogBundlesInspected > 0 {
 			coverageMessage = "The Xcode Cloud API and inspected log bundles did not expose a detailed App Store import rejection."
 		}
-		result.CoverageWarnings = append(result.CoverageWarnings, xcodeCloudDoctorCoverageWarning{
+		result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
 			ID:          "app_store_import_detail_unavailable",
 			Message:     coverageMessage,
 			Remediation: "Check the App Store Connect delivery notification or build processing state; do not infer an ITMS root cause from the generic Xcode Cloud issue.",
@@ -423,7 +380,7 @@ func finishXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
 	}
 }
 
-func doctorRunFailed(result *xcodeCloudDoctorResult) bool {
+func doctorRunFailed(result *asc.XcodeCloudDoctorResult) bool {
 	if result == nil || result.Run == nil {
 		return false
 	}
@@ -431,7 +388,7 @@ func doctorRunFailed(result *xcodeCloudDoctorResult) bool {
 		!strings.EqualFold(strings.TrimSpace(result.Run.CompletionStatus), string(asc.CiBuildRunCompletionStatusSucceeded))
 }
 
-func doctorHasAppStorePreparationIssue(result *xcodeCloudDoctorResult) bool {
+func doctorHasAppStorePreparationIssue(result *asc.XcodeCloudDoctorResult) bool {
 	for _, action := range result.Actions {
 		for _, issue := range action.Issues {
 			text := strings.ToLower(issue.Category + " " + issue.Message)

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -1,0 +1,444 @@
+package xcodecloud
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type xcodeCloudDoctorOptions struct {
+	Wait         bool
+	PollInterval time.Duration
+	SkipLogs     bool
+	SaveLogs     string
+}
+
+type xcodeCloudDoctorResult struct {
+	Run              *asc.XcodeCloudStatusResult       `json:"run"`
+	Summary          xcodeCloudDoctorSummary           `json:"summary"`
+	Actions          []xcodeCloudDoctorAction          `json:"actions"`
+	LogBundles       []xcodeCloudDoctorLogBundle       `json:"logBundles"`
+	CoverageWarnings []xcodeCloudDoctorCoverageWarning `json:"coverageWarnings"`
+	Conclusion       string                            `json:"conclusion"`
+	NextAction       string                            `json:"nextAction"`
+}
+
+type xcodeCloudDoctorSummary struct {
+	TotalActions        int `json:"totalActions"`
+	FailedActions       int `json:"failedActions"`
+	SkippedActions      int `json:"skippedActions"`
+	Errors              int `json:"errors"`
+	Warnings            int `json:"warnings"`
+	Artifacts           int `json:"artifacts"`
+	LogBundles          int `json:"logBundles"`
+	LogBundlesInspected int `json:"logBundlesInspected"`
+}
+
+type xcodeCloudDoctorAction struct {
+	ID                string                     `json:"id"`
+	Name              string                     `json:"name,omitempty"`
+	ActionType        string                     `json:"actionType,omitempty"`
+	ExecutionProgress string                     `json:"executionProgress,omitempty"`
+	CompletionStatus  string                     `json:"completionStatus,omitempty"`
+	IsRequiredToPass  *bool                      `json:"isRequiredToPass,omitempty"`
+	Issues            []xcodeCloudDoctorIssue    `json:"issues"`
+	Artifacts         []xcodeCloudDoctorArtifact `json:"artifacts"`
+}
+
+type xcodeCloudDoctorIssue struct {
+	ID         string            `json:"id"`
+	IssueType  string            `json:"issueType,omitempty"`
+	Category   string            `json:"category,omitempty"`
+	Message    string            `json:"message,omitempty"`
+	FileSource *asc.FileLocation `json:"fileSource,omitempty"`
+}
+
+type xcodeCloudDoctorArtifact struct {
+	ID       string `json:"id"`
+	FileType string `json:"fileType,omitempty"`
+	FileName string `json:"fileName,omitempty"`
+	FileSize int    `json:"fileSize,omitempty"`
+}
+
+type xcodeCloudDoctorCoverageWarning struct {
+	ID          string `json:"id"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation"`
+}
+
+// XcodeCloudDoctorCommand returns the xcode-cloud doctor subcommand.
+func XcodeCloudDoctorCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("doctor", flag.ExitOnError)
+
+	runID := fs.String("run-id", "", "Build run ID to diagnose")
+	wait := fs.Bool("wait", false, "Wait for the build run to complete before diagnosing it")
+	pollInterval := fs.Duration("poll-interval", 10*time.Second, "Poll interval when waiting")
+	timeout := fs.Duration("timeout", 0, "Timeout for Xcode Cloud requests (0 = use ASC_TIMEOUT or 30m default)")
+	skipLogs := fs.Bool("skip-logs", false, "Skip automatic inspection of failed-action log bundles")
+	saveLogs := fs.String("save-logs", "", "Directory in which to retain inspected log bundles")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "doctor",
+		ShortUsage: "asc xcode-cloud doctor --run-id \"BUILD_RUN_ID\" [flags]",
+		ShortHelp:  "Diagnose an Xcode Cloud build run and inspect failure logs.",
+		LongHelp: `Diagnose an Xcode Cloud build run.
+
+The command combines run status, actions, issues, and artifacts into one report.
+For failed runs, it inspects failed-action LOG_BUNDLE artifacts in memory and
+reports App Store import diagnostics when those details are present. Use
+--save-logs to retain the downloaded bundles. A failed build is report data and
+does not make doctor exit non-zero.
+
+Examples:
+  asc xcode-cloud doctor --run-id "BUILD_RUN_ID"
+  asc xcode-cloud doctor --run-id "BUILD_RUN_ID" --wait
+  asc xcode-cloud doctor --run-id "BUILD_RUN_ID" --wait --save-logs ./xcode-cloud-logs
+  asc xcode-cloud doctor --run-id "BUILD_RUN_ID" --skip-logs --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.WithDiagnostic(shared.UsageError("xcode-cloud doctor does not accept positional arguments"), shared.DiagnosticInvalidInput, "")
+			}
+			runIDValue := strings.TrimSpace(*runID)
+			if runIDValue == "" {
+				fmt.Fprintln(os.Stderr, "Error: --run-id is required")
+				return shared.MissingRequiredUsageError("--run-id")
+			}
+			if *timeout < 0 {
+				return shared.UsageError("--timeout must be greater than or equal to 0")
+			}
+			if *wait && *pollInterval <= 0 {
+				return shared.UsageError("--poll-interval must be greater than 0")
+			}
+			if !*wait && flagWasSet(fs, "poll-interval") {
+				return shared.UsageError("--poll-interval requires --wait")
+			}
+			if *skipLogs && strings.TrimSpace(*saveLogs) != "" {
+				return shared.UsageError("--save-logs and --skip-logs are mutually exclusive")
+			}
+			if flagWasSet(fs, "save-logs") && strings.TrimSpace(*saveLogs) == "" {
+				return shared.UsageError("--save-logs must not be empty")
+			}
+
+			client, err := shared.GetASCClient()
+			if err != nil {
+				return fmt.Errorf("xcode-cloud doctor: %w", err)
+			}
+
+			requestCtx, cancel := contextWithXcodeCloudTimeout(ctx, *timeout)
+			defer cancel()
+
+			result, err := diagnoseXcodeCloudRun(requestCtx, client, runIDValue, xcodeCloudDoctorOptions{
+				Wait:         *wait,
+				PollInterval: *pollInterval,
+				SkipLogs:     *skipLogs,
+				SaveLogs:     strings.TrimSpace(*saveLogs),
+			})
+			if err != nil {
+				return fmt.Errorf("xcode-cloud doctor: %w", err)
+			}
+
+			return printXcodeCloudDoctorResult(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	set := false
+	fs.Visit(func(current *flag.Flag) {
+		if current.Name == name {
+			set = true
+		}
+	})
+	return set
+}
+
+func diagnoseXcodeCloudRun(ctx context.Context, client *asc.Client, runID string, options xcodeCloudDoctorOptions) (*xcodeCloudDoctorResult, error) {
+	var (
+		run *asc.CiBuildRunResponse
+		err error
+	)
+	if options.Wait {
+		run, err = waitForBuildRunForDoctor(ctx, client, runID, options.PollInterval)
+	} else {
+		run, err = getCiBuildRun(ctx, client, runID)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	actions, err := listBuildActionsForRunAllowEmpty(ctx, client, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &xcodeCloudDoctorResult{
+		Run:              buildStatusResult(run),
+		Actions:          make([]xcodeCloudDoctorAction, 0, len(actions)),
+		LogBundles:       make([]xcodeCloudDoctorLogBundle, 0),
+		CoverageWarnings: make([]xcodeCloudDoctorCoverageWarning, 0),
+	}
+	for _, action := range actions {
+		actionResult, err := diagnoseXcodeCloudAction(ctx, client, action)
+		if err != nil {
+			return nil, err
+		}
+		result.Actions = append(result.Actions, actionResult)
+	}
+
+	summarizeXcodeCloudDoctorResult(result)
+	if options.SkipLogs && result.Summary.LogBundles > 0 && doctorRunFailed(result) {
+		result.CoverageWarnings = append(result.CoverageWarnings, xcodeCloudDoctorCoverageWarning{
+			ID:          "log_bundle_inspection_skipped",
+			Message:     "Log bundle inspection was disabled with --skip-logs.",
+			Remediation: "Re-run without --skip-logs to inspect failed-action log bundles.",
+		})
+	}
+	if shouldInspectDoctorLogs(result, options) {
+		if err := inspectXcodeCloudDoctorLogs(ctx, client, result, options); err != nil {
+			return nil, err
+		}
+	}
+	finishXcodeCloudDoctorResult(result)
+	return result, nil
+}
+
+func waitForBuildRunForDoctor(ctx context.Context, client *asc.Client, runID string, pollInterval time.Duration) (*asc.CiBuildRunResponse, error) {
+	lastStatus := "unknown"
+	run, err := asc.PollUntil(ctx, pollInterval, func(ctx context.Context) (*asc.CiBuildRunResponse, bool, error) {
+		resp, err := getCiBuildRun(ctx, client, runID)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to check status: %w", err)
+		}
+		lastStatus = string(resp.Data.Attributes.ExecutionProgress)
+		return resp, asc.IsBuildRunComplete(resp.Data.Attributes.ExecutionProgress), nil
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, fmt.Errorf("canceled waiting for build run %s (last status: %s)", runID, lastStatus)
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("timed out waiting for build run %s (last status: %s)", runID, lastStatus)
+		}
+		return nil, err
+	}
+	return run, nil
+}
+
+func diagnoseXcodeCloudAction(ctx context.Context, client *asc.Client, action asc.CiBuildActionResource) (xcodeCloudDoctorAction, error) {
+	actionID := strings.TrimSpace(action.ID)
+	result := xcodeCloudDoctorAction{
+		ID:                actionID,
+		Name:              action.Attributes.Name,
+		ActionType:        action.Attributes.ActionType,
+		ExecutionProgress: string(action.Attributes.ExecutionProgress),
+		CompletionStatus:  string(action.Attributes.CompletionStatus),
+		IsRequiredToPass:  action.Attributes.IsRequiredToPass,
+		Issues:            make([]xcodeCloudDoctorIssue, 0),
+		Artifacts:         make([]xcodeCloudDoctorArtifact, 0),
+	}
+	if actionID == "" {
+		return result, nil
+	}
+
+	issues, err := listAllXcodeCloudActionIssues(ctx, client, actionID)
+	if err != nil {
+		return result, fmt.Errorf("list issues for action %q: %w", actionID, err)
+	}
+	for _, issue := range issues {
+		result.Issues = append(result.Issues, xcodeCloudDoctorIssue{
+			ID:         issue.ID,
+			IssueType:  issue.Attributes.IssueType,
+			Category:   issue.Attributes.Category,
+			Message:    issue.Attributes.Message,
+			FileSource: issue.Attributes.FileSource,
+		})
+	}
+
+	artifacts, err := listAllXcodeCloudActionArtifacts(ctx, client, actionID)
+	if err != nil {
+		return result, fmt.Errorf("list artifacts for action %q: %w", actionID, err)
+	}
+	for _, artifact := range artifacts {
+		result.Artifacts = append(result.Artifacts, xcodeCloudDoctorArtifact{
+			ID:       artifact.ID,
+			FileType: artifact.Attributes.FileType,
+			FileName: artifact.Attributes.FileName,
+			FileSize: artifact.Attributes.FileSize,
+		})
+	}
+	return result, nil
+}
+
+func listAllXcodeCloudActionIssues(ctx context.Context, client *asc.Client, actionID string) ([]asc.CiIssueResource, error) {
+	resp, err := client.GetCiBuildActionIssues(ctx, actionID, asc.WithCiIssuesLimit(200))
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(resp.Links.Next) == "" {
+		return resp.Data, nil
+	}
+	allPages, err := asc.PaginateAll(ctx, resp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetCiBuildActionIssues(ctx, actionID, asc.WithCiIssuesNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+	allIssues, ok := allPages.(*asc.CiIssuesResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected issues response type %T", allPages)
+	}
+	return allIssues.Data, nil
+}
+
+func listAllXcodeCloudActionArtifacts(ctx context.Context, client *asc.Client, actionID string) ([]asc.CiArtifactResource, error) {
+	resp, err := client.GetCiBuildActionArtifacts(ctx, actionID, asc.WithCiArtifactsLimit(200))
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(resp.Links.Next) == "" {
+		return resp.Data, nil
+	}
+	allPages, err := asc.PaginateAll(ctx, resp, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return client.GetCiBuildActionArtifacts(ctx, actionID, asc.WithCiArtifactsNextURL(nextURL))
+	})
+	if err != nil {
+		return nil, err
+	}
+	allArtifacts, ok := allPages.(*asc.CiArtifactsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected artifacts response type %T", allPages)
+	}
+	return allArtifacts.Data, nil
+}
+
+func summarizeXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
+	result.Summary.TotalActions = len(result.Actions)
+	for _, action := range result.Actions {
+		switch strings.ToUpper(strings.TrimSpace(action.CompletionStatus)) {
+		case "FAILED", "ERRORED", "CANCELED":
+			result.Summary.FailedActions++
+		case "SKIPPED":
+			result.Summary.SkippedActions++
+		}
+		for _, issue := range action.Issues {
+			switch strings.ToUpper(strings.TrimSpace(issue.IssueType)) {
+			case "ERROR", "TEST_FAILURE":
+				result.Summary.Errors++
+			case "WARNING", "ANALYZER_WARNING":
+				result.Summary.Warnings++
+			}
+		}
+		result.Summary.Artifacts += len(action.Artifacts)
+		for _, artifact := range action.Artifacts {
+			if strings.EqualFold(strings.TrimSpace(artifact.FileType), "LOG_BUNDLE") {
+				result.Summary.LogBundles++
+			}
+		}
+	}
+}
+
+func shouldInspectDoctorLogs(result *xcodeCloudDoctorResult, options xcodeCloudDoctorOptions) bool {
+	if options.SkipLogs || result.Summary.LogBundles == 0 {
+		return false
+	}
+	if strings.TrimSpace(options.SaveLogs) != "" {
+		return true
+	}
+	return !strings.EqualFold(strings.TrimSpace(result.Run.CompletionStatus), string(asc.CiBuildRunCompletionStatusSucceeded)) &&
+		asc.IsBuildRunComplete(asc.CiBuildRunExecutionProgress(result.Run.ExecutionProgress))
+}
+
+func finishXcodeCloudDoctorResult(result *xcodeCloudDoctorResult) {
+	status := strings.ToUpper(strings.TrimSpace(result.Run.CompletionStatus))
+	if !strings.EqualFold(result.Run.ExecutionProgress, string(asc.CiBuildRunExecutionProgressComplete)) {
+		result.Conclusion = "The Xcode Cloud build run is not complete."
+		result.NextAction = "Re-run this command with --wait to diagnose the terminal result."
+		return
+	}
+	if status == string(asc.CiBuildRunCompletionStatusSucceeded) {
+		result.Conclusion = "The Xcode Cloud build run completed successfully."
+		result.NextAction = "No corrective action is required."
+		return
+	}
+
+	hasImportDiagnostic := false
+	hasSuccessfulExport := false
+	for _, bundle := range result.LogBundles {
+		if bundle.ExportStatus == "SUCCEEDED" {
+			hasSuccessfulExport = true
+		}
+		if len(bundle.Diagnostics) > 0 {
+			hasImportDiagnostic = true
+		}
+	}
+	if hasImportDiagnostic {
+		result.Conclusion = "The Xcode Cloud log bundles contain App Store import diagnostics."
+		result.NextAction = "Resolve the reported ITMS diagnostics, then start a new build run."
+		return
+	}
+	if hasSuccessfulExport || doctorHasAppStorePreparationIssue(result) {
+		if hasSuccessfulExport {
+			result.Conclusion = "The archive export succeeded, but Xcode Cloud reported a later failure without an ITMS-level import diagnostic."
+			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
+		} else if result.Summary.LogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
+			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure, but its available log bundles were not inspected."
+			result.NextAction = "Re-run without --skip-logs, then check App Store Connect if the logs still contain no import detail."
+		} else {
+			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure without an ITMS-level import diagnostic."
+			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
+		}
+		coverageMessage := "The Xcode Cloud API did not expose a detailed App Store import rejection."
+		if result.Summary.LogBundlesInspected > 0 {
+			coverageMessage = "The Xcode Cloud API and inspected log bundles did not expose a detailed App Store import rejection."
+		}
+		result.CoverageWarnings = append(result.CoverageWarnings, xcodeCloudDoctorCoverageWarning{
+			ID:          "app_store_import_detail_unavailable",
+			Message:     coverageMessage,
+			Remediation: "Check the App Store Connect delivery notification or build processing state; do not infer an ITMS root cause from the generic Xcode Cloud issue.",
+		})
+		return
+	}
+
+	if result.Summary.LogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
+		result.Conclusion = "The Xcode Cloud build run failed, but its available log bundles were not inspected."
+		result.NextAction = "Re-run without --skip-logs or download the listed log bundle artifacts for inspection."
+	} else if result.Summary.Errors > 0 {
+		result.Conclusion = "The Xcode Cloud build run failed and reported actionable issues."
+		result.NextAction = "Resolve the reported issues, then start a new build run."
+	} else {
+		result.Conclusion = "The Xcode Cloud build run failed without a more specific diagnostic."
+		result.NextAction = "Review the available issues and artifacts in the report."
+	}
+}
+
+func doctorRunFailed(result *xcodeCloudDoctorResult) bool {
+	if result == nil || result.Run == nil {
+		return false
+	}
+	return asc.IsBuildRunComplete(asc.CiBuildRunExecutionProgress(result.Run.ExecutionProgress)) &&
+		!strings.EqualFold(strings.TrimSpace(result.Run.CompletionStatus), string(asc.CiBuildRunCompletionStatusSucceeded))
+}
+
+func doctorHasAppStorePreparationIssue(result *xcodeCloudDoctorResult) bool {
+	for _, action := range result.Actions {
+		for _, issue := range action.Issues {
+			text := strings.ToLower(issue.Category + " " + issue.Message)
+			if strings.Contains(text, "app store connect") || strings.Contains(text, "prepare build for app store") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -77,6 +77,9 @@ Examples:
 			if flagWasSet(fs, "save-logs") && strings.TrimSpace(*saveLogs) == "" {
 				return shared.UsageError("--save-logs must not be empty")
 			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return err
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -336,6 +336,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	failedActionLogBundles := doctorFailedActionLogBundleCount(result)
 	failedActionLogBundlesInspected := doctorFailedActionLogBundlesInspected(result)
 	failedActionLogBundlesSaved := doctorFailedActionLogBundlesSaved(result)
+	failedActionLogBundleInspectionFailed := doctorHasCoverageWarning(result, "log_bundle_inspection_failed")
 	failedActionIDs := doctorFailedActionIDs(result)
 	for _, bundle := range result.LogBundles {
 		if _, failed := failedActionIDs[bundle.ActionID]; !failed {
@@ -361,6 +362,8 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure, but its available log bundles were not inspected."
 			if failedActionLogBundlesSaved > 0 {
 				result.NextAction = "Inspect the saved failed-action log bundles, then check App Store Connect if they contain no import detail."
+			} else if failedActionLogBundleInspectionFailed {
+				result.NextAction = "Follow the log bundle inspection remediation in this report, then check App Store Connect if the bundle contains no import detail."
 			} else {
 				result.NextAction = "Re-run without --skip-logs, then check App Store Connect if the logs still contain no import detail."
 			}
@@ -384,6 +387,8 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 		result.Conclusion = "The Xcode Cloud build run failed, but its available log bundles were not inspected."
 		if failedActionLogBundlesSaved > 0 {
 			result.NextAction = "Inspect the saved failed-action log bundles for the underlying failure."
+		} else if failedActionLogBundleInspectionFailed {
+			result.NextAction = "Follow the log bundle inspection remediation in this report to inspect the failed-action logs locally."
 		} else {
 			result.NextAction = "Re-run without --skip-logs or download the listed log bundle artifacts for inspection."
 		}
@@ -447,6 +452,18 @@ func doctorFailedActionLogBundlesSaved(result *asc.XcodeCloudDoctorResult) int {
 		}
 	}
 	return count
+}
+
+func doctorHasCoverageWarning(result *asc.XcodeCloudDoctorResult, id string) bool {
+	if result == nil {
+		return false
+	}
+	for _, warning := range result.CoverageWarnings {
+		if warning.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func doctorRunFailed(result *asc.XcodeCloudDoctorResult) bool {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -334,6 +334,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	hasImportDiagnostic := false
 	hasSuccessfulExport := false
 	failedActionLogBundles := doctorFailedActionLogBundleCount(result)
+	failedActionLogBundlesInspected := doctorFailedActionLogBundlesInspected(result)
 	failedActionIDs := doctorFailedActionIDs(result)
 	for _, bundle := range result.LogBundles {
 		if _, failed := failedActionIDs[bundle.ActionID]; !failed {
@@ -355,7 +356,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 		if hasSuccessfulExport {
 			result.Conclusion = "The archive export succeeded, but Xcode Cloud reported a later failure without an ITMS-level import diagnostic."
 			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
-		} else if failedActionLogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
+		} else if failedActionLogBundles > 0 && failedActionLogBundlesInspected == 0 {
 			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure, but its available log bundles were not inspected."
 			result.NextAction = "Re-run without --skip-logs, then check App Store Connect if the logs still contain no import detail."
 		} else {
@@ -363,7 +364,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
 		}
 		coverageMessage := "The Xcode Cloud API did not expose a detailed App Store import rejection."
-		if result.Summary.LogBundlesInspected > 0 {
+		if failedActionLogBundlesInspected > 0 {
 			coverageMessage = "The Xcode Cloud API and inspected log bundles did not expose a detailed App Store import rejection."
 		}
 		result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
@@ -374,7 +375,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 		return
 	}
 
-	if failedActionLogBundles > 0 && result.Summary.LogBundlesInspected == 0 {
+	if failedActionLogBundles > 0 && failedActionLogBundlesInspected == 0 {
 		result.Conclusion = "The Xcode Cloud build run failed, but its available log bundles were not inspected."
 		result.NextAction = "Re-run without --skip-logs or download the listed log bundle artifacts for inspection."
 	} else if result.Summary.Errors > 0 {
@@ -415,6 +416,17 @@ func doctorFailedActionIDs(result *asc.XcodeCloudDoctorResult) map[string]struct
 		}
 	}
 	return failed
+}
+
+func doctorFailedActionLogBundlesInspected(result *asc.XcodeCloudDoctorResult) int {
+	failedActionIDs := doctorFailedActionIDs(result)
+	count := 0
+	for _, bundle := range result.LogBundles {
+		if _, failed := failedActionIDs[bundle.ActionID]; failed && bundle.Inspected {
+			count++
+		}
+	}
+	return count
 }
 
 func doctorRunFailed(result *asc.XcodeCloudDoctorResult) bool {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -303,8 +303,7 @@ func shouldInspectDoctorLogs(result *asc.XcodeCloudDoctorResult, options xcodeCl
 	if strings.TrimSpace(options.SaveLogs) != "" {
 		return true
 	}
-	return !strings.EqualFold(strings.TrimSpace(result.Run.CompletionStatus), string(asc.CiBuildRunCompletionStatusSucceeded)) &&
-		asc.IsBuildRunComplete(asc.CiBuildRunExecutionProgress(result.Run.ExecutionProgress))
+	return doctorRunFailed(result)
 }
 
 func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
@@ -384,8 +383,12 @@ func doctorRunFailed(result *asc.XcodeCloudDoctorResult) bool {
 	if result == nil || result.Run == nil {
 		return false
 	}
-	return asc.IsBuildRunComplete(asc.CiBuildRunExecutionProgress(result.Run.ExecutionProgress)) &&
-		!strings.EqualFold(strings.TrimSpace(result.Run.CompletionStatus), string(asc.CiBuildRunCompletionStatusSucceeded))
+	if !asc.IsBuildRunComplete(asc.CiBuildRunExecutionProgress(result.Run.ExecutionProgress)) {
+		return false
+	}
+	status := strings.ToUpper(strings.TrimSpace(result.Run.CompletionStatus))
+	return status == string(asc.CiBuildRunCompletionStatusFailed) ||
+		status == string(asc.CiBuildRunCompletionStatusErrored)
 }
 
 func doctorHasAppStorePreparationIssue(result *asc.XcodeCloudDoctorResult) bool {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -334,7 +334,11 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	hasImportDiagnostic := false
 	hasSuccessfulExport := false
 	failedActionLogBundles := doctorFailedActionLogBundleCount(result)
+	failedActionIDs := doctorFailedActionIDs(result)
 	for _, bundle := range result.LogBundles {
+		if _, failed := failedActionIDs[bundle.ActionID]; !failed {
+			continue
+		}
 		if bundle.ExportStatus == "SUCCEEDED" {
 			hasSuccessfulExport = true
 		}
@@ -400,6 +404,19 @@ func doctorFailedActionLogBundleCount(result *asc.XcodeCloudDoctorResult) int {
 	return count
 }
 
+func doctorFailedActionIDs(result *asc.XcodeCloudDoctorResult) map[string]struct{} {
+	failed := make(map[string]struct{})
+	if result == nil {
+		return failed
+	}
+	for _, action := range result.Actions {
+		if isFailedDoctorAction(action.CompletionStatus) {
+			failed[action.ID] = struct{}{}
+		}
+	}
+	return failed
+}
+
 func doctorRunFailed(result *asc.XcodeCloudDoctorResult) bool {
 	if result == nil || result.Run == nil {
 		return false
@@ -414,7 +431,15 @@ func doctorRunFailed(result *asc.XcodeCloudDoctorResult) bool {
 
 func doctorHasAppStorePreparationIssue(result *asc.XcodeCloudDoctorResult) bool {
 	for _, action := range result.Actions {
+		if !isFailedDoctorAction(action.CompletionStatus) {
+			continue
+		}
 		for _, issue := range action.Issues {
+			switch strings.ToUpper(strings.TrimSpace(issue.IssueType)) {
+			case "ERROR", "TEST_FAILURE":
+			default:
+				continue
+			}
 			text := strings.ToLower(issue.Category + " " + issue.Message)
 			if strings.Contains(text, "app store connect") || strings.Contains(text, "prepare build for app store") {
 				return true

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -338,6 +338,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	hasSuccessfulExport := false
 	failedActionLogBundles := doctorFailedActionLogBundleCount(result)
 	failedActionLogBundlesInspected := doctorFailedActionLogBundlesInspected(result)
+	failedActionLogBundlesPartiallyInspected := failedActionLogBundlesInspected < failedActionLogBundles
 	failedActionLogBundlesSaved := doctorFailedActionLogBundlesSaved(result)
 	failedActionLogBundleInspectionFailed := doctorHasCoverageWarning(result, "log_bundle_inspection_failed")
 	failedActionIDs := doctorFailedActionIDs(result)
@@ -357,41 +358,50 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 		result.NextAction = "Resolve the reported ITMS diagnostics, then start a new build run."
 		return
 	}
-	if hasSuccessfulExport || doctorHasAppStorePreparationIssue(result) {
-		if hasSuccessfulExport {
-			result.Conclusion = "The archive export succeeded, but Xcode Cloud reported a later failure without an ITMS-level import diagnostic."
-			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
-		} else if failedActionLogBundles > 0 && failedActionLogBundlesInspected == 0 {
-			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure, but its available log bundles were not inspected."
-			if failedActionLogBundlesSaved > 0 {
+	hasAppStorePreparationIssue := doctorHasAppStorePreparationIssue(result)
+	if hasSuccessfulExport || hasAppStorePreparationIssue {
+		if failedActionLogBundlesPartiallyInspected {
+			if hasAppStorePreparationIssue {
+				result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure, but one or more failed-action log bundles were not inspected."
+			} else {
+				result.Conclusion = "The archive export succeeded, but one or more failed-action log bundles were not inspected."
+			}
+			if failedActionLogBundleInspectionFailed {
+				result.NextAction = "Follow the log bundle inspection remediation in this report, then check App Store Connect if the available logs contain no import detail."
+			} else if failedActionLogBundlesSaved > 0 {
 				result.NextAction = "Inspect the saved failed-action log bundles, then check App Store Connect if they contain no import detail."
-			} else if failedActionLogBundleInspectionFailed {
-				result.NextAction = "Follow the log bundle inspection remediation in this report, then check App Store Connect if the bundle contains no import detail."
 			} else {
 				result.NextAction = "Re-run without --skip-logs, then check App Store Connect if the logs still contain no import detail."
 			}
+		} else if hasSuccessfulExport {
+			result.Conclusion = "The archive export succeeded, but Xcode Cloud reported a later failure without an ITMS-level import diagnostic."
+			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
 		} else {
 			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure without an ITMS-level import diagnostic."
 			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
 		}
 		coverageMessage := "The Xcode Cloud API did not expose a detailed App Store import rejection."
-		if failedActionLogBundlesInspected > 0 {
+		coverageRemediation := "Check the App Store Connect delivery notification or build processing state; do not infer an ITMS root cause from the generic Xcode Cloud issue."
+		if failedActionLogBundlesPartiallyInspected {
+			coverageMessage = "One or more failed-action log bundles were not inspected, so a detailed App Store import rejection may be missing."
+			coverageRemediation = "Complete the log bundle inspection remediation in this report before checking the App Store Connect delivery notification or build processing state."
+		} else if failedActionLogBundlesInspected > 0 {
 			coverageMessage = "The Xcode Cloud API and inspected log bundles did not expose a detailed App Store import rejection."
 		}
 		result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
 			ID:          "app_store_import_detail_unavailable",
 			Message:     coverageMessage,
-			Remediation: "Check the App Store Connect delivery notification or build processing state; do not infer an ITMS root cause from the generic Xcode Cloud issue.",
+			Remediation: coverageRemediation,
 		})
 		return
 	}
 
-	if failedActionLogBundles > 0 && failedActionLogBundlesInspected == 0 {
-		result.Conclusion = "The Xcode Cloud build run failed, but its available log bundles were not inspected."
-		if failedActionLogBundlesSaved > 0 {
-			result.NextAction = "Inspect the saved failed-action log bundles for the underlying failure."
-		} else if failedActionLogBundleInspectionFailed {
+	if failedActionLogBundlesPartiallyInspected {
+		result.Conclusion = "The Xcode Cloud build run failed, but one or more failed-action log bundles were not inspected."
+		if failedActionLogBundleInspectionFailed {
 			result.NextAction = "Follow the log bundle inspection remediation in this report to inspect the failed-action logs locally."
+		} else if failedActionLogBundlesSaved > 0 {
+			result.NextAction = "Inspect the saved failed-action log bundles for the underlying failure."
 		} else {
 			result.NextAction = "Re-run without --skip-logs or download the listed log bundle artifacts for inspection."
 		}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor.go
@@ -335,6 +335,7 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 	hasSuccessfulExport := false
 	failedActionLogBundles := doctorFailedActionLogBundleCount(result)
 	failedActionLogBundlesInspected := doctorFailedActionLogBundlesInspected(result)
+	failedActionLogBundlesSaved := doctorFailedActionLogBundlesSaved(result)
 	failedActionIDs := doctorFailedActionIDs(result)
 	for _, bundle := range result.LogBundles {
 		if _, failed := failedActionIDs[bundle.ActionID]; !failed {
@@ -358,7 +359,11 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
 		} else if failedActionLogBundles > 0 && failedActionLogBundlesInspected == 0 {
 			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure, but its available log bundles were not inspected."
-			result.NextAction = "Re-run without --skip-logs, then check App Store Connect if the logs still contain no import detail."
+			if failedActionLogBundlesSaved > 0 {
+				result.NextAction = "Inspect the saved failed-action log bundles, then check App Store Connect if they contain no import detail."
+			} else {
+				result.NextAction = "Re-run without --skip-logs, then check App Store Connect if the logs still contain no import detail."
+			}
 		} else {
 			result.Conclusion = "Xcode Cloud reported an App Store Connect preparation failure without an ITMS-level import diagnostic."
 			result.NextAction = "Check the App Store Connect delivery notification or build processing state for the server-side import rejection."
@@ -377,7 +382,11 @@ func finishXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult) {
 
 	if failedActionLogBundles > 0 && failedActionLogBundlesInspected == 0 {
 		result.Conclusion = "The Xcode Cloud build run failed, but its available log bundles were not inspected."
-		result.NextAction = "Re-run without --skip-logs or download the listed log bundle artifacts for inspection."
+		if failedActionLogBundlesSaved > 0 {
+			result.NextAction = "Inspect the saved failed-action log bundles for the underlying failure."
+		} else {
+			result.NextAction = "Re-run without --skip-logs or download the listed log bundle artifacts for inspection."
+		}
 	} else if result.Summary.Errors > 0 {
 		result.Conclusion = "The Xcode Cloud build run failed and reported actionable issues."
 		result.NextAction = "Resolve the reported issues, then start a new build run."
@@ -423,6 +432,17 @@ func doctorFailedActionLogBundlesInspected(result *asc.XcodeCloudDoctorResult) i
 	count := 0
 	for _, bundle := range result.LogBundles {
 		if _, failed := failedActionIDs[bundle.ActionID]; failed && bundle.Inspected {
+			count++
+		}
+	}
+	return count
+}
+
+func doctorFailedActionLogBundlesSaved(result *asc.XcodeCloudDoctorResult) int {
+	failedActionIDs := doctorFailedActionIDs(result)
+	count := 0
+	for _, bundle := range result.LogBundles {
+		if _, failed := failedActionIDs[bundle.ActionID]; failed && strings.TrimSpace(bundle.SavedPath) != "" {
 			count++
 		}
 	}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_command_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_command_test.go
@@ -1,0 +1,32 @@
+package xcodecloud
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestXcodeCloudDoctorValidatesOutputBeforeSaveSideEffects(t *testing.T) {
+	saveDirectory := filepath.Join(t.TempDir(), "logs")
+	command := XcodeCloudDoctorCommand()
+	command.FlagSet.SetOutput(io.Discard)
+	if err := command.Parse([]string{
+		"--run-id", "run-1",
+		"--save-logs", saveDirectory,
+		"--output", "table",
+		"--pretty",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := command.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--pretty") {
+		t.Fatalf("run error = %v, want invalid output combination", err)
+	}
+	if _, statErr := os.Stat(saveDirectory); !os.IsNotExist(statErr) {
+		t.Fatalf("save directory stat error = %v, want no filesystem side effect", statErr)
+	}
+}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -233,6 +233,7 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 
 	analysis := doctorLogBundleAnalysis{Diagnostics: make([]asc.XcodeCloudDoctorLogDiagnostic, 0)}
 	var total int64
+	readableEntries := 0
 	for _, file := range reader.File {
 		if file.FileInfo().IsDir() || !isDoctorLogTextFile(file.Name) {
 			continue
@@ -262,7 +263,11 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 			continue
 		}
 		total += int64(len(contents))
+		readableEntries++
 		analyzeDoctorLogText(&analysis, file.Name, string(contents))
+	}
+	if readableEntries == 0 {
+		return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle contains no readable text entries")
 	}
 	return analysis, nil
 }

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -40,7 +40,7 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 		}
 	}
 
-	inspectAll := strings.TrimSpace(options.SaveLogs) != "" || len(failedActions) == 0
+	inspectAll := strings.TrimSpace(options.SaveLogs) != ""
 	var saveRoot rootfs.Root
 	if strings.TrimSpace(options.SaveLogs) != "" {
 		var err error
@@ -158,7 +158,7 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 			continue
 		}
 		if file.UncompressedSize64 > maxDoctorLogEntryBytes {
-			continue
+			return doctorLogBundleAnalysis{}, fmt.Errorf("log entry %q exceeds the %d-byte inspection limit", file.Name, maxDoctorLogEntryBytes)
 		}
 		if file.UncompressedSize64 > uint64(maxDoctorLogUncompressedBytes-int(total)) {
 			return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle exceeds the %d-byte uncompressed inspection limit", maxDoctorLogUncompressedBytes)
@@ -175,7 +175,10 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 		if closeErr != nil {
 			return doctorLogBundleAnalysis{}, fmt.Errorf("close log entry %q: %w", file.Name, closeErr)
 		}
-		if len(contents) > maxDoctorLogEntryBytes || bytes.IndexByte(contents, 0) >= 0 {
+		if len(contents) > maxDoctorLogEntryBytes {
+			return doctorLogBundleAnalysis{}, fmt.Errorf("log entry %q exceeds the %d-byte inspection limit", file.Name, maxDoctorLogEntryBytes)
+		}
+		if bytes.IndexByte(contents, 0) >= 0 {
 			continue
 		}
 		total += int64(len(contents))
@@ -236,7 +239,7 @@ func isDoctorLogTextFile(name string) bool {
 
 func isFailedDoctorAction(status string) bool {
 	switch strings.ToUpper(strings.TrimSpace(status)) {
-	case "FAILED", "ERRORED", "CANCELED":
+	case "FAILED", "ERRORED":
 		return true
 	default:
 		return false

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -219,6 +219,9 @@ func openDoctorLogBundle(ctx context.Context, client *asc.Client, artifactID str
 }
 
 func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
+	if len(data) == 0 {
+		return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle is empty")
+	}
 	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		if bytes.IndexByte(data, 0) >= 0 {
@@ -261,6 +264,9 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 			return doctorLogBundleAnalysis{}, fmt.Errorf("log entry %q exceeds the %d-byte inspection limit", file.Name, maxDoctorLogEntryBytes)
 		}
 		total += int64(len(contents))
+		if len(contents) == 0 {
+			continue
+		}
 		if bytes.IndexByte(contents, 0) >= 0 {
 			continue
 		}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -64,23 +64,29 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 			if !strings.EqualFold(strings.TrimSpace(artifact.FileType), "LOG_BUNDLE") {
 				continue
 			}
-			bundleResult, data, inspectErr := downloadAndAnalyzeDoctorLogBundle(ctx, client, action.ID, artifact)
+			var (
+				bundleResult asc.XcodeCloudDoctorLogBundle
+				inspectErr   error
+			)
 			if strings.TrimSpace(options.SaveLogs) != "" {
-				if len(data) == 0 && inspectErr != nil {
+				name := doctorSavedLogBundleName(artifact)
+				bundleResult, inspectErr = downloadSaveAndAnalyzeDoctorLogBundle(ctx, client, action.ID, artifact, saveRoot, options.SaveLogs, name)
+				if inspectErr != nil && bundleResult.SavedPath == "" {
 					return fmt.Errorf("download log bundle %s for --save-logs: %w", artifact.ID, inspectErr)
 				}
-				name := doctorSavedLogBundleName(artifact)
-				if err := saveRoot.CreateNewFileAtomic(name, data, 0o600); err != nil {
-					return fmt.Errorf("save log bundle %q: %w", filepath.Join(options.SaveLogs, name), err)
-				}
-				bundleResult.SavedPath = filepath.Join(options.SaveLogs, name)
+			} else {
+				bundleResult, inspectErr = downloadAndAnalyzeDoctorLogBundle(ctx, client, action.ID, artifact)
 			}
 			if inspectErr != nil {
 				result.LogBundles = append(result.LogBundles, bundleResult)
+				remediation := fmt.Sprintf("Download artifact %s with asc xcode-cloud artifacts download and inspect it locally.", artifact.ID)
+				if bundleResult.SavedPath != "" {
+					remediation = fmt.Sprintf("Inspect the saved bundle %s locally.", asc.SanitizeTerminalText(bundleResult.SavedPath))
+				}
 				result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
 					ID:          "log_bundle_inspection_failed",
 					Message:     fmt.Sprintf("Could not inspect log bundle %s: %s", artifact.ID, asc.SanitizeTerminalText(inspectErr.Error())),
-					Remediation: fmt.Sprintf("Download artifact %s with asc xcode-cloud artifacts download and inspect it locally.", artifact.ID),
+					Remediation: remediation,
 				})
 				continue
 			}
@@ -93,48 +99,108 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 	return nil
 }
 
-func downloadAndAnalyzeDoctorLogBundle(ctx context.Context, client *asc.Client, actionID string, artifact asc.XcodeCloudDoctorArtifact) (asc.XcodeCloudDoctorLogBundle, []byte, error) {
-	result := asc.XcodeCloudDoctorLogBundle{
+func newDoctorLogBundleResult(actionID string, artifact asc.XcodeCloudDoctorArtifact) asc.XcodeCloudDoctorLogBundle {
+	return asc.XcodeCloudDoctorLogBundle{
 		ArtifactID:  artifact.ID,
 		ActionID:    actionID,
 		FileName:    artifact.FileName,
 		FileSize:    artifact.FileSize,
 		Diagnostics: make([]asc.XcodeCloudDoctorLogDiagnostic, 0),
 	}
+}
+
+func downloadAndAnalyzeDoctorLogBundle(ctx context.Context, client *asc.Client, actionID string, artifact asc.XcodeCloudDoctorArtifact) (asc.XcodeCloudDoctorLogBundle, error) {
+	result := newDoctorLogBundleResult(actionID, artifact)
 	if artifact.FileSize > maxDoctorLogBundleBytes {
-		return result, nil, fmt.Errorf("bundle size %d exceeds the %d-byte inspection limit", artifact.FileSize, maxDoctorLogBundleBytes)
+		return result, fmt.Errorf("bundle size %d exceeds the %d-byte inspection limit", artifact.FileSize, maxDoctorLogBundleBytes)
 	}
 
-	detail, err := client.GetCiArtifact(ctx, artifact.ID)
+	body, err := openDoctorLogBundle(ctx, client, artifact.ID)
 	if err != nil {
-		return result, nil, fmt.Errorf("fetch artifact details: %w", err)
+		return result, err
 	}
-	downloadURL := strings.TrimSpace(detail.Data.Attributes.DownloadURL)
-	if downloadURL == "" {
-		return result, nil, fmt.Errorf("artifact has no download URL")
-	}
-	download, err := client.DownloadCiArtifact(ctx, downloadURL)
-	if err != nil {
-		return result, nil, fmt.Errorf("download artifact: %w", err)
-	}
-	defer download.Body.Close()
+	defer body.Close()
 
-	data, err := io.ReadAll(io.LimitReader(download.Body, maxDoctorLogBundleBytes+1))
+	data, err := io.ReadAll(io.LimitReader(body, maxDoctorLogBundleBytes+1))
 	if err != nil {
-		return result, nil, fmt.Errorf("read artifact: %w", err)
+		return result, fmt.Errorf("read artifact: %w", err)
 	}
 	if len(data) > maxDoctorLogBundleBytes {
-		return result, nil, fmt.Errorf("download exceeds the %d-byte inspection limit", maxDoctorLogBundleBytes)
+		return result, fmt.Errorf("download exceeds the %d-byte inspection limit", maxDoctorLogBundleBytes)
 	}
 
 	analysis, err := analyzeDoctorLogBundle(data)
 	if err != nil {
-		return result, data, err
+		return result, err
 	}
 	result.Inspected = true
 	result.ExportStatus = analysis.ExportStatus
 	result.Diagnostics = analysis.Diagnostics
-	return result, data, nil
+	return result, nil
+}
+
+func downloadSaveAndAnalyzeDoctorLogBundle(
+	ctx context.Context,
+	client *asc.Client,
+	actionID string,
+	artifact asc.XcodeCloudDoctorArtifact,
+	saveRoot rootfs.Root,
+	saveDirectory string,
+	name string,
+) (asc.XcodeCloudDoctorLogBundle, error) {
+	result := newDoctorLogBundleResult(actionID, artifact)
+	body, err := openDoctorLogBundle(ctx, client, artifact.ID)
+	if err != nil {
+		return result, err
+	}
+	defer body.Close()
+	return saveAndAnalyzeDoctorLogBundle(saveRoot, saveDirectory, name, result, body, maxDoctorLogBundleBytes)
+}
+
+func saveAndAnalyzeDoctorLogBundle(
+	saveRoot rootfs.Root,
+	saveDirectory string,
+	name string,
+	result asc.XcodeCloudDoctorLogBundle,
+	reader io.Reader,
+	inspectionLimit int64,
+) (asc.XcodeCloudDoctorLogBundle, error) {
+	written, err := saveRoot.CreateNewFrom(name, reader, 0o600)
+	if err != nil {
+		return result, fmt.Errorf("save log bundle %q: %w", filepath.Join(saveDirectory, name), err)
+	}
+	result.SavedPath = filepath.Join(saveDirectory, name)
+	if written > inspectionLimit {
+		return result, fmt.Errorf("saved bundle size %d exceeds the %d-byte inspection limit", written, inspectionLimit)
+	}
+	data, err := saveRoot.ReadFileLimited(name, inspectionLimit)
+	if err != nil {
+		return result, fmt.Errorf("read saved log bundle: %w", err)
+	}
+	analysis, err := analyzeDoctorLogBundle(data)
+	if err != nil {
+		return result, err
+	}
+	result.Inspected = true
+	result.ExportStatus = analysis.ExportStatus
+	result.Diagnostics = analysis.Diagnostics
+	return result, nil
+}
+
+func openDoctorLogBundle(ctx context.Context, client *asc.Client, artifactID string) (io.ReadCloser, error) {
+	detail, err := client.GetCiArtifact(ctx, artifactID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch artifact details: %w", err)
+	}
+	downloadURL := strings.TrimSpace(detail.Data.Attributes.DownloadURL)
+	if downloadURL == "" {
+		return nil, fmt.Errorf("artifact has no download URL")
+	}
+	download, err := client.DownloadCiArtifact(ctx, downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("download artifact: %w", err)
+	}
+	return download.Body, nil
 }
 
 func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -28,8 +28,9 @@ const (
 var doctorITMSCodePattern = regexp.MustCompile(`(?i)\bITMS-[0-9]+\b`)
 
 type doctorLogBundleAnalysis struct {
-	ExportStatus string
-	Diagnostics  []asc.XcodeCloudDoctorLogDiagnostic
+	ExportStatus         string
+	Diagnostics          []asc.XcodeCloudDoctorLogDiagnostic
+	DiagnosticsTruncated bool
 }
 
 func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result *asc.XcodeCloudDoctorResult, options xcodeCloudDoctorOptions) error {
@@ -91,6 +92,17 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 				continue
 			}
 			result.LogBundles = append(result.LogBundles, bundleResult)
+			if bundleResult.DiagnosticsTruncated {
+				remediation := fmt.Sprintf("Re-run with --save-logs and inspect artifact %s locally for additional diagnostics.", artifact.ID)
+				if bundleResult.SavedPath != "" {
+					remediation = fmt.Sprintf("Inspect the saved bundle %s locally for additional diagnostics.", asc.SanitizeTerminalText(bundleResult.SavedPath))
+				}
+				result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
+					ID:          "log_diagnostics_truncated",
+					Message:     fmt.Sprintf("Log bundle %s contains more than %d distinct ITMS diagnostics; only the first %d are reported.", artifact.ID, maxDoctorDiagnostics, maxDoctorDiagnostics),
+					Remediation: remediation,
+				})
+			}
 			if bundleResult.Inspected {
 				result.Summary.LogBundlesInspected++
 			}
@@ -136,6 +148,7 @@ func downloadAndAnalyzeDoctorLogBundle(ctx context.Context, client *asc.Client, 
 	result.Inspected = true
 	result.ExportStatus = analysis.ExportStatus
 	result.Diagnostics = analysis.Diagnostics
+	result.DiagnosticsTruncated = analysis.DiagnosticsTruncated
 	return result, nil
 }
 
@@ -184,6 +197,7 @@ func saveAndAnalyzeDoctorLogBundle(
 	result.Inspected = true
 	result.ExportStatus = analysis.ExportStatus
 	result.Diagnostics = analysis.Diagnostics
+	result.DiagnosticsTruncated = analysis.DiagnosticsTruncated
 	return result, nil
 }
 
@@ -266,9 +280,6 @@ func analyzeDoctorLogText(analysis *doctorLogBundleAnalysis, sourceFile, content
 		seen[diagnostic.Code+"\x00"+diagnostic.Message] = struct{}{}
 	}
 	for _, line := range strings.Split(contents, "\n") {
-		if len(analysis.Diagnostics) >= maxDoctorDiagnostics {
-			return
-		}
 		code := strings.ToUpper(doctorITMSCodePattern.FindString(line))
 		if code == "" {
 			continue
@@ -284,6 +295,10 @@ func analyzeDoctorLogText(analysis *doctorLogBundleAnalysis, sourceFile, content
 		key := code + "\x00" + message
 		if _, exists := seen[key]; exists {
 			continue
+		}
+		if len(analysis.Diagnostics) >= maxDoctorDiagnostics {
+			analysis.DiagnosticsTruncated = true
+			return
 		}
 		seen[key] = struct{}{}
 		analysis.Diagnostics = append(analysis.Diagnostics, asc.XcodeCloudDoctorLogDiagnostic{

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -76,6 +77,9 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 				bundleResult, inspectErr = downloadAndAnalyzeDoctorLogBundle(ctx, client, action.ID, artifact)
 			}
 			if inspectErr != nil {
+				if errors.Is(inspectErr, context.Canceled) || errors.Is(inspectErr, context.DeadlineExceeded) {
+					return inspectErr
+				}
 				result.LogBundles = append(result.LogBundles, bundleResult)
 				remediation := fmt.Sprintf("Download artifact %s with asc xcode-cloud artifacts download and inspect it locally.", artifact.ID)
 				if bundleResult.SavedPath != "" {
@@ -256,10 +260,10 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 		if len(contents) > maxDoctorLogEntryBytes {
 			return doctorLogBundleAnalysis{}, fmt.Errorf("log entry %q exceeds the %d-byte inspection limit", file.Name, maxDoctorLogEntryBytes)
 		}
+		total += int64(len(contents))
 		if bytes.IndexByte(contents, 0) >= 0 {
 			continue
 		}
-		total += int64(len(contents))
 		readableEntries++
 		analyzeDoctorLogText(&analysis, file.Name, string(contents))
 	}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -72,9 +72,6 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 			if strings.TrimSpace(options.SaveLogs) != "" {
 				name := doctorSavedLogBundleName(artifact)
 				bundleResult, inspectErr = downloadSaveAndAnalyzeDoctorLogBundle(ctx, client, action.ID, artifact, saveRoot, options.SaveLogs, name)
-				if inspectErr != nil && bundleResult.SavedPath == "" {
-					return fmt.Errorf("download log bundle %s for --save-logs: %w", artifact.ID, inspectErr)
-				}
 			} else {
 				bundleResult, inspectErr = downloadAndAnalyzeDoctorLogBundle(ctx, client, action.ID, artifact)
 			}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -1,0 +1,281 @@
+package xcodecloud
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+)
+
+const (
+	maxDoctorLogBundleBytes       = 64 << 20
+	maxDoctorLogEntryBytes        = 8 << 20
+	maxDoctorLogUncompressedBytes = 64 << 20
+	maxDoctorLogEntries           = 2000
+	maxDoctorDiagnostics          = 20
+	maxDoctorDiagnosticLength     = 2048
+)
+
+var doctorITMSCodePattern = regexp.MustCompile(`(?i)\bITMS-[0-9]+\b`)
+
+type xcodeCloudDoctorLogBundle struct {
+	ArtifactID   string                          `json:"artifactId"`
+	ActionID     string                          `json:"actionId"`
+	FileName     string                          `json:"fileName,omitempty"`
+	FileSize     int                             `json:"fileSize,omitempty"`
+	Inspected    bool                            `json:"inspected"`
+	SavedPath    string                          `json:"savedPath,omitempty"`
+	ExportStatus string                          `json:"exportStatus,omitempty"`
+	Diagnostics  []xcodeCloudDoctorLogDiagnostic `json:"diagnostics"`
+}
+
+type xcodeCloudDoctorLogDiagnostic struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	SourceFile string `json:"sourceFile,omitempty"`
+}
+
+type doctorLogBundleAnalysis struct {
+	ExportStatus string
+	Diagnostics  []xcodeCloudDoctorLogDiagnostic
+}
+
+func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result *xcodeCloudDoctorResult, options xcodeCloudDoctorOptions) error {
+	failedActions := make(map[string]struct{})
+	for _, action := range result.Actions {
+		if isFailedDoctorAction(action.CompletionStatus) {
+			failedActions[action.ID] = struct{}{}
+		}
+	}
+
+	inspectAll := strings.TrimSpace(options.SaveLogs) != "" || len(failedActions) == 0
+	var saveRoot rootfs.Root
+	if strings.TrimSpace(options.SaveLogs) != "" {
+		var err error
+		saveRoot, err = rootfs.New(options.SaveLogs)
+		if err != nil {
+			return fmt.Errorf("prepare --save-logs directory: %w", err)
+		}
+		defer saveRoot.Close()
+		if err := saveRoot.MkdirAll(".", 0o700); err != nil {
+			return fmt.Errorf("prepare --save-logs directory: %w", err)
+		}
+	}
+
+	for _, action := range result.Actions {
+		if !inspectAll {
+			if _, failed := failedActions[action.ID]; !failed {
+				continue
+			}
+		}
+		for _, artifact := range action.Artifacts {
+			if !strings.EqualFold(strings.TrimSpace(artifact.FileType), "LOG_BUNDLE") {
+				continue
+			}
+			bundleResult, data, inspectErr := downloadAndAnalyzeDoctorLogBundle(ctx, client, action.ID, artifact)
+			if strings.TrimSpace(options.SaveLogs) != "" {
+				if len(data) == 0 && inspectErr != nil {
+					return fmt.Errorf("download log bundle %s for --save-logs: %w", artifact.ID, inspectErr)
+				}
+				name := doctorSavedLogBundleName(artifact)
+				if err := saveRoot.CreateNewFileAtomic(name, data, 0o600); err != nil {
+					return fmt.Errorf("save log bundle %q: %w", filepath.Join(options.SaveLogs, name), err)
+				}
+				bundleResult.SavedPath = filepath.Join(options.SaveLogs, name)
+			}
+			if inspectErr != nil {
+				result.LogBundles = append(result.LogBundles, bundleResult)
+				result.CoverageWarnings = append(result.CoverageWarnings, xcodeCloudDoctorCoverageWarning{
+					ID:          "log_bundle_inspection_failed",
+					Message:     fmt.Sprintf("Could not inspect log bundle %s: %s", artifact.ID, asc.SanitizeTerminalText(inspectErr.Error())),
+					Remediation: fmt.Sprintf("Download artifact %s with asc xcode-cloud artifacts download and inspect it locally.", artifact.ID),
+				})
+				continue
+			}
+			result.LogBundles = append(result.LogBundles, bundleResult)
+			if bundleResult.Inspected {
+				result.Summary.LogBundlesInspected++
+			}
+		}
+	}
+	return nil
+}
+
+func downloadAndAnalyzeDoctorLogBundle(ctx context.Context, client *asc.Client, actionID string, artifact xcodeCloudDoctorArtifact) (xcodeCloudDoctorLogBundle, []byte, error) {
+	result := xcodeCloudDoctorLogBundle{
+		ArtifactID:  artifact.ID,
+		ActionID:    actionID,
+		FileName:    artifact.FileName,
+		FileSize:    artifact.FileSize,
+		Diagnostics: make([]xcodeCloudDoctorLogDiagnostic, 0),
+	}
+	if artifact.FileSize > maxDoctorLogBundleBytes {
+		return result, nil, fmt.Errorf("bundle size %d exceeds the %d-byte inspection limit", artifact.FileSize, maxDoctorLogBundleBytes)
+	}
+
+	detail, err := client.GetCiArtifact(ctx, artifact.ID)
+	if err != nil {
+		return result, nil, fmt.Errorf("fetch artifact details: %w", err)
+	}
+	downloadURL := strings.TrimSpace(detail.Data.Attributes.DownloadURL)
+	if downloadURL == "" {
+		return result, nil, fmt.Errorf("artifact has no download URL")
+	}
+	download, err := client.DownloadCiArtifact(ctx, downloadURL)
+	if err != nil {
+		return result, nil, fmt.Errorf("download artifact: %w", err)
+	}
+	defer download.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(download.Body, maxDoctorLogBundleBytes+1))
+	if err != nil {
+		return result, nil, fmt.Errorf("read artifact: %w", err)
+	}
+	if len(data) > maxDoctorLogBundleBytes {
+		return result, nil, fmt.Errorf("download exceeds the %d-byte inspection limit", maxDoctorLogBundleBytes)
+	}
+
+	analysis, err := analyzeDoctorLogBundle(data)
+	if err != nil {
+		return result, data, err
+	}
+	result.Inspected = true
+	result.ExportStatus = analysis.ExportStatus
+	result.Diagnostics = analysis.Diagnostics
+	return result, data, nil
+}
+
+func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		if bytes.IndexByte(data, 0) >= 0 {
+			return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle is neither a ZIP archive nor plain text")
+		}
+		analysis := doctorLogBundleAnalysis{Diagnostics: make([]xcodeCloudDoctorLogDiagnostic, 0)}
+		analyzeDoctorLogText(&analysis, "", string(data))
+		return analysis, nil
+	}
+	if len(reader.File) > maxDoctorLogEntries {
+		return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle contains %d entries; limit is %d", len(reader.File), maxDoctorLogEntries)
+	}
+
+	analysis := doctorLogBundleAnalysis{Diagnostics: make([]xcodeCloudDoctorLogDiagnostic, 0)}
+	var total int64
+	for _, file := range reader.File {
+		if file.FileInfo().IsDir() || !isDoctorLogTextFile(file.Name) {
+			continue
+		}
+		if file.UncompressedSize64 > maxDoctorLogEntryBytes {
+			continue
+		}
+		if file.UncompressedSize64 > uint64(maxDoctorLogUncompressedBytes-int(total)) {
+			return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle exceeds the %d-byte uncompressed inspection limit", maxDoctorLogUncompressedBytes)
+		}
+		entry, err := file.Open()
+		if err != nil {
+			return doctorLogBundleAnalysis{}, fmt.Errorf("open log entry %q: %w", file.Name, err)
+		}
+		contents, readErr := io.ReadAll(io.LimitReader(entry, maxDoctorLogEntryBytes+1))
+		closeErr := entry.Close()
+		if readErr != nil {
+			return doctorLogBundleAnalysis{}, fmt.Errorf("read log entry %q: %w", file.Name, readErr)
+		}
+		if closeErr != nil {
+			return doctorLogBundleAnalysis{}, fmt.Errorf("close log entry %q: %w", file.Name, closeErr)
+		}
+		if len(contents) > maxDoctorLogEntryBytes || bytes.IndexByte(contents, 0) >= 0 {
+			continue
+		}
+		total += int64(len(contents))
+		analyzeDoctorLogText(&analysis, file.Name, string(contents))
+	}
+	return analysis, nil
+}
+
+func analyzeDoctorLogText(analysis *doctorLogBundleAnalysis, sourceFile, contents string) {
+	upper := strings.ToUpper(contents)
+	if strings.Contains(upper, "** EXPORT FAILED **") {
+		analysis.ExportStatus = "FAILED"
+	} else if analysis.ExportStatus == "" && strings.Contains(upper, "** EXPORT SUCCEEDED **") {
+		analysis.ExportStatus = "SUCCEEDED"
+	}
+
+	seen := make(map[string]struct{}, len(analysis.Diagnostics))
+	for _, diagnostic := range analysis.Diagnostics {
+		seen[diagnostic.Code+"\x00"+diagnostic.Message] = struct{}{}
+	}
+	for _, line := range strings.Split(contents, "\n") {
+		if len(analysis.Diagnostics) >= maxDoctorDiagnostics {
+			return
+		}
+		code := strings.ToUpper(doctorITMSCodePattern.FindString(line))
+		if code == "" {
+			continue
+		}
+		message := strings.TrimSpace(asc.SanitizeTerminalText(line))
+		if len(message) > maxDoctorDiagnosticLength {
+			message = message[:maxDoctorDiagnosticLength] + "…"
+		}
+		key := code + "\x00" + message
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		analysis.Diagnostics = append(analysis.Diagnostics, xcodeCloudDoctorLogDiagnostic{
+			Code:       code,
+			Message:    message,
+			SourceFile: sourceFile,
+		})
+	}
+}
+
+func isDoctorLogTextFile(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".log", ".txt", ".json", ".xml":
+		return true
+	default:
+		return false
+	}
+}
+
+func isFailedDoctorAction(status string) bool {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "FAILED", "ERRORED", "CANCELED":
+		return true
+	default:
+		return false
+	}
+}
+
+func doctorSavedLogBundleName(artifact xcodeCloudDoctorArtifact) string {
+	artifactID := sanitizeDoctorFileComponent(artifact.ID)
+	fileName := sanitizeDoctorFileComponent(filepath.Base(strings.TrimSpace(artifact.FileName)))
+	if fileName == "" {
+		fileName = "log-bundle.zip"
+	}
+	if artifactID == "" {
+		return fileName
+	}
+	return artifactID + "-" + fileName
+}
+
+func sanitizeDoctorFileComponent(value string) string {
+	value = strings.TrimSpace(value)
+	var builder strings.Builder
+	for _, char := range value {
+		if unicode.IsLetter(char) || unicode.IsDigit(char) || char == '.' || char == '-' || char == '_' {
+			builder.WriteRune(char)
+		} else {
+			builder.WriteByte('_')
+		}
+	}
+	return strings.Trim(builder.String(), "._")
+}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
@@ -26,29 +27,12 @@ const (
 
 var doctorITMSCodePattern = regexp.MustCompile(`(?i)\bITMS-[0-9]+\b`)
 
-type xcodeCloudDoctorLogBundle struct {
-	ArtifactID   string                          `json:"artifactId"`
-	ActionID     string                          `json:"actionId"`
-	FileName     string                          `json:"fileName,omitempty"`
-	FileSize     int                             `json:"fileSize,omitempty"`
-	Inspected    bool                            `json:"inspected"`
-	SavedPath    string                          `json:"savedPath,omitempty"`
-	ExportStatus string                          `json:"exportStatus,omitempty"`
-	Diagnostics  []xcodeCloudDoctorLogDiagnostic `json:"diagnostics"`
-}
-
-type xcodeCloudDoctorLogDiagnostic struct {
-	Code       string `json:"code"`
-	Message    string `json:"message"`
-	SourceFile string `json:"sourceFile,omitempty"`
-}
-
 type doctorLogBundleAnalysis struct {
 	ExportStatus string
-	Diagnostics  []xcodeCloudDoctorLogDiagnostic
+	Diagnostics  []asc.XcodeCloudDoctorLogDiagnostic
 }
 
-func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result *xcodeCloudDoctorResult, options xcodeCloudDoctorOptions) error {
+func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result *asc.XcodeCloudDoctorResult, options xcodeCloudDoctorOptions) error {
 	failedActions := make(map[string]struct{})
 	for _, action := range result.Actions {
 		if isFailedDoctorAction(action.CompletionStatus) {
@@ -93,7 +77,7 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 			}
 			if inspectErr != nil {
 				result.LogBundles = append(result.LogBundles, bundleResult)
-				result.CoverageWarnings = append(result.CoverageWarnings, xcodeCloudDoctorCoverageWarning{
+				result.CoverageWarnings = append(result.CoverageWarnings, asc.XcodeCloudDoctorCoverageWarning{
 					ID:          "log_bundle_inspection_failed",
 					Message:     fmt.Sprintf("Could not inspect log bundle %s: %s", artifact.ID, asc.SanitizeTerminalText(inspectErr.Error())),
 					Remediation: fmt.Sprintf("Download artifact %s with asc xcode-cloud artifacts download and inspect it locally.", artifact.ID),
@@ -109,13 +93,13 @@ func inspectXcodeCloudDoctorLogs(ctx context.Context, client *asc.Client, result
 	return nil
 }
 
-func downloadAndAnalyzeDoctorLogBundle(ctx context.Context, client *asc.Client, actionID string, artifact xcodeCloudDoctorArtifact) (xcodeCloudDoctorLogBundle, []byte, error) {
-	result := xcodeCloudDoctorLogBundle{
+func downloadAndAnalyzeDoctorLogBundle(ctx context.Context, client *asc.Client, actionID string, artifact asc.XcodeCloudDoctorArtifact) (asc.XcodeCloudDoctorLogBundle, []byte, error) {
+	result := asc.XcodeCloudDoctorLogBundle{
 		ArtifactID:  artifact.ID,
 		ActionID:    actionID,
 		FileName:    artifact.FileName,
 		FileSize:    artifact.FileSize,
-		Diagnostics: make([]xcodeCloudDoctorLogDiagnostic, 0),
+		Diagnostics: make([]asc.XcodeCloudDoctorLogDiagnostic, 0),
 	}
 	if artifact.FileSize > maxDoctorLogBundleBytes {
 		return result, nil, fmt.Errorf("bundle size %d exceeds the %d-byte inspection limit", artifact.FileSize, maxDoctorLogBundleBytes)
@@ -159,7 +143,7 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 		if bytes.IndexByte(data, 0) >= 0 {
 			return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle is neither a ZIP archive nor plain text")
 		}
-		analysis := doctorLogBundleAnalysis{Diagnostics: make([]xcodeCloudDoctorLogDiagnostic, 0)}
+		analysis := doctorLogBundleAnalysis{Diagnostics: make([]asc.XcodeCloudDoctorLogDiagnostic, 0)}
 		analyzeDoctorLogText(&analysis, "", string(data))
 		return analysis, nil
 	}
@@ -167,7 +151,7 @@ func analyzeDoctorLogBundle(data []byte) (doctorLogBundleAnalysis, error) {
 		return doctorLogBundleAnalysis{}, fmt.Errorf("log bundle contains %d entries; limit is %d", len(reader.File), maxDoctorLogEntries)
 	}
 
-	analysis := doctorLogBundleAnalysis{Diagnostics: make([]xcodeCloudDoctorLogDiagnostic, 0)}
+	analysis := doctorLogBundleAnalysis{Diagnostics: make([]asc.XcodeCloudDoctorLogDiagnostic, 0)}
 	var total int64
 	for _, file := range reader.File {
 		if file.FileInfo().IsDir() || !isDoctorLogTextFile(file.Name) {
@@ -222,14 +206,18 @@ func analyzeDoctorLogText(analysis *doctorLogBundleAnalysis, sourceFile, content
 		}
 		message := strings.TrimSpace(asc.SanitizeTerminalText(line))
 		if len(message) > maxDoctorDiagnosticLength {
-			message = message[:maxDoctorDiagnosticLength] + "…"
+			truncated := message[:maxDoctorDiagnosticLength]
+			for len(truncated) > 0 && !utf8.ValidString(truncated) {
+				truncated = truncated[:len(truncated)-1]
+			}
+			message = truncated + "…"
 		}
 		key := code + "\x00" + message
 		if _, exists := seen[key]; exists {
 			continue
 		}
 		seen[key] = struct{}{}
-		analysis.Diagnostics = append(analysis.Diagnostics, xcodeCloudDoctorLogDiagnostic{
+		analysis.Diagnostics = append(analysis.Diagnostics, asc.XcodeCloudDoctorLogDiagnostic{
 			Code:       code,
 			Message:    message,
 			SourceFile: sourceFile,
@@ -255,7 +243,7 @@ func isFailedDoctorAction(status string) bool {
 	}
 }
 
-func doctorSavedLogBundleName(artifact xcodeCloudDoctorArtifact) string {
+func doctorSavedLogBundleName(artifact asc.XcodeCloudDoctorArtifact) string {
 	artifactID := sanitizeDoctorFileComponent(artifact.ID)
 	fileName := sanitizeDoctorFileComponent(filepath.Base(strings.TrimSpace(artifact.FileName)))
 	if fileName == "" {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -111,6 +111,38 @@ func TestFinishXcodeCloudDoctorResultReportsCanceledAndSkippedRuns(t *testing.T)
 	}
 }
 
+func TestShouldInspectDoctorLogsOnlyForFailuresUnlessSaving(t *testing.T) {
+	tests := []struct {
+		status  string
+		options xcodeCloudDoctorOptions
+		want    bool
+	}{
+		{status: "FAILED", want: true},
+		{status: "ERRORED", want: true},
+		{status: "SUCCEEDED", want: false},
+		{status: "CANCELED", want: false},
+		{status: "SKIPPED", want: false},
+		{status: "CANCELED", options: xcodeCloudDoctorOptions{SaveLogs: "logs"}, want: true},
+		{status: "SKIPPED", options: xcodeCloudDoctorOptions{SaveLogs: "logs"}, want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.status+test.options.SaveLogs, func(t *testing.T) {
+			result := &asc.XcodeCloudDoctorResult{
+				Run: &asc.XcodeCloudStatusResult{
+					ExecutionProgress: "COMPLETE",
+					CompletionStatus:  test.status,
+				},
+				Summary: asc.XcodeCloudDoctorSummary{LogBundles: 1},
+			}
+
+			if got := shouldInspectDoctorLogs(result, test.options); got != test.want {
+				t.Fatalf("shouldInspectDoctorLogs(%s, %+v) = %t, want %t", test.status, test.options, got, test.want)
+			}
+		})
+	}
+}
+
 func TestAnalyzeDoctorLogBundleRejectsUnknownBinary(t *testing.T) {
 	if _, err := analyzeDoctorLogBundle([]byte{'P', 'K', 0, 1, 2}); err == nil {
 		t.Fatal("analyzeDoctorLogBundle() error = nil, want binary format error")

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -4,11 +4,14 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 func TestAnalyzeDoctorLogBundleFindsITMSDiagnosticsAndExportStatus(t *testing.T) {
@@ -247,6 +250,27 @@ func TestFinishXcodeCloudDoctorResultUsesFailedActionInspectionCount(t *testing.
 	}
 }
 
+func TestFinishXcodeCloudDoctorResultPointsToSavedFailedActionLogs(t *testing.T) {
+	result := &asc.XcodeCloudDoctorResult{
+		Run: &asc.XcodeCloudStatusResult{ExecutionProgress: "COMPLETE", CompletionStatus: "FAILED"},
+		Actions: []asc.XcodeCloudDoctorAction{{
+			ID:               "failed-archive",
+			CompletionStatus: "FAILED",
+			Artifacts:        []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
+		}},
+		LogBundles: []asc.XcodeCloudDoctorLogBundle{{
+			ActionID:  "failed-archive",
+			SavedPath: "/tmp/logs/failed.zip",
+		}},
+	}
+
+	finishXcodeCloudDoctorResult(result)
+
+	if !strings.Contains(result.NextAction, "saved failed-action log bundles") {
+		t.Fatalf("NextAction = %q, want saved bundle guidance", result.NextAction)
+	}
+}
+
 func TestDoctorHasAppStorePreparationIssueUsesFailedErrorActions(t *testing.T) {
 	result := &asc.XcodeCloudDoctorResult{Actions: []asc.XcodeCloudDoctorAction{
 		{
@@ -285,6 +309,48 @@ func TestAnalyzeDoctorLogBundleRejectsOversizedTextEntry(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "IDEDistribution.standard.log") {
 		t.Fatalf("analyzeDoctorLogBundle() error = %v, want oversized entry error", err)
 	}
+}
+
+func TestSaveAndAnalyzeDoctorLogBundleKeepsOversizedFile(t *testing.T) {
+	directory := t.TempDir()
+	root, err := rootfs.New(directory)
+	if err != nil {
+		t.Fatalf("rootfs.New() error = %v", err)
+	}
+	defer root.Close()
+
+	const inspectionLimit = int64(32)
+	name := "large-log-bundle.zip"
+	result := asc.XcodeCloudDoctorLogBundle{}
+
+	result, err = saveAndAnalyzeDoctorLogBundle(
+		root,
+		directory,
+		name,
+		result,
+		io.LimitReader(doctorZeroReader{}, inspectionLimit+1),
+		inspectionLimit,
+	)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("saveAndAnalyzeDoctorLogBundle() error = %v, want inspection limit error", err)
+	}
+	if result.SavedPath == "" || result.Inspected {
+		t.Fatalf("result = %+v, want saved but not inspected", result)
+	}
+	info, statErr := os.Stat(filepath.Join(directory, name))
+	if statErr != nil {
+		t.Fatalf("saved bundle stat error = %v", statErr)
+	}
+	if info.Size() != inspectionLimit+1 || info.Mode().Perm() != 0o600 {
+		t.Fatalf("saved bundle info = size %d mode %o", info.Size(), info.Mode().Perm())
+	}
+}
+
+type doctorZeroReader struct{}
+
+func (doctorZeroReader) Read(buffer []byte) (int, error) {
+	clear(buffer)
+	return len(buffer), nil
 }
 
 func TestAnalyzeDoctorLogBundleRejectsUnknownBinary(t *testing.T) {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -3,8 +3,15 @@ package xcodecloud
 import (
 	"archive/zip"
 	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -361,6 +368,50 @@ func TestAnalyzeDoctorLogBundleRejectsArchiveWithoutReadableTextEntries(t *testi
 	}
 }
 
+func TestInspectXcodeCloudDoctorLogsContinuesAfterSaveFailure(t *testing.T) {
+	directory := t.TempDir()
+	artifacts := []asc.XcodeCloudDoctorArtifact{
+		{ID: "artifact-1", FileName: "first.zip", FileType: "LOG_BUNDLE"},
+		{ID: "artifact-2", FileName: "second.zip", FileType: "LOG_BUNDLE"},
+	}
+	blockedPath := filepath.Join(directory, doctorSavedLogBundleName(artifacts[1]))
+	if err := os.WriteFile(blockedPath, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("write blocked destination: %v", err)
+	}
+	bundle := doctorLogBundleFixture(t, map[string]string{"Export/export.log": "** EXPORT SUCCEEDED **"})
+	client := newDoctorLogTestClient(t, doctorLogRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		body := bundle
+		contentType := "application/octet-stream"
+		if strings.HasPrefix(request.URL.Path, "/v1/ciArtifacts/") {
+			artifactID := filepath.Base(request.URL.Path)
+			body = []byte(fmt.Sprintf(`{"data":{"type":"ciArtifacts","id":%q,"attributes":{"downloadUrl":"https://appstoreconnect.apple.com/downloads/%s.zip"}}}`, artifactID, artifactID))
+			contentType = "application/json"
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{contentType}},
+			Request:    request,
+		}, nil
+	}))
+	result := &asc.XcodeCloudDoctorResult{Actions: []asc.XcodeCloudDoctorAction{{
+		ID:               "failed-action",
+		CompletionStatus: "FAILED",
+		Artifacts:        artifacts,
+	}}}
+
+	err := inspectXcodeCloudDoctorLogs(context.Background(), client, result, xcodeCloudDoctorOptions{SaveLogs: directory})
+	if err != nil {
+		t.Fatalf("inspectXcodeCloudDoctorLogs() error = %v, want report with coverage warning", err)
+	}
+	if len(result.LogBundles) != 2 || !result.LogBundles[0].Inspected || result.LogBundles[1].SavedPath != "" {
+		t.Fatalf("log bundles = %+v, want first inspected and second reported as unsaved", result.LogBundles)
+	}
+	if len(result.CoverageWarnings) != 1 || result.CoverageWarnings[0].ID != "log_bundle_inspection_failed" {
+		t.Fatalf("coverage warnings = %+v, want save failure warning", result.CoverageWarnings)
+	}
+}
+
 func TestSaveAndAnalyzeDoctorLogBundleKeepsOversizedFile(t *testing.T) {
 	directory := t.TempDir()
 	root, err := rootfs.New(directory)
@@ -437,4 +488,31 @@ func doctorLogBundleFixture(t *testing.T, files map[string]string) []byte {
 		t.Fatalf("close zip: %v", err)
 	}
 	return buffer.Bytes()
+}
+
+type doctorLogRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function doctorLogRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func newDoctorLogTestClient(t *testing.T, transport http.RoundTripper) *asc.Client {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	encodedKey, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "AuthKey_TEST.p8")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: encodedKey}), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	client, err := asc.NewClientWithHTTPClient("KEY123", "ISS456", keyPath, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("create ASC client: %v", err)
+	}
+	return client
 }

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -113,12 +113,14 @@ func TestFinishXcodeCloudDoctorResultReportsCanceledAndSkippedRuns(t *testing.T)
 
 func TestShouldInspectDoctorLogsOnlyForFailuresUnlessSaving(t *testing.T) {
 	tests := []struct {
-		status  string
-		options xcodeCloudDoctorOptions
-		want    bool
+		status            string
+		executionProgress string
+		options           xcodeCloudDoctorOptions
+		want              bool
 	}{
 		{status: "FAILED", want: true},
 		{status: "ERRORED", want: true},
+		{status: "FAILED", executionProgress: "RUNNING", want: false},
 		{status: "SUCCEEDED", want: false},
 		{status: "CANCELED", want: false},
 		{status: "SKIPPED", want: false},
@@ -127,19 +129,72 @@ func TestShouldInspectDoctorLogsOnlyForFailuresUnlessSaving(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.status+test.options.SaveLogs, func(t *testing.T) {
+		t.Run(test.status+test.executionProgress+test.options.SaveLogs, func(t *testing.T) {
+			executionProgress := test.executionProgress
+			if executionProgress == "" {
+				executionProgress = "COMPLETE"
+			}
 			result := &asc.XcodeCloudDoctorResult{
 				Run: &asc.XcodeCloudStatusResult{
-					ExecutionProgress: "COMPLETE",
+					ExecutionProgress: executionProgress,
 					CompletionStatus:  test.status,
 				},
 				Summary: asc.XcodeCloudDoctorSummary{LogBundles: 1},
+				Actions: []asc.XcodeCloudDoctorAction{{
+					CompletionStatus: "FAILED",
+					Artifacts:        []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
+				}},
 			}
 
 			if got := shouldInspectDoctorLogs(result, test.options); got != test.want {
 				t.Fatalf("shouldInspectDoctorLogs(%s, %+v) = %t, want %t", test.status, test.options, got, test.want)
 			}
 		})
+	}
+}
+
+func TestDoctorFailureAggregationExcludesCanceledActions(t *testing.T) {
+	result := &asc.XcodeCloudDoctorResult{Actions: []asc.XcodeCloudDoctorAction{
+		{ID: "failed", CompletionStatus: "FAILED", Artifacts: []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}}},
+		{ID: "errored", CompletionStatus: "ERRORED", Artifacts: []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}}},
+		{ID: "canceled", CompletionStatus: "CANCELED", Artifacts: []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}}},
+	}}
+
+	summarizeXcodeCloudDoctorResult(result)
+
+	if result.Summary.FailedActions != 2 || result.Summary.CanceledActions != 1 {
+		t.Fatalf("summary = %+v, want 2 failed and 1 canceled action", result.Summary)
+	}
+	if got := doctorFailedActionLogBundleCount(result); got != 2 {
+		t.Fatalf("doctorFailedActionLogBundleCount() = %d, want 2", got)
+	}
+}
+
+func TestFinishXcodeCloudDoctorResultIgnoresSuccessfulActionLogBundles(t *testing.T) {
+	result := &asc.XcodeCloudDoctorResult{
+		Run: &asc.XcodeCloudStatusResult{ExecutionProgress: "COMPLETE", CompletionStatus: "FAILED"},
+		Actions: []asc.XcodeCloudDoctorAction{{
+			CompletionStatus: "SUCCEEDED",
+			Artifacts:        []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
+		}},
+		Summary: asc.XcodeCloudDoctorSummary{LogBundles: 1, Errors: 1},
+	}
+
+	finishXcodeCloudDoctorResult(result)
+
+	if strings.Contains(result.Conclusion, "not inspected") || strings.Contains(result.NextAction, "--skip-logs") {
+		t.Fatalf("successful-action bundle produced misleading remediation: conclusion=%q nextAction=%q", result.Conclusion, result.NextAction)
+	}
+}
+
+func TestAnalyzeDoctorLogBundleRejectsOversizedTextEntry(t *testing.T) {
+	data := doctorLogBundleFixture(t, map[string]string{
+		"Export/IDEDistribution.standard.log": strings.Repeat("x", maxDoctorLogEntryBytes+1),
+	})
+
+	_, err := analyzeDoctorLogBundle(data)
+	if err == nil || !strings.Contains(err.Error(), "IDEDistribution.standard.log") {
+		t.Fatalf("analyzeDoctorLogBundle() error = %v, want oversized entry error", err)
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -195,7 +195,7 @@ func TestFinishXcodeCloudDoctorResultIgnoresSuccessfulActionLogBundles(t *testin
 				Artifacts:        []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
 			},
 		},
-		Summary: asc.XcodeCloudDoctorSummary{LogBundles: 1, Errors: 1},
+		Summary: asc.XcodeCloudDoctorSummary{LogBundles: 1, LogBundlesInspected: 1, Errors: 1},
 		LogBundles: []asc.XcodeCloudDoctorLogBundle{{
 			ActionID:     "successful-archive",
 			Inspected:    true,
@@ -211,6 +211,39 @@ func TestFinishXcodeCloudDoctorResultIgnoresSuccessfulActionLogBundles(t *testin
 
 	if !strings.Contains(result.Conclusion, "reported actionable issues") {
 		t.Fatalf("successful-action bundle changed diagnosis: conclusion=%q nextAction=%q", result.Conclusion, result.NextAction)
+	}
+}
+
+func TestFinishXcodeCloudDoctorResultUsesFailedActionInspectionCount(t *testing.T) {
+	result := &asc.XcodeCloudDoctorResult{
+		Run: &asc.XcodeCloudStatusResult{ExecutionProgress: "COMPLETE", CompletionStatus: "FAILED"},
+		Actions: []asc.XcodeCloudDoctorAction{
+			{
+				ID:               "failed-archive",
+				CompletionStatus: "FAILED",
+				Issues: []asc.XcodeCloudDoctorIssue{{
+					IssueType: "ERROR",
+					Message:   "Preparing build for App Store Connect failed",
+				}},
+				Artifacts: []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
+			},
+			{ID: "successful-archive", CompletionStatus: "SUCCEEDED"},
+		},
+		Summary: asc.XcodeCloudDoctorSummary{LogBundles: 2, LogBundlesInspected: 1, Errors: 1},
+		LogBundles: []asc.XcodeCloudDoctorLogBundle{{
+			ActionID:  "successful-archive",
+			Inspected: true,
+		}},
+		CoverageWarnings: []asc.XcodeCloudDoctorCoverageWarning{},
+	}
+
+	finishXcodeCloudDoctorResult(result)
+
+	if !strings.Contains(result.Conclusion, "available log bundles were not inspected") {
+		t.Fatalf("Conclusion = %q, want failed-action inspection gap", result.Conclusion)
+	}
+	if len(result.CoverageWarnings) != 1 || strings.Contains(result.CoverageWarnings[0].Message, "inspected log bundles") {
+		t.Fatalf("coverage warnings = %+v, must not count successful-action inspection", result.CoverageWarnings)
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -57,8 +57,14 @@ func TestFinishXcodeCloudDoctorResultDoesNotInventImportFailure(t *testing.T) {
 			ExecutionProgress: "COMPLETE",
 			CompletionStatus:  "FAILED",
 		},
+		Actions: []asc.XcodeCloudDoctorAction{{
+			ID:               "archive-ios",
+			CompletionStatus: "FAILED",
+			Artifacts:        []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
+		}},
 		LogBundles: []asc.XcodeCloudDoctorLogBundle{{
 			ArtifactID:   "log-92",
+			ActionID:     "archive-ios",
 			Inspected:    true,
 			ExportStatus: "SUCCEEDED",
 			Diagnostics:  []asc.XcodeCloudDoctorLogDiagnostic{},
@@ -173,17 +179,67 @@ func TestDoctorFailureAggregationExcludesCanceledActions(t *testing.T) {
 func TestFinishXcodeCloudDoctorResultIgnoresSuccessfulActionLogBundles(t *testing.T) {
 	result := &asc.XcodeCloudDoctorResult{
 		Run: &asc.XcodeCloudStatusResult{ExecutionProgress: "COMPLETE", CompletionStatus: "FAILED"},
-		Actions: []asc.XcodeCloudDoctorAction{{
-			CompletionStatus: "SUCCEEDED",
-			Artifacts:        []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
-		}},
+		Actions: []asc.XcodeCloudDoctorAction{
+			{
+				ID:               "failed-test",
+				CompletionStatus: "FAILED",
+				Issues: []asc.XcodeCloudDoctorIssue{{
+					IssueType: "ERROR",
+					Category:  "Testing",
+					Message:   "A test failed",
+				}},
+			},
+			{
+				ID:               "successful-archive",
+				CompletionStatus: "SUCCEEDED",
+				Artifacts:        []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
+			},
+		},
 		Summary: asc.XcodeCloudDoctorSummary{LogBundles: 1, Errors: 1},
+		LogBundles: []asc.XcodeCloudDoctorLogBundle{{
+			ActionID:     "successful-archive",
+			Inspected:    true,
+			ExportStatus: "SUCCEEDED",
+			Diagnostics: []asc.XcodeCloudDoctorLogDiagnostic{{
+				Code:    "ITMS-90000",
+				Message: "Incidental diagnostic",
+			}},
+		}},
 	}
 
 	finishXcodeCloudDoctorResult(result)
 
-	if strings.Contains(result.Conclusion, "not inspected") || strings.Contains(result.NextAction, "--skip-logs") {
-		t.Fatalf("successful-action bundle produced misleading remediation: conclusion=%q nextAction=%q", result.Conclusion, result.NextAction)
+	if !strings.Contains(result.Conclusion, "reported actionable issues") {
+		t.Fatalf("successful-action bundle changed diagnosis: conclusion=%q nextAction=%q", result.Conclusion, result.NextAction)
+	}
+}
+
+func TestDoctorHasAppStorePreparationIssueUsesFailedErrorActions(t *testing.T) {
+	result := &asc.XcodeCloudDoctorResult{Actions: []asc.XcodeCloudDoctorAction{
+		{
+			CompletionStatus: "SUCCEEDED",
+			Issues: []asc.XcodeCloudDoctorIssue{{
+				IssueType: "WARNING",
+				Message:   "App Store Connect warning",
+			}},
+		},
+		{
+			CompletionStatus: "FAILED",
+			Issues: []asc.XcodeCloudDoctorIssue{{
+				IssueType: "ERROR",
+				Message:   "Compilation failed",
+			}},
+		},
+	}}
+
+	if doctorHasAppStorePreparationIssue(result) {
+		t.Fatal("successful warning must not be treated as the failed run's App Store preparation issue")
+	}
+
+	result.Actions[1].Issues[0].Category = "PrepareBuildForAppStoreConnect"
+	result.Actions[1].Issues[0].Message = "Preparing build for App Store Connect failed"
+	if !doctorHasAppStorePreparationIssue(result) {
+		t.Fatal("failed error action's App Store preparation issue was not detected")
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -368,6 +369,32 @@ func TestAnalyzeDoctorLogBundleRejectsArchiveWithoutReadableTextEntries(t *testi
 	}
 }
 
+func TestAnalyzeDoctorLogBundleCountsBinaryCandidatesTowardAggregateLimit(t *testing.T) {
+	var buffer bytes.Buffer
+	archive := zip.NewWriter(&buffer)
+	for index := 0; index <= maxDoctorLogUncompressedBytes/maxDoctorLogEntryBytes; index++ {
+		entry, err := archive.Create(fmt.Sprintf("Build/%d.log", index))
+		if err != nil {
+			t.Fatalf("create binary log entry: %v", err)
+		}
+		size := int64(maxDoctorLogEntryBytes)
+		if index == maxDoctorLogUncompressedBytes/maxDoctorLogEntryBytes {
+			size = 1
+		}
+		if _, err := io.CopyN(entry, doctorZeroReader{}, size); err != nil {
+			t.Fatalf("write binary log entry: %v", err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatalf("close binary log archive: %v", err)
+	}
+
+	_, err := analyzeDoctorLogBundle(buffer.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "uncompressed inspection limit") {
+		t.Fatalf("analyzeDoctorLogBundle() error = %v, want aggregate limit error", err)
+	}
+}
+
 func TestInspectXcodeCloudDoctorLogsContinuesAfterSaveFailure(t *testing.T) {
 	directory := t.TempDir()
 	artifacts := []asc.XcodeCloudDoctorArtifact{
@@ -409,6 +436,28 @@ func TestInspectXcodeCloudDoctorLogsContinuesAfterSaveFailure(t *testing.T) {
 	}
 	if len(result.CoverageWarnings) != 1 || result.CoverageWarnings[0].ID != "log_bundle_inspection_failed" {
 		t.Fatalf("coverage warnings = %+v, want save failure warning", result.CoverageWarnings)
+	}
+}
+
+func TestInspectXcodeCloudDoctorLogsPropagatesCancellation(t *testing.T) {
+	client := newDoctorLogTestClient(t, doctorLogRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	}))
+	result := &asc.XcodeCloudDoctorResult{Actions: []asc.XcodeCloudDoctorAction{{
+		ID:               "failed-action",
+		CompletionStatus: "FAILED",
+		Artifacts: []asc.XcodeCloudDoctorArtifact{{
+			ID:       "artifact-1",
+			FileType: "LOG_BUNDLE",
+		}},
+	}}}
+
+	err := inspectXcodeCloudDoctorLogs(context.Background(), client, result, xcodeCloudDoctorOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("inspectXcodeCloudDoctorLogs() error = %v, want context cancellation", err)
+	}
+	if len(result.CoverageWarnings) != 0 {
+		t.Fatalf("coverage warnings = %+v, must not downgrade cancellation", result.CoverageWarnings)
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -266,7 +266,7 @@ func TestFinishXcodeCloudDoctorResultUsesFailedActionInspectionCount(t *testing.
 
 	finishXcodeCloudDoctorResult(result)
 
-	if !strings.Contains(result.Conclusion, "available log bundles were not inspected") {
+	if !strings.Contains(result.Conclusion, "failed-action log bundles were not inspected") {
 		t.Fatalf("Conclusion = %q, want failed-action inspection gap", result.Conclusion)
 	}
 	if len(result.CoverageWarnings) != 1 || strings.Contains(result.CoverageWarnings[0].Message, "inspected log bundles") {
@@ -314,6 +314,41 @@ func TestFinishXcodeCloudDoctorResultDoesNotRepeatFailedInspection(t *testing.T)
 
 	if !strings.Contains(result.NextAction, "inspection remediation") || strings.Contains(result.NextAction, "Re-run") {
 		t.Fatalf("NextAction = %q, want existing inspection failure remediation", result.NextAction)
+	}
+}
+
+func TestFinishXcodeCloudDoctorResultReportsPartialFailedBundleCoverage(t *testing.T) {
+	result := &asc.XcodeCloudDoctorResult{
+		Run: &asc.XcodeCloudStatusResult{ExecutionProgress: "COMPLETE", CompletionStatus: "FAILED"},
+		Actions: []asc.XcodeCloudDoctorAction{{
+			ID:               "failed-archive",
+			CompletionStatus: "FAILED",
+			Issues: []asc.XcodeCloudDoctorIssue{{
+				IssueType: "ERROR",
+				Message:   "Preparing build for App Store Connect failed",
+			}},
+			Artifacts: []asc.XcodeCloudDoctorArtifact{
+				{ID: "log-1", FileType: "LOG_BUNDLE"},
+				{ID: "log-2", FileType: "LOG_BUNDLE"},
+			},
+		}},
+		LogBundles: []asc.XcodeCloudDoctorLogBundle{
+			{ArtifactID: "log-1", ActionID: "failed-archive", Inspected: true, ExportStatus: "SUCCEEDED"},
+			{ArtifactID: "log-2", ActionID: "failed-archive"},
+		},
+		CoverageWarnings: []asc.XcodeCloudDoctorCoverageWarning{{ID: "log_bundle_inspection_failed"}},
+	}
+
+	finishXcodeCloudDoctorResult(result)
+
+	if !strings.Contains(result.Conclusion, "one or more failed-action log bundles were not inspected") {
+		t.Fatalf("Conclusion = %q, want partial inspection caveat", result.Conclusion)
+	}
+	if !strings.Contains(result.NextAction, "inspection remediation") || strings.Contains(result.NextAction, "server-side import rejection") {
+		t.Fatalf("NextAction = %q, want inspection-first guidance", result.NextAction)
+	}
+	if len(result.CoverageWarnings) != 2 || result.CoverageWarnings[1].ID != "app_store_import_detail_unavailable" || !strings.Contains(result.CoverageWarnings[1].Message, "not inspected") {
+		t.Fatalf("coverage warnings = %+v, want explicit partial App Store coverage", result.CoverageWarnings)
 	}
 }
 
@@ -366,6 +401,21 @@ func TestAnalyzeDoctorLogBundleRejectsArchiveWithoutReadableTextEntries(t *testi
 	_, err := analyzeDoctorLogBundle(data)
 	if err == nil || !strings.Contains(err.Error(), "no readable text entries") {
 		t.Fatalf("analyzeDoctorLogBundle() error = %v, want readable-text coverage error", err)
+	}
+}
+
+func TestAnalyzeDoctorLogBundleRejectsEmptyContent(t *testing.T) {
+	tests := map[string][]byte{
+		"plain": nil,
+		"zip":   doctorLogBundleFixture(t, map[string]string{"Build/empty.log": ""}),
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := analyzeDoctorLogBundle(data)
+			if err == nil {
+				t.Fatal("analyzeDoctorLogBundle() error = nil, want empty-content error")
+			}
+		})
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
@@ -32,20 +33,37 @@ func TestAnalyzeDoctorLogBundleFindsITMSDiagnosticsAndExportStatus(t *testing.T)
 	}
 }
 
+func TestAnalyzeDoctorLogTextTruncatesDiagnosticsOnUTF8Boundary(t *testing.T) {
+	analysis := doctorLogBundleAnalysis{Diagnostics: make([]asc.XcodeCloudDoctorLogDiagnostic, 0)}
+	contents := "ITMS-90000: x" + strings.Repeat("é", maxDoctorDiagnosticLength)
+
+	analyzeDoctorLogText(&analysis, "export.log", contents)
+
+	if len(analysis.Diagnostics) != 1 {
+		t.Fatalf("Diagnostics = %+v, want one diagnostic", analysis.Diagnostics)
+	}
+	if !utf8.ValidString(analysis.Diagnostics[0].Message) {
+		t.Fatalf("diagnostic message is not valid UTF-8: %q", analysis.Diagnostics[0].Message)
+	}
+	if !strings.HasSuffix(analysis.Diagnostics[0].Message, "…") {
+		t.Fatalf("diagnostic message = %q, want ellipsis suffix", analysis.Diagnostics[0].Message)
+	}
+}
+
 func TestFinishXcodeCloudDoctorResultDoesNotInventImportFailure(t *testing.T) {
-	result := &xcodeCloudDoctorResult{
+	result := &asc.XcodeCloudDoctorResult{
 		Run: &asc.XcodeCloudStatusResult{
 			BuildRunID:        "run-92",
 			ExecutionProgress: "COMPLETE",
 			CompletionStatus:  "FAILED",
 		},
-		LogBundles: []xcodeCloudDoctorLogBundle{{
+		LogBundles: []asc.XcodeCloudDoctorLogBundle{{
 			ArtifactID:   "log-92",
 			Inspected:    true,
 			ExportStatus: "SUCCEEDED",
-			Diagnostics:  []xcodeCloudDoctorLogDiagnostic{},
+			Diagnostics:  []asc.XcodeCloudDoctorLogDiagnostic{},
 		}},
-		CoverageWarnings: []xcodeCloudDoctorCoverageWarning{},
+		CoverageWarnings: []asc.XcodeCloudDoctorCoverageWarning{},
 	}
 
 	finishXcodeCloudDoctorResult(result)
@@ -61,6 +79,38 @@ func TestFinishXcodeCloudDoctorResultDoesNotInventImportFailure(t *testing.T) {
 	}
 }
 
+func TestFinishXcodeCloudDoctorResultReportsCanceledAndSkippedRuns(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		conclusion string
+	}{
+		{name: "canceled", status: "CANCELED", conclusion: "was canceled"},
+		{name: "skipped", status: "SKIPPED", conclusion: "was skipped"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := &asc.XcodeCloudDoctorResult{
+				Run: &asc.XcodeCloudStatusResult{
+					BuildRunID:        "run-1",
+					ExecutionProgress: "COMPLETE",
+					CompletionStatus:  test.status,
+				},
+			}
+
+			finishXcodeCloudDoctorResult(result)
+
+			if !strings.Contains(strings.ToLower(result.Conclusion), test.conclusion) {
+				t.Fatalf("Conclusion = %q, want %q", result.Conclusion, test.conclusion)
+			}
+			if strings.Contains(strings.ToLower(result.Conclusion), "failed") {
+				t.Fatalf("Conclusion = %q, must not describe %s run as failed", result.Conclusion, test.status)
+			}
+		})
+	}
+}
+
 func TestAnalyzeDoctorLogBundleRejectsUnknownBinary(t *testing.T) {
 	if _, err := analyzeDoctorLogBundle([]byte{'P', 'K', 0, 1, 2}); err == nil {
 		t.Fatal("analyzeDoctorLogBundle() error = nil, want binary format error")
@@ -68,7 +118,7 @@ func TestAnalyzeDoctorLogBundleRejectsUnknownBinary(t *testing.T) {
 }
 
 func TestDoctorSavedLogBundleNameSanitizesRemoteComponents(t *testing.T) {
-	artifact := xcodeCloudDoctorArtifact{
+	artifact := asc.XcodeCloudDoctorArtifact{
 		ID:       "../../artifact/id",
 		FileName: `..\..\Build 92 Logs.zip`,
 	}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -1,0 +1,98 @@
+package xcodecloud
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestAnalyzeDoctorLogBundleFindsITMSDiagnosticsAndExportStatus(t *testing.T) {
+	data := doctorLogBundleFixture(t, map[string]string{
+		"Export/IDEDistribution.standard.log": "** EXPORT SUCCEEDED **\nerror: ITMS-90478: Invalid Version",
+		"Export/duplicate.log":                "error: ITMS-90478: Invalid Version",
+		"Export/binary.log":                   "ignored\x00binary",
+	})
+
+	analysis, err := analyzeDoctorLogBundle(data)
+	if err != nil {
+		t.Fatalf("analyzeDoctorLogBundle() error = %v", err)
+	}
+	if analysis.ExportStatus != "SUCCEEDED" {
+		t.Fatalf("ExportStatus = %q, want SUCCEEDED", analysis.ExportStatus)
+	}
+	if len(analysis.Diagnostics) != 1 {
+		t.Fatalf("Diagnostics = %+v, want one deduplicated diagnostic", analysis.Diagnostics)
+	}
+	if analysis.Diagnostics[0].Code != "ITMS-90478" {
+		t.Fatalf("diagnostic code = %q, want ITMS-90478", analysis.Diagnostics[0].Code)
+	}
+}
+
+func TestFinishXcodeCloudDoctorResultDoesNotInventImportFailure(t *testing.T) {
+	result := &xcodeCloudDoctorResult{
+		Run: &asc.XcodeCloudStatusResult{
+			BuildRunID:        "run-92",
+			ExecutionProgress: "COMPLETE",
+			CompletionStatus:  "FAILED",
+		},
+		LogBundles: []xcodeCloudDoctorLogBundle{{
+			ArtifactID:   "log-92",
+			Inspected:    true,
+			ExportStatus: "SUCCEEDED",
+			Diagnostics:  []xcodeCloudDoctorLogDiagnostic{},
+		}},
+		CoverageWarnings: []xcodeCloudDoctorCoverageWarning{},
+	}
+
+	finishXcodeCloudDoctorResult(result)
+
+	if !strings.Contains(result.Conclusion, "without an ITMS-level import diagnostic") {
+		t.Fatalf("unexpected conclusion %q", result.Conclusion)
+	}
+	if len(result.CoverageWarnings) != 1 || result.CoverageWarnings[0].ID != "app_store_import_detail_unavailable" {
+		t.Fatalf("unexpected coverage warnings: %+v", result.CoverageWarnings)
+	}
+	if strings.Contains(result.Conclusion, "Invalid Version") || strings.Contains(result.Conclusion, "pre-release train") {
+		t.Fatalf("conclusion invented an import root cause: %q", result.Conclusion)
+	}
+}
+
+func TestAnalyzeDoctorLogBundleRejectsUnknownBinary(t *testing.T) {
+	if _, err := analyzeDoctorLogBundle([]byte{'P', 'K', 0, 1, 2}); err == nil {
+		t.Fatal("analyzeDoctorLogBundle() error = nil, want binary format error")
+	}
+}
+
+func TestDoctorSavedLogBundleNameSanitizesRemoteComponents(t *testing.T) {
+	artifact := xcodeCloudDoctorArtifact{
+		ID:       "../../artifact/id",
+		FileName: `..\..\Build 92 Logs.zip`,
+	}
+	name := doctorSavedLogBundleName(artifact)
+	if strings.Contains(name, "/") || strings.Contains(name, `\`) || strings.Contains(name, "..") {
+		t.Fatalf("unsafe saved name %q", name)
+	}
+}
+
+func doctorLogBundleFixture(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	archive := zip.NewWriter(&buffer)
+	for name, contents := range files {
+		file, err := archive.Create(name)
+		if err != nil {
+			t.Fatalf("create %q: %v", name, err)
+		}
+		if _, err := io.WriteString(file, contents); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buffer.Bytes()
+}

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -3,6 +3,7 @@ package xcodecloud
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -33,6 +34,21 @@ func TestAnalyzeDoctorLogBundleFindsITMSDiagnosticsAndExportStatus(t *testing.T)
 	}
 	if analysis.Diagnostics[0].Code != "ITMS-90478" {
 		t.Fatalf("diagnostic code = %q, want ITMS-90478", analysis.Diagnostics[0].Code)
+	}
+}
+
+func TestAnalyzeDoctorLogBundleReportsDiagnosticTruncation(t *testing.T) {
+	lines := make([]string, 0, maxDoctorDiagnostics+1)
+	for index := 0; index <= maxDoctorDiagnostics; index++ {
+		lines = append(lines, fmt.Sprintf("error: ITMS-%05d: diagnostic %d", index, index))
+	}
+
+	analysis, err := analyzeDoctorLogBundle([]byte(strings.Join(lines, "\n")))
+	if err != nil {
+		t.Fatalf("analyzeDoctorLogBundle() error = %v", err)
+	}
+	if len(analysis.Diagnostics) != maxDoctorDiagnostics || !analysis.DiagnosticsTruncated {
+		t.Fatalf("analysis = %+v, want %d diagnostics and explicit truncation", analysis, maxDoctorDiagnostics)
 	}
 }
 

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -271,6 +271,28 @@ func TestFinishXcodeCloudDoctorResultPointsToSavedFailedActionLogs(t *testing.T)
 	}
 }
 
+func TestFinishXcodeCloudDoctorResultDoesNotRepeatFailedInspection(t *testing.T) {
+	result := &asc.XcodeCloudDoctorResult{
+		Run: &asc.XcodeCloudStatusResult{ExecutionProgress: "COMPLETE", CompletionStatus: "FAILED"},
+		Actions: []asc.XcodeCloudDoctorAction{{
+			ID:               "failed-archive",
+			CompletionStatus: "FAILED",
+			Issues: []asc.XcodeCloudDoctorIssue{{
+				IssueType: "ERROR",
+				Message:   "Preparing build for App Store Connect failed",
+			}},
+			Artifacts: []asc.XcodeCloudDoctorArtifact{{FileType: "LOG_BUNDLE"}},
+		}},
+		CoverageWarnings: []asc.XcodeCloudDoctorCoverageWarning{{ID: "log_bundle_inspection_failed"}},
+	}
+
+	finishXcodeCloudDoctorResult(result)
+
+	if !strings.Contains(result.NextAction, "inspection remediation") || strings.Contains(result.NextAction, "Re-run") {
+		t.Fatalf("NextAction = %q, want existing inspection failure remediation", result.NextAction)
+	}
+}
+
 func TestDoctorHasAppStorePreparationIssueUsesFailedErrorActions(t *testing.T) {
 	result := &asc.XcodeCloudDoctorResult{Actions: []asc.XcodeCloudDoctorAction{
 		{

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_logs_test.go
@@ -349,6 +349,18 @@ func TestAnalyzeDoctorLogBundleRejectsOversizedTextEntry(t *testing.T) {
 	}
 }
 
+func TestAnalyzeDoctorLogBundleRejectsArchiveWithoutReadableTextEntries(t *testing.T) {
+	data := doctorLogBundleFixture(t, map[string]string{
+		"Build/Build.xcactivitylog": "binary activity log",
+		"Export/binary.log":         "ignored\x00binary",
+	})
+
+	_, err := analyzeDoctorLogBundle(data)
+	if err == nil || !strings.Contains(err.Error(), "no readable text entries") {
+		t.Fatalf("analyzeDoctorLogBundle() error = %v, want readable-text coverage error", err)
+	}
+}
+
 func TestSaveAndAnalyzeDoctorLogBundleKeepsOversizedFile(t *testing.T) {
 	directory := t.TempDir()
 	root, err := rootfs.New(directory)

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_output.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_output.go
@@ -1,105 +1,10 @@
 package xcodecloud
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
-func printXcodeCloudDoctorResult(result *xcodeCloudDoctorResult, output string, pretty bool) error {
-	return shared.PrintOutputWithRenderers(
-		result,
-		output,
-		pretty,
-		func() error { renderXcodeCloudDoctorResult(result, false); return nil },
-		func() error { renderXcodeCloudDoctorResult(result, true); return nil },
-	)
-}
-
-func renderXcodeCloudDoctorResult(result *xcodeCloudDoctorResult, markdown bool) {
-	buildNumber := "N/A"
-	if result.Run.BuildNumber > 0 {
-		buildNumber = strconv.Itoa(result.Run.BuildNumber)
-	}
-	summaryRows := [][]string{
-		{"runId", result.Run.BuildRunID},
-		{"buildNumber", buildNumber},
-		{"executionProgress", shared.OrNA(result.Run.ExecutionProgress)},
-		{"completionStatus", shared.OrNA(result.Run.CompletionStatus)},
-		{"totalActions", strconv.Itoa(result.Summary.TotalActions)},
-		{"failedActions", strconv.Itoa(result.Summary.FailedActions)},
-		{"errors", strconv.Itoa(result.Summary.Errors)},
-		{"warnings", strconv.Itoa(result.Summary.Warnings)},
-		{"artifacts", strconv.Itoa(result.Summary.Artifacts)},
-		{"logBundles", strconv.Itoa(result.Summary.LogBundles)},
-		{"logBundlesInspected", strconv.Itoa(result.Summary.LogBundlesInspected)},
-		{"conclusion", result.Conclusion},
-		{"nextAction", result.NextAction},
-	}
-	shared.RenderSection("Summary", []string{"field", "value"}, summaryRows, markdown)
-
-	actionRows := make([][]string, 0, len(result.Actions))
-	for _, action := range result.Actions {
-		actionRows = append(actionRows, []string{
-			action.ID,
-			action.Name,
-			action.ActionType,
-			action.ExecutionProgress,
-			action.CompletionStatus,
-			strconv.Itoa(len(action.Issues)),
-			strconv.Itoa(len(action.Artifacts)),
-		})
-	}
-	shared.RenderSection("Actions", []string{"id", "name", "type", "progress", "status", "issues", "artifacts"}, actionRows, markdown)
-
-	issueRows := make([][]string, 0, result.Summary.Errors+result.Summary.Warnings)
-	artifactRows := make([][]string, 0, result.Summary.Artifacts)
-	for _, action := range result.Actions {
-		for _, issue := range action.Issues {
-			location := ""
-			if issue.FileSource != nil {
-				location = issue.FileSource.Path
-				if issue.FileSource.LineNumber > 0 {
-					location = fmt.Sprintf("%s:%d", location, issue.FileSource.LineNumber)
-				}
-			}
-			issueRows = append(issueRows, []string{action.ID, issue.IssueType, issue.Category, issue.Message, location})
-		}
-		for _, artifact := range action.Artifacts {
-			artifactRows = append(artifactRows, []string{
-				action.ID,
-				artifact.ID,
-				artifact.FileType,
-				artifact.FileName,
-				strconv.Itoa(artifact.FileSize),
-			})
-		}
-	}
-	shared.RenderSection("Issues", []string{"actionId", "type", "category", "message", "location"}, issueRows, markdown)
-	shared.RenderSection("Artifacts", []string{"actionId", "id", "type", "name", "bytes"}, artifactRows, markdown)
-
-	logRows := make([][]string, 0, len(result.LogBundles))
-	for _, bundle := range result.LogBundles {
-		codes := make([]string, 0, len(bundle.Diagnostics))
-		for _, diagnostic := range bundle.Diagnostics {
-			codes = append(codes, diagnostic.Code)
-		}
-		logRows = append(logRows, []string{
-			bundle.ActionID,
-			bundle.ArtifactID,
-			strconv.FormatBool(bundle.Inspected),
-			shared.OrNA(bundle.ExportStatus),
-			strings.Join(codes, ","),
-			bundle.SavedPath,
-		})
-	}
-	shared.RenderSection("Log Bundles", []string{"actionId", "artifactId", "inspected", "exportStatus", "diagnostics", "savedPath"}, logRows, markdown)
-
-	coverageRows := make([][]string, 0, len(result.CoverageWarnings))
-	for _, warning := range result.CoverageWarnings {
-		coverageRows = append(coverageRows, []string{warning.ID, warning.Message, warning.Remediation})
-	}
-	shared.RenderSection("Coverage Warnings", []string{"id", "message", "remediation"}, coverageRows, markdown)
+func printXcodeCloudDoctorResult(result *asc.XcodeCloudDoctorResult, output string, pretty bool) error {
+	return shared.PrintOutput(result, output, pretty)
 }

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_output.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_output.go
@@ -1,0 +1,105 @@
+package xcodecloud
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func printXcodeCloudDoctorResult(result *xcodeCloudDoctorResult, output string, pretty bool) error {
+	return shared.PrintOutputWithRenderers(
+		result,
+		output,
+		pretty,
+		func() error { renderXcodeCloudDoctorResult(result, false); return nil },
+		func() error { renderXcodeCloudDoctorResult(result, true); return nil },
+	)
+}
+
+func renderXcodeCloudDoctorResult(result *xcodeCloudDoctorResult, markdown bool) {
+	buildNumber := "N/A"
+	if result.Run.BuildNumber > 0 {
+		buildNumber = strconv.Itoa(result.Run.BuildNumber)
+	}
+	summaryRows := [][]string{
+		{"runId", result.Run.BuildRunID},
+		{"buildNumber", buildNumber},
+		{"executionProgress", shared.OrNA(result.Run.ExecutionProgress)},
+		{"completionStatus", shared.OrNA(result.Run.CompletionStatus)},
+		{"totalActions", strconv.Itoa(result.Summary.TotalActions)},
+		{"failedActions", strconv.Itoa(result.Summary.FailedActions)},
+		{"errors", strconv.Itoa(result.Summary.Errors)},
+		{"warnings", strconv.Itoa(result.Summary.Warnings)},
+		{"artifacts", strconv.Itoa(result.Summary.Artifacts)},
+		{"logBundles", strconv.Itoa(result.Summary.LogBundles)},
+		{"logBundlesInspected", strconv.Itoa(result.Summary.LogBundlesInspected)},
+		{"conclusion", result.Conclusion},
+		{"nextAction", result.NextAction},
+	}
+	shared.RenderSection("Summary", []string{"field", "value"}, summaryRows, markdown)
+
+	actionRows := make([][]string, 0, len(result.Actions))
+	for _, action := range result.Actions {
+		actionRows = append(actionRows, []string{
+			action.ID,
+			action.Name,
+			action.ActionType,
+			action.ExecutionProgress,
+			action.CompletionStatus,
+			strconv.Itoa(len(action.Issues)),
+			strconv.Itoa(len(action.Artifacts)),
+		})
+	}
+	shared.RenderSection("Actions", []string{"id", "name", "type", "progress", "status", "issues", "artifacts"}, actionRows, markdown)
+
+	issueRows := make([][]string, 0, result.Summary.Errors+result.Summary.Warnings)
+	artifactRows := make([][]string, 0, result.Summary.Artifacts)
+	for _, action := range result.Actions {
+		for _, issue := range action.Issues {
+			location := ""
+			if issue.FileSource != nil {
+				location = issue.FileSource.Path
+				if issue.FileSource.LineNumber > 0 {
+					location = fmt.Sprintf("%s:%d", location, issue.FileSource.LineNumber)
+				}
+			}
+			issueRows = append(issueRows, []string{action.ID, issue.IssueType, issue.Category, issue.Message, location})
+		}
+		for _, artifact := range action.Artifacts {
+			artifactRows = append(artifactRows, []string{
+				action.ID,
+				artifact.ID,
+				artifact.FileType,
+				artifact.FileName,
+				strconv.Itoa(artifact.FileSize),
+			})
+		}
+	}
+	shared.RenderSection("Issues", []string{"actionId", "type", "category", "message", "location"}, issueRows, markdown)
+	shared.RenderSection("Artifacts", []string{"actionId", "id", "type", "name", "bytes"}, artifactRows, markdown)
+
+	logRows := make([][]string, 0, len(result.LogBundles))
+	for _, bundle := range result.LogBundles {
+		codes := make([]string, 0, len(bundle.Diagnostics))
+		for _, diagnostic := range bundle.Diagnostics {
+			codes = append(codes, diagnostic.Code)
+		}
+		logRows = append(logRows, []string{
+			bundle.ActionID,
+			bundle.ArtifactID,
+			strconv.FormatBool(bundle.Inspected),
+			shared.OrNA(bundle.ExportStatus),
+			strings.Join(codes, ","),
+			bundle.SavedPath,
+		})
+	}
+	shared.RenderSection("Log Bundles", []string{"actionId", "artifactId", "inspected", "exportStatus", "diagnostics", "savedPath"}, logRows, markdown)
+
+	coverageRows := make([][]string, 0, len(result.CoverageWarnings))
+	for _, warning := range result.CoverageWarnings {
+		coverageRows = append(coverageRows, []string{warning.ID, warning.Message, warning.Remediation})
+	}
+	shared.RenderSection("Coverage Warnings", []string{"id", "message", "remediation"}, coverageRows, markdown)
+}


### PR DESCRIPTION
Stacked on #2147.

## What changed

Adds `asc xcode-cloud doctor --run-id BUILD_RUN_ID`, a read-only report that combines run status, actions, issues, and artifacts. `--wait` polls before diagnosis.

For failed runs, doctor downloads only failed-action `LOG_BUNDLE` artifacts into memory, extracts ITMS diagnostics when present, and records whether archive export succeeded. `--save-logs DIR` retains the bundles with mode `0600`; `--skip-logs` disables inspection. Downloads and archive reads have size limits, remote filenames cannot escape the chosen directory, and existing files are never overwritten.

A failed Xcode Cloud run remains report data, so doctor exits zero when collection succeeds. The output states when neither the Xcode Cloud API nor its log bundle exposes the downstream App Store import rejection.

## Verification

- Added command, polling, JSON/table, API-error, save/refusal, and bounded log-analysis coverage
- Ran the built command against Presset run 92: it found three actions and 12 artifacts, inspected the failed iOS log bundle, saw `EXPORT SUCCEEDED`, found no ITMS detail, and returned the App Store import coverage warning
- Ran formatting, command/docs checks, lint, and the complete test suite with `ASC_BYPASS_KEYCHAIN=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the experimental `xcode-cloud doctor` command for diagnosing Xcode Cloud runs.
  - Supports waiting for completion, failure summaries, issue and artifact details, and log-bundle inspection.
  - Analyzes failed-action logs for export results and ITMS diagnostic codes.
  - Saves log bundles safely without overwriting existing files.
  - Provides table and JSON output formats.
  - Validates required and conflicting options, polling settings, and API errors.
  - Displays conclusions for canceled, skipped, successful, and incomplete runs.

- **Tests**
  - Added comprehensive coverage for run states, log inspection, output rendering, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->