### PR TITLE
test(pricing): adapt merged availability fixtures

### DIFF
--- a/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
+++ b/internal/cli/cmdtest/pricing_availability_remove_from_sale_test.go
@@ -3,6 +3,7 @@ package cmdtest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -474,6 +475,7 @@ func TestPricingAvailabilityRemoveFromSaleFailsClosedWhenPlatformStateIsUnverifi
 
 func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
@@ -489,7 +491,7 @@ func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T)
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
 			mu.Lock()
 			defer mu.Unlock()
-			return territoryAvailabilityResponse(t, states), nil
+			return territoryAvailabilityResponse(fixture, states), nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
 			patches.Add(1)
 			mu.Lock()
@@ -551,6 +553,7 @@ func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledged(t *testing.T)
 
 func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledgedReportsUnverifiedListings(t *testing.T) {
 	setupAuth(t)
+	fixture := handlertest.New(t)
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
@@ -562,7 +565,7 @@ func TestPricingAvailabilityRemoveFromSaleAllPlatformsAcknowledgedReportsUnverif
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/app-1/appAvailabilityV2":
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`), nil
 		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-1/territoryAvailabilities":
-			return territoryAvailabilityResponse(t, states), nil
+			return territoryAvailabilityResponse(fixture, states), nil
 		case req.Method == http.MethodPatch && req.URL.Path == "/v1/territoryAvailabilities/ta-usa":
 			states["USA"] = false
 			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"territoryAvailabilities","id":"ta-usa","attributes":{"available":false}}}`), nil


### PR DESCRIPTION
## Problem

After the ten 4.9.1 milestone PRs were merged, final-main lint and test compilation exposed a semantic cross-PR conflict. PR #2133 changed `territoryAvailabilityResponse` to require the goroutine-safe `handlertest.Asserter`, while two tests added through the later #2081 integration still passed `*testing.T`. The combined file also needed `fmt`, which #2133 had correctly removed from its earlier version.

This did not appear as a textual merge conflict, but final accumulated-main typechecking failed.

## Fix

- Restore the required `fmt` import.
- Bind one `handlertest.Asserter` in each affected test.
- Pass that asserter to `territoryAvailabilityResponse`.
- Preserve the off-test-goroutine failure safety introduced by #2133.

No production code changes.

## Verification

- Focused pricing availability tests
- Focused pricing race tests, repeated three times
- `internal/handlertest` race tests, repeated three times
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- Repository pre-commit command-doc, formatting, lint, and short-test hooks

The branch is one additive commit on final main `b8208f82a5ddd795a347fb6b65eed3de9fcd06d7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved multi-platform remove-from-sale test coverage with error-aware response validation.
  * Added consistent assertion handling across territory response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->