### PR TITLE
docs(auth): clarify credential precedence

### DIFF
--- a/authentication.mdx
+++ b/authentication.mdx
@@ -220,7 +220,7 @@ When config is consulted, its path is selected in this order:
 
 When `ASC_CONFIG_PATH` is unset, an empty local config can fall back to global credentials. Once the local config contains any credential fields, it intentionally shadows the global credential store; incomplete credential data can therefore error instead of falling back. Setting `ASC_CONFIG_PATH` disables global fallback entirely.
 
-`asc auth login --bypass-keychain` controls where that login writes: global config by default, or local config with `--local`. `ASC_BYPASS_KEYCHAIN` controls how later commands read credentials. The login flag does not persist the read behavior.
+`asc auth login --bypass-keychain` or a truthy `ASC_BYPASS_KEYCHAIN` controls where that login writes: global config by default, or local config with `--local`. The environment variable also controls how later commands read credentials; the login flag does not persist the read behavior.
 
 Within stored credentials, an explicitly selected profile wins. Without one, `asc` uses the stored default, or the only stored credential when exactly one exists. Multiple credentials without a default are never selected arbitrarily; resolution either errors or uses an allowed environment fallback.
 

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -30,11 +30,13 @@ Before using `asc`, you need to create an API key in App Store Connect:
   </Step>
 
   <Step title="Note your credentials">
-    You'll need three values:
+    Team API keys use three values:
 
     * **Key ID**: 10-character alphanumeric (e.g., `ABC123DEFG`)
     * **Issuer ID**: UUID format (e.g., `12345678-abcd-1234-abcd-123456789012`)
     * **Private Key**: The `.p8` file you just downloaded
+
+    Individual API keys use the key ID and private key with key type `individual`; they do not use an issuer ID.
   </Step>
 </Steps>
 
@@ -98,6 +100,8 @@ This creates `~/.asc/config.json` with `0600` permissions.
   Config file storage is less secure than keychain. Use keychain when possible, especially on shared systems.
 </Warning>
 
+If keychain credentials also exist, set `ASC_BYPASS_KEYCHAIN=1` for commands that should use this config instead.
+
 #### Local (per-project) config
 
 For project-specific credentials:
@@ -123,6 +127,9 @@ This creates `./.asc/config.json` in your current directory.
 For CI/CD pipelines or ephemeral environments:
 
 ```bash  theme={null}
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+unset ASC_PRIVATE_KEY ASC_PRIVATE_KEY_B64
+export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="ABC123DEFG"
 export ASC_ISSUER_ID="12345678-abcd-1234-abcd-123456789012"
 export ASC_PRIVATE_KEY_PATH="$HOME/.asc/AuthKey_ABC123.p8"
@@ -132,10 +139,12 @@ Alternatively, pass the key content directly:
 
 <CodeGroup>
   ```bash Base64-encoded key theme={null}
+  unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
   export ASC_PRIVATE_KEY_B64="LS0tLS1CRUdJTi..."
   ```
 
   ```bash Raw PEM content theme={null}
+  unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY_B64
   export ASC_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
   MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHk...
   -----END PRIVATE KEY-----"
@@ -189,18 +198,70 @@ Override the default with `--profile`:
 asc --profile "WorkApp" apps list
 ```
 
-## Credential resolution order
+## Credential resolution
 
-`asc` resolves credentials in this order:
+Authentication does not use one universal `environment > config > keychain` order. Profile selection, environment completeness, and keychain bypass change which source is consulted first. This matrix is the source of truth for App Store Connect API credentials:
 
-1. **Explicit profile flag**: `--profile "ProfileName"`
-2. **Environment variables**: `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH` (or `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64`)
-3. **Default profile**: The profile marked as default in keychain/config
-4. **Single stored credential**: If only one profile exists, use it automatically
+| Selector and bypass state | First source | Environment behavior |
+| --- | --- | --- |
+| No `--profile` or `ASC_PROFILE`; keychain enabled; complete environment metadata | Environment | Supplies the whole credential and skips stored lookup |
+| No profile; keychain enabled; incomplete environment metadata | Keychain selection, with config fallback when keychain is unavailable, empty, or its selected default is stored in config | Fills only fields missing from the returned stored credential. Missing/default-selection errors may fall back to environment; keychain denial and other lookup errors do not. |
+| `--profile NAME` or `ASC_PROFILE=NAME`; keychain enabled | Named stored profile, keychain first and then config | Complete environment credentials do not replace the profile. Environment can fill missing fields only after stored resolution returns that profile. |
+| No profile; `ASC_BYPASS_KEYCHAIN` enabled | Default or single complete credential from the active config | Uses that config credential. Environment fallback follows only missing-config or permitted default-selection errors; incomplete credential-bearing config errors. |
+| Profile selected; `ASC_BYPASS_KEYCHAIN` enabled | Named complete profile in the active config | Uses that profile. Environment is not a replacement for a missing or incomplete named config profile. |
 
-<Note>
-  Use `--strict-auth` or `ASC_STRICT_AUTH=true` to fail when credentials are resolved from multiple sources (helps catch mixed-source errors).
-</Note>
+A complete team-key environment set has `ASC_KEY_ID`, `ASC_ISSUER_ID`, a valid `ASC_KEY_TYPE` (unset defaults to `team`), and one private-key source: `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, or `ASC_PRIVATE_KEY_B64`. An individual-key set uses `ASC_KEY_TYPE=individual`, `ASC_KEY_ID`, and one private-key source; `ASC_ISSUER_ID` is ignored. Base64 must decode before the environment fast path is selected. Key paths and PEM contents are still read and validated when a command creates the API client.
+
+When config is consulted, its path is selected in this order:
+
+1. `ASC_CONFIG_PATH` (must be absolute)
+2. The nearest `.asc/config.json` found from the current directory upward
+3. `~/.asc/config.json`
+
+When `ASC_CONFIG_PATH` is unset, an empty local config can fall back to global credentials. Once the local config contains any credential fields, it intentionally shadows the global credential store; incomplete credential data can therefore error instead of falling back. Setting `ASC_CONFIG_PATH` disables global fallback entirely.
+
+`asc auth login --bypass-keychain` controls where that login writes: global config by default, or local config with `--local`. `ASC_BYPASS_KEYCHAIN` controls how later commands read credentials. The login flag does not persist the read behavior.
+
+Within stored credentials, an explicitly selected profile wins. Without one, `asc` uses the stored default, or the only stored credential when exactly one exists. Multiple credentials without a default are never selected arbitrarily; resolution either errors or uses an allowed environment fallback.
+
+<Warning>
+  If keychain access is explicitly denied, `asc` stops instead of silently switching sources. Set `ASC_BYPASS_KEYCHAIN=1` for intentional config-backed authentication. For environment-only authentication, clear `ASC_PROFILE`, `ASC_BYPASS_KEYCHAIN`, and `ASC_CONFIG_PATH`, then provide a complete environment credential set so stored lookup is skipped.
+</Warning>
+
+### Mixed sources and strict authentication
+
+Environment variables that are present but unused do not count as mixed authentication. A mix occurs when the final credential takes required fields from different sources, such as a key ID from config and an issuer ID from the environment.
+
+By default, `asc` warns and continues with a mixed credential. Use `--strict-auth` or `ASC_STRICT_AUTH=true` to fail instead.
+
+### Common patterns
+
+<CodeGroup>
+  ```bash CI with environment credentials theme={null}
+  unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+  unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
+  export ASC_KEY_TYPE="team"
+  export ASC_KEY_ID="ABC123DEFG"
+  export ASC_ISSUER_ID="12345678-abcd-1234-abcd-123456789012"
+  export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
+
+  # No profile selected: the complete environment set skips stored lookup.
+  asc apps list
+  ```
+
+  ```bash Force a stored profile theme={null}
+  # Root flags appear before the command group.
+  asc --profile "WorkApp" apps list
+  ```
+
+  ```bash Config or environment only theme={null}
+  # After creating or restoring this config file:
+  unset ASC_PROFILE
+  export ASC_BYPASS_KEYCHAIN=1
+  export ASC_CONFIG_PATH="$PWD/.asc/config.json"
+  asc apps list
+  ```
+</CodeGroup>
 
 ## Apple Ads authentication
 
@@ -371,9 +432,11 @@ This removes credentials from both keychain and config files.
 | `ASC_PRIVATE_KEY_PATH` | Path to `.p8` file            | `/path/to/AuthKey.p8`                  |
 | `ASC_PRIVATE_KEY`      | Raw PEM content               | `-----BEGIN PRIVATE KEY-----\n...`     |
 | `ASC_PRIVATE_KEY_B64`  | Base64-encoded PEM            | `LS0tLS1CRUdJTi...`                    |
+| `ASC_KEY_TYPE`         | API key type (`team` or `individual`) | `team`                         |
 | `ASC_PROFILE`          | Named profile to use          | `MyApp`                                |
 | `ASC_BYPASS_KEYCHAIN`  | Skip keychain, use config/env | `1`, `true`, `yes`, `on`               |
-| `ASC_STRICT_AUTH`      | Fail on mixed sources         | `1`, `true`, `yes`, `on`               |
+| `ASC_STRICT_AUTH`      | Fail when required fields mix sources | `1`, `true`, `yes`, `y`, `on`   |
+| `ASC_CONFIG_PATH`      | Absolute config path          | `/path/to/config.json`                 |
 
 ### Apple Ads environment variables
 

--- a/cicd/overview.mdx
+++ b/cicd/overview.mdx
@@ -28,8 +28,14 @@ All CI platforms follow the same basic pattern:
 
   - run: asc apps list
     env:
+      ASC_PROFILE: ""
+      ASC_BYPASS_KEYCHAIN: ""
+      ASC_CONFIG_PATH: ""
+      ASC_KEY_TYPE: team
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_PRIVATE_KEY_PATH: ""
+      ASC_PRIVATE_KEY: ""
       ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
   ```
 
@@ -72,22 +78,25 @@ All CI platforms follow the same basic pattern:
 
 All CI platforms use the same authentication environment variables:
 
-| Variable               | Description                             | Required |
-| ---------------------- | --------------------------------------- | -------- |
-| `ASC_KEY_ID`           | App Store Connect API Key ID            | Yes      |
-| `ASC_ISSUER_ID`        | App Store Connect Issuer ID             | Yes      |
-| `ASC_PRIVATE_KEY_B64`  | Base64-encoded private key (`.p8` file) | Yes\*    |
-| `ASC_PRIVATE_KEY_PATH` | Path to `.p8` file (alternative)        | Yes\*    |
-| `ASC_PRIVATE_KEY`      | Raw private key content (alternative)   | Yes\*    |
+| Variable               | Description                             | Required       |
+| ---------------------- | --------------------------------------- | -------------- |
+| `ASC_KEY_TYPE`         | `team` (default) or `individual`        | For individual |
+| `ASC_KEY_ID`           | App Store Connect API Key ID            | Yes            |
+| `ASC_ISSUER_ID`        | App Store Connect Issuer ID             | Team keys only |
+| `ASC_PRIVATE_KEY_B64`  | Base64-encoded private key (`.p8` file) | Yes\*          |
+| `ASC_PRIVATE_KEY_PATH` | Path to `.p8` file (alternative)        | Yes\*          |
+| `ASC_PRIVATE_KEY`      | Raw private key content (alternative)   | Yes\*          |
 
 \*One of these three private key options is required.
+
+The examples below use team keys and pin `ASC_KEY_TYPE=team`. For an individual key, set `ASC_KEY_TYPE=individual` and omit `ASC_ISSUER_ID`; issuer values are ignored for individual keys.
 
 ### Generating API Keys
 
 1. Visit [App Store Connect API Keys](https://appstoreconnect.apple.com/access/integrations/api)
 2. Create a new API key with appropriate permissions
 3. Download the `.p8` private key file (only available once!)
-4. Note the Key ID and Issuer ID
+4. Note the Key ID. Team keys also use the Issuer ID; individual keys use `ASC_KEY_TYPE=individual` without an issuer.
 
 ### Storing Credentials
 
@@ -100,6 +109,7 @@ All CI platforms use the same authentication environment variables:
     Store credentials in **Settings > Secrets and variables > Actions**:
 
     * `ASC_KEY_ID`
+    * `ASC_KEY_TYPE` (`team` for this example)
     * `ASC_ISSUER_ID`
     * `ASC_PRIVATE_KEY_B64`
 
@@ -114,6 +124,7 @@ All CI platforms use the same authentication environment variables:
     Store credentials in **Settings > CI/CD > Variables**:
 
     * `ASC_KEY_ID`
+    * `ASC_KEY_TYPE` (`team` for this example)
     * `ASC_ISSUER_ID`
     * `ASC_PRIVATE_KEY_B64`
 
@@ -124,6 +135,7 @@ All CI platforms use the same authentication environment variables:
     Store credentials in **Workflow > Secrets**:
 
     * `ASC_KEY_ID`
+    * `ASC_KEY_TYPE` (`team` for this example)
     * `ASC_ISSUER_ID`
     * `ASC_PRIVATE_KEY_B64`
 
@@ -134,6 +146,7 @@ All CI platforms use the same authentication environment variables:
     Store credentials in **Project Settings > Environment Variables**:
 
     * `ASC_KEY_ID`
+    * `ASC_KEY_TYPE` (`team` for this example)
     * `ASC_ISSUER_ID`
     * `ASC_PRIVATE_KEY_B64`
   </Tab>
@@ -149,7 +162,7 @@ Customize `asc` behavior in CI:
 | `ASC_TIMEOUT`        | Per-request timeout (e.g., `90s`, `2m`)     | `30s`        |
 | `ASC_UPLOAD_TIMEOUT` | Upload timeout (e.g., `5m`, `10m`)          | `5m`         |
 | `ASC_DEBUG`          | Enable debug logging (`true`, `api`)        | -            |
-| `ASC_STRICT_AUTH`    | Fail on multiple credential sources         | `false`      |
+| `ASC_STRICT_AUTH`    | Fail when resolved credential fields mix sources | `false` |
 | `ASC_APP_ID`         | Default app ID for commands                 | -            |
 
 ## Common CI/CD Workflows

--- a/commands/auth.mdx
+++ b/commands/auth.mdx
@@ -6,14 +6,17 @@
 
 Authentication commands manage your App Store Connect API credentials. Credentials are stored securely in the system keychain when available, with a config file fallback.
 
-## Authentication Resolution
+## Authentication resolution
 
-Credentials are resolved in this order:
+Resolution depends on whether a profile is selected, whether environment credentials are complete, and whether keychain access is bypassed. See the [credential resolution matrix](/authentication#credential-resolution) for the authoritative behavior.
 
-1. Selected profile (keychain or config)
-2. Environment variables (fallback for missing fields)
+The short version:
 
-Use `--strict-auth` or `ASC_STRICT_AUTH=true` to fail when sources are mixed.
+* `--profile` or `ASC_PROFILE` selects a stored profile and disables the environment-only fast path.
+* Without a profile and with keychain bypass disabled, a complete environment credential set skips stored lookup.
+* Environment fields can fill gaps only after an eligible stored credential is returned.
+* `ASC_BYPASS_KEYCHAIN=1` skips keychain; environment fallback follows only missing-config or permitted default-selection errors.
+* `--strict-auth` or `ASC_STRICT_AUTH=true` rejects credentials assembled from multiple sources.
 
 ## Commands
 
@@ -66,8 +69,12 @@ Register and store App Store Connect API key credentials.
   App Store Connect API Key ID
 </ParamField>
 
-<ParamField path="--issuer-id" type="string" required>
-  App Store Connect Issuer ID
+<ParamField path="--issuer-id" type="string">
+  App Store Connect Issuer ID. Required for team keys; omit for individual keys.
+</ParamField>
+
+<ParamField path="--key-type" type="string" default="team">
+  App Store Connect API key type: `team` or `individual`
 </ParamField>
 
 <ParamField path="--private-key" type="string" required>
@@ -94,6 +101,7 @@ Register and store App Store Connect API key credentials.
 
 ```bash  theme={null}
 asc auth login --name "MyKey" --key-id "ABC123" --issuer-id "DEF456" --private-key /path/to/AuthKey.p8
+asc auth login --name "MyIndividualKey" --key-id "ABC123" --key-type individual --private-key /path/to/AuthKey.p8
 asc auth login --bypass-keychain --local --name "MyKey" --key-id "ABC123" --issuer-id "DEF456" --private-key /path/to/AuthKey.p8
 asc auth login --network --name "MyKey" --key-id "ABC123" --issuer-id "DEF456" --private-key /path/to/AuthKey.p8
 ```
@@ -265,9 +273,11 @@ No issues found.
 * `ASC_PRIVATE_KEY_PATH` - Path to .p8 file
 * `ASC_PRIVATE_KEY` - PEM-encoded private key
 * `ASC_PRIVATE_KEY_B64` - Base64-encoded private key
-* `ASC_BYPASS_KEYCHAIN` - Set to `1`, `true`, `yes`, `y`, or `on` to bypass keychain
-* `ASC_STRICT_AUTH` - Set to `true`, `1`, `yes`, `y`, or `on` to fail on mixed credential sources
+* `ASC_KEY_TYPE` - API key type: `team` (default) or `individual`
+* `ASC_BYPASS_KEYCHAIN` - Set to `1`, `true`, `yes`, or `on` to bypass keychain
+* `ASC_STRICT_AUTH` - Set to `true`, `1`, `yes`, `y`, or `on` to fail when required credential fields mix sources
 * `ASC_PROFILE` - Select a named profile
+* `ASC_CONFIG_PATH` - Select an absolute config file path
 
 ## Generating API Keys
 

--- a/commands/global-flags.mdx
+++ b/commands/global-flags.mdx
@@ -21,7 +21,7 @@ asc --profile staging builds upload --app "123456789" --ipa "MyApp.ipa"
 
 ### `--strict-auth`
 
-Fail when credentials are resolved from multiple sources (e.g., both environment variables and keychain).
+Fail when the resolved credential takes required fields from multiple sources.
 
 ```bash  theme={null}
 asc --strict-auth apps list
@@ -31,7 +31,7 @@ asc --strict-auth apps list
 
 **Environment variable**: `ASC_STRICT_AUTH` (accepts `true/false`, `1/0`, `yes/no`, `y/n`, `on/off`)
 
-This flag helps catch configuration issues where credentials might be coming from unexpected sources.
+Unused values in another source do not trigger strict mode. See the [credential resolution matrix](/authentication#credential-resolution) for field-level behavior.
 
 ## Debug and Logging Flags
 
@@ -150,13 +150,15 @@ asc --profile production apps list
 
 ### Flag Priority
 
-When the same setting is configured in multiple places, the CLI uses this priority order (highest to lowest):
+For non-authentication settings, the CLI generally uses this priority order (highest to lowest):
 
 1. Explicit command-line flags
 2. Environment variables
 3. Profile-specific config file settings
 4. Global config file settings
 5. Built-in defaults
+
+Authentication credentials use conditional precedence instead. See the [credential resolution matrix](/authentication#credential-resolution).
 
 ### Boolean Flags
 
@@ -194,7 +196,9 @@ These environment variables don't have corresponding flags but control global be
 | `ASC_UPLOAD_TIMEOUT_SECONDS` | Upload timeout in seconds       | `300`                             |
 | `ASC_APP_ID`                 | Default app ID                  | App Store Connect app ID          |
 | `ASC_VENDOR_NUMBER`          | Vendor number for reports       | Sales/finance vendor number       |
-| `ASC_BYPASS_KEYCHAIN`        | Ignore keychain, use config/env | `true/false`, `1/0`               |
+| `ASC_BYPASS_KEYCHAIN`        | Ignore keychain, use config/env | `true/false`, `1/0`, `yes/no`, `on/off` |
+| `ASC_CONFIG_PATH`            | Select an absolute config path  | `/path/to/config.json`             |
+| `ASC_KEY_TYPE`               | API key type                    | `team`, `individual`               |
 
 ## Examples
 
@@ -211,16 +215,18 @@ asc --profile production --strict-auth validate --app "123456789" --version "1.2
 ### CI Pipeline
 
 ```bash  theme={null}
+# Set environment before every authenticated command. The "ci" profile must
+# already exist in the selected keychain or default config store.
+export ASC_PROFILE=ci
+unset ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+export ASC_STRICT_AUTH=true
+export ASC_DEFAULT_OUTPUT=json
+
 # Run validation with JUnit report
 asc --report junit --report-file validation-results.xml \
   validate \
   --app "$APP_ID" \
   --version "$VERSION"
-
-# Set environment for all commands in CI
-export ASC_PROFILE=ci
-export ASC_STRICT_AUTH=true
-export ASC_DEFAULT_OUTPUT=json
 
 asc apps list
 asc builds list --app "$APP_ID"

--- a/configuration/environment-variables.mdx
+++ b/configuration/environment-variables.mdx
@@ -16,6 +16,12 @@ These variables configure API authentication credentials.
   Your App Store Connect API issuer ID
 </ParamField>
 
+<ParamField path="ASC_KEY_TYPE" type="string">
+  App Store Connect API key type: `team` (default) or `individual`
+
+  Individual keys do not require an issuer ID, and `ASC_ISSUER_ID` is ignored.
+</ParamField>
+
 <ParamField path="ASC_PRIVATE_KEY_PATH" type="string">
   Path to your private key (.p8) file
 </ParamField>
@@ -31,11 +37,11 @@ These variables configure API authentication credentials.
 <ParamField path="ASC_BYPASS_KEYCHAIN" type="boolean">
   Ignore keychain and use config/env auth only
 
-  Set to `true`, `1`, `yes`, `y`, or `on` to bypass keychain lookup.
+  Set to `true`, `1`, `yes`, or `on` to bypass keychain lookup. The active config is tried before environment fallback.
 </ParamField>
 
 <ParamField path="ASC_STRICT_AUTH" type="boolean">
-  Fail when credentials resolve from multiple sources
+  Fail when required fields in the resolved credential come from multiple sources
 
   Set to `true`, `1`, `yes`, `y`, or `on` to enable strict mode.
 </ParamField>
@@ -250,17 +256,11 @@ variables to opt out or adjust runtime handling.
 
 ### App Store Connect precedence
 
-App Store Connect credentials and defaults are resolved in this order:
+Non-authentication settings use explicit command flags before environment variables, config values, and built-in defaults.
 
-1. **Command-line flags** (highest priority)
-2. **Environment variables**
-3. **Config file** (`~/.asc/config.json` or `.asc/config.json`)
-4. **Keychain** (for credentials only)
-5. **Built-in defaults** (lowest priority)
+Credentials are conditional rather than a single linear order. A selected profile wins over complete environment credentials; without a profile and with keychain bypass disabled, a complete environment set can skip stored lookup; keychain bypass makes the active config the first stored source. See the [credential resolution matrix](/authentication#credential-resolution) for the authoritative branches and config-path order.
 
-<Note>
-  When `ASC_STRICT_AUTH=true`, the CLI will fail if credentials are found in multiple sources (e.g., both environment variables and keychain).
-</Note>
+`ASC_STRICT_AUTH=true` fails only when the resolved credential combines required fields from multiple sources. Merely defining an environment variable that is not used does not trigger strict mode.
 
 ### Apple Ads precedence
 
@@ -280,6 +280,9 @@ Apple Ads credentials and defaults are resolved in this order:
 ### Basic authentication
 
 ```bash  theme={null}
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY ASC_PRIVATE_KEY_B64
+export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="ABC123"
 export ASC_ISSUER_ID="DEF456"
 export ASC_PRIVATE_KEY_PATH="$HOME/.asc/AuthKey_ABC123.p8"
@@ -290,10 +293,12 @@ asc apps list
 ### CI/CD authentication with base64-encoded key
 
 ```bash  theme={null}
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
+export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="ABC123"
 export ASC_ISSUER_ID="DEF456"
 export ASC_PRIVATE_KEY_B64="LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t..."
-export ASC_BYPASS_KEYCHAIN="true"
 
 asc builds upload --app 123456789 --ipa MyApp.ipa
 ```

--- a/configuration/profiles.mdx
+++ b/configuration/profiles.mdx
@@ -6,7 +6,7 @@ Authentication profiles allow you to manage multiple App Store Connect API keys 
 
 ## Overview
 
-Profiles are stored in the configuration file (`~/.asc/config.json` or `.asc/config.json`) and can reference credentials from the keychain or config file.
+Profiles can be stored in the system keychain or in the active config file (`~/.asc/config.json` or `.asc/config.json`).
 
 ## Creating profiles
 
@@ -104,7 +104,7 @@ The CLI supports both global and local (project-specific) configuration:
 * **Global config:** `~/.asc/config.json` (used by default)
 * **Local config:** `.asc/config.json` in your project directory
 
-Local configs take precedence over global configs. This is useful for project-specific API keys:
+Local configs take precedence over the global config when config storage is consulted. When `ASC_CONFIG_PATH` is unset, an empty local config can fall back to global credentials, but a local config containing any credential fields shadows them and incomplete data can error. Local config does not automatically override keychain credentials. This is useful for project-specific API keys:
 
 ```bash  theme={null}
 # In your project directory
@@ -112,26 +112,30 @@ mkdir -p .asc
 echo '.asc/' >> .gitignore  # Don't commit credentials
 
 asc auth login \
+  --bypass-keychain \
+  --local \
   --name "ProjectKey" \
   --key-id "PROJECT123" \
   --issuer-id "PROJECT456" \
   --private-key /path/to/ProjectKey.p8
 ```
 
-Now all commands run from this directory will use the project-specific key by default.
+For subsequent commands, bypass keychain so the local config is the stored source:
 
-## Credential resolution order
+```bash  theme={null}
+unset ASC_PROFILE ASC_CONFIG_PATH
+export ASC_BYPASS_KEYCHAIN=1
+asc apps list
+```
 
-When you run a command, credentials are resolved in this order:
+## Credential resolution
 
-1. **`--profile` flag** (highest priority)
-2. **`ASC_PROFILE` environment variable**
-3. **Default profile** from config (`default_key_name`)
-4. **Unnamed credentials** from config or environment variables
-5. **Keychain** (if no profile specified)
+`--profile` selects a stored profile for one invocation and wins over `ASC_PROFILE`. Either selector disables the environment-only fast path. Environment fields can fill gaps only after stored resolution returns an eligible profile; a missing or incomplete config profile errors instead of being replaced by environment credentials. With no selected profile and keychain bypass disabled, complete environment credentials may take precedence over stored credentials.
+
+See the [credential resolution matrix](/authentication#credential-resolution) for the complete behavior, including keychain bypass, config-path selection, default and single-profile fallback, and strict authentication.
 
 <Warning>
-  Use `ASC_STRICT_AUTH=true` to fail when credentials are found in multiple sources. This helps prevent accidental credential mixing.
+  Use `ASC_STRICT_AUTH=true` to fail when a resolved credential combines required fields from multiple sources. This helps prevent accidental credential mixing.
 </Warning>
 
 ## Profile management commands
@@ -183,22 +187,28 @@ asc auth switch --name ClientB
 asc apps list  # Uses ClientB by default now
 ```
 
-### CI/CD with profile selection
+### CI/CD with environment credentials
 
 ```yaml  theme={null}
 # .github/workflows/release.yml
 env:
-  ASC_PROFILE: Production
+  ASC_PROFILE: ""
+  ASC_BYPASS_KEYCHAIN: ""
+  ASC_CONFIG_PATH: ""
+  ASC_KEY_TYPE: team
   ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
   ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+  ASC_PRIVATE_KEY_PATH: ""
+  ASC_PRIVATE_KEY: ""
   ASC_PRIVATE_KEY_B64: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
-  ASC_BYPASS_KEYCHAIN: true
   ASC_APP_ID: ${{ secrets.APP_ID }}
 
 steps:
   - name: Upload to TestFlight
     run: asc builds upload --app "$ASC_APP_ID" --ipa MyApp.ipa
 ```
+
+With no profile selected, this complete environment set skips stored credential lookup. If CI restores a config containing a named profile instead, set `ASC_PROFILE=Production` and `ASC_BYPASS_KEYCHAIN=true`, then omit the credential environment variables. Bypass makes the restored config deterministic even if the runner also has a matching keychain profile.
 
 ### Testing with staging vs production keys
 
@@ -228,7 +238,7 @@ If you see "profile not found" errors:
 
 ### Multiple credential sources
 
-If credentials are found in multiple places:
+If the resolved credential takes required fields from multiple places:
 
 ```bash  theme={null}
 # Enable strict auth to fail loudly

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -43,14 +43,17 @@ func AuthCommand() *ffcli.Command {
 Authentication is handled via App Store Connect API keys. Generate keys at:
 https://appstoreconnect.apple.com/access/integrations/api
 
-Credentials are stored in the system keychain when available, with a config fallback.
-A repo-local ./.asc/config.json (if present) takes precedence.
+Credentials can come from the system keychain, the active config file, or environment variables.
 
-Credential resolution order:
-  1) Selected profile (keychain/config)
-  2) Environment variables (fallback for missing fields)
+Credential resolution:
+  - --profile or ASC_PROFILE selects a stored profile and disables the env-only fast path.
+  - With no profile and keychain bypass disabled, a complete environment set skips stored lookup.
+  - After stored selection succeeds, environment variables can fill eligible missing fields.
+  - ASC_BYPASS_KEYCHAIN skips keychain; env fallback follows only missing/default-selection config errors.
 
-Use --strict-auth or ASC_STRICT_AUTH=true (also: 1, yes, y, on) to fail when sources are mixed.
+Config selection: ASC_CONFIG_PATH; otherwise nearest ancestor .asc/config.json; otherwise ~/.asc/config.json.
+
+Use --strict-auth or ASC_STRICT_AUTH=true (also: 1, yes, y, on) to reject split-source fields.
 Set ASC_BYPASS_KEYCHAIN to 1/true/yes/on to bypass keychain.
 
 Use "asc auth status" to see which credentials/profile are currently active.
@@ -58,6 +61,7 @@ Use "asc auth status" to see which credentials/profile are currently active.
 Examples:
   asc auth status
   asc auth status --verbose
+  asc --profile work apps list
   asc auth switch --name work
   asc auth export-to-config --confirm`,
 		FlagSet:   fs,

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -61,6 +61,20 @@ func TestAuthHelpHighlightsStatusDiscoverability(t *testing.T) {
 	}
 }
 
+func TestAuthHelpExplainsCredentialResolutionBranches(t *testing.T) {
+	longHelp := AuthCommand().LongHelp
+	for _, expected := range []string{
+		"--profile or ASC_PROFILE selects a stored profile and disables the env-only fast path.",
+		"With no profile and keychain bypass disabled, a complete environment set skips stored lookup.",
+		"ASC_BYPASS_KEYCHAIN skips keychain; env fallback follows only missing/default-selection config errors.",
+		"Config selection: ASC_CONFIG_PATH; otherwise nearest ancestor .asc/config.json; otherwise ~/.asc/config.json.",
+	} {
+		if !strings.Contains(longHelp, expected) {
+			t.Fatalf("expected AuthCommand().LongHelp to contain %q, got %q", expected, longHelp)
+		}
+	}
+}
+
 func TestAuthCommandUnknownSubcommand(t *testing.T) {
 	cmd := AuthCommand()
 	_, stderr := captureAuthOutput(t, func() {

--- a/resources/contributing.mdx
+++ b/resources/contributing.mdx
@@ -65,7 +65,11 @@ export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export ASC_APP_ID="YOUR_APP_ID"
 
-ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$(mktemp -d)/config.json" make test-integration
+(
+  ASC_TEST_CONFIG_DIR="$(mktemp -d)"
+  trap 'rm -rf "$ASC_TEST_CONFIG_DIR"' EXIT
+  ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_DIR/config.json" make test-integration
+)
 ```
 
 ### Headless Alternative
@@ -85,10 +89,14 @@ export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export ASC_APP_ID="YOUR_APP_ID"
 
-ASC_TEST_CONFIG_PATH="$(mktemp -d)/config.json"
-ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc testflight feedback list --app "$ASC_APP_ID"
-ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc testflight crashes list --app "$ASC_APP_ID"
-ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc reviews --app "$ASC_APP_ID"
+(
+  ASC_TEST_CONFIG_DIR="$(mktemp -d)"
+  trap 'rm -rf "$ASC_TEST_CONFIG_DIR"' EXIT
+  ASC_TEST_CONFIG_PATH="$ASC_TEST_CONFIG_DIR/config.json"
+  ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc testflight feedback list --app "$ASC_APP_ID"
+  ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc testflight crashes list --app "$ASC_APP_ID"
+  ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc reviews --app "$ASC_APP_ID"
+)
 ```
 
 ### Credential storage

--- a/resources/contributing.mdx
+++ b/resources/contributing.mdx
@@ -58,23 +58,19 @@ To run integration tests, set credentials in your environment:
 
 ```bash  theme={null}
 unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+unset ASC_PRIVATE_KEY ASC_PRIVATE_KEY_B64
 export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export ASC_APP_ID="YOUR_APP_ID"
 
-make test-integration
+ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$(mktemp -d)/config.json" make test-integration
 ```
 
 ### Headless Alternative
 
-For CI/CD or headless environments, use base64-encoded keys:
-
-```bash  theme={null}
-unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
-export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
-```
+The integration harness requires `ASC_PRIVATE_KEY_PATH`. In headless CI, decode the private-key secret to a restricted temporary `.p8` file and export its path before running the target. CLI commands support `ASC_PRIVATE_KEY_B64`, but these integration tests do not consume it directly.
 
 ## Local API Testing (Optional)
 
@@ -82,15 +78,17 @@ If you have App Store Connect API credentials, you can run real API calls locall
 
 ```bash  theme={null}
 unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+unset ASC_PRIVATE_KEY ASC_PRIVATE_KEY_B64
 export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export ASC_APP_ID="YOUR_APP_ID"
 
-asc testflight feedback list --app "$ASC_APP_ID"
-asc testflight crashes list --app "$ASC_APP_ID"
-asc reviews --app "$ASC_APP_ID"
+ASC_TEST_CONFIG_PATH="$(mktemp -d)/config.json"
+ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc testflight feedback list --app "$ASC_APP_ID"
+ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc testflight crashes list --app "$ASC_APP_ID"
+ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_PATH" asc reviews --app "$ASC_APP_ID"
 ```
 
 ### Credential storage

--- a/resources/contributing.mdx
+++ b/resources/contributing.mdx
@@ -57,6 +57,8 @@ Integration tests hit the real App Store Connect API and are **skipped by defaul
 To run integration tests, set credentials in your environment:
 
 ```bash  theme={null}
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
@@ -70,6 +72,7 @@ make test-integration
 For CI/CD or headless environments, use base64-encoded keys:
 
 ```bash  theme={null}
+unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
 export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
 ```
 
@@ -78,6 +81,8 @@ export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
 If you have App Store Connect API credentials, you can run real API calls locally:
 
 ```bash  theme={null}
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
@@ -88,15 +93,17 @@ asc testflight crashes list --app "$ASC_APP_ID"
 asc reviews --app "$ASC_APP_ID"
 ```
 
-### Credential Storage
+### Credential storage
 
-Credentials are stored:
+Credential storage locations include:
 
 1. **macOS**: System keychain (when available)
 2. **Fallback**: Config file at `~/.asc/config.json` (restricted permissions)
 3. **Repo-local**: `./.asc/config.json` (also supported)
 
 **Important**: Do not commit secrets or `.p8` files to the repository.
+
+Storage location is not the same as credential precedence. See the [credential resolution matrix](/authentication#credential-resolution) before live testing with multiple sources.
 
 ## Local Validation
 

--- a/resources/faq.mdx
+++ b/resources/faq.mdx
@@ -52,12 +52,14 @@
 
   ```bash  theme={null}
   unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+  unset ASC_PRIVATE_KEY ASC_PRIVATE_KEY_B64
   export ASC_KEY_TYPE="team"
   export ASC_KEY_ID="YOUR_KEY_ID"
   export ASC_ISSUER_ID="YOUR_ISSUER_ID"
   export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 
   # Or use base64-encoded key for CI/CD
+  unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
   unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
   export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
   ```

--- a/resources/faq.mdx
+++ b/resources/faq.mdx
@@ -51,11 +51,14 @@
   Yes. The CLI supports multiple authentication methods:
 
   ```bash  theme={null}
+  unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+  export ASC_KEY_TYPE="team"
   export ASC_KEY_ID="YOUR_KEY_ID"
   export ASC_ISSUER_ID="YOUR_ISSUER_ID"
   export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 
   # Or use base64-encoded key for CI/CD
+  unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
   export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
   ```
 
@@ -65,7 +68,7 @@
   export ASC_BYPASS_KEYCHAIN=1
   ```
 
-  Priority order: Environment variables > Config file > Keychain
+  Authentication precedence is conditional. A selected profile wins, a complete environment set can skip stored lookup when no profile is selected and keychain bypass is disabled, and keychain bypass makes config the first stored source. See the [credential resolution matrix](/authentication#credential-resolution) for the complete behavior.
 </Accordion>
 
 <Accordion title="What permissions does my API key need?">

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -13,6 +13,7 @@
 ```bash  theme={null}
 # A complete environment set skips keychain when no profile is selected
 unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+unset ASC_PRIVATE_KEY ASC_PRIVATE_KEY_B64
 export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
@@ -22,6 +23,7 @@ export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 Alternatively, use base64-encoded keys for headless environments:
 
 ```bash  theme={null}
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
 unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
 export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
 ```
@@ -230,13 +232,14 @@ ASC_BYPASS_KEYCHAIN=1 make test
 
 ```bash  theme={null}
 unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+unset ASC_PRIVATE_KEY ASC_PRIVATE_KEY_B64
 export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export ASC_APP_ID="YOUR_APP_ID"
 
-make test-integration
+ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$(mktemp -d)/config.json" make test-integration
 ```
 
 ## Platform-Specific Issues

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -11,8 +11,9 @@
 **Solution**:
 
 ```bash  theme={null}
-# Bypass keychain and use environment variables
-export ASC_BYPASS_KEYCHAIN=1
+# A complete environment set skips keychain when no profile is selected
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
@@ -21,21 +22,23 @@ export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 Alternatively, use base64-encoded keys for headless environments:
 
 ```bash  theme={null}
+unset ASC_PRIVATE_KEY_PATH ASC_PRIVATE_KEY
 export ASC_PRIVATE_KEY_B64="BASE64_ENCODED_KEY"
 ```
+
+If you intentionally use config storage, set `ASC_BYPASS_KEYCHAIN=1`. In bypass mode, the active config is tried before environment fallback.
 
 ### Multiple Credential Sources Conflict
 
 **Problem**: Error message about credentials resolving from multiple sources.
 
-**Solution**: Enable strict auth mode to identify the conflict:
+**Solution**: Enable strict auth mode on an authenticated command to identify the conflict:
 
 ```bash  theme={null}
-export ASC_STRICT_AUTH=true
-asc auth status
+ASC_STRICT_AUTH=true asc apps list
 ```
 
-Then choose one credential source (keychain, config file, or environment variables) and remove the others.
+`asc auth doctor` can also report mixed-source conflicts, but an authenticated command exercises the exact runtime credential path. Make sure every required field comes from one source, or remove partial values that are being used as fallback. Values that are present but unused do not trigger strict mode. See the [credential resolution matrix](/authentication#credential-resolution).
 
 ### JWT Token Expiration
 
@@ -162,10 +165,13 @@ Finance reports use Apple fiscal months, not calendar months.
 
 **Problem**: CLI can't find configuration file.
 
-**Solution**: Check config file locations (in priority order):
+**Solution**: Check config selection in this order:
 
-1. `./.asc/config.json` (repo-local)
-2. `~/.asc/config.json` (user home)
+1. `ASC_CONFIG_PATH` (absolute path, when set)
+2. Nearest `.asc/config.json` from the current directory upward
+3. `~/.asc/config.json` (user home)
+
+When `ASC_CONFIG_PATH` is unset, an empty local config can fall back to global credentials. A local config containing credential fields shadows the global store, and incomplete credential data can error instead of falling back. Setting `ASC_CONFIG_PATH` disables global fallback.
 
 Ensure file permissions are restrictive:
 
@@ -177,12 +183,14 @@ chmod 600 ~/.asc/config.json
 
 **Problem**: Settings not taking effect.
 
-**Solution**: Priority order (highest to lowest):
+**Solution**: For non-authentication settings, priority is generally:
 
 1. Command-line flags (e.g., `--output json`)
 2. Environment variables (e.g., `ASC_DEFAULT_OUTPUT`)
 3. Config file settings
 4. Default values (TTY-aware for output)
+
+Authentication credentials use conditional precedence. See the [credential resolution matrix](/authentication#credential-resolution).
 
 ## Debug Mode
 
@@ -221,6 +229,8 @@ ASC_BYPASS_KEYCHAIN=1 make test
 **Solution**: Integration tests are opt-in. Set credentials and use:
 
 ```bash  theme={null}
+unset ASC_PROFILE ASC_BYPASS_KEYCHAIN ASC_CONFIG_PATH
+export ASC_KEY_TYPE="team"
 export ASC_KEY_ID="YOUR_KEY_ID"
 export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -239,7 +239,11 @@ export ASC_ISSUER_ID="YOUR_ISSUER_ID"
 export ASC_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export ASC_APP_ID="YOUR_APP_ID"
 
-ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$(mktemp -d)/config.json" make test-integration
+(
+  ASC_TEST_CONFIG_DIR="$(mktemp -d)"
+  trap 'rm -rf "$ASC_TEST_CONFIG_DIR"' EXIT
+  ASC_BYPASS_KEYCHAIN=1 ASC_CONFIG_PATH="$ASC_TEST_CONFIG_DIR/config.json" make test-integration
+)
 ```
 
 ## Platform-Specific Issues


### PR DESCRIPTION
## Summary

- replace conflicting linear auth-precedence claims with one source-backed credential resolution matrix
- distinguish profile selection, complete environment fast-path auth, keychain/config fallback, bypass mode, and config-path selection
- document team vs individual keys and make CI/config examples deterministic by clearing competing selectors and private-key sources
- update `asc auth --help` with the same branch model and protect it with a regression test

## Why

The website described App Store Connect credentials as several incompatible linear orders, including environment before config before keychain. The resolver is conditional: a selected profile disables the environment fast path, complete environment credentials skip stored lookup only when no profile is selected and bypass is disabled, and bypass mode makes the active config the first source.

That mismatch can make an agent select stale credentials, assume environment values replace a missing named profile, or set keychain bypass while intending environment-only auth.

## Compatibility

This changes documentation and auth help only. Credential resolution behavior, output contracts, and exit codes are unchanged.

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/auth ./internal/cli/shared ./internal/auth -count=1`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- manual `ASC_BYPASS_KEYCHAIN=1 ./asc auth --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for team and individual API key authentication.
  * Added options to select key types, profiles, configuration paths, and keychain usage.
  * Documented the `ASC_KEY_TYPE` environment variable and updated authentication login options.

* **Documentation**
  * Expanded authentication, CI/CD, configuration, troubleshooting, FAQ, and contribution guidance.
  * Clarified credential resolution, strict authentication behavior, mixed credential sources, and environment setup.
  * Updated CLI help with profile and credential-resolution details, including individual-key usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->