### PR TITLE
apps wall: add Elite Soccer Tactic Board

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -424,6 +424,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/23/60/71/236071d7-7827-efd9-4c8f-03db0cee6aa9/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Elite Soccer Tactic Board",
+    "link": "https://apps.apple.com/us/app/elite-soccer-tactic-board/id6476522645?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/22/e0/85/22e085b9-1969-da7c-4d35-3bfe75009463/SoccerIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Embers to Dyson",
     "link": "https://apps.apple.com/us/app/embers-to-dyson/id6756216261?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/5c/b3/ab/5cb3ab34-60e5-81f8-c555-518185d61f87/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Elite Soccer Tactic Board` to the Wall of Apps

## Entry

- App ID: 6476522645
- App: Elite Soccer Tactic Board
- Link: https://apps.apple.com/us/app/elite-soccer-tactic-board/id6476522645?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Elite Soccer Tactic Board app to the app showcase, including its App Store link and icon.
  * Added the Sunrise Sunset Time SolarWatch app to the app showcase, including its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->