### PR TITLE
fix(metadata): add targeted flag recovery guidance

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -215,6 +215,12 @@ func isMetadataVersionValue(value string) bool {
 	if value == "" || strings.HasPrefix(value, "-") {
 		return false
 	}
+	// flag.ParseBool accepts 1 and 0, but both are also valid app-version
+	// components. Treat numeric spellings as metadata values and reserve the
+	// global-flag recovery for textual booleans.
+	if value == "1" || value == "0" {
+		return true
+	}
 	_, boolErr := strconv.ParseBool(value)
 	return boolErr != nil
 }

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -142,6 +142,9 @@ func printConciseUnknownCommand(analysis invocationAnalysis, commandName string)
 func printConciseUnknownFlag(root *ffcli.Command, analysis invocationAnalysis, commandName string) {
 	flagName := unknownFlagName(analysis)
 	fmt.Fprintf(os.Stderr, "Error: %s\n", unknownFlagError(analysis, commandName))
+	if printMetadataValidateFlagRecovery(flagName, commandName) {
+		return
+	}
 	if name, ok := flagLookupName(flagName); ok && root != nil && root.FlagSet != nil && root.FlagSet.Lookup(name) != nil {
 		fmt.Fprintf(
 			os.Stderr,
@@ -171,6 +174,20 @@ func printConciseUnknownFlag(root *ffcli.Command, analysis invocationAnalysis, c
 	}
 	fmt.Fprintln(os.Stderr, "For help:")
 	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
+}
+
+func printMetadataValidateFlagRecovery(flagName, commandName string) bool {
+	if commandName != "asc metadata validate" || (flagName != "--app" && flagName != "--version") {
+		return false
+	}
+
+	fmt.Fprintln(os.Stderr, "`asc metadata validate` reads from `--dir`; omit `--app` and `--version`. Run `asc metadata pull` first if needed.")
+	fmt.Fprintln(os.Stderr, "Try:")
+	fmt.Fprintln(os.Stderr, `  asc metadata validate --dir "./metadata"`)
+	fmt.Fprintln(os.Stderr, `  asc metadata pull --app "APP_ID" --version "1.2.3" --dir "./metadata"`)
+	fmt.Fprintln(os.Stderr, "For help:")
+	fmt.Fprintln(os.Stderr, "  asc metadata validate --help")
+	return true
 }
 
 func flagLookupName(token string) (string, bool) {

--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -23,6 +23,7 @@ type invocationAnalysis struct {
 	command      *ffcli.Command
 	shape        telemetry.InvocationShape
 	unknownToken string
+	unknownIndex int
 	unknownFlag  bool
 }
 
@@ -85,6 +86,7 @@ func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
 				command:      current,
 				shape:        shapeForCommand(current, true),
 				unknownToken: token,
+				unknownIndex: i,
 				unknownFlag:  true,
 			}
 		}
@@ -143,10 +145,10 @@ func printConciseUnknownCommand(analysis invocationAnalysis, commandName string)
 	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
 }
 
-func printConciseUnknownFlag(root *ffcli.Command, analysis invocationAnalysis, commandName string) {
+func printConciseUnknownFlag(root *ffcli.Command, analysis invocationAnalysis, commandName string, args []string) {
 	flagName := unknownFlagName(analysis)
 	fmt.Fprintf(os.Stderr, "Error: %s\n", unknownFlagError(analysis, commandName))
-	if printMetadataValidateFlagRecovery(flagName, commandName) {
+	if printMetadataValidateFlagRecovery(flagName, commandName, analysis, args) {
 		return
 	}
 	if name, ok := flagLookupName(flagName); ok && root != nil && root.FlagSet != nil && root.FlagSet.Lookup(name) != nil {
@@ -180,8 +182,11 @@ func printConciseUnknownFlag(root *ffcli.Command, analysis invocationAnalysis, c
 	fmt.Fprintf(os.Stderr, "  %s --help\n", commandName)
 }
 
-func printMetadataValidateFlagRecovery(flagName, commandName string) bool {
+func printMetadataValidateFlagRecovery(flagName, commandName string, analysis invocationAnalysis, args []string) bool {
 	if commandName != "asc metadata validate" || (flagName != "--app" && flagName != "--version") {
+		return false
+	}
+	if flagName == "--version" && !metadataVersionValueProvided(analysis, args) {
 		return false
 	}
 
@@ -192,6 +197,26 @@ func printMetadataValidateFlagRecovery(flagName, commandName string) bool {
 	fmt.Fprintln(os.Stderr, "For help:")
 	fmt.Fprintln(os.Stderr, "  asc metadata validate --help")
 	return true
+}
+
+func metadataVersionValueProvided(analysis invocationAnalysis, args []string) bool {
+	if _, value, found := strings.Cut(analysis.unknownToken, "="); found {
+		return isMetadataVersionValue(value)
+	}
+	nextIndex := analysis.unknownIndex + 1
+	if nextIndex < 0 || nextIndex >= len(args) {
+		return false
+	}
+	return isMetadataVersionValue(args[nextIndex])
+}
+
+func isMetadataVersionValue(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.HasPrefix(value, "-") {
+		return false
+	}
+	_, boolErr := strconv.ParseBool(value)
+	return boolErr != nil
 }
 
 func flagLookupName(token string) (string, bool) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,7 +74,7 @@ func Run(args []string, versionInfo string) int {
 			badFlagSyntax = firstLine
 		}
 		if analysis.unknownFlag && isUnknownFlagParseFailure(parseErr, parseOutput.String()) {
-			printConciseUnknownFlag(root, analysis, getCommandName(root, args))
+			printConciseUnknownFlag(root, analysis, getCommandName(root, args), args)
 		} else if strings.HasPrefix(badFlagSyntax, "bad flag syntax:") {
 			fmt.Fprintf(os.Stderr, "Error: %s\nFor help:\n  asc --help\n", shared.SanitizeTerminal(badFlagSyntax))
 		} else {

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1491,6 +1491,8 @@ func TestRun_MetadataValidateUnsupportedFlagsExplainDirectoryWorkflow(t *testing
 		{name: "app", args: []string{"metadata", "validate", "--app", "PRIVATE_VALUE"}, unsupportedFlag: "--app"},
 		{name: "spaced version", args: []string{"metadata", "validate", "--version", "PRIVATE_VALUE"}, unsupportedFlag: "--version"},
 		{name: "equals version", args: []string{"metadata", "validate", "--version=PRIVATE_VALUE"}, unsupportedFlag: "--version"},
+		{name: "spaced numeric version", args: []string{"metadata", "validate", "--version", "1"}, unsupportedFlag: "--version"},
+		{name: "equals numeric version", args: []string{"metadata", "validate", "--version=1"}, unsupportedFlag: "--version"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1572,7 +1574,7 @@ func TestRun_MetadataPullMissingVersionPointsToDiscovery(t *testing.T) {
 	}
 	want := "Error: --version is required\n" +
 		"Find versions:\n" +
-		"  asc versions list --app \"APP_ID\"\n"
+		"  asc versions list --app \"APP_ID\" --paginate\n"
 	if stderr != want {
 		t.Fatalf("stderr = %q, want %q", stderr, want)
 	}

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1493,6 +1493,8 @@ func TestRun_MetadataValidateUnsupportedFlagsExplainDirectoryWorkflow(t *testing
 		{name: "equals version", args: []string{"metadata", "validate", "--version=PRIVATE_VALUE"}, unsupportedFlag: "--version"},
 		{name: "spaced numeric version", args: []string{"metadata", "validate", "--version", "1"}, unsupportedFlag: "--version"},
 		{name: "equals numeric version", args: []string{"metadata", "validate", "--version=1"}, unsupportedFlag: "--version"},
+		{name: "spaced zero version", args: []string{"metadata", "validate", "--version", "0"}, unsupportedFlag: "--version"},
+		{name: "equals zero version", args: []string{"metadata", "validate", "--version=0"}, unsupportedFlag: "--version"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1483,10 +1483,19 @@ func TestRun_UnknownFlagReturnsConciseRecovery(t *testing.T) {
 func TestRun_MetadataValidateUnsupportedFlagsExplainDirectoryWorkflow(t *testing.T) {
 	resetReportFlags(t)
 
-	for _, unsupportedFlag := range []string{"--app", "--version"} {
-		t.Run(unsupportedFlag, func(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		unsupportedFlag string
+	}{
+		{name: "app", args: []string{"metadata", "validate", "--app", "PRIVATE_VALUE"}, unsupportedFlag: "--app"},
+		{name: "spaced version", args: []string{"metadata", "validate", "--version", "PRIVATE_VALUE"}, unsupportedFlag: "--version"},
+		{name: "equals version", args: []string{"metadata", "validate", "--version=PRIVATE_VALUE"}, unsupportedFlag: "--version"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			stdout, stderr := captureCommandOutput(t, func() {
-				if code := Run([]string{"metadata", "validate", unsupportedFlag, "PRIVATE_VALUE"}, "1.0.0"); code != ExitUsage {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
 					t.Fatalf("exit code = %d, want %d", code, ExitUsage)
 				}
 			})
@@ -1494,7 +1503,7 @@ func TestRun_MetadataValidateUnsupportedFlagsExplainDirectoryWorkflow(t *testing
 			if stdout != "" {
 				t.Fatalf("stdout = %q, want empty", stdout)
 			}
-			want := "Error: unknown flag `" + unsupportedFlag + "` for `asc metadata validate`\n" +
+			want := "Error: unknown flag `" + test.unsupportedFlag + "` for `asc metadata validate`\n" +
 				"`asc metadata validate` reads from `--dir`; omit `--app` and `--version`. Run `asc metadata pull` first if needed.\n" +
 				"Try:\n" +
 				"  asc metadata validate --dir \"./metadata\"\n" +
@@ -1506,6 +1515,38 @@ func TestRun_MetadataValidateUnsupportedFlagsExplainDirectoryWorkflow(t *testing
 			}
 			if strings.Contains(stderr, "PRIVATE_VALUE") {
 				t.Fatalf("stderr leaked unsupported flag value: %q", stderr)
+			}
+		})
+	}
+}
+
+func TestRun_MetadataValidateBareVersionPreservesGlobalFlagRecovery(t *testing.T) {
+	resetReportFlags(t)
+
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{name: "bare", args: []string{"metadata", "validate", "--version"}},
+		{name: "equals boolean", args: []string{"metadata", "validate", "--version=false"}},
+		{name: "spaced boolean", args: []string{"metadata", "validate", "--version", "true"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			want := "Error: unknown flag `--version` for `asc metadata validate`\n" +
+				"`--version` is a global flag; the flag and any required valid value must appear before the command name.\n" +
+				"For help:\n" +
+				"  asc --help\n"
+			if stderr != want {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
 			}
 		})
 	}

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -1479,6 +1479,70 @@ func TestRun_UnknownFlagReturnsConciseRecovery(t *testing.T) {
 	}
 }
 
+func TestRun_MetadataValidateUnsupportedFlagsExplainDirectoryWorkflow(t *testing.T) {
+	resetReportFlags(t)
+
+	for _, unsupportedFlag := range []string{"--app", "--version"} {
+		t.Run(unsupportedFlag, func(t *testing.T) {
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run([]string{"metadata", "validate", unsupportedFlag, "PRIVATE_VALUE"}, "1.0.0"); code != ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			want := "Error: unknown flag `" + unsupportedFlag + "` for `asc metadata validate`\n" +
+				"`asc metadata validate` reads from `--dir`; omit `--app` and `--version`. Run `asc metadata pull` first if needed.\n" +
+				"Try:\n" +
+				"  asc metadata validate --dir \"./metadata\"\n" +
+				"  asc metadata pull --app \"APP_ID\" --version \"1.2.3\" --dir \"./metadata\"\n" +
+				"For help:\n" +
+				"  asc metadata validate --help\n"
+			if stderr != want {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
+			}
+			if strings.Contains(stderr, "PRIVATE_VALUE") {
+				t.Fatalf("stderr leaked unsupported flag value: %q", stderr)
+			}
+		})
+	}
+}
+
+func TestRun_MetadataPullMissingVersionPointsToDiscovery(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
+		gotContext = eventContext
+	}
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"metadata", "pull", "--app", "app-1", "--dir", "./metadata"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	want := "Error: --version is required\n" +
+		"Find versions:\n" +
+		"  asc versions list --app \"APP_ID\"\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if gotContext.FailureParameter != "--version" ||
+		gotContext.DiagnosticCode != string(shared.DiagnosticRequiredInputMissing) ||
+		gotContext.ErrorKind != telemetry.ErrorKindMissingRequired ||
+		gotContext.FailureStage != telemetry.FailureStageValidation ||
+		gotContext.OutcomeKind != telemetry.OutcomeUsageError {
+		t.Fatalf("telemetry context = %+v, want missing --version validation", gotContext)
+	}
+}
+
 func TestRun_CommonWrongCommandPathsRecoverInOneStep(t *testing.T) {
 	resetReportFlags(t)
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")

--- a/docs/design/metadata-recovery-guidance.md
+++ b/docs/design/metadata-recovery-guidance.md
@@ -10,7 +10,8 @@ metadata must be fetched first.
 `asc metadata pull --version` remains required. The CLI does not select a
 version implicitly because that could fetch or overwrite metadata for the wrong
 App Store version. A missing value now returns a concise usage error and points
-to `asc versions list --app "APP_ID"` for discovery.
+to `asc versions list --app "APP_ID" --paginate` for discovery, so versions on
+later API pages are included.
 
 ## Compatibility
 

--- a/docs/design/metadata-recovery-guidance.md
+++ b/docs/design/metadata-recovery-guidance.md
@@ -1,0 +1,26 @@
+# Metadata recovery guidance
+
+## Decision
+
+`asc metadata validate` remains an offline, directory-based command. It does not
+accept `--app` or `--version`; those unsupported flags now produce a targeted
+recovery message that points to `--dir` and shows `asc metadata pull` when local
+metadata must be fetched first.
+
+`asc metadata pull --version` remains required. The CLI does not select a
+version implicitly because that could fetch or overwrite metadata for the wrong
+App Store version. A missing value now returns a concise usage error and points
+to `asc versions list --app "APP_ID"` for discovery.
+
+## Compatibility
+
+No flag is accepted and ignored. Both failures retain usage exit code 2, empty
+stdout, and their existing telemetry classes. The pull preflight still runs
+before authentication or HTTP. Explicit help and successful metadata output are
+unchanged.
+
+## Verification
+
+Command-level tests cover both unsupported validation flags, fixed recovery
+commands, redaction of following flag values, missing-version diagnostics,
+canonical telemetry, no full help dump, and the existing required-input cases.

--- a/internal/cli/cmdtest/metadata_pull_test.go
+++ b/internal/cli/cmdtest/metadata_pull_test.go
@@ -12,15 +12,18 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func TestMetadataPullValidationErrors(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
+		name         string
+		args         []string
+		wantErr      string
+		wantReported bool
 	}{
 		{
 			name:    "missing app",
@@ -28,9 +31,10 @@ func TestMetadataPullValidationErrors(t *testing.T) {
 			wantErr: "Error: --app is required (or set ASC_APP_ID)",
 		},
 		{
-			name:    "missing version",
-			args:    []string{"metadata", "pull", "--app", "app-1", "--dir", "./metadata"},
-			wantErr: "Error: --version is required",
+			name:         "missing version",
+			args:         []string{"metadata", "pull", "--app", "app-1", "--dir", "./metadata"},
+			wantErr:      "Error: --version is required\nFind versions:\n  asc versions list --app \"APP_ID\"\n",
+			wantReported: true,
 		},
 		{
 			name:    "missing dir",
@@ -57,13 +61,21 @@ func TestMetadataPullValidationErrors(t *testing.T) {
 				runErr = root.Run(context.Background())
 			})
 
-			if !errors.Is(runErr, flag.ErrHelp) {
+			if test.wantReported {
+				if !shared.IsReportedUsageError(runErr) {
+					t.Fatalf("expected reported usage error, got %v", runErr)
+				}
+			} else if !errors.Is(runErr, flag.ErrHelp) {
 				t.Fatalf("expected ErrHelp, got %v", runErr)
 			}
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
 			}
-			if !strings.Contains(stderr, test.wantErr) {
+			if test.wantReported {
+				if stderr != test.wantErr {
+					t.Fatalf("stderr = %q, want %q", stderr, test.wantErr)
+				}
+			} else if !strings.Contains(stderr, test.wantErr) {
 				t.Fatalf("expected %q in stderr, got %q", test.wantErr, stderr)
 			}
 		})

--- a/internal/cli/cmdtest/metadata_pull_test.go
+++ b/internal/cli/cmdtest/metadata_pull_test.go
@@ -65,6 +65,12 @@ func TestMetadataPullValidationErrors(t *testing.T) {
 				if !shared.IsReportedUsageError(runErr) {
 					t.Fatalf("expected reported usage error, got %v", runErr)
 				}
+				if errors.Is(runErr, flag.ErrHelp) {
+					t.Fatalf("reported usage error must not trigger full help: %v", runErr)
+				}
+				if got := runErr.Error(); got != "--version is required" {
+					t.Fatalf("error = %q, want %q", got, "--version is required")
+				}
 			} else if !errors.Is(runErr, flag.ErrHelp) {
 				t.Fatalf("expected ErrHelp, got %v", runErr)
 			}

--- a/internal/cli/cmdtest/metadata_pull_test.go
+++ b/internal/cli/cmdtest/metadata_pull_test.go
@@ -33,7 +33,7 @@ func TestMetadataPullValidationErrors(t *testing.T) {
 		{
 			name:         "missing version",
 			args:         []string{"metadata", "pull", "--app", "app-1", "--dir", "./metadata"},
-			wantErr:      "Error: --version is required\nFind versions:\n  asc versions list --app \"APP_ID\"\n",
+			wantErr:      "Error: --version is required\nFind versions:\n  asc versions list --app \"APP_ID\" --paginate\n",
 			wantReported: true,
 		},
 		{

--- a/internal/cli/metadata/pull.go
+++ b/internal/cli/metadata/pull.go
@@ -222,7 +222,7 @@ func missingMetadataPullVersionError() error {
 	const message = "--version is required"
 	fmt.Fprintln(os.Stderr, "Error: "+message)
 	fmt.Fprintln(os.Stderr, "Find versions:")
-	fmt.Fprintln(os.Stderr, `  asc versions list --app "APP_ID"`)
+	fmt.Fprintln(os.Stderr, `  asc versions list --app "APP_ID" --paginate`)
 	return shared.WithDiagnostic(
 		shared.NewReportedUsageError(shared.UsageErrorMissingRequired, message),
 		shared.DiagnosticRequiredInputMissing,

--- a/internal/cli/metadata/pull.go
+++ b/internal/cli/metadata/pull.go
@@ -70,7 +70,7 @@ Examples:
 
 			versionValue := strings.TrimSpace(*version)
 			if versionValue == "" {
-				return shared.UsageError("--version is required")
+				return missingMetadataPullVersionError()
 			}
 
 			dirValue := strings.TrimSpace(*dir)
@@ -216,6 +216,18 @@ Examples:
 			)
 		},
 	}
+}
+
+func missingMetadataPullVersionError() error {
+	const message = "--version is required"
+	fmt.Fprintln(os.Stderr, "Error: "+message)
+	fmt.Fprintln(os.Stderr, "Find versions:")
+	fmt.Fprintln(os.Stderr, `  asc versions list --app "APP_ID"`)
+	return shared.WithDiagnostic(
+		shared.NewReportedUsageError(shared.UsageErrorMissingRequired, message),
+		shared.DiagnosticRequiredInputMissing,
+		"--version",
+	)
 }
 
 func ensureNoExistingPullTargets(plans []WritePlan) error {


### PR DESCRIPTION
## What changed

- Give `metadata validate --app` and `--version` a command-specific recovery path explaining that validation reads local files from `--dir`.
- Show both the offline validation command and `metadata pull` when files need to be fetched first.
- Keep `metadata pull --version` required, but replace the full help dump with a concise error pointing to `asc versions list`.

## Why

Current Rork telemetry recorded 73 unsupported `metadata validate --version` attempts, 12 unsupported `--app` attempts, and 112 `metadata pull` calls missing `--version`. Accepting the validation flags would be misleading because validation is offline. Choosing a pull version automatically could read or overwrite the wrong version.

## Compatibility

No unsupported flag is accepted or ignored. These failures keep exit 2, empty stdout, and their current telemetry classification. Pull preflight still stops before authentication or HTTP. Explicit help and successful metadata output do not change.

## Verification

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Built-binary checks cover both recovery paths, empty stdout, concise stderr, and exit 2.
- Command tests cover both unsupported validate flags, following-value redaction, missing-version discovery, and `--version` telemetry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved guidance for unsupported `--app` and `--version` flags during metadata validation, including inline and separated values.
  - Clarified that validation uses a local directory and suggested appropriate recovery commands.
  - Added paginated version-discovery guidance when `metadata pull` is missing the required version.
  - Preserved correct handling for valid and boolean `--version` values, including numeric values.
  - Maintained concise errors, correct exit codes, telemetry behavior, and sensitive-value redaction.
  - Clarified that `xcode-cloud status --id` is deprecated in favor of `--run-id`, with an error when both are supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->