### PR TITLE
apps wall: add DuoCam Multicam Video Camera

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -409,6 +409,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/c3/12/31/c31231ef-8a43-d6dd-84e2-23728b669d59/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "DuoCam Multicam Video Camera",
+    "link": "https://apps.apple.com/us/app/duocam-multicam-video-camera/id1482277903?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f5/49/21/f5492122-83dc-594c-82ae-3010784cb984/AppIcon-0-0-1x_U007ephone-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Echo Sleep: AI Sleep Sounds",
     "link": "https://apps.apple.com/us/app/echo-sleep-ai-sleep-sounds/id6746497347?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/98/d0/fe/98d0feb7-d137-eb25-a475-9c06caf643ed/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `DuoCam Multicam Video Camera` to the Wall of Apps

## Entry

- App ID: 1482277903
- App: DuoCam Multicam Video Camera
- Link: https://apps.apple.com/us/app/duocam-multicam-video-camera/id1482277903?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DuoCam Multicam Video Camera to the app catalog, including its App Store link and icon.
  * Added Elite Soccer Tactic Board to the app catalog, including its App Store link and icon.
  * Added Sunrise Sunset Time SolarWatch to the app catalog, including its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->