### PR TITLE
feat(auth): stage logout confirmation

### DIFF
--- a/authentication.mdx
+++ b/authentication.mdx
@@ -319,16 +319,18 @@ This can:
 ### Remove a specific profile
 
 ```bash  theme={null}
-asc auth logout --name "WorkApp"
+asc auth logout --name "WorkApp" --confirm
 ```
 
 ### Remove all credentials
 
 ```bash  theme={null}
-asc auth logout --all
+asc auth logout --all --confirm
 ```
 
-This removes credentials from both keychain and config files.
+`--all` always attempts config cleanup and also attempts keychain cleanup. If config cleanup succeeds, a keychain cleanup error is treated as non-fatal.
+
+For compatibility, logout still runs without `--confirm` after printing a deprecation warning. Confirmation will be required in 5.0.0.
 
 ## Security best practices
 

--- a/commands/auth.mdx
+++ b/commands/auth.mdx
@@ -135,20 +135,25 @@ Default profile set to 'Personal'
 Remove stored API credentials.
 
 <ParamField path="--all" type="boolean" default="false">
-  Remove all stored credentials (default behavior)
+  Remove all stored credentials
 </ParamField>
 
 <ParamField path="--name" type="string">
   Remove a named credential
 </ParamField>
 
+<ParamField path="--confirm" type="boolean" default="false">
+  Confirm credential removal. This will be required in 5.0.0.
+</ParamField>
+
 **Examples:**
 
 ```bash  theme={null}
-asc auth logout
-asc auth logout --all
-asc auth logout --name "MyKey"
+asc auth logout --all --confirm
+asc auth logout --name "MyKey" --confirm
 ```
+
+For compatibility, omitting `--name` still removes all credentials and omitting `--confirm` prints a deprecation warning. Pass an explicit target and `--confirm` now; confirmation will be required in 5.0.0. An explicit `--confirm=false` is rejected before credentials are changed.
 
 **Output:**
 

--- a/configuration/profiles.mdx
+++ b/configuration/profiles.mdx
@@ -157,13 +157,13 @@ asc auth status
 ### Remove a profile
 
 ```bash  theme={null}
-asc auth logout --name ProfileName
+asc auth logout --name ProfileName --confirm
 ```
 
 ### Remove all profiles
 
 ```bash  theme={null}
-asc auth logout --all
+asc auth logout --all --confirm
 ```
 
 ## Example workflows

--- a/docs/release-notes-auth-logout-confirmation.md
+++ b/docs/release-notes-auth-logout-confirmation.md
@@ -1,0 +1,21 @@
+# Auth logout confirmation migration
+
+`asc auth logout` now accepts `--confirm` so scripts can migrate before
+confirmation becomes mandatory in 5.0.0. New invocations should name the target
+explicitly:
+
+```bash
+asc auth logout --name "PROFILE" --confirm
+asc auth logout --all --confirm
+```
+
+During the compatibility window, existing logout calls still remove credentials
+but print this warning to stderr:
+
+```text
+Warning: auth logout without --confirm is deprecated and will be rejected in 5.0.0; pass --confirm to acknowledge credential removal.
+```
+
+Bare `asc auth logout` continues to target all stored App Store Connect
+credentials. Stray positional arguments and an explicit `--confirm=false` are
+now rejected before any credential store is changed.

--- a/installation.mdx
+++ b/installation.mdx
@@ -278,7 +278,7 @@ Reload your shell to activate completions.
     Optionally remove keychain entries:
 
     ```bash  theme={null}
-    asc auth logout --all        # before removing binary
+    asc auth logout --all --confirm  # before removing binary
     ```
   </Tab>
 </Tabs>

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -308,67 +308,6 @@ func TestIntegrationAuthConfig(t *testing.T) {
 			t.Fatalf("expected builds response, got: %s", output)
 		}
 	})
-
-	t.Run("auth_logout_clears_credentials_preserves_settings", func(t *testing.T) {
-		tempDir := t.TempDir()
-		configPath := filepath.Join(tempDir, "config.json")
-
-		// Create config with credentials AND other settings
-		cfg := &config.Config{
-			KeyID:          keyID,
-			IssuerID:       issuerID,
-			PrivateKeyPath: keyPath,
-			DefaultKeyName: "LogoutTestKey",
-			AppID:          "12345",
-			VendorNumber:   "67890",
-			Timeout: func() config.DurationValue {
-				value, err := config.ParseDurationValue("60s")
-				if err != nil {
-					t.Fatalf("ParseDurationValue(\"60s\") error: %v", err)
-				}
-				return value
-			}(),
-		}
-		if err := config.SaveAt(configPath, cfg); err != nil {
-			t.Fatalf("failed to save config: %v", err)
-		}
-
-		// Logout
-		cmd := exec.Command(ascBinary, "auth", "logout")
-		cmd.Env = append(os.Environ(), "ASC_CONFIG_PATH="+configPath)
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("auth logout failed: %v\nOutput: %s", err, output)
-		}
-
-		// Verify config still exists
-		data, err := os.ReadFile(configPath)
-		if err != nil {
-			t.Fatalf("config file should still exist: %v", err)
-		}
-
-		// Verify credentials are cleared but settings are preserved
-		var loadedCfg config.Config
-		if err := json.Unmarshal(data, &loadedCfg); err != nil {
-			t.Fatalf("failed to parse config: %v", err)
-		}
-
-		// Credentials should be cleared
-		if loadedCfg.KeyID != "" || loadedCfg.IssuerID != "" || loadedCfg.PrivateKeyPath != "" {
-			t.Fatal("credentials should be cleared after logout")
-		}
-
-		// Settings should be preserved
-		if loadedCfg.AppID != "12345" {
-			t.Fatalf("AppID should be preserved, got %q", loadedCfg.AppID)
-		}
-		if loadedCfg.VendorNumber != "67890" {
-			t.Fatalf("VendorNumber should be preserved, got %q", loadedCfg.VendorNumber)
-		}
-		if loadedCfg.Timeout.String() != "60s" {
-			t.Fatalf("Timeout should be preserved, got %q", loadedCfg.Timeout.String())
-		}
-	})
 }
 
 // filterEnv removes specified environment variables from the env slice

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1492,6 +1492,45 @@ func TestRemoveAllCredentials(t *testing.T) {
 	}
 }
 
+func TestRemoveAllCredentialsPreservesConfigSettings(t *testing.T) {
+	withArrayKeyring(t)
+
+	configPath, err := config.Path()
+	if err != nil {
+		t.Fatalf("config.Path() error: %v", err)
+	}
+	timeout, err := config.ParseDurationValue("60s")
+	if err != nil {
+		t.Fatalf("ParseDurationValue() error: %v", err)
+	}
+	if err := config.SaveAt(configPath, &config.Config{
+		KeyID:          "KEY123",
+		IssuerID:       "ISS456",
+		PrivateKeyPath: "/tmp/AuthKey.p8",
+		DefaultKeyName: "demo",
+		AppID:          "12345",
+		VendorNumber:   "67890",
+		Timeout:        timeout,
+	}); err != nil {
+		t.Fatalf("config.SaveAt() error: %v", err)
+	}
+
+	if err := RemoveAllCredentials(); err != nil {
+		t.Fatalf("RemoveAllCredentials() error: %v", err)
+	}
+
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt() error: %v", err)
+	}
+	if cfg.KeyID != "" || cfg.IssuerID != "" || cfg.PrivateKeyPath != "" || cfg.DefaultKeyName != "" {
+		t.Fatalf("expected credentials cleared, got %+v", cfg)
+	}
+	if cfg.AppID != "12345" || cfg.VendorNumber != "67890" || cfg.Timeout.String() != "60s" {
+		t.Fatalf("expected settings preserved, got %+v", cfg)
+	}
+}
+
 func TestRemoveAllCredentials_ClearsStoredKeychainMetadata(t *testing.T) {
 	withArrayKeyring(t)
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -28,6 +28,8 @@ var (
 	listCredentialSummaries  = authsvc.ListCredentialSummaries
 	keychainAvailable        = authsvc.KeychainAvailable
 	migrateKeychainToConfig  = authsvc.MigrateKeychainToConfig
+	removeStoredCredential   = authsvc.RemoveCredentials
+	removeStoredCredentials  = authsvc.RemoveAllCredentials
 )
 
 // Auth command factory
@@ -805,25 +807,42 @@ Examples:
 	}
 }
 
+const authLogoutConfirmDeprecationWarning = "Warning: auth logout without --confirm is deprecated and will be rejected in 5.0.0; pass --confirm to acknowledge credential removal."
+
 // AuthLogout command factory
 func AuthLogoutCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("auth logout", flag.ExitOnError)
-	all := fs.Bool("all", false, "Remove all stored credentials (default)")
+	all := fs.Bool("all", false, "Remove all stored credentials")
 	name := fs.String("name", "", "Remove a named credential")
+	confirm := fs.Bool("confirm", false, "Confirm credential removal (required in 5.0.0)")
 
 	return &ffcli.Command{
 		Name:       "logout",
-		ShortUsage: "asc auth logout [flags]",
+		ShortUsage: "asc auth logout [--name NAME | --all] [--confirm]",
 		ShortHelp:  "Remove stored API credentials.",
 		LongHelp: `Remove stored API credentials.
 
+Omitting --name continues to remove all credentials during the compatibility
+window. Pass --confirm now; it will be required in 5.0.0.
+
 Examples:
-  asc auth logout
-  asc auth logout --all
-  asc auth logout --name "MyKey"`,
+  asc auth logout --all --confirm
+  asc auth logout --name "MyKey" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.RejectPositionalArgs(args); err != nil {
+				return err
+			}
+			confirmProvided := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "confirm" {
+					confirmProvided = true
+				}
+			})
+			if confirmProvided && !*confirm {
+				return shared.UsageError("--confirm must be true when specified")
+			}
 			trimmedName := strings.TrimSpace(*name)
 			if trimmedName == "" && *name != "" {
 				return shared.UsageError("--name cannot be blank")
@@ -831,16 +850,19 @@ Examples:
 			if trimmedName != "" && *all {
 				return shared.UsageError("--all and --name are mutually exclusive")
 			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, authLogoutConfirmDeprecationWarning)
+			}
 
 			if trimmedName != "" {
-				if err := authsvc.RemoveCredentials(trimmedName); err != nil {
+				if err := removeStoredCredential(trimmedName); err != nil {
 					return fmt.Errorf("auth logout: failed to remove credentials: %w", err)
 				}
 				fmt.Printf("Successfully removed stored credential '%s'\n", trimmedName)
 				return nil
 			}
 
-			if err := authsvc.RemoveAllCredentials(); err != nil {
+			if err := removeStoredCredentials(); err != nil {
 				return fmt.Errorf("auth logout: failed to remove credentials: %w", err)
 			}
 

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -773,7 +773,45 @@ func TestAuthSwitchCommand(t *testing.T) {
 	})
 }
 
+type authLogoutTestCalls struct {
+	names []string
+	all   int
+}
+
+func stubLogoutRemovers(t *testing.T) *authLogoutTestCalls {
+	t.Helper()
+	calls := &authLogoutTestCalls{}
+	restore := SetLogoutCredentialRemovers(
+		func(name string) error {
+			calls.names = append(calls.names, name)
+			return nil
+		},
+		func() error {
+			calls.all++
+			return nil
+		},
+	)
+	t.Cleanup(restore)
+	return calls
+}
+
 func TestAuthLogoutCommand(t *testing.T) {
+	t.Run("help recommends confirmation", func(t *testing.T) {
+		cmd := AuthLogoutCommand()
+		if cmd.FlagSet.Lookup("confirm") == nil {
+			t.Fatal("expected --confirm flag")
+		}
+		for _, expected := range []string{
+			`asc auth logout --all --confirm`,
+			`asc auth logout --name "MyKey" --confirm`,
+			"will be required in 5.0.0",
+		} {
+			if !strings.Contains(cmd.LongHelp, expected) {
+				t.Fatalf("expected logout help to contain %q, got %q", expected, cmd.LongHelp)
+			}
+		}
+	})
+
 	t.Run("blank name rejected", func(t *testing.T) {
 		cmd := AuthLogoutCommand()
 		if err := cmd.FlagSet.Parse([]string{"--name", "   "}); err != nil {
@@ -807,61 +845,77 @@ func TestAuthLogoutCommand(t *testing.T) {
 	})
 
 	t.Run("remove named credential", func(t *testing.T) {
-		cfgPath := filepath.Join(t.TempDir(), "config.json")
-		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
-		t.Setenv("ASC_CONFIG_PATH", cfgPath)
-		if err := authsvc.StoreCredentialsConfigAt("demo", "KEY", "ISS", "/tmp/AuthKey.p8", cfgPath); err != nil {
-			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
-		}
+		calls := stubLogoutRemovers(t)
 
 		cmd := AuthLogoutCommand()
-		if err := cmd.FlagSet.Parse([]string{"--name", "demo"}); err != nil {
+		if err := cmd.FlagSet.Parse([]string{"--name", "demo", "--confirm"}); err != nil {
 			t.Fatalf("Parse() error: %v", err)
 		}
 		if err := cmd.Exec(context.Background(), []string{}); err != nil {
 			t.Fatalf("Exec() error: %v", err)
 		}
 
-		cfg, err := config.LoadAt(cfgPath)
-		if err != nil {
-			t.Fatalf("LoadAt() error: %v", err)
-		}
-		if cfg.DefaultKeyName != "" {
-			t.Fatalf("expected cleared default key, got %q", cfg.DefaultKeyName)
+		if len(calls.names) != 1 || calls.names[0] != "demo" || calls.all != 0 {
+			t.Fatalf("unexpected removal calls: %+v", calls)
 		}
 	})
 
 	t.Run("remove all credentials", func(t *testing.T) {
-		cfgPath := filepath.Join(t.TempDir(), "config.json")
-		t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
-		t.Setenv("ASC_CONFIG_PATH", cfgPath)
-		if err := authsvc.StoreCredentialsConfigAt("one", "KEY1", "ISS1", "/tmp/AuthKey1.p8", cfgPath); err != nil {
-			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
-		}
-		if err := authsvc.StoreCredentialsConfigAt("two", "KEY2", "ISS2", "/tmp/AuthKey2.p8", cfgPath); err != nil {
-			t.Fatalf("StoreCredentialsConfigAt() error: %v", err)
-		}
+		calls := stubLogoutRemovers(t)
 
 		cmd := AuthLogoutCommand()
-		if err := cmd.FlagSet.Parse([]string{"--all"}); err != nil {
+		if err := cmd.FlagSet.Parse([]string{"--all", "--confirm"}); err != nil {
 			t.Fatalf("Parse() error: %v", err)
 		}
-		execErr := cmd.Exec(context.Background(), []string{})
+		if err := cmd.Exec(context.Background(), []string{}); err != nil {
+			t.Fatalf("Exec() error: %v", err)
+		}
+		if len(calls.names) != 0 || calls.all != 1 {
+			t.Fatalf("unexpected removal calls: %+v", calls)
+		}
+	})
 
-		// Only skip on specific keychain interaction errors (errSecInteractionNotAllowed = -25301)
-		// This is expected in CI environments where keychain is locked
-		if execErr != nil && (strings.Contains(execErr.Error(), "errSecInteractionNotAllowed") ||
-			strings.Contains(execErr.Error(), "(-25301)")) {
-			t.Skipf("skipping: keychain interaction not allowed - %v", execErr)
+	t.Run("missing confirm warns during compatibility window", func(t *testing.T) {
+		calls := stubLogoutRemovers(t)
+
+		cmd := AuthLogoutCommand()
+		if err := cmd.FlagSet.Parse([]string{"--name", "legacy"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			if err := cmd.Exec(context.Background(), []string{}); err != nil {
+				t.Fatalf("Exec() error: %v", err)
+			}
+		})
+		wantWarning := "Warning: auth logout without --confirm is deprecated and will be rejected in 5.0.0; pass --confirm to acknowledge credential removal.\n"
+		if stderr != wantWarning {
+			t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
 		}
 
-		// Verify: either no error (success) or config was cleared
-		cfg, err := config.LoadAt(cfgPath)
-		if err != nil {
-			t.Fatalf("LoadAt() error: %v", err)
+		if len(calls.names) != 1 || calls.names[0] != "legacy" || calls.all != 0 {
+			t.Fatalf("unexpected removal calls: %+v", calls)
 		}
-		if len(cfg.Keys) != 0 || cfg.DefaultKeyName != "" || cfg.KeyID != "" {
-			t.Fatalf("expected cleared credentials, got %+v", cfg)
+	})
+
+	t.Run("unexpected arguments are rejected before removal", func(t *testing.T) {
+		calls := stubLogoutRemovers(t)
+
+		cmd := AuthLogoutCommand()
+		if err := cmd.FlagSet.Parse([]string{"--all", "--confirm"}); err != nil {
+			t.Fatalf("Parse() error: %v", err)
+		}
+		_, stderr := captureAuthOutput(t, func() {
+			err := cmd.Exec(context.Background(), []string{"unexpected"})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("Exec() error = %v, want flag.ErrHelp", err)
+			}
+		})
+		if !strings.Contains(stderr, "unexpected argument(s): unexpected") {
+			t.Fatalf("expected unexpected-argument error, got %q", stderr)
+		}
+
+		if len(calls.names) != 0 || calls.all != 0 {
+			t.Fatalf("expected no removal, got %+v", calls)
 		}
 	})
 }

--- a/internal/cli/auth/test_hooks.go
+++ b/internal/cli/auth/test_hooks.go
@@ -78,6 +78,23 @@ func SetMigrateKeychainToConfig(fn func(authsvc.MigrateKeychainToConfigOptions) 
 	}
 }
 
+// SetLogoutCredentialRemovers replaces the credential removal hooks for tests.
+// It returns a restore function to reset the previous handlers.
+func SetLogoutCredentialRemovers(remove func(string) error, removeAll func() error) func() {
+	previousRemove := removeStoredCredential
+	previousRemoveAll := removeStoredCredentials
+	if remove != nil {
+		removeStoredCredential = remove
+	}
+	if removeAll != nil {
+		removeStoredCredentials = removeAll
+	}
+	return func() {
+		removeStoredCredential = previousRemove
+		removeStoredCredentials = previousRemoveAll
+	}
+}
+
 // NewPermissionWarning builds a permission warning error for tests.
 func NewPermissionWarning(err error) error {
 	if err == nil {

--- a/internal/cli/cmdtest/auth_logout_test.go
+++ b/internal/cli/cmdtest/auth_logout_test.go
@@ -1,0 +1,162 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+	"testing"
+
+	authcmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/auth"
+)
+
+type authLogoutCalls struct {
+	names []string
+	all   int
+}
+
+func stubAuthLogoutRemovers(t *testing.T) *authLogoutCalls {
+	t.Helper()
+	calls := &authLogoutCalls{}
+	restore := authcmd.SetLogoutCredentialRemovers(
+		func(name string) error {
+			calls.names = append(calls.names, name)
+			return nil
+		},
+		func() error {
+			calls.all++
+			return nil
+		},
+	)
+	t.Cleanup(restore)
+	return calls
+}
+
+func TestAuthLogoutConfirmRemovesNamedCredentialWithoutWarning(t *testing.T) {
+	calls := stubAuthLogoutRemovers(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"auth", "logout", "--name", "demo", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stdout != "Successfully removed stored credential 'demo'\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no warning with --confirm, got %q", stderr)
+	}
+	if len(calls.names) != 1 || calls.names[0] != "demo" || calls.all != 0 {
+		t.Fatalf("unexpected removal calls: %+v", calls)
+	}
+}
+
+func TestAuthLogoutConfirmRemovesAllCredentialsWithoutWarning(t *testing.T) {
+	calls := stubAuthLogoutRemovers(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"auth", "logout", "--all", "--confirm"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stdout != "Successfully removed stored credentials\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no warning with --confirm, got %q", stderr)
+	}
+	if len(calls.names) != 0 || calls.all != 1 {
+		t.Fatalf("unexpected removal calls: %+v", calls)
+	}
+}
+
+func TestAuthLogoutWithoutConfirmWarnsAndPreservesLegacyRemoval(t *testing.T) {
+	calls := stubAuthLogoutRemovers(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"auth", "logout"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stdout != "Successfully removed stored credentials\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	wantWarning := "Warning: auth logout without --confirm is deprecated and will be rejected in 5.0.0; pass --confirm to acknowledge credential removal.\n"
+	if stderr != wantWarning {
+		t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
+	}
+	if len(calls.names) != 0 || calls.all != 1 {
+		t.Fatalf("unexpected removal calls: %+v", calls)
+	}
+}
+
+func TestAuthLogoutRejectsExplicitFalseConfirmBeforeRemoval(t *testing.T) {
+	calls := stubAuthLogoutRemovers(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"auth", "logout", "--all", "--confirm=false"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("run error = %v, want flag.ErrHelp", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "--confirm must be true when specified") {
+		t.Fatalf("expected explicit-false error, got %q", stderr)
+	}
+	if len(calls.names) != 0 || calls.all != 0 {
+		t.Fatalf("expected no removal, got %+v", calls)
+	}
+}
+
+func TestAuthLogoutRejectsPositionalArgsBeforeRemoval(t *testing.T) {
+	calls := stubAuthLogoutRemovers(t)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"auth", "logout", "--all", "--confirm", "unexpected"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		err := root.Run(context.Background())
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("run error = %v, want flag.ErrHelp", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "unexpected argument(s): unexpected") {
+		t.Fatalf("expected positional-argument error, got %q", stderr)
+	}
+	if len(calls.names) != 0 || calls.all != 0 {
+		t.Fatalf("expected no removal, got %+v", calls)
+	}
+}


### PR DESCRIPTION
## Summary

- accept `asc auth logout --confirm` for named and all-credential removal
- preserve existing unconfirmed logout during a compatibility window, with a stderr deprecation warning before 5.0.0 enforcement
- reject positional arguments and explicit `--confirm=false` before any removal
- isolate CLI tests from real credential stores and move settings-preservation coverage to an array keyring

## Why

Live 30-day telemetry shows six agent invocations already attempted the unsupported `--confirm` flag. A hard requirement immediately would break 31 successful current-version calls, including 25 CI calls, so this stages the safety contract without breaking automation.

## Compatibility

- confirmed calls keep the existing success output
- omitted confirmation still succeeds for now and adds a stderr warning
- bare logout still targets all credentials during the compatibility window
- `--confirm=false` and positional arguments fail before side effects
- confirmation becomes mandatory in 5.0.0

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `make build`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused auth, cmdtest, and array-keyring removal tests
- integration-tag package compiles; the normal repository integration target does not run `internal/auth`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--confirm` support for logging out of named profiles or all stored credentials.
  * Added validation for confirmation options and unexpected arguments.

* **Bug Fixes**
  * Improved credential cleanup while preserving unrelated configuration settings.

* **Documentation**
  * Clarified authentication sources, profile and keychain precedence, environment setup, and strict-auth behavior.
  * Updated logout, profile, and uninstall instructions, including confirmation requirements and compatibility guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->