### PR TITLE
fix(analytics): warn when report output is truncated

### DIFF
--- a/internal/asc/analytics_output.go
+++ b/internal/asc/analytics_output.go
@@ -59,6 +59,16 @@ type AnalyticsReportGetResult struct {
 	Links     Links                      `json:"links"`
 }
 
+// GetLinks returns pagination links for shared truncation warnings.
+func (r *AnalyticsReportGetResult) GetLinks() *Links {
+	return &r.Links
+}
+
+// GetData returns report data for shared pagination helpers.
+func (r *AnalyticsReportGetResult) GetData() any {
+	return r.Data
+}
+
 // AnalyticsReportGetReport represents an analytics report with instances.
 type AnalyticsReportGetReport struct {
 	ID          string                       `json:"id"`

--- a/internal/cli/cmdtest/analytics_request_timeouts_test.go
+++ b/internal/cli/cmdtest/analytics_request_timeouts_test.go
@@ -105,6 +105,50 @@ func TestAnalyticsViewRefreshesTimeoutForEachRequest(t *testing.T) {
 	assertAnalyticsDeadlinesRefresh(t, deadlines)
 }
 
+func TestAnalyticsViewWarnsWhenReportsHaveAnotherPage(t *testing.T) {
+	setupAnalyticsTimeoutTest(t)
+
+	const reportsNextURL = "https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/" + analyticsViewRequestID + "/reports?cursor=reports-next"
+	requestCount := 0
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			assertAnalyticsTimeoutRequest(t, req, "/v1/analyticsReportRequests/"+analyticsViewRequestID+"/reports", "limit=200")
+			return analyticsViewJSONResponse(`{
+				"data":[{"type":"analyticsReports","id":"report-1","attributes":{"name":"App Sessions"}}],
+				"links":{"next":"` + reportsNextURL + `"}
+			}`), nil
+		case 2:
+			assertAnalyticsTimeoutRequest(t, req, "/v1/analyticsReports/report-1/instances", "limit=200")
+			return analyticsViewJSONResponse(`{"data":[],"links":{}}`), nil
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+	setAnalyticsTimeoutTestClient(t, transport)
+
+	stdout, stderr, runErr := runCommand(t, []string{
+		"analytics", "view",
+		"--request-id", analyticsViewRequestID,
+		"--output", "json",
+	})
+	if runErr != nil {
+		t.Fatalf("run error: %v", runErr)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+	if !strings.Contains(stdout, `"id":"report-1"`) || !strings.Contains(stdout, `"next":"`+reportsNextURL+`"`) {
+		t.Fatalf("analytics view output lost the first page response: %s", stdout)
+	}
+	wantWarning := "Warning: showing 1 results; more pages exist (use --paginate or --next where supported)\n"
+	if stderr != wantWarning {
+		t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
+	}
+}
+
 func TestAnalyticsDownloadRefreshesTimeoutThroughBodyTransfer(t *testing.T) {
 	setupAnalyticsTimeoutTest(t)
 


### PR DESCRIPTION
## Summary

Make the computed `AnalyticsReportGetResult` implement the repository's existing paginated-response contract.

When `asc analytics view` returns a first page whose `links.next` is non-empty, shared output now emits the standard stderr warning:

```text
Warning: showing 1 results; more pages exist (use --paginate or --next where supported)
```

## Why

The shared truncation warning added for collection reads only runs for values implementing `asc.PaginatedResponse`. `analytics view` preserves `data` and `links` in its computed result, but the result did not expose `GetLinks`/`GetData`, so agents could parse `.data` and unknowingly operate on a partial first page.

This is especially risky because `analytics view` fetches instances for every report in the returned page; the output looks complete even when another reports page exists.

## Compatibility

- JSON output is unchanged.
- Table and Markdown data are unchanged.
- Requests, flags, exit codes, and pagination behavior are unchanged.
- The only user-visible change is a stderr diagnostic when `links.next` proves the rendered result is truncated.
- Fully paginated output remains quiet because aggregation clears `links.next`.

## Tests

- RED/GREEN command test with one report, a non-empty reports `links.next`, and complete instance retrieval.
- Asserts the first-page JSON content and next URL are preserved.
- Asserts the exact standard truncation warning.
- Existing paginated `analytics view` timeout test remains quiet.
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics views now clearly warn when additional report pages are available but pagination has not been enabled.
  * The initial page of analytics results remains available while notifying users that more data exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->