### PR TITLE
fix(xcode-cloud): accept deprecated --id on status

### DIFF
--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1479,6 +1479,46 @@ func TestRun_UnknownFlagReturnsConciseRecovery(t *testing.T) {
 	}
 }
 
+func TestRun_XcodeCloudStatusIDAliasHelpAndConflictTelemetry(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"xcode-cloud", "status", "--help"}, "1.0.0"); code != ExitSuccess {
+			t.Fatalf("help exit code = %d, want %d", code, ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("help stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, "--id") || !strings.Contains(stdout, "DEPRECATED: use --run-id") {
+		t.Fatalf("help does not mark --id deprecated: %q", stdout)
+	}
+
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		gotContext = eventContext
+	}
+	stdout, stderr = captureCommandOutput(t, func() {
+		if code := Run([]string{"xcode-cloud", "status", "--run-id", "run-1", "--id", "run-1"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("conflict exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("conflict stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "--id conflicts with --run-id; use only --run-id") {
+		t.Fatalf("conflict stderr = %q", stderr)
+	}
+	if gotContext.FailureParameter != "--run-id" ||
+		gotContext.DiagnosticCode != string(shared.DiagnosticConflictingInput) ||
+		gotContext.FailureStage != telemetry.FailureStageValidation ||
+		gotContext.OutcomeKind != telemetry.OutcomeUsageError {
+		t.Fatalf("telemetry context = %+v, want canonical --run-id conflict", gotContext)
+	}
+}
+
 func TestRun_CommonWrongCommandPathsRecoverInOneStep(t *testing.T) {
 	resetReportFlags(t)
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")

--- a/docs/design/xcode-cloud-status-id-alias.md
+++ b/docs/design/xcode-cloud-status-id-alias.md
@@ -1,0 +1,31 @@
+# Xcode Cloud status ID alias
+
+## Decision
+
+`asc xcode-cloud status` keeps `--run-id` as its canonical build-run selector
+and accepts `--id` as a deprecated compatibility alias. The alias is visible in
+command help during the migration window because repeated agent invocations show
+that callers infer it from nearby Xcode Cloud commands.
+
+The alias is normalized before required-input checks, authentication, or HTTP.
+Supplying both spellings is a usage error even when the values match. Conflict
+diagnostics and telemetry name only the canonical `--run-id` parameter.
+
+## Compatibility and migration
+
+Existing `--run-id` invocations and JSON output are unchanged. An invocation
+that uses only `--id` performs the same request and emits one warning on stderr:
+
+```text
+Warning: `--id` is deprecated. Use `--run-id`.
+```
+
+New scripts should use `--run-id`. The alias may be removed in the next major
+release after the standard deprecation window. Release notes are generated from
+the pull request, whose title and body identify the alias and replacement.
+
+## Verification
+
+Tests cover visible deprecated help, alias-only JSON output, the exact request
+path, dual-spelling rejection, exit code 2, canonical telemetry, and the
+no-request conflict path.

--- a/docs/design/xcode-cloud-status-id-alias.md
+++ b/docs/design/xcode-cloud-status-id-alias.md
@@ -21,8 +21,8 @@ Warning: `--id` is deprecated. Use `--run-id`.
 ```
 
 New scripts should use `--run-id`. The alias may be removed in the next major
-release after the standard deprecation window. Release notes are generated from
-the pull request, whose title and body identify the alias and replacement.
+release after the standard deprecation window. The migration is recorded in
+[`release-notes-xcode-cloud-status-id-alias.md`](../release-notes-xcode-cloud-status-id-alias.md).
 
 ## Verification
 

--- a/docs/release-notes-xcode-cloud-status-id-alias.md
+++ b/docs/release-notes-xcode-cloud-status-id-alias.md
@@ -1,0 +1,14 @@
+# Xcode Cloud status ID alias
+
+`asc xcode-cloud status` now accepts `--id` as a deprecated compatibility alias
+for `--run-id`. Existing alias calls continue after printing this warning to
+stderr:
+
+```text
+Warning: `--id` is deprecated. Use `--run-id`.
+```
+
+New scripts should use `asc xcode-cloud status --run-id "BUILD_RUN_ID"`.
+Supplying both `--id` and `--run-id` is a usage error, even when the values
+match. The alias may be removed in the next major release after the standard
+deprecation window.

--- a/internal/cli/cmdtest/xcode_cloud_status_id_alias_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_status_id_alias_test.go
@@ -1,0 +1,99 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestXcodeCloudStatusDeprecatedIDAliasReturnsJSON(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	requestCount := 0
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/ciBuildRuns/run-1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		body := `{"data":{"type":"ciBuildRuns","id":"run-1","attributes":{"number":42,"executionProgress":"COMPLETE","completionStatus":"SUCCEEDED"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "status", "--id", "run-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	var result struct {
+		BuildRunID string `json:"buildRunId"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output %q: %v", stdout, err)
+	}
+	if result.BuildRunID != "run-1" {
+		t.Fatalf("buildRunId = %q, want run-1", result.BuildRunID)
+	}
+	if stderr != "Warning: `--id` is deprecated. Use `--run-id`.\n" {
+		t.Fatalf("stderr = %q, want deprecation warning", stderr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+}
+
+func TestXcodeCloudStatusRejectsIDAndRunIDBeforeNetwork(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected network request: %s %s", req.Method, req.URL.String())
+		return nil, errors.New("unexpected network request")
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"xcode-cloud", "status", "--run-id", "run-1", "--id", "run-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !shared.IsReportedUsageError(runErr) {
+		t.Fatalf("run error = %v, want concise usage error", runErr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "--id conflicts with --run-id; use only --run-id") {
+		t.Fatalf("stderr = %q, want dual-use conflict", stderr)
+	}
+	if strings.Contains(stderr, "DESCRIPTION\n") || strings.Contains(stderr, "USAGE\n") {
+		t.Fatalf("stderr includes full help: %q", stderr)
+	}
+	diagnostic, ok := shared.DiagnosticFromError(runErr)
+	if !ok || diagnostic.Code != shared.DiagnosticConflictingInput || diagnostic.Parameter != "--run-id" {
+		t.Fatalf("diagnostic = %+v (ok=%t), want canonical --run-id conflict", diagnostic, ok)
+	}
+}

--- a/internal/cli/shared/flag_aliases.go
+++ b/internal/cli/shared/flag_aliases.go
@@ -36,13 +36,24 @@ func (f *DeprecatedStringFlagAlias) Set(value string) error {
 // BindDeprecatedStringFlagAlias accepts a compatibility spelling without
 // advertising it as part of the command's canonical interface.
 func BindDeprecatedStringFlagAlias(fs *flag.FlagSet, aliasName, canonicalName string) *DeprecatedStringFlagAlias {
+	alias := bindDeprecatedStringFlagAlias(fs, aliasName, canonicalName)
+	HideFlagFromHelp(fs.Lookup(alias.aliasName))
+	return alias
+}
+
+// BindVisibleDeprecatedStringFlagAlias accepts a compatibility spelling and
+// keeps its deprecation notice visible during the stable migration window.
+func BindVisibleDeprecatedStringFlagAlias(fs *flag.FlagSet, aliasName, canonicalName string) *DeprecatedStringFlagAlias {
+	return bindDeprecatedStringFlagAlias(fs, aliasName, canonicalName)
+}
+
+func bindDeprecatedStringFlagAlias(fs *flag.FlagSet, aliasName, canonicalName string) *DeprecatedStringFlagAlias {
 	alias := &DeprecatedStringFlagAlias{
 		flagSet:       fs,
 		aliasName:     strings.TrimSpace(aliasName),
 		canonicalName: strings.TrimSpace(canonicalName),
 	}
 	fs.Var(alias, alias.aliasName, fmt.Sprintf("DEPRECATED: use --%s", alias.canonicalName))
-	HideFlagFromHelp(fs.Lookup(alias.aliasName))
 	return alias
 }
 
@@ -67,6 +78,25 @@ func (f *DeprecatedStringFlagAlias) Apply(canonical *string) error {
 		*canonical = aliasValue
 	}
 
+	return nil
+}
+
+// ApplyExclusive copies a supplied alias into the canonical value and rejects
+// any invocation that explicitly supplies both spellings.
+func (f *DeprecatedStringFlagAlias) ApplyExclusive(canonical *string) error {
+	if f == nil || !f.set {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Warning: `--%s` is deprecated. Use `--%s`.\n", f.aliasName, f.canonicalName)
+	if f.canonicalWasSet() {
+		message := fmt.Sprintf("--%s conflicts with --%s; use only --%s", f.aliasName, f.canonicalName, f.canonicalName)
+		fmt.Fprintln(os.Stderr, "Error: "+message)
+		return NewReportedUsageError(UsageErrorInvalidValue, message)
+	}
+	if canonical != nil {
+		*canonical = strings.TrimSpace(f.value)
+	}
 	return nil
 }
 

--- a/internal/cli/shared/flag_aliases_test.go
+++ b/internal/cli/shared/flag_aliases_test.go
@@ -90,6 +90,40 @@ func TestBindDeprecatedStringFlagAliasHidesCompatibilityFlag(t *testing.T) {
 	}
 }
 
+func TestVisibleDeprecatedStringFlagAliasRejectsDualUse(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	canonical := fs.String("canonical", "", "Canonical value")
+	alias := BindVisibleDeprecatedStringFlagAlias(fs, "legacy", "canonical")
+	if err := fs.Parse([]string{"--canonical", "same", "--legacy", "same"}); err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	visible := false
+	for _, item := range VisibleHelpFlags(fs) {
+		if item.Name == "legacy" && item.Usage == "DEPRECATED: use --canonical" {
+			visible = true
+		}
+	}
+	if !visible {
+		t.Fatal("deprecated compatibility flag was not marked in help")
+	}
+
+	_, stderr := captureOutput(t, func() {
+		err := alias.ApplyExclusive(canonical)
+		if err == nil || !strings.Contains(err.Error(), "--legacy conflicts with --canonical") {
+			t.Fatalf("ApplyExclusive() error = %v, want dual-use conflict", err)
+		}
+		if !IsReportedUsageError(err) {
+			t.Fatalf("ApplyExclusive() error = %v, want concise usage error", err)
+		}
+	})
+	wantStderr := "Warning: `--legacy` is deprecated. Use `--canonical`.\n" +
+		"Error: --legacy conflicts with --canonical; use only --canonical\n"
+	if stderr != wantStderr {
+		t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
+	}
+}
+
 func TestDeprecatedIntFlagAliasApply(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/cli/xcodecloud/xcode_cloud.go
+++ b/internal/cli/xcodecloud/xcode_cloud.go
@@ -344,6 +344,7 @@ func XcodeCloudStatusCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
 
 	runID := fs.String("run-id", "", "Build run ID to check")
+	legacyRunID := shared.BindVisibleDeprecatedStringFlagAlias(fs, "id", "run-id")
 	wait := fs.Bool("wait", false, "Wait for build to complete")
 	pollInterval := fs.Duration("poll-interval", 10*time.Second, "Poll interval when waiting")
 	timeout := fs.Duration("timeout", 0, "Timeout for Xcode Cloud requests (0 = use ASC_TIMEOUT or 30m default)")
@@ -363,6 +364,9 @@ Examples:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := legacyRunID.ApplyExclusive(runID); err != nil {
+				return shared.WithDiagnostic(err, shared.DiagnosticConflictingInput, "--run-id")
+			}
 			if strings.TrimSpace(*runID) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --run-id is required")
 				return shared.MissingRequiredUsageError("--run-id")


### PR DESCRIPTION
## What changed

- Accept `--id` as a visible deprecated alias for `--run-id` on `asc xcode-cloud status`.
- Reject any invocation that supplies both spellings before authentication or HTTP.
- Record the canonical `--run-id` parameter for the conflict diagnostic and telemetry.
- Keep JSON output and the existing `--run-id` request path unchanged.

## Why

Rork telemetry recorded 222 current 4.6.1 failures from agents trying `asc xcode-cloud status --id`. The events are concentrated in one installation, but the guess follows the CLI surface: nearby Xcode Cloud commands use `--id`, while status uses `--run-id`. The existing unknown-flag suggestion did not stop the retry loop.

## Compatibility

`--run-id` remains canonical. Alias-only calls emit one warning on stderr and continue. Both spellings return exit 2 with concise guidance, even when their values match. New automation should use `--run-id`; the alias can be removed in the next major release after the deprecation window.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built-binary help shows the deprecated alias.
- Built-binary dual use returns exit 2 with empty stdout.
- Command tests cover alias JSON output, the exact GET path, conflict behavior, no HTTP on conflict, and canonical telemetry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deprecated `--id` alias support for the Xcode Cloud status command’s canonical `--run-id` option.
  - Help output displays the alias and deprecation notice.
  - Alias-only usage warns users while preserving existing output and request behavior.

- **Bug Fixes**
  - Supplying both options now returns a concise usage error and prevents a request from being sent.

- **Documentation**
  - Documented alias behavior, validation, diagnostics, telemetry, and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->