### PR TITLE
fix(subscriptions): validate price-point stream output flags

### DIFF
--- a/internal/cli/cmdtest/subscriptions_price_points_test.go
+++ b/internal/cli/cmdtest/subscriptions_price_points_test.go
@@ -244,6 +244,47 @@ func TestSubscriptionsPricePointsListStreamOutput(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsPricePointsListStreamAcceptsCaseInsensitiveJSONOutput(t *testing.T) {
+	setupAuth(t)
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"data":[{"type":"subscriptionPricePoints","id":"pp-1"}],"links":{}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"subscriptions", "pricing", "price-points", "list",
+			"--subscription-id", "8000000001",
+			"--paginate",
+			"--stream",
+			"--output", "JSON",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"pp-1"`) {
+		t.Fatalf("stdout = %q, want streamed JSON output", stdout)
+	}
+}
+
 func TestSubscriptionsPricePointsListStreamRejectsRepeatedNextURL(t *testing.T) {
 	setupAuth(t)
 

--- a/internal/cli/cmdtest/subscriptions_price_points_test.go
+++ b/internal/cli/cmdtest/subscriptions_price_points_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
 func TestSubscriptionsPricePointsListPaginateUsesPerPageTimeout(t *testing.T) {
@@ -119,8 +121,62 @@ func TestSubscriptionsPricePointsListStreamRequiresPaginate(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsPricePointsListStreamRejectsIncompatibleOutputFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "table output",
+			args:    []string{"--output", "table"},
+			wantErr: "--stream requires --output json",
+		},
+		{
+			name:    "markdown output",
+			args:    []string{"--output", "markdown"},
+			wantErr: "--stream requires --output json",
+		},
+		{
+			name:    "pretty JSON",
+			args:    []string{"--pretty"},
+			wantErr: "--stream cannot be combined with --pretty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{
+				"subscriptions", "pricing", "price-points", "list",
+				"--subscription-id", "8000000001",
+				"--paginate",
+				"--stream",
+			}
+			args = append(args, test.args...)
+
+			stdout, stderr, runErr := runRootCommand(t, args)
+			if runErr == nil {
+				t.Fatal("expected usage error, got nil")
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitUsage)
+			}
+			if !strings.Contains(runErr.Error(), test.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", runErr, test.wantErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, test.wantErr) {
+				t.Fatalf("stderr = %q, want it to contain %q", stderr, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestSubscriptionsPricePointsListStreamOutput(t *testing.T) {
 	setupAuth(t)
+	t.Setenv("ASC_DEFAULT_OUTPUT", "table")
 
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {

--- a/internal/cli/cmdtest/subscriptions_price_points_test.go
+++ b/internal/cli/cmdtest/subscriptions_price_points_test.go
@@ -244,7 +244,7 @@ func TestSubscriptionsPricePointsListStreamOutput(t *testing.T) {
 	}
 }
 
-func TestSubscriptionsPricePointsListStreamAcceptsCaseInsensitiveJSONOutput(t *testing.T) {
+func TestSubscriptionsPricePointsListStreamAcceptsNormalizedJSONOutput(t *testing.T) {
 	setupAuth(t)
 
 	originalTransport := http.DefaultTransport
@@ -260,28 +260,39 @@ func TestSubscriptionsPricePointsListStreamAcceptsCaseInsensitiveJSONOutput(t *t
 		}, nil
 	})
 
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{
-			"subscriptions", "pricing", "price-points", "list",
-			"--subscription-id", "8000000001",
-			"--paginate",
-			"--stream",
-			"--output", "JSON",
-		}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		if err := root.Run(context.Background()); err != nil {
-			t.Fatalf("run error: %v", err)
-		}
-	})
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "uppercase", value: "JSON"},
+		{name: "padded", value: " json "},
+		{name: "empty fallback", value: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"subscriptions", "pricing", "price-points", "list",
+					"--subscription-id", "8000000001",
+					"--paginate",
+					"--stream",
+					"--output", tc.value,
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
 
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
-	}
-	if !strings.Contains(stdout, `"id":"pp-1"`) {
-		t.Fatalf("stdout = %q, want streamed JSON output", stdout)
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if !strings.Contains(stdout, `"id":"pp-1"`) {
+				t.Fatalf("stdout = %q, want streamed JSON output", stdout)
+			}
+		})
 	}
 }
 

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -117,7 +117,11 @@ Examples:
 			if *stream && !*paginate {
 				return shared.UsageError("--stream requires --paginate")
 			}
-			if *stream && flagWasProvided(fs, "output") && shared.NormalizeOutputFormat(*output.Output) != "json" {
+			streamOutput := shared.NormalizeOutputFormat(*output.Output)
+			if streamOutput == "" {
+				streamOutput = "json"
+			}
+			if *stream && flagWasProvided(fs, "output") && streamOutput != "json" {
 				return shared.UsageError("--stream requires --output json")
 			}
 			if *stream && *output.Pretty {

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -117,7 +117,7 @@ Examples:
 			if *stream && !*paginate {
 				return shared.UsageError("--stream requires --paginate")
 			}
-			if *stream && flagWasProvided(fs, "output") && *output.Output != "json" {
+			if *stream && flagWasProvided(fs, "output") && shared.NormalizeOutputFormat(*output.Output) != "json" {
 				return shared.UsageError("--stream requires --output json")
 			}
 			if *stream && *output.Pretty {

--- a/internal/cli/subscriptions/price_points.go
+++ b/internal/cli/subscriptions/price_points.go
@@ -63,7 +63,7 @@ func SubscriptionsPricePointsListCommand() *ffcli.Command {
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
-	stream := fs.Bool("stream", false, "Stream pages as NDJSON (one JSON object per page, requires --paginate)")
+	stream := fs.Bool("stream", false, "Stream pages as NDJSON (requires --paginate; explicit --output must be json; incompatible with --pretty)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -84,7 +84,8 @@ When --territory-fields is set, the CLI automatically includes the territory
 relationship so the requested fields are present in the response.
 
 Use --stream with --paginate to emit each page as a separate JSON line (NDJSON)
-instead of buffering all pages in memory. This gives immediate feedback and
+instead of buffering all pages in memory. If --output is set, it must be json;
+streaming cannot be combined with --pretty. This gives immediate feedback and
 reduces memory usage for very large result sets.
 
 Examples:
@@ -115,6 +116,12 @@ Examples:
 			}
 			if *stream && !*paginate {
 				return shared.UsageError("--stream requires --paginate")
+			}
+			if *stream && flagWasProvided(fs, "output") && *output.Output != "json" {
+				return shared.UsageError("--stream requires --output json")
+			}
+			if *stream && *output.Pretty {
+				return shared.UsageError("--stream cannot be combined with --pretty")
 			}
 
 			priceFilter := shared.PriceFilter{


### PR DESCRIPTION
## Summary

- reject explicit table or markdown output for price-point streaming because the stream contract is NDJSON
- reject pretty-printed streaming, which cannot preserve one JSON object per line
- preserve plain stream behavior when the TTY-aware implicit default is table, and continue accepting explicit JSON
- validate before authentication or HTTP work with usage exit code 2 and no stdout

## Evidence

The command is materially used across invocation sources, but telemetry does not record paginate, stream, output, or pretty flags. The defect is therefore established by deterministic CLI reproduction and regression coverage, not attributed to aggregate failures.

Before this change, explicit table, markdown, and pretty options were silently accepted and ignored while minified NDJSON was emitted.

## Validation

- focused command tests, including RED then GREEN
- focused race test
- adjacent subscriptions tests
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- clean diff and synthetic merge against current main

This PR does not change the NDJSON stream shape or the default non-stream output contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved streaming price-point listing guidance to clarify JSON output requirements and `--pretty` restrictions.
  * JSON output format values now accept uppercase, lowercase, and padded variations.

* **Bug Fixes**
  * Streaming price-point listings now validate incompatible output options and return clear usage errors without producing invalid output.
  * Empty or unsupported output format values are handled consistently during streaming requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->