### PR TITLE
feat(xcode-cloud): diagnose waited runs

### DIFF
--- a/internal/cli/cmdtest/xcode_cloud_run_doctor_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_run_doctor_test.go
@@ -1,0 +1,157 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestXcodeCloudRunDoctorRequiresWait(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	if err := root.Parse([]string{"xcode-cloud", "run", "--workflow-id", "wf-1", "--git-reference-id", "ref-1", "--doctor"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := root.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--doctor requires --wait") {
+		t.Fatalf("run error = %v, want --doctor/--wait validation", err)
+	}
+}
+
+func TestXcodeCloudRunWaitDoctorReturnsDiagnosticReportForFailedRun(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	requests := make(map[string]int)
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests[req.Method+" "+req.URL.Path]++
+		var body string
+		switch req.Method + " " + req.URL.Path {
+		case "POST /v1/ciBuildRuns":
+			body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"executionProgress":"PENDING"}}}`
+		case "GET /v1/ciBuildRuns/run-1":
+			body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"number":93,"executionProgress":"COMPLETE","completionStatus":"FAILED"}}}`
+		case "GET /v1/ciBuildRuns/run-1/actions":
+			body = `{"data":[{"type":"ciBuildActions","id":"action-1","attributes":{"name":"Build - iOS","actionType":"BUILD","executionProgress":"COMPLETE","completionStatus":"FAILED"}}]}`
+		case "GET /v1/ciBuildActions/action-1/issues":
+			body = `{"data":[{"type":"ciIssues","id":"issue-1","attributes":{"issueType":"ERROR","category":"Xcodebuild","message":"Swift compilation failed"}}]}`
+		case "GET /v1/ciBuildActions/action-1/artifacts":
+			body = `{"data":[]}`
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"xcode-cloud", "run",
+			"--workflow-id", "wf-1",
+			"--git-reference-id", "ref-1",
+			"--wait",
+			"--doctor",
+			"--poll-interval", "1ms",
+			"--output", "json",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var result struct {
+		Run struct {
+			BuildRunID       string `json:"buildRunId"`
+			CompletionStatus string `json:"completionStatus"`
+		} `json:"run"`
+		Conclusion string `json:"conclusion"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output %q: %v", stdout, err)
+	}
+	if result.Run.BuildRunID != "run-1" || result.Run.CompletionStatus != "FAILED" {
+		t.Fatalf("unexpected run: %+v", result.Run)
+	}
+	if !strings.Contains(result.Conclusion, "actionable issues") {
+		t.Fatalf("unexpected conclusion %q", result.Conclusion)
+	}
+	for _, request := range []string{
+		"POST /v1/ciBuildRuns",
+		"GET /v1/ciBuildRuns/run-1",
+		"GET /v1/ciBuildRuns/run-1/actions",
+		"GET /v1/ciBuildActions/action-1/issues",
+		"GET /v1/ciBuildActions/action-1/artifacts",
+	} {
+		if requests[request] != 1 {
+			t.Fatalf("request count for %s = %d, want 1", request, requests[request])
+		}
+	}
+}
+
+func TestXcodeCloudRunWaitWithoutDoctorKeepsFailureExit(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.Method + " " + req.URL.Path {
+		case "POST /v1/ciBuildRuns":
+			body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"executionProgress":"PENDING"}}}`
+		case "GET /v1/ciBuildRuns/run-1":
+			body = `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"executionProgress":"COMPLETE","completionStatus":"FAILED"}}}`
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"xcode-cloud", "run",
+			"--workflow-id", "wf-1",
+			"--git-reference-id", "ref-1",
+			"--wait",
+			"--poll-interval", "1ms",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "completed with status: FAILED") {
+		t.Fatalf("run error = %v, want failed-run exit", runErr)
+	}
+	if !strings.Contains(stdout, `"completionStatus":"FAILED"`) {
+		t.Fatalf("legacy wait output changed: %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/xcode_cloud_run_doctor_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_run_doctor_test.go
@@ -10,6 +10,23 @@ import (
 	"testing"
 )
 
+func TestXcodeCloudRunDoctorFlagIsExperimental(t *testing.T) {
+	run := findSubcommand(RootCommand("1.2.3"), "xcode-cloud", "run")
+	if run == nil {
+		t.Fatal("expected xcode-cloud run command")
+	}
+	doctor := run.FlagSet.Lookup("doctor")
+	if doctor == nil {
+		t.Fatal("expected --doctor flag")
+	}
+	if !strings.HasPrefix(doctor.Usage, "[experimental]") {
+		t.Fatalf("--doctor usage = %q, want [experimental] prefix", doctor.Usage)
+	}
+	if !strings.Contains(run.LongHelp, "experimental --doctor flag") {
+		t.Fatalf("xcode-cloud run help does not characterize --doctor lifecycle: %q", run.LongHelp)
+	}
+}
+
 func TestXcodeCloudRunDoctorRequiresWait(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -84,6 +84,7 @@ func XcodeCloudRunCommand() *ffcli.Command {
 	sourceRunID := fs.String("source-run-id", "", "Source build run ID to rerun")
 	clean := fs.Bool("clean", false, "Request a clean build")
 	wait := fs.Bool("wait", false, "Wait for build to complete")
+	doctor := fs.Bool("doctor", false, "After waiting, diagnose the completed run and inspect failure logs")
 	pollInterval := fs.Duration("poll-interval", 10*time.Second, "Poll interval when waiting")
 	timeout := fs.Duration("timeout", 0, "Timeout for Xcode Cloud requests (0 = use ASC_TIMEOUT or 30m default)")
 	output := shared.BindOutputFlags(fs)
@@ -101,12 +102,17 @@ Standard mode:
 Rerun mode:
 - Use --source-run-id to rerun from an existing build run (without workflow/source selectors)
 
+Diagnostic mode:
+- Add --wait --doctor to return the combined doctor report after completion
+- A failed build is report data in diagnostic mode and does not make the command exit non-zero
+
 Examples:
   asc xcode-cloud run --app "123456789" --workflow "CI" --branch "main"
   asc xcode-cloud run --workflow-id "WORKFLOW_ID" --git-reference-id "REF_ID"
   asc xcode-cloud run --workflow-id "WORKFLOW_ID" --pull-request-id "PR_ID"
   asc xcode-cloud run --source-run-id "BUILD_RUN_ID" --clean
   asc xcode-cloud run --app "123456789" --workflow "Deploy" --branch "release/1.0" --wait
+  asc xcode-cloud run --app "123456789" --workflow "Deploy" --branch "main" --wait --doctor
   asc xcode-cloud run --app "123456789" --workflow "CI" --branch "main" --wait --poll-interval 30s --timeout 1h`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -150,6 +156,9 @@ Examples:
 			}
 			if *wait && *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")
+			}
+			if *doctor && !*wait {
+				return shared.UsageError("--doctor requires --wait")
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
@@ -309,6 +318,16 @@ Examples:
 
 			if !*wait {
 				return shared.PrintOutput(result, *output.Output, *output.Pretty)
+			}
+			if *doctor {
+				doctorResult, err := diagnoseXcodeCloudRun(requestCtx, client, resp.Data.ID, xcodeCloudDoctorOptions{
+					Wait:         true,
+					PollInterval: *pollInterval,
+				})
+				if err != nil {
+					return fmt.Errorf("xcode-cloud run: diagnose build: %w", err)
+				}
+				return printXcodeCloudDoctorResult(doctorResult, *output.Output, *output.Pretty)
 			}
 
 			// Wait for completion

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -84,7 +84,7 @@ func XcodeCloudRunCommand() *ffcli.Command {
 	sourceRunID := fs.String("source-run-id", "", "Source build run ID to rerun")
 	clean := fs.Bool("clean", false, "Request a clean build")
 	wait := fs.Bool("wait", false, "Wait for build to complete")
-	doctor := fs.Bool("doctor", false, "After waiting, diagnose the completed run and inspect failure logs")
+	doctor := fs.Bool("doctor", false, "[experimental] After waiting, diagnose the completed run and inspect failure logs")
 	pollInterval := fs.Duration("poll-interval", 10*time.Second, "Poll interval when waiting")
 	timeout := fs.Duration("timeout", 0, "Timeout for Xcode Cloud requests (0 = use ASC_TIMEOUT or 30m default)")
 	output := shared.BindOutputFlags(fs)
@@ -103,7 +103,7 @@ Rerun mode:
 - Use --source-run-id to rerun from an existing build run (without workflow/source selectors)
 
 Diagnostic mode:
-- Add --wait --doctor to return the combined doctor report after completion
+- Add --wait and the experimental --doctor flag to return the combined doctor report after completion
 - A failed build is report data in diagnostic mode and does not make the command exit non-zero
 
 Examples:

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -160,6 +160,9 @@ Examples:
 			if *doctor && !*wait {
 				return shared.UsageError("--doctor requires --wait")
 			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return err
+			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if hasWorkflowName && !hasSourceRunID && resolvedAppID == "" {

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_command_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_command_test.go
@@ -36,6 +36,7 @@ func TestXcodeCloudRunValidatesOutputBeforeTriggerSideEffects(t *testing.T) {
 	t.Setenv("ASC_KEY_ID", "")
 	t.Setenv("ASC_ISSUER_ID", "")
 	t.Setenv("ASC_PRIVATE_KEY", "")
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 
 	command := XcodeCloudRunCommand()
 	command.FlagSet.SetOutput(io.Discard)

--- a/internal/cli/xcodecloud/xcode_cloud_doctor_command_test.go
+++ b/internal/cli/xcodecloud/xcode_cloud_doctor_command_test.go
@@ -30,3 +30,26 @@ func TestXcodeCloudDoctorValidatesOutputBeforeSaveSideEffects(t *testing.T) {
 		t.Fatalf("save directory stat error = %v, want no filesystem side effect", statErr)
 	}
 }
+
+func TestXcodeCloudRunValidatesOutputBeforeTriggerSideEffects(t *testing.T) {
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_KEY_ID", "")
+	t.Setenv("ASC_ISSUER_ID", "")
+	t.Setenv("ASC_PRIVATE_KEY", "")
+
+	command := XcodeCloudRunCommand()
+	command.FlagSet.SetOutput(io.Discard)
+	if err := command.Parse([]string{
+		"--workflow-id", "workflow-1",
+		"--git-reference-id", "reference-1",
+		"--output", "table",
+		"--pretty",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	err := command.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--pretty") {
+		t.Fatalf("run error = %v, want invalid output combination before authentication or trigger", err)
+	}
+}


### PR DESCRIPTION
## What changed

Adds the optional shorthand:

```sh
asc xcode-cloud run ... --wait --doctor
```

After triggering the workflow, the command waits for completion and returns the same report as `xcode-cloud doctor`, including failed-action log inspection. `--doctor` requires `--wait`.

Without `--doctor`, the existing `run --wait` JSON and failure exit behavior remain unchanged. In doctor mode, a failed build is report data and exits zero when diagnosis succeeds.

Invalid output combinations are rejected before authentication or build-trigger side effects.

## Tests

- Covered flag validation and the full trigger, wait, failure, and doctor-report path
- Added a characterization test for the existing `run --wait` failed-run exit
- Verified output validation happens before authentication or triggering a run
- Verified built-binary help plus exit code 2 for invalid flag combinations
- Ran formatting, command/docs checks, lint, and the complete test suite with `ASC_BYPASS_KEYCHAIN=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental `--doctor` option to `xcode-cloud run`.
  * Diagnostic mode waits for completion and displays a combined diagnostic report.
  * Failed builds continue to return a non-zero exit status.
  * Added validation requiring `--wait` when using `--doctor`.

* **Bug Fixes**
  * Improved validation for incompatible output formatting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->