### PR TITLE
fix(itunes): cap oversized Retry-After delays

### DIFF
--- a/internal/itunes/retry.go
+++ b/internal/itunes/retry.go
@@ -112,12 +112,34 @@ func publicRetryDelay(headers http.Header, now time.Time, maxDelay time.Duration
 	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
 		return publicRetryDelayFromSeconds(seconds, maxDelay)
 	}
+	// ParseInt rejects positive values above MaxInt64, but Retry-After's
+	// delay-seconds grammar has no such bound. Treat an all-digit positive
+	// overflow as an arbitrarily long delay and apply the configured cap.
+	if isPositiveDecimal(value) {
+		const maxDuration = time.Duration(1<<63 - 1)
+		return capPublicRetryDelay(maxDuration, maxDelay)
+	}
 	if deadline, err := http.ParseTime(value); err == nil {
 		if delay := deadline.Sub(now); delay > 0 {
 			return capPublicRetryDelay(delay, maxDelay)
 		}
 	}
 	return 0
+}
+
+func isPositiveDecimal(value string) bool {
+	value = strings.TrimPrefix(value, "+")
+	if value == "" {
+		return false
+	}
+	positive := false
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+		positive = positive || value[i] != '0'
+	}
+	return positive
 }
 
 func publicRetryDelayFromSeconds(seconds int64, maxDelay time.Duration) time.Duration {

--- a/internal/itunes/retry_test.go
+++ b/internal/itunes/retry_test.go
@@ -462,6 +462,7 @@ func TestPublicRetryDelayParsesRetryAfterHeader(t *testing.T) {
 		{name: "seconds", value: "2", want: 2 * time.Second},
 		{name: "seconds capped", value: "600", want: maxDelay},
 		{name: "seconds overflow capped", value: "9223372036854775807", want: maxDelay},
+		{name: "seconds beyond int64 capped", value: "9223372036854775808", want: maxDelay},
 		{name: "zero seconds", value: "0", want: 0},
 		{name: "negative seconds", value: "-5", want: 0},
 		{name: "unparsable", value: "soon", want: 0},


### PR DESCRIPTION
## Summary

- treat positive numeric Retry-After values beyond int64 as an arbitrarily long delay
- apply the existing public retry cap instead of falling through to a zero-delay retry
- add a regression for 9223372036854775808

## Validation

- RED reproduced as 0s instead of the configured 30s cap
- focused and full internal/itunes tests
- race tests for internal/itunes and internal/asc
- full `ASC_BYPASS_KEYCHAIN=1 make test`
- normal pre-commit docs, format, lint, and short repository suite

No mutation retry policy changed and no live App Store Connect mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of extremely large `Retry-After` values.
  * Excessive retry delays are now safely capped at the configured maximum instead of causing errors or unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->