### PR TITLE
fix(metadata): keep required-input errors concise

### DIFF
--- a/cmd/metadata_usage_diagnostics_test.go
+++ b/cmd/metadata_usage_diagnostics_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+)
+
+type metadataUsageRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn metadataUsageRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestRunMetadataRequiredInputsAreConciseAndStructured(t *testing.T) {
+	resetReportFlags(t)
+	for _, key := range []string{
+		"ASC_APP_ID", "ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH",
+		"ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_B64", "ASC_KEY_TYPE", "ASC_STRICT_AUTH",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = metadataUsageRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("metadata required-input validation unexpectedly reached the network: " + req.URL.String())
+	})
+
+	tests := []struct {
+		name          string
+		args          []string
+		wantError     string
+		wantParameter string
+	}{
+		{
+			name:          "pull missing app",
+			args:          []string{"metadata", "pull", "--version", "1.2.3", "--dir", "./metadata"},
+			wantError:     "--app is required (or set ASC_APP_ID)",
+			wantParameter: "--app",
+		},
+		{
+			name:          "pull missing version",
+			args:          []string{"metadata", "pull", "--app", "app-1", "--dir", "./metadata"},
+			wantError:     "--version is required",
+			wantParameter: "--version",
+		},
+		{
+			name:          "pull missing dir",
+			args:          []string{"metadata", "pull", "--app", "app-1", "--version", "1.2.3"},
+			wantError:     "--dir is required",
+			wantParameter: "--dir",
+		},
+		{
+			name:          "push missing app",
+			args:          []string{"metadata", "push", "--version", "1.2.3", "--dir", "./metadata"},
+			wantError:     "--app is required (or set ASC_APP_ID)",
+			wantParameter: "--app",
+		},
+		{
+			name:          "push missing version",
+			args:          []string{"metadata", "push", "--app", "app-1", "--dir", "./metadata"},
+			wantError:     "--version is required",
+			wantParameter: "--version",
+		},
+		{
+			name:          "push missing dir",
+			args:          []string{"metadata", "push", "--app", "app-1", "--version", "1.2.3"},
+			wantError:     "--dir is required",
+			wantParameter: "--dir",
+		},
+		{
+			name:          "plan missing app",
+			args:          []string{"metadata", "plan", "--version", "1.2.3", "--dir", "./metadata"},
+			wantError:     "--app is required (or set ASC_APP_ID)",
+			wantParameter: "--app",
+		},
+		{
+			name:          "plan missing version",
+			args:          []string{"metadata", "plan", "--app", "app-1", "--dir", "./metadata"},
+			wantError:     "--version is required",
+			wantParameter: "--version",
+		},
+		{
+			name:          "plan missing dir",
+			args:          []string{"metadata", "plan", "--app", "app-1", "--version", "1.2.3"},
+			wantError:     "--dir is required",
+			wantParameter: "--dir",
+		},
+		{
+			name:          "apply missing app",
+			args:          []string{"metadata", "apply", "--version", "1.2.3", "--dir", "./metadata"},
+			wantError:     "--app is required (or set ASC_APP_ID)",
+			wantParameter: "--app",
+		},
+		{
+			name:          "apply missing version",
+			args:          []string{"metadata", "apply", "--app", "app-1", "--dir", "./metadata"},
+			wantError:     "--version is required",
+			wantParameter: "--version",
+		},
+		{
+			name:          "apply missing dir",
+			args:          []string{"metadata", "apply", "--app", "app-1", "--version", "1.2.3"},
+			wantError:     "--dir is required",
+			wantParameter: "--dir",
+		},
+		{
+			name:          "validate missing dir",
+			args:          []string{"metadata", "validate"},
+			wantError:     "--dir is required",
+			wantParameter: "--dir",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalEmitTelemetry := emitTelemetry
+			t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+			var gotExitCode int
+			var gotContext telemetry.EventContext
+			emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+				gotExitCode = exitCode
+				gotContext = eventContext
+			}
+
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "1.2.3"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if want := "Error: " + test.wantError + "\n"; stderr != want {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
+			}
+			if strings.Contains(stderr, "DESCRIPTION") || strings.Contains(stderr, "USAGE") || strings.Contains(stderr, "FLAGS") {
+				t.Fatalf("required-input failure dumped command help: %q", stderr)
+			}
+			if gotExitCode != ExitUsage ||
+				gotContext.ErrorKind != telemetry.ErrorKindMissingRequired ||
+				gotContext.FailureStage != telemetry.FailureStageValidation ||
+				gotContext.OutcomeKind != telemetry.OutcomeUsageError ||
+				gotContext.FailureParameter != test.wantParameter ||
+				gotContext.DiagnosticCode != string(shared.DiagnosticRequiredInputMissing) {
+				t.Fatalf("unexpected telemetry: exit=%d context=%+v", gotExitCode, gotContext)
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/metadata_apply_test.go
+++ b/internal/cli/cmdtest/metadata_apply_test.go
@@ -17,18 +17,21 @@ import (
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	metadatacli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/metadata"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestMetadataApplyValidationErrors(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
+		name        string
+		args        []string
+		wantErr     string
+		wantConcise bool
 	}{
 		{
-			name:    "metadata apply missing dir",
-			args:    []string{"metadata", "apply", "--app", "123456789", "--version", "1.2.3"},
-			wantErr: "--dir is required",
+			name:        "metadata apply missing dir",
+			args:        []string{"metadata", "apply", "--app", "123456789", "--version", "1.2.3"},
+			wantErr:     "--dir is required",
+			wantConcise: true,
 		},
 		{
 			name:    "metadata apply positional args rejected",
@@ -47,7 +50,15 @@ func TestMetadataApplyValidationErrors(t *testing.T) {
 					t.Fatalf("parse error: %v", err)
 				}
 				err := root.Run(context.Background())
-				if !errors.Is(err, flag.ErrHelp) {
+				if test.wantConcise {
+					if errors.Is(err, flag.ErrHelp) || !shared.IsReportedUsageError(err) {
+						t.Fatalf("expected reported usage error without ErrHelp, got %v", err)
+					}
+					diagnostic, ok := shared.DiagnosticFromError(err)
+					if !ok || diagnostic.Code != shared.DiagnosticRequiredInputMissing || diagnostic.Parameter != "--dir" {
+						t.Fatalf("diagnostic = %+v, found=%t", diagnostic, ok)
+					}
+				} else if !errors.Is(err, flag.ErrHelp) {
 					t.Fatalf("expected ErrHelp, got %v", err)
 				}
 			})
@@ -57,6 +68,9 @@ func TestMetadataApplyValidationErrors(t *testing.T) {
 			}
 			if !strings.Contains(stderr, test.wantErr) {
 				t.Fatalf("expected error %q, got %q", test.wantErr, stderr)
+			}
+			if test.wantConcise && stderr != "Error: "+test.wantErr+"\n" {
+				t.Fatalf("stderr = %q, want %q", stderr, "Error: "+test.wantErr+"\n")
 			}
 		})
 	}

--- a/internal/cli/cmdtest/metadata_pull_test.go
+++ b/internal/cli/cmdtest/metadata_pull_test.go
@@ -12,30 +12,40 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestMetadataPullValidationErrors(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
+		name          string
+		args          []string
+		wantErr       string
+		wantParameter string
+		wantConcise   bool
 	}{
 		{
-			name:    "missing app",
-			args:    []string{"metadata", "pull", "--version", "1.2.3", "--dir", "./metadata"},
-			wantErr: "Error: --app is required (or set ASC_APP_ID)",
+			name:          "missing app",
+			args:          []string{"metadata", "pull", "--version", "1.2.3", "--dir", "./metadata"},
+			wantErr:       "Error: --app is required (or set ASC_APP_ID)",
+			wantParameter: "--app",
+			wantConcise:   true,
 		},
 		{
-			name:    "missing version",
-			args:    []string{"metadata", "pull", "--app", "app-1", "--dir", "./metadata"},
-			wantErr: "Error: --version is required",
+			name:          "missing version",
+			args:          []string{"metadata", "pull", "--app", "app-1", "--dir", "./metadata"},
+			wantErr:       "Error: --version is required",
+			wantParameter: "--version",
+			wantConcise:   true,
 		},
 		{
-			name:    "missing dir",
-			args:    []string{"metadata", "pull", "--app", "app-1", "--version", "1.2.3"},
-			wantErr: "Error: --dir is required",
+			name:          "missing dir",
+			args:          []string{"metadata", "pull", "--app", "app-1", "--version", "1.2.3"},
+			wantErr:       "Error: --dir is required",
+			wantParameter: "--dir",
+			wantConcise:   true,
 		},
 		{
 			name:    "invalid include",
@@ -57,13 +67,24 @@ func TestMetadataPullValidationErrors(t *testing.T) {
 				runErr = root.Run(context.Background())
 			})
 
-			if !errors.Is(runErr, flag.ErrHelp) {
+			if test.wantConcise {
+				if errors.Is(runErr, flag.ErrHelp) || !shared.IsReportedUsageError(runErr) {
+					t.Fatalf("expected reported usage error without ErrHelp, got %v", runErr)
+				}
+				diagnostic, ok := shared.DiagnosticFromError(runErr)
+				if !ok || diagnostic.Code != shared.DiagnosticRequiredInputMissing || diagnostic.Parameter != test.wantParameter {
+					t.Fatalf("diagnostic = %+v, found=%t", diagnostic, ok)
+				}
+			} else if !errors.Is(runErr, flag.ErrHelp) {
 				t.Fatalf("expected ErrHelp, got %v", runErr)
 			}
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if !strings.Contains(stderr, test.wantErr) {
+			if test.wantConcise && stderr != test.wantErr+"\n" {
+				t.Fatalf("stderr = %q, want %q", stderr, test.wantErr+"\n")
+			}
+			if !test.wantConcise && !strings.Contains(stderr, test.wantErr) {
 				t.Fatalf("expected %q in stderr, got %q", test.wantErr, stderr)
 			}
 		})

--- a/internal/cli/cmdtest/metadata_validate_test.go
+++ b/internal/cli/cmdtest/metadata_validate_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestMetadataValidateRequiresDir(t *testing.T) {
@@ -24,14 +26,18 @@ func TestMetadataValidateRequiresDir(t *testing.T) {
 		runErr = root.Run(context.Background())
 	})
 
-	if !errors.Is(runErr, flag.ErrHelp) {
-		t.Fatalf("expected ErrHelp, got %v", runErr)
+	if errors.Is(runErr, flag.ErrHelp) || !shared.IsReportedUsageError(runErr) {
+		t.Fatalf("expected reported usage error without ErrHelp, got %v", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --dir is required") {
-		t.Fatalf("expected missing dir error, got %q", stderr)
+	if stderr != "Error: --dir is required\n" {
+		t.Fatalf("stderr = %q, want concise missing-dir error", stderr)
+	}
+	diagnostic, ok := shared.DiagnosticFromError(runErr)
+	if !ok || diagnostic.Code != shared.DiagnosticRequiredInputMissing || diagnostic.Parameter != "--dir" {
+		t.Fatalf("diagnostic = %+v, found=%t", diagnostic, ok)
 	}
 }
 

--- a/internal/cli/cmdtest/migrate_metadata_alias_test.go
+++ b/internal/cli/cmdtest/migrate_metadata_alias_test.go
@@ -2,11 +2,10 @@ package cmdtest
 
 import (
 	"context"
-	"errors"
-	"flag"
 	"io"
-	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestMigrateMetadataPullAliasDelegatesToMetadataCommand(t *testing.T) {
@@ -23,14 +22,14 @@ func TestMigrateMetadataPullAliasDelegatesToMetadataCommand(t *testing.T) {
 		runErr = root.Run(context.Background())
 	})
 
-	if !errors.Is(runErr, flag.ErrHelp) {
-		t.Fatalf("expected ErrHelp, got %v", runErr)
+	if !shared.IsReportedUsageError(runErr) {
+		t.Fatalf("expected reported usage error, got %v", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --app is required (or set ASC_APP_ID)") {
-		t.Fatalf("expected metadata pull validation error, got %q", stderr)
+	if stderr != "Error: --app is required (or set ASC_APP_ID)\n" {
+		t.Fatalf("expected concise metadata pull validation error, got %q", stderr)
 	}
 }
 
@@ -48,14 +47,14 @@ func TestMigrateMetadataPushAliasDelegatesToMetadataCommand(t *testing.T) {
 		runErr = root.Run(context.Background())
 	})
 
-	if !errors.Is(runErr, flag.ErrHelp) {
-		t.Fatalf("expected ErrHelp, got %v", runErr)
+	if !shared.IsReportedUsageError(runErr) {
+		t.Fatalf("expected reported usage error, got %v", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --app is required (or set ASC_APP_ID)") {
-		t.Fatalf("expected metadata push validation error, got %q", stderr)
+	if stderr != "Error: --app is required (or set ASC_APP_ID)\n" {
+		t.Fatalf("expected concise metadata push validation error, got %q", stderr)
 	}
 }
 
@@ -71,13 +70,13 @@ func TestMigrateMetadataValidateAliasDelegatesToMetadataCommand(t *testing.T) {
 		runErr = root.Run(context.Background())
 	})
 
-	if !errors.Is(runErr, flag.ErrHelp) {
-		t.Fatalf("expected ErrHelp, got %v", runErr)
+	if !shared.IsReportedUsageError(runErr) {
+		t.Fatalf("expected reported usage error, got %v", runErr)
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --dir is required") {
-		t.Fatalf("expected metadata validate validation error, got %q", stderr)
+	if stderr != "Error: --dir is required\n" {
+		t.Fatalf("expected concise metadata validate validation error, got %q", stderr)
 	}
 }

--- a/internal/cli/metadata/diagnostics.go
+++ b/internal/cli/metadata/diagnostics.go
@@ -1,0 +1,19 @@
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func metadataRequiredInputError(parameter, message string) error {
+	trimmed := strings.TrimSpace(message)
+	fmt.Fprintf(os.Stderr, "Error: %s\n", trimmed)
+	return shared.WithDiagnostic(
+		shared.NewReportedUsageError(shared.UsageErrorMissingRequired, trimmed),
+		shared.DiagnosticRequiredInputMissing,
+		parameter,
+	)
+}

--- a/internal/cli/metadata/execute_push.go
+++ b/internal/cli/metadata/execute_push.go
@@ -40,17 +40,17 @@ func ExecutePushWithWarnings(ctx context.Context, opts PushExecutionOptions) (Pu
 	errorPrefix := metadataMutationErrorPrefix(opts.CommandName)
 	resolvedAppID := shared.ResolveAppID(opts.AppID)
 	if resolvedAppID == "" {
-		return PushPlanResult{}, nil, shared.UsageError("--app is required (or set ASC_APP_ID)")
+		return PushPlanResult{}, nil, metadataRequiredInputError("--app", "--app is required (or set ASC_APP_ID)")
 	}
 
 	versionValue := strings.TrimSpace(opts.Version)
 	if versionValue == "" {
-		return PushPlanResult{}, nil, shared.UsageError("--version is required")
+		return PushPlanResult{}, nil, metadataRequiredInputError("--version", "--version is required")
 	}
 
 	dirValue := strings.TrimSpace(opts.Dir)
 	if dirValue == "" {
-		return PushPlanResult{}, nil, shared.UsageError("--dir is required")
+		return PushPlanResult{}, nil, metadataRequiredInputError("--dir", "--dir is required")
 	}
 	if strings.TrimSpace(opts.ReviewDir) != "" && !opts.DryRun && !opts.Confirm {
 		return PushPlanResult{}, nil, shared.UsageError("--confirm is required when applying an approved metadata plan")

--- a/internal/cli/metadata/pull.go
+++ b/internal/cli/metadata/pull.go
@@ -65,17 +65,17 @@ Examples:
 
 			resolvedAppID := shared.ResolveAppID(*appID)
 			if resolvedAppID == "" {
-				return shared.UsageError("--app is required (or set ASC_APP_ID)")
+				return metadataRequiredInputError("--app", "--app is required (or set ASC_APP_ID)")
 			}
 
 			versionValue := strings.TrimSpace(*version)
 			if versionValue == "" {
-				return shared.UsageError("--version is required")
+				return metadataRequiredInputError("--version", "--version is required")
 			}
 
 			dirValue := strings.TrimSpace(*dir)
 			if dirValue == "" {
-				return shared.UsageError("--dir is required")
+				return metadataRequiredInputError("--dir", "--dir is required")
 			}
 
 			platformValue := strings.TrimSpace(*platform)

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -79,7 +79,7 @@ Examples:
 
 			dirValue := strings.TrimSpace(*dir)
 			if dirValue == "" {
-				return shared.UsageError("--dir is required")
+				return metadataRequiredInputError("--dir", "--dir is required")
 			}
 
 			result, err := validateDir(dirValue, *subscriptionApp)

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -431,6 +431,7 @@ var knownFailureParameters = map[string]struct{}{
 	"devices-file":                      {},
 	"domain":                            {},
 	"domain-id":                         {},
+	"dir":                               {},
 	"dry-run":                           {},
 	"duration":                          {},
 	"end-date":                          {},

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -356,6 +356,63 @@ func TestBuildEventWithContextStripsKnownFailureParameterValue(t *testing.T) {
 	}
 }
 
+func TestBuildEventWithContextAllowsDirWithoutItsValue(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+
+	ev, ok := BuildEventWithContext(
+		"asc metadata validate",
+		"1.2.3",
+		0,
+		2,
+		EventContext{
+			InvocationShape:  InvocationShapeLeaf,
+			ErrorKind:        ErrorKindMissingRequired,
+			FailureStage:     FailureStageValidation,
+			FailureParameter: "--dir=/Users/example/private-metadata",
+		},
+	)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if ev.FailureParameter == nil || *ev.FailureParameter != "--dir" {
+		t.Fatalf("FailureParameter = %v, want --dir", ev.FailureParameter)
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	if strings.Contains(string(data), "private-metadata") {
+		t.Fatalf("payload leaked --dir value: %s", data)
+	}
+
+	for _, parameter := range []string{
+		"/Users/example/private-metadata",
+		"--dir /Users/example/private-metadata",
+	} {
+		t.Run(parameter, func(t *testing.T) {
+			pathEvent, pathOK := BuildEventWithContext(
+				"asc metadata validate",
+				"1.2.3",
+				0,
+				2,
+				EventContext{
+					InvocationShape:  InvocationShapeLeaf,
+					ErrorKind:        ErrorKindMissingRequired,
+					FailureStage:     FailureStageValidation,
+					FailureParameter: parameter,
+				},
+			)
+			if !pathOK {
+				t.Fatal("expected event")
+			}
+			if pathEvent.FailureParameter != nil {
+				t.Fatalf("FailureParameter = %q, want nil", *pathEvent.FailureParameter)
+			}
+		})
+	}
+}
+
 func TestBuildEventWithContextCanonicalizesFailureStage(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)

--- a/internal/telemetry/required_parameters_contract_test.go
+++ b/internal/telemetry/required_parameters_contract_test.go
@@ -38,10 +38,14 @@ func TestRequiredUsageLiteralParametersAreAllowlisted(t *testing.T) {
 		}
 		ast.Inspect(file, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)
-			if !ok || len(call.Args) != 1 || !isRequiredUsageCall(call.Fun) {
+			if !ok {
 				return true
 			}
-			literal, ok := call.Args[0].(*ast.BasicLit)
+			parameterArgument, ok := requiredUsageParameterArgument(call)
+			if !ok {
+				return true
+			}
+			literal, ok := parameterArgument.(*ast.BasicLit)
 			if !ok || literal.Kind != token.STRING {
 				return true
 			}
@@ -70,13 +74,26 @@ func TestRequiredUsageLiteralParametersAreAllowlisted(t *testing.T) {
 	}
 }
 
-func isRequiredUsageCall(function ast.Expr) bool {
-	switch expression := function.(type) {
+func requiredUsageParameterArgument(call *ast.CallExpr) (ast.Expr, bool) {
+	var name string
+	switch expression := call.Fun.(type) {
 	case *ast.Ident:
-		return expression.Name == "MissingRequiredUsageError"
+		name = expression.Name
 	case *ast.SelectorExpr:
-		return expression.Sel.Name == "MissingRequiredUsageError"
-	default:
-		return false
+		name = expression.Sel.Name
 	}
+
+	switch name {
+	case "MissingRequiredUsageError":
+		if len(call.Args) == 1 {
+			return call.Args[0], true
+		}
+	case "metadataRequiredInputError":
+		if len(call.Args) == 2 {
+			return call.Args[0], true
+		}
+	default:
+		return nil, false
+	}
+	return nil, false
 }


### PR DESCRIPTION
## What changed

Missing `--app`, `--version`, and `--dir` inputs now produce one concise error for the core metadata workflows: `pull`, `push`, `plan`, `apply`, and `validate`.

The commands keep the existing exit code 2 and first-line error text, leave stdout empty, and do not reach auth or the network. They no longer append the full command help page. The errors also carry `required_input_missing` diagnostics and a public flag name.

This also adds `dir` to the CLI telemetry allowlist. Values are stripped before serialization, and the contract test now checks this metadata-specific helper. The Rork collector has its own allowlist and must add `--dir` before that parameter becomes visible downstream; until then it is safely discarded.

## Why

The rolling seven-day slice contained roughly 13,000 metadata commands and 1,100 usage errors. A current 4.7.0 slice still showed usage errors on `pull`, `push`, `apply`, and `validate`, although raw stderr is intentionally not collected and unattributed events cannot be assumed to be missing `--dir`.

One agent chat supplied the missing behavioral evidence: after a successful pull, the agent made three zero-duration malformed push attempts, misread the help dump, and guessed at unsupported fixes. The current CLI reproduced the amplifier: a missing required input emitted about 1.7 KB of help after the useful line. This branch emits only the corrective line (29 bytes for the tested missing-version case).

The newest 4.7.1 slice is still small and did not show a missing-required `metadata push` event, so this is deliberately a narrow fix rather than a global usage-rendering change.

## Compatibility and scope

- Existing valid metadata behavior, JSON output, explicit `--help`, and network requests are unchanged.
- Invalid values, schema findings, keyword workflows, `metadata init`, and conditional `--confirm` failures retain their current behavior.
- Missing required inputs intentionally stop unwrapping as `flag.ErrHelp`; they remain usage errors with exit code 2.
- `--dir` values and paths are never included in telemetry.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- `ASC_BYPASS_KEYCHAIN=1 go test ./cmd ./internal/cli/cmdtest ./internal/cli/metadata ./internal/telemetry -count=1`
- Manual missing-input and explicit-help checks with `ASC_BYPASS_KEYCHAIN=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata commands now provide concise, structured validation errors when required inputs such as application, version, or directory are missing.
  * Validation failures consistently report the relevant parameter and avoid displaying unnecessary command help.
  * Missing metadata versions now include guidance for discovering the correct version.
  * Directory values are safely sanitized in failure telemetry while preserving the parameter name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->