### PR TITLE
apps wall: add Sunrise Sunset Time SolarWatch

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1586,6 +1586,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6d/87/66/6d87668f-1acf-38dc-9242-4e571ea81a0e/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Sunrise Sunset Time SolarWatch",
+    "link": "https://apps.apple.com/us/app/sunrise-sunset-time-solarwatch/id1191365122?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/07/93/2e/07932e05-1ccc-04ea-7dc9-65ed5dffcf1c/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Super Shot: EXIF Photo Frame",
     "link": "https://apps.apple.com/us/app/super-shot-exif-photo-frame/id6760384143?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/49/01/f9/4901f9f9-8d90-7283-bbec-6e506aec4391/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Sunrise Sunset Time SolarWatch` to the Wall of Apps

## Entry

- App ID: 1191365122
- App: Sunrise Sunset Time SolarWatch
- Link: https://apps.apple.com/us/app/sunrise-sunset-time-solarwatch/id1191365122?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Sunrise Sunset Time SolarWatch app to the app catalog.
  * Included its App Store listing and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->