### PR TITLE
fix(auth): normalize stored profile names

### DIFF
--- a/internal/auth/doctor_test.go
+++ b/internal/auth/doctor_test.go
@@ -229,6 +229,8 @@ func TestDoctorEnvironmentRequiresWritablePrivateKeyTempDir(t *testing.T) {
 }
 
 func TestDoctorEnvironmentSkipsIgnoredPrivateKeys(t *testing.T) {
+	withSeparateKeyrings(t)
+
 	t.Run("selected profile", func(t *testing.T) {
 		tempDir := t.TempDir()
 		storedKeyPath := filepath.Join(tempDir, "stored.p8")

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -505,14 +505,14 @@ func completeCredentialPayload(payload credentialPayload) bool {
 	if !config.IsIndividualCredentialKeyType(payload.KeyType) && strings.TrimSpace(payload.IssuerID) == "" {
 		return false
 	}
-	if strings.TrimSpace(payload.PrivateKeyPath) != "" {
-		return true
+	// Credential resolution prefers embedded key material over the key path,
+	// so a present-but-invalid PEM makes the entry unusable at auth time even
+	// when a key path is also stored.
+	if strings.TrimSpace(payload.PrivateKeyPEM) != "" {
+		_, err := LoadPrivateKeyFromPEM([]byte(payload.PrivateKeyPEM))
+		return err == nil
 	}
-	if strings.TrimSpace(payload.PrivateKeyPEM) == "" {
-		return false
-	}
-	_, err := LoadPrivateKeyFromPEM([]byte(payload.PrivateKeyPEM))
-	return err == nil
+	return strings.TrimSpace(payload.PrivateKeyPath) != ""
 }
 
 func credentialPayloadsMatch(first, second credentialPayload) bool {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -381,7 +381,11 @@ func StoreCredentials(name, keyID, issuerID, keyPath string) error {
 
 // StoreCredentialsWithKeyType stores credentials with an explicit App Store Connect key type.
 func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string) error {
+	originalName := name
 	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("credential name is required")
+	}
 	payload := credentialPayload{
 		KeyID:          keyID,
 		IssuerID:       issuerID,
@@ -393,6 +397,11 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	}
 
 	if err := storeInKeychain(name, payload); err == nil {
+		if originalName != name {
+			if err := removeFromKeychain(originalName); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+				return fmt.Errorf("remove pre-normalized keychain credential %q: %w", originalName, err)
+			}
+		}
 		// Successfully stored in keychain - remove matching config entry for security
 		if err := removeFromConfigIfPresent(name); err != nil && !errors.Is(err, config.ErrNotFound) {
 			// Log but don't fail - keychain is the authoritative storage

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -505,7 +505,14 @@ func completeCredentialPayload(payload credentialPayload) bool {
 	if !config.IsIndividualCredentialKeyType(payload.KeyType) && strings.TrimSpace(payload.IssuerID) == "" {
 		return false
 	}
-	return strings.TrimSpace(payload.PrivateKeyPath) != "" || strings.TrimSpace(payload.PrivateKeyPEM) != ""
+	if strings.TrimSpace(payload.PrivateKeyPath) != "" {
+		return true
+	}
+	if strings.TrimSpace(payload.PrivateKeyPEM) == "" {
+		return false
+	}
+	_, err := LoadPrivateKeyFromPEM([]byte(payload.PrivateKeyPEM))
+	return err == nil
 }
 
 func credentialPayloadsMatch(first, second credentialPayload) bool {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -468,7 +468,9 @@ func rejectNormalizedCredentialCollision(originalName, normalizedName string, in
 		}
 	}
 
-	if canonicalFound && originalFound && canonical != original && canonical != incoming {
+	if canonicalFound && originalFound &&
+		!credentialPayloadsMatch(canonical, original) &&
+		!credentialPayloadsMatch(canonical, incoming) {
 		return fmt.Errorf(
 			"credential profile name %q conflicts with existing normalized profile %q; remove one before retrying",
 			originalName,
@@ -503,7 +505,22 @@ func completeCredentialPayload(payload credentialPayload) bool {
 	if !config.IsIndividualCredentialKeyType(payload.KeyType) && strings.TrimSpace(payload.IssuerID) == "" {
 		return false
 	}
-	return payload.PrivateKeyPath != "" || strings.TrimSpace(payload.PrivateKeyPEM) != ""
+	return strings.TrimSpace(payload.PrivateKeyPath) != "" || strings.TrimSpace(payload.PrivateKeyPEM) != ""
+}
+
+func credentialPayloadsMatch(first, second credentialPayload) bool {
+	if first.KeyID != second.KeyID ||
+		first.IssuerID != second.IssuerID ||
+		config.NormalizeCredentialKeyType(first.KeyType) != config.NormalizeCredentialKeyType(second.KeyType) {
+		return false
+	}
+
+	firstPEM := strings.TrimSpace(first.PrivateKeyPEM)
+	secondPEM := strings.TrimSpace(second.PrivateKeyPEM)
+	if firstPEM != "" && secondPEM != "" {
+		return first.PrivateKeyPEM == second.PrivateKeyPEM
+	}
+	return first.PrivateKeyPath == second.PrivateKeyPath
 }
 
 func loadPrivateKeyPEMForStorage(path string) (string, error) {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -472,8 +472,12 @@ func rejectNormalizedCredentialCollision(originalName, normalizedName string, in
 		!credentialPayloadsMatch(canonical, original) &&
 		!credentialPayloadsMatch(canonical, incoming) {
 		return fmt.Errorf(
-			"credential profile name %q conflicts with existing normalized profile %q; remove one before retrying",
+			"credential profile name %q conflicts with existing normalized profile %q; "+
+				"remove the existing profile with 'asc auth logout --name %q' and retry, "+
+				"or re-run 'asc auth login' with --name %q to overwrite it",
 			originalName,
+			normalizedName,
+			normalizedName,
 			normalizedName,
 		)
 	}

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -515,12 +515,23 @@ func credentialPayloadsMatch(first, second credentialPayload) bool {
 		return false
 	}
 
-	firstPEM := strings.TrimSpace(first.PrivateKeyPEM)
-	secondPEM := strings.TrimSpace(second.PrivateKeyPEM)
+	firstPEM := credentialPrivateKeyForComparison(first)
+	secondPEM := credentialPrivateKeyForComparison(second)
 	if firstPEM != "" && secondPEM != "" {
-		return first.PrivateKeyPEM == second.PrivateKeyPEM
+		return firstPEM == secondPEM
 	}
 	return first.PrivateKeyPath == second.PrivateKeyPath
+}
+
+func credentialPrivateKeyForComparison(payload credentialPayload) string {
+	if strings.TrimSpace(payload.PrivateKeyPEM) != "" {
+		return payload.PrivateKeyPEM
+	}
+	privateKeyPEM, err := loadPrivateKeyPEMForStorage(payload.PrivateKeyPath)
+	if err != nil || strings.TrimSpace(privateKeyPEM) == "" {
+		return ""
+	}
+	return privateKeyPEM
 }
 
 func loadPrivateKeyPEMForStorage(path string) (string, error) {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -386,6 +386,9 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	if name == "" {
 		return fmt.Errorf("credential name is required")
 	}
+	if err := rejectNormalizedCredentialCollision(originalName, name); err != nil {
+		return err
+	}
 	payload := credentialPayload{
 		KeyID:          keyID,
 		IssuerID:       issuerID,
@@ -401,6 +404,10 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 			if err := removeFromKeychain(originalName); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
 				return fmt.Errorf("remove pre-normalized keychain credential %q: %w", originalName, err)
 			}
+			if err := removeFromLegacyKeychain(originalName); err != nil &&
+				!errors.Is(err, keyring.ErrKeyNotFound) && !isKeyringUnavailable(err) {
+				return fmt.Errorf("remove pre-normalized legacy keychain credential %q: %w", originalName, err)
+			}
 		}
 		// Successfully stored in keychain - remove matching config entry for security
 		if err := removeFromConfigIfPresent(name); err != nil && !errors.Is(err, config.ErrNotFound) {
@@ -413,6 +420,70 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	}
 
 	return storeInConfig(name, payload)
+}
+
+func rejectNormalizedCredentialCollision(originalName, normalizedName string) error {
+	if originalName == normalizedName {
+		return nil
+	}
+
+	current, err := keyringOpener()
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return nil
+		}
+		return err
+	}
+	keyrings := []keyring.Keyring{current}
+	legacy, err := legacyKeyringOpener()
+	if err == nil {
+		keyrings = append(keyrings, legacy)
+	} else if !isKeyringUnavailable(err) {
+		return err
+	}
+
+	var canonicalPayloads []credentialPayload
+	var originalPayloads []credentialPayload
+	for _, kr := range keyrings {
+		if payload, found, err := credentialPayloadFromKeyring(kr, normalizedName); err != nil {
+			return err
+		} else if found {
+			canonicalPayloads = append(canonicalPayloads, payload)
+		}
+		if payload, found, err := credentialPayloadFromKeyring(kr, originalName); err != nil {
+			return err
+		} else if found {
+			originalPayloads = append(originalPayloads, payload)
+		}
+	}
+
+	for _, canonical := range canonicalPayloads {
+		for _, original := range originalPayloads {
+			if canonical != original {
+				return fmt.Errorf(
+					"credential profile name %q conflicts with existing normalized profile %q; remove one before retrying",
+					originalName,
+					normalizedName,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func credentialPayloadFromKeyring(kr keyring.Keyring, name string) (credentialPayload, bool, error) {
+	item, err := kr.Get(keyringKey(name))
+	if errors.Is(err, keyring.ErrKeyNotFound) {
+		return credentialPayload{}, false, nil
+	}
+	if err != nil {
+		return credentialPayload{}, false, err
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		return credentialPayload{}, false, fmt.Errorf("invalid keychain entry %q: %w", item.Key, err)
+	}
+	return payload, true, nil
 }
 
 func loadPrivateKeyPEMForStorage(path string) (string, error) {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -381,6 +381,7 @@ func StoreCredentials(name, keyID, issuerID, keyPath string) error {
 
 // StoreCredentialsWithKeyType stores credentials with an explicit App Store Connect key type.
 func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string) error {
+	name = strings.TrimSpace(name)
 	payload := credentialPayload{
 		KeyID:          keyID,
 		IssuerID:       issuerID,

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -518,6 +518,11 @@ func credentialPayloadsMatch(first, second credentialPayload) bool {
 	firstPEM := credentialPrivateKeyForComparison(first)
 	secondPEM := credentialPrivateKeyForComparison(second)
 	if firstPEM != "" && secondPEM != "" {
+		firstKey, firstErr := LoadPrivateKeyFromPEM([]byte(firstPEM))
+		secondKey, secondErr := LoadPrivateKeyFromPEM([]byte(secondPEM))
+		if firstErr == nil && secondErr == nil {
+			return firstKey.Equal(secondKey)
+		}
 		return firstPEM == secondPEM
 	}
 	return first.PrivateKeyPath == second.PrivateKeyPath

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -396,16 +396,23 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	if privateKeyPEM, err := loadPrivateKeyPEMForStorage(keyPath); err == nil && strings.TrimSpace(privateKeyPEM) != "" {
 		payload.PrivateKeyPEM = privateKeyPEM
 	}
-	if err := rejectNormalizedCredentialCollision(originalName, name); err != nil {
+	currentAvailable, legacyAvailable, err := rejectNormalizedCredentialCollision(originalName, name)
+	if err != nil {
 		return err
 	}
+	if !currentAvailable {
+		return storeInConfig(name, payload)
+	}
 	previousCanonical, previousCanonicalFound, err := currentKeychainItem(name)
-	if err != nil && !isKeyringUnavailable(err) {
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return storeInConfig(name, payload)
+		}
 		return err
 	}
 
 	if err := storeInKeychain(name, payload); err == nil {
-		if err := removePreNormalizedKeychainEntries(name); err != nil {
+		if err := removePreNormalizedKeychainEntries(name, legacyAvailable); err != nil {
 			if rollbackErr := restoreCurrentKeychainItem(name, previousCanonical, previousCanonicalFound); rollbackErr != nil {
 				return fmt.Errorf("%w; restore canonical credential: %w", err, rollbackErr)
 			}
@@ -464,32 +471,40 @@ type keychainItemSnapshot struct {
 // Collision preflight has already established that no distinct usable
 // credential will be discarded. If any removal fails, already-removed entries
 // are restored so callers can safely retry the normalization.
-func removePreNormalizedKeychainEntries(normalizedName string) error {
+func removePreNormalizedKeychainEntries(normalizedName string, includeLegacy bool) error {
 	current, err := preNormalizedKeychainItems(keyringOpener, normalizedName, "keychain")
 	if err != nil {
 		return err
 	}
-	legacy, err := preNormalizedKeychainItems(legacyKeyringOpener, normalizedName, "legacy keychain")
-	if err != nil {
-		return err
+	items := current
+	if includeLegacy {
+		legacy, err := preNormalizedKeychainItems(legacyKeyringOpener, normalizedName, "legacy keychain")
+		if err != nil {
+			return err
+		}
+		items = append(items, legacy...)
 	}
 
-	items := append(current, legacy...)
+	_, err = removeKeychainItems(items)
+	return err
+}
+
+func removeKeychainItems(items []keychainItemSnapshot) ([]keychainItemSnapshot, error) {
 	removed := make([]keychainItemSnapshot, 0, len(items))
 	for _, snapshot := range items {
 		if err := snapshot.store.Remove(snapshot.item.Key); err != nil {
 			if errors.Is(err, keyring.ErrKeyNotFound) {
 				continue
 			}
-			removeErr := fmt.Errorf("remove pre-normalized %s credentials: %w", snapshot.source, err)
+			removeErr := fmt.Errorf("remove %s credential %q: %w", snapshot.source, snapshot.item.Key, err)
 			if rollbackErr := restoreKeychainItems(removed); rollbackErr != nil {
-				return fmt.Errorf("%w; restore removed credentials: %w", removeErr, rollbackErr)
+				return removed, fmt.Errorf("%w; restore removed credentials: %w", removeErr, rollbackErr)
 			}
-			return removeErr
+			return nil, removeErr
 		}
 		removed = append(removed, snapshot)
 	}
-	return nil
+	return removed, nil
 }
 
 func preNormalizedKeychainItems(
@@ -497,19 +512,22 @@ func preNormalizedKeychainItems(
 	normalizedName string,
 	source string,
 ) ([]keychainItemSnapshot, error) {
+	return normalizedKeychainItems(opener, normalizedName, false, source)
+}
+
+func normalizedKeychainItems(
+	opener func() (keyring.Keyring, error),
+	normalizedName string,
+	includeCanonical bool,
+	source string,
+) ([]keychainItemSnapshot, error) {
 	kr, err := opener()
 	if err != nil {
-		if isKeyringUnavailable(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("list pre-normalized %s credentials: %w", source, err)
+		return nil, fmt.Errorf("list %s credentials: %w", source, err)
 	}
 	keys, err := kr.Keys()
 	if err != nil {
-		if isKeyringUnavailable(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("list pre-normalized %s credentials: %w", source, err)
+		return nil, fmt.Errorf("list %s credentials: %w", source, err)
 	}
 	sort.Strings(keys)
 
@@ -519,7 +537,7 @@ func preNormalizedKeychainItems(
 			continue
 		}
 		name := strings.TrimPrefix(key, keyringItemPrefix)
-		if name == normalizedName || strings.TrimSpace(name) != normalizedName {
+		if strings.TrimSpace(name) != normalizedName || (!includeCanonical && name == normalizedName) {
 			continue
 		}
 		item, err := kr.Get(key)
@@ -527,7 +545,7 @@ func preNormalizedKeychainItems(
 			continue
 		}
 		if err != nil {
-			return nil, fmt.Errorf("read pre-normalized %s credential %q: %w", source, name, err)
+			return nil, fmt.Errorf("read %s credential %q: %w", source, name, err)
 		}
 		items = append(items, keychainItemSnapshot{store: kr, item: item, source: source})
 	}
@@ -545,55 +563,10 @@ func restoreKeychainItems(items []keychainItemSnapshot) error {
 	return errors.Join(errs...)
 }
 
-func removeNormalizedKeychainEntries(
-	opener func() (keyring.Keyring, error),
-	normalizedName string,
-	includeCanonical bool,
-) (bool, error) {
-	kr, err := opener()
+func rejectNormalizedCredentialCollision(originalName, normalizedName string) (bool, bool, error) {
+	payloads, currentAvailable, legacyAvailable, err := normalizedCredentialPayloads(normalizedName)
 	if err != nil {
-		if isKeyringUnavailable(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	keys, err := kr.Keys()
-	if err != nil {
-		if isKeyringUnavailable(err) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	names := make([]string, 0)
-	for _, key := range keys {
-		if !strings.HasPrefix(key, keyringItemPrefix) {
-			continue
-		}
-		name := strings.TrimPrefix(key, keyringItemPrefix)
-		if strings.TrimSpace(name) != normalizedName || (!includeCanonical && name == normalizedName) {
-			continue
-		}
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	removed := false
-	for _, name := range names {
-		if err := kr.Remove(keyringKey(name)); err != nil {
-			if errors.Is(err, keyring.ErrKeyNotFound) {
-				continue
-			}
-			return removed, err
-		}
-		removed = true
-	}
-	return removed, nil
-}
-
-func rejectNormalizedCredentialCollision(originalName, normalizedName string) error {
-	payloads, err := normalizedCredentialPayloads(normalizedName)
-	if err != nil {
-		return err
+		return false, false, err
 	}
 	names := make([]string, 0, len(payloads))
 	for name := range payloads {
@@ -601,7 +574,7 @@ func rejectNormalizedCredentialCollision(originalName, normalizedName string) er
 	}
 	sort.Strings(names)
 	if len(names) < 2 {
-		return nil
+		return currentAvailable, legacyAvailable, nil
 	}
 
 	first := payloads[names[0]]
@@ -609,7 +582,7 @@ func rejectNormalizedCredentialCollision(originalName, normalizedName string) er
 		if credentialPayloadsMatch(first, payloads[name]) {
 			continue
 		}
-		return fmt.Errorf(
+		return currentAvailable, legacyAvailable, fmt.Errorf(
 			"credential profile name %q conflicts with existing normalized profile %q; "+
 				"remove the existing profile with 'asc auth logout --name %q' and retry",
 			originalName,
@@ -617,38 +590,41 @@ func rejectNormalizedCredentialCollision(originalName, normalizedName string) er
 			normalizedName,
 		)
 	}
-	return nil
+	return currentAvailable, legacyAvailable, nil
 }
 
-func normalizedCredentialPayloads(normalizedName string) (map[string]credentialPayload, error) {
+func normalizedCredentialPayloads(normalizedName string) (map[string]credentialPayload, bool, bool, error) {
 	payloads := make(map[string]credentialPayload)
 	seen := make(map[string]struct{})
 
 	current, err := keyringOpener()
 	if err != nil {
 		if isKeyringUnavailable(err) {
-			return payloads, nil
+			return payloads, false, false, nil
 		}
-		return nil, err
+		return nil, false, false, err
 	}
 	if err := collectNormalizedCredentialPayloads(current, normalizedName, payloads, seen); err != nil {
 		if isKeyringUnavailable(err) {
-			return payloads, nil
+			return payloads, false, false, nil
 		}
-		return nil, err
+		return nil, false, false, err
 	}
 
 	legacy, err := legacyKeyringOpener()
 	if err != nil {
 		if isKeyringUnavailable(err) {
-			return payloads, nil
+			return payloads, true, false, nil
 		}
-		return nil, err
+		return nil, false, false, err
 	}
-	if err := collectNormalizedCredentialPayloads(legacy, normalizedName, payloads, seen); err != nil && !isKeyringUnavailable(err) {
-		return nil, err
+	if err := collectNormalizedCredentialPayloads(legacy, normalizedName, payloads, seen); err != nil {
+		if isKeyringUnavailable(err) {
+			return payloads, true, false, nil
+		}
+		return nil, false, false, err
 	}
-	return payloads, nil
+	return payloads, true, true, nil
 }
 
 func collectNormalizedCredentialPayloads(
@@ -1272,22 +1248,32 @@ func RemoveCredentials(name string) error {
 	if name == "" {
 		return fmt.Errorf("credential name is required")
 	}
-	removedCurrent, err := removeNormalizedKeychainEntries(keyringOpener, name, true)
-	if err != nil {
-		return err
-	}
-	removedLegacy, err := removeNormalizedKeychainEntries(legacyKeyringOpener, name, true)
-	if err != nil {
-		return err
+	removed := make([]keychainItemSnapshot, 0)
+	if !shouldBypassKeychain() {
+		current, err := normalizedKeychainItems(keyringOpener, name, true, "keychain")
+		if err != nil {
+			return err
+		}
+		legacy, err := normalizedKeychainItems(legacyKeyringOpener, name, true, "legacy keychain")
+		if err != nil {
+			return err
+		}
+		removed, err = removeKeychainItems(append(current, legacy...))
+		if err != nil {
+			return err
+		}
 	}
 
 	configErr := removeFromConfigIfPresent(name)
 	if configErr != nil &&
 		!errors.Is(configErr, config.ErrNotFound) &&
 		!errors.Is(configErr, keyring.ErrKeyNotFound) {
+		if rollbackErr := restoreKeychainItems(removed); rollbackErr != nil {
+			return fmt.Errorf("%w; restore removed credentials: %w", configErr, rollbackErr)
+		}
 		return configErr
 	}
-	if removedCurrent || removedLegacy || configErr == nil {
+	if len(removed) > 0 || configErr == nil {
 		return clearDefaultNameIf(name)
 	}
 	return configErr
@@ -1896,29 +1882,107 @@ func removeFromConfigIfPresent(name string) error {
 		return err
 	}
 
-	removed := false
+	type configRemoval struct {
+		path     string
+		original *config.Config
+		updated  *config.Config
+	}
+	removals := make([]configRemoval, 0, len(paths))
 	missingCredential := false
 	for _, path := range paths {
-		err := removeFromConfigAt(name, path)
-		switch {
-		case err == nil:
-			removed = true
-		case errors.Is(err, config.ErrNotFound):
+		cfg, err := config.LoadAt(path)
+		if errors.Is(err, config.ErrNotFound) {
 			continue
-		case errors.Is(err, keyring.ErrKeyNotFound):
+		}
+		if err != nil {
+			return err
+		}
+		updated := cloneConfigForCredentialRemoval(cfg)
+		if !removeCredentialFromConfig(updated, name) {
 			missingCredential = true
-		default:
+			continue
+		}
+		removals = append(removals, configRemoval{path: path, original: cfg, updated: updated})
+	}
+
+	for index, removal := range removals {
+		if err := config.SaveAt(removal.path, removal.updated); err != nil {
+			rollbackErrors := make([]error, 0, index+1)
+			for rollbackIndex := index; rollbackIndex >= 0; rollbackIndex-- {
+				prior := removals[rollbackIndex]
+				if rollbackErr := config.SaveAt(prior.path, prior.original); rollbackErr != nil {
+					rollbackErrors = append(rollbackErrors, fmt.Errorf("restore config %q: %w", prior.path, rollbackErr))
+				}
+			}
+			if rollbackErr := errors.Join(rollbackErrors...); rollbackErr != nil {
+				return fmt.Errorf("%w; restore earlier config credentials: %w", err, rollbackErr)
+			}
 			return err
 		}
 	}
 
-	if removed {
+	if len(removals) > 0 {
 		return nil
 	}
 	if missingCredential {
 		return keyring.ErrKeyNotFound
 	}
 	return nil
+}
+
+func cloneConfigForCredentialRemoval(cfg *config.Config) *config.Config {
+	cloned := *cfg
+	cloned.Keys = append([]config.Credential(nil), cfg.Keys...)
+	cloned.KeychainMetadata = append([]config.KeychainMetadata(nil), cfg.KeychainMetadata...)
+	return &cloned
+}
+
+func removeCredentialFromConfig(cfg *config.Config, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		cfg.KeyID = ""
+		cfg.IssuerID = ""
+		cfg.PrivateKeyPath = ""
+		cfg.KeyType = ""
+		cfg.DefaultKeyName = ""
+		cfg.Keys = nil
+		cfg.KeychainMetadata = nil
+		return true
+	}
+
+	removed := false
+	if len(cfg.Keys) > 0 {
+		filtered := cfg.Keys[:0]
+		for _, cred := range cfg.Keys {
+			if strings.TrimSpace(cred.Name) == name {
+				removed = true
+				continue
+			}
+			filtered = append(filtered, cred)
+		}
+		cfg.Keys = filtered
+	}
+	if len(cfg.KeychainMetadata) > 0 {
+		filteredMetadata := cfg.KeychainMetadata[:0]
+		for _, entry := range cfg.KeychainMetadata {
+			if strings.TrimSpace(entry.Name) == name {
+				removed = true
+				continue
+			}
+			filteredMetadata = append(filteredMetadata, entry)
+		}
+		cfg.KeychainMetadata = filteredMetadata
+	}
+
+	if strings.TrimSpace(cfg.DefaultKeyName) == name {
+		cfg.KeyID = ""
+		cfg.IssuerID = ""
+		cfg.PrivateKeyPath = ""
+		cfg.KeyType = ""
+		cfg.DefaultKeyName = ""
+		removed = true
+	}
+	return removed
 }
 
 func removeFromKeychain(name string) error {
@@ -2321,61 +2385,6 @@ func clearDefaultNameIf(name string) error {
 		return config.Save(cfg)
 	}
 	return nil
-}
-
-func removeFromConfigAt(name, path string) error {
-	cfg, err := config.LoadAt(path)
-	if err != nil {
-		return err
-	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		cfg.KeyID = ""
-		cfg.IssuerID = ""
-		cfg.PrivateKeyPath = ""
-		cfg.KeyType = ""
-		cfg.DefaultKeyName = ""
-		cfg.Keys = nil
-		cfg.KeychainMetadata = nil
-		return config.SaveAt(path, cfg)
-	}
-
-	removed := false
-	if len(cfg.Keys) > 0 {
-		filtered := cfg.Keys[:0]
-		for _, cred := range cfg.Keys {
-			if strings.TrimSpace(cred.Name) == name {
-				removed = true
-				continue
-			}
-			filtered = append(filtered, cred)
-		}
-		cfg.Keys = filtered
-	}
-	if len(cfg.KeychainMetadata) > 0 {
-		filteredMetadata := cfg.KeychainMetadata[:0]
-		for _, entry := range cfg.KeychainMetadata {
-			if strings.TrimSpace(entry.Name) == name {
-				removed = true
-				continue
-			}
-			filteredMetadata = append(filteredMetadata, entry)
-		}
-		cfg.KeychainMetadata = filteredMetadata
-	}
-
-	if strings.TrimSpace(cfg.DefaultKeyName) == name {
-		cfg.KeyID = ""
-		cfg.IssuerID = ""
-		cfg.PrivateKeyPath = ""
-		cfg.KeyType = ""
-		cfg.DefaultKeyName = ""
-		removed = true
-	}
-	if !removed {
-		return keyring.ErrKeyNotFound
-	}
-	return config.SaveAt(path, cfg)
 }
 
 func configCleanupPaths() ([]string, error) {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -490,10 +490,20 @@ func credentialPayloadForCollision(kr keyring.Keyring, name string) (credentialP
 	if err := json.Unmarshal(item.Data, &payload); err != nil {
 		return credentialPayload{}, false, nil
 	}
-	if payload == (credentialPayload{}) {
+	if !completeCredentialPayload(payload) {
 		return credentialPayload{}, false, nil
 	}
 	return payload, true, nil
+}
+
+func completeCredentialPayload(payload credentialPayload) bool {
+	if strings.TrimSpace(payload.KeyID) == "" || !config.IsValidCredentialKeyType(payload.KeyType) {
+		return false
+	}
+	if !config.IsIndividualCredentialKeyType(payload.KeyType) && strings.TrimSpace(payload.IssuerID) == "" {
+		return false
+	}
+	return payload.PrivateKeyPath != "" || strings.TrimSpace(payload.PrivateKeyPEM) != ""
 }
 
 func loadPrivateKeyPEMForStorage(path string) (string, error) {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -399,9 +399,16 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	if err := rejectNormalizedCredentialCollision(originalName, name); err != nil {
 		return err
 	}
+	previousCanonical, previousCanonicalFound, err := currentKeychainItem(name)
+	if err != nil && !isKeyringUnavailable(err) {
+		return err
+	}
 
 	if err := storeInKeychain(name, payload); err == nil {
 		if err := removePreNormalizedKeychainEntries(name); err != nil {
+			if rollbackErr := restoreCurrentKeychainItem(name, previousCanonical, previousCanonicalFound); rollbackErr != nil {
+				return fmt.Errorf("%w; restore canonical credential: %w", err, rollbackErr)
+			}
 			return err
 		}
 		// Successfully stored in keychain - remove matching config entry for security
@@ -417,18 +424,125 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	return storeInConfig(name, payload)
 }
 
+func currentKeychainItem(name string) (keyring.Item, bool, error) {
+	kr, err := keyringOpener()
+	if err != nil {
+		return keyring.Item{}, false, err
+	}
+	item, err := kr.Get(keyringKey(name))
+	if errors.Is(err, keyring.ErrKeyNotFound) {
+		return keyring.Item{}, false, nil
+	}
+	if err != nil {
+		return keyring.Item{}, false, err
+	}
+	return item, true, nil
+}
+
+func restoreCurrentKeychainItem(name string, previous keyring.Item, found bool) error {
+	kr, err := keyringOpener()
+	if err != nil {
+		return err
+	}
+	if found {
+		return kr.Set(previous)
+	}
+	if err := kr.Remove(keyringKey(name)); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+		return err
+	}
+	return nil
+}
+
+type keychainItemSnapshot struct {
+	store  keyring.Keyring
+	item   keyring.Item
+	source string
+}
+
 // removePreNormalizedKeychainEntries removes every non-canonical spelling from
 // the current and legacy keychains.
 // Collision preflight has already established that no distinct usable
-// credential will be discarded.
+// credential will be discarded. If any removal fails, already-removed entries
+// are restored so callers can safely retry the normalization.
 func removePreNormalizedKeychainEntries(normalizedName string) error {
-	if _, err := removeNormalizedKeychainEntries(keyringOpener, normalizedName, false); err != nil {
-		return fmt.Errorf("remove pre-normalized keychain credentials: %w", err)
+	current, err := preNormalizedKeychainItems(keyringOpener, normalizedName, "keychain")
+	if err != nil {
+		return err
 	}
-	if _, err := removeNormalizedKeychainEntries(legacyKeyringOpener, normalizedName, false); err != nil {
-		return fmt.Errorf("remove pre-normalized legacy keychain credentials: %w", err)
+	legacy, err := preNormalizedKeychainItems(legacyKeyringOpener, normalizedName, "legacy keychain")
+	if err != nil {
+		return err
+	}
+
+	items := append(current, legacy...)
+	removed := make([]keychainItemSnapshot, 0, len(items))
+	for _, snapshot := range items {
+		if err := snapshot.store.Remove(snapshot.item.Key); err != nil {
+			if errors.Is(err, keyring.ErrKeyNotFound) {
+				continue
+			}
+			removeErr := fmt.Errorf("remove pre-normalized %s credentials: %w", snapshot.source, err)
+			if rollbackErr := restoreKeychainItems(removed); rollbackErr != nil {
+				return fmt.Errorf("%w; restore removed credentials: %w", removeErr, rollbackErr)
+			}
+			return removeErr
+		}
+		removed = append(removed, snapshot)
 	}
 	return nil
+}
+
+func preNormalizedKeychainItems(
+	opener func() (keyring.Keyring, error),
+	normalizedName string,
+	source string,
+) ([]keychainItemSnapshot, error) {
+	kr, err := opener()
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list pre-normalized %s credentials: %w", source, err)
+	}
+	keys, err := kr.Keys()
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list pre-normalized %s credentials: %w", source, err)
+	}
+	sort.Strings(keys)
+
+	items := make([]keychainItemSnapshot, 0)
+	for _, key := range keys {
+		if !strings.HasPrefix(key, keyringItemPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(key, keyringItemPrefix)
+		if name == normalizedName || strings.TrimSpace(name) != normalizedName {
+			continue
+		}
+		item, err := kr.Get(key)
+		if errors.Is(err, keyring.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read pre-normalized %s credential %q: %w", source, name, err)
+		}
+		items = append(items, keychainItemSnapshot{store: kr, item: item, source: source})
+	}
+	return items, nil
+}
+
+func restoreKeychainItems(items []keychainItemSnapshot) error {
+	errs := make([]error, 0)
+	for index := len(items) - 1; index >= 0; index-- {
+		snapshot := items[index]
+		if err := snapshot.store.Set(snapshot.item); err != nil {
+			errs = append(errs, fmt.Errorf("%s credential %q: %w", snapshot.source, snapshot.item.Key, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func removeNormalizedKeychainEntries(
@@ -605,10 +719,9 @@ func completeCredentialPayload(payload credentialPayload) bool {
 	if strings.TrimSpace(payload.PrivateKeyPath) == "" {
 		return false
 	}
-	// A path-only entry is usable only if resolution's loader can read and
-	// parse the referenced key file.
-	_, err := LoadPrivateKey(payload.PrivateKeyPath)
-	return err == nil
+	// Path-only entries must satisfy the same parsing and permission checks as
+	// production client creation before they can block normalization repair.
+	return ValidateKeyFile(payload.PrivateKeyPath) == nil
 }
 
 func credentialPayloadsMatch(first, second credentialPayload) bool {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -386,9 +386,6 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	if name == "" {
 		return fmt.Errorf("credential name is required")
 	}
-	if err := rejectNormalizedCredentialCollision(originalName, name); err != nil {
-		return err
-	}
 	payload := credentialPayload{
 		KeyID:          keyID,
 		IssuerID:       issuerID,
@@ -397,6 +394,9 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	}
 	if privateKeyPEM, err := loadPrivateKeyPEMForStorage(keyPath); err == nil && strings.TrimSpace(privateKeyPEM) != "" {
 		payload.PrivateKeyPEM = privateKeyPEM
+	}
+	if err := rejectNormalizedCredentialCollision(originalName, name, payload); err != nil {
+		return err
 	}
 
 	if err := storeInKeychain(name, payload); err == nil {
@@ -422,7 +422,7 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	return storeInConfig(name, payload)
 }
 
-func rejectNormalizedCredentialCollision(originalName, normalizedName string) error {
+func rejectNormalizedCredentialCollision(originalName, normalizedName string, incoming credentialPayload) error {
 	if originalName == normalizedName {
 		return nil
 	}
@@ -459,7 +459,7 @@ func rejectNormalizedCredentialCollision(originalName, normalizedName string) er
 
 	for _, canonical := range canonicalPayloads {
 		for _, original := range originalPayloads {
-			if canonical != original {
+			if canonical != original && canonical != incoming {
 				return fmt.Errorf(
 					"credential profile name %q conflicts with existing normalized profile %q; remove one before retrying",
 					originalName,

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -490,6 +490,9 @@ func credentialPayloadForCollision(kr keyring.Keyring, name string) (credentialP
 	if err := json.Unmarshal(item.Data, &payload); err != nil {
 		return credentialPayload{}, false, nil
 	}
+	if payload == (credentialPayload{}) {
+		return credentialPayload{}, false, nil
+	}
 	return payload, true, nil
 }
 

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -434,44 +434,51 @@ func rejectNormalizedCredentialCollision(originalName, normalizedName string, in
 		}
 		return err
 	}
-	keyrings := []keyring.Keyring{current}
 	legacy, err := legacyKeyringOpener()
-	if err == nil {
-		keyrings = append(keyrings, legacy)
-	} else if !isKeyringUnavailable(err) {
+	if err != nil && !isKeyringUnavailable(err) {
 		return err
 	}
 
-	var canonicalPayloads []credentialPayload
-	var originalPayloads []credentialPayload
-	for _, kr := range keyrings {
-		if payload, found, err := credentialPayloadFromKeyring(kr, normalizedName); err != nil {
-			return err
-		} else if found {
-			canonicalPayloads = append(canonicalPayloads, payload)
+	canonical, canonicalFound, err := credentialPayloadForCollision(current, normalizedName)
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return nil
 		}
-		if payload, found, err := credentialPayloadFromKeyring(kr, originalName); err != nil {
-			return err
-		} else if found {
-			originalPayloads = append(originalPayloads, payload)
+		return err
+	}
+	original, originalFound, err := credentialPayloadForCollision(current, originalName)
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return nil
+		}
+		return err
+	}
+	if err == nil && legacy != nil {
+		if !canonicalFound {
+			canonical, canonicalFound, err = credentialPayloadForCollision(legacy, normalizedName)
+			if err != nil && !isKeyringUnavailable(err) {
+				return err
+			}
+		}
+		if !originalFound {
+			original, originalFound, err = credentialPayloadForCollision(legacy, originalName)
+			if err != nil && !isKeyringUnavailable(err) {
+				return err
+			}
 		}
 	}
 
-	for _, canonical := range canonicalPayloads {
-		for _, original := range originalPayloads {
-			if canonical != original && canonical != incoming {
-				return fmt.Errorf(
-					"credential profile name %q conflicts with existing normalized profile %q; remove one before retrying",
-					originalName,
-					normalizedName,
-				)
-			}
-		}
+	if canonicalFound && originalFound && canonical != original && canonical != incoming {
+		return fmt.Errorf(
+			"credential profile name %q conflicts with existing normalized profile %q; remove one before retrying",
+			originalName,
+			normalizedName,
+		)
 	}
 	return nil
 }
 
-func credentialPayloadFromKeyring(kr keyring.Keyring, name string) (credentialPayload, bool, error) {
+func credentialPayloadForCollision(kr keyring.Keyring, name string) (credentialPayload, bool, error) {
 	item, err := kr.Get(keyringKey(name))
 	if errors.Is(err, keyring.ErrKeyNotFound) {
 		return credentialPayload{}, false, nil
@@ -481,7 +488,7 @@ func credentialPayloadFromKeyring(kr keyring.Keyring, name string) (credentialPa
 	}
 	var payload credentialPayload
 	if err := json.Unmarshal(item.Data, &payload); err != nil {
-		return credentialPayload{}, false, fmt.Errorf("invalid keychain entry %q: %w", item.Key, err)
+		return credentialPayload{}, false, nil
 	}
 	return payload, true, nil
 }

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -396,12 +396,12 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	if privateKeyPEM, err := loadPrivateKeyPEMForStorage(keyPath); err == nil && strings.TrimSpace(privateKeyPEM) != "" {
 		payload.PrivateKeyPEM = privateKeyPEM
 	}
-	if err := rejectNormalizedCredentialCollision(originalName, name, payload); err != nil {
+	if err := rejectNormalizedCredentialCollision(originalName, name); err != nil {
 		return err
 	}
 
 	if err := storeInKeychain(name, payload); err == nil {
-		if err := removePreNormalizedKeychainEntries(name, originalName); err != nil {
+		if err := removePreNormalizedKeychainEntries(name); err != nil {
 			return err
 		}
 		// Successfully stored in keychain - remove matching config entry for security
@@ -417,117 +417,155 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	return storeInConfig(name, payload)
 }
 
-// removePreNormalizedKeychainEntries removes stored spellings whose trimmed
-// form equals the just-stored canonical profile name. Sweeping both keychains
-// on every successful store keeps canonical-name logins effective at clearing
-// orphaned pre-normalized entries, which RemoveCredentials cannot target
-// because it trims its argument.
-func removePreNormalizedKeychainEntries(normalizedName, originalName string) error {
-	variants := make(map[string]struct{})
-	if originalName != normalizedName {
-		variants[originalName] = struct{}{}
+// removePreNormalizedKeychainEntries removes every non-canonical spelling from
+// the current and legacy keychains.
+// Collision preflight has already established that no distinct usable
+// credential will be discarded.
+func removePreNormalizedKeychainEntries(normalizedName string) error {
+	if _, err := removeNormalizedKeychainEntries(keyringOpener, normalizedName, false); err != nil {
+		return fmt.Errorf("remove pre-normalized keychain credentials: %w", err)
 	}
-	collectPreNormalizedKeychainNames(keyringOpener, normalizedName, variants)
-	collectPreNormalizedKeychainNames(legacyKeyringOpener, normalizedName, variants)
-
-	names := make([]string, 0, len(variants))
-	for variant := range variants {
-		names = append(names, variant)
-	}
-	sort.Strings(names)
-	for _, variant := range names {
-		if err := removeFromKeychain(variant); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
-			return fmt.Errorf("remove pre-normalized keychain credential %q: %w", variant, err)
-		}
-		if err := removeFromLegacyKeychain(variant); err != nil &&
-			!errors.Is(err, keyring.ErrKeyNotFound) && !isKeyringUnavailable(err) {
-			return fmt.Errorf("remove pre-normalized legacy keychain credential %q: %w", variant, err)
-		}
+	if _, err := removeNormalizedKeychainEntries(legacyKeyringOpener, normalizedName, false); err != nil {
+		return fmt.Errorf("remove pre-normalized legacy keychain credentials: %w", err)
 	}
 	return nil
 }
 
-// collectPreNormalizedKeychainNames gathers stored profile names that trim to
-// the canonical name. Enumeration is best-effort: failures leave the
-// deterministic originalName cleanup contract intact.
-func collectPreNormalizedKeychainNames(opener func() (keyring.Keyring, error), normalizedName string, variants map[string]struct{}) {
+func removeNormalizedKeychainEntries(
+	opener func() (keyring.Keyring, error),
+	normalizedName string,
+	includeCanonical bool,
+) (bool, error) {
 	kr, err := opener()
 	if err != nil {
-		return
+		if isKeyringUnavailable(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	keys, err := kr.Keys()
 	if err != nil {
-		return
+		if isKeyringUnavailable(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	names := make([]string, 0)
+	for _, key := range keys {
+		if !strings.HasPrefix(key, keyringItemPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(key, keyringItemPrefix)
+		if strings.TrimSpace(name) != normalizedName || (!includeCanonical && name == normalizedName) {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	removed := false
+	for _, name := range names {
+		if err := kr.Remove(keyringKey(name)); err != nil {
+			if errors.Is(err, keyring.ErrKeyNotFound) {
+				continue
+			}
+			return removed, err
+		}
+		removed = true
+	}
+	return removed, nil
+}
+
+func rejectNormalizedCredentialCollision(originalName, normalizedName string) error {
+	payloads, err := normalizedCredentialPayloads(normalizedName)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(payloads))
+	for name := range payloads {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) < 2 {
+		return nil
+	}
+
+	first := payloads[names[0]]
+	for _, name := range names[1:] {
+		if credentialPayloadsMatch(first, payloads[name]) {
+			continue
+		}
+		return fmt.Errorf(
+			"credential profile name %q conflicts with existing normalized profile %q; "+
+				"remove the existing profile with 'asc auth logout --name %q' and retry",
+			originalName,
+			normalizedName,
+			normalizedName,
+		)
+	}
+	return nil
+}
+
+func normalizedCredentialPayloads(normalizedName string) (map[string]credentialPayload, error) {
+	payloads := make(map[string]credentialPayload)
+	seen := make(map[string]struct{})
+
+	current, err := keyringOpener()
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return payloads, nil
+		}
+		return nil, err
+	}
+	if err := collectNormalizedCredentialPayloads(current, normalizedName, payloads, seen); err != nil {
+		if isKeyringUnavailable(err) {
+			return payloads, nil
+		}
+		return nil, err
+	}
+
+	legacy, err := legacyKeyringOpener()
+	if err != nil {
+		if isKeyringUnavailable(err) {
+			return payloads, nil
+		}
+		return nil, err
+	}
+	if err := collectNormalizedCredentialPayloads(legacy, normalizedName, payloads, seen); err != nil && !isKeyringUnavailable(err) {
+		return nil, err
+	}
+	return payloads, nil
+}
+
+func collectNormalizedCredentialPayloads(
+	kr keyring.Keyring,
+	normalizedName string,
+	payloads map[string]credentialPayload,
+	seen map[string]struct{},
+) error {
+	keys, err := kr.Keys()
+	if err != nil {
+		return err
 	}
 	for _, key := range keys {
 		if !strings.HasPrefix(key, keyringItemPrefix) {
 			continue
 		}
 		name := strings.TrimPrefix(key, keyringItemPrefix)
-		if name != normalizedName && strings.TrimSpace(name) == normalizedName {
-			variants[name] = struct{}{}
+		if strings.TrimSpace(name) != normalizedName {
+			continue
 		}
-	}
-}
-
-func rejectNormalizedCredentialCollision(originalName, normalizedName string, incoming credentialPayload) error {
-	if originalName == normalizedName {
-		return nil
-	}
-
-	current, err := keyringOpener()
-	if err != nil {
-		if isKeyringUnavailable(err) {
-			return nil
+		if _, exists := seen[name]; exists {
+			continue
 		}
-		return err
-	}
-	legacy, err := legacyKeyringOpener()
-	if err != nil && !isKeyringUnavailable(err) {
-		return err
-	}
-
-	canonical, canonicalFound, err := credentialPayloadForCollision(current, normalizedName)
-	if err != nil {
-		if isKeyringUnavailable(err) {
-			return nil
+		payload, found, err := credentialPayloadForCollision(kr, name)
+		if err != nil {
+			return err
 		}
-		return err
-	}
-	original, originalFound, err := credentialPayloadForCollision(current, originalName)
-	if err != nil {
-		if isKeyringUnavailable(err) {
-			return nil
+		if found {
+			seen[name] = struct{}{}
+			payloads[name] = payload
 		}
-		return err
-	}
-	if err == nil && legacy != nil {
-		if !canonicalFound {
-			canonical, canonicalFound, err = credentialPayloadForCollision(legacy, normalizedName)
-			if err != nil && !isKeyringUnavailable(err) {
-				return err
-			}
-		}
-		if !originalFound {
-			original, originalFound, err = credentialPayloadForCollision(legacy, originalName)
-			if err != nil && !isKeyringUnavailable(err) {
-				return err
-			}
-		}
-	}
-
-	if canonicalFound && originalFound &&
-		!credentialPayloadsMatch(canonical, original) &&
-		!credentialPayloadsMatch(canonical, incoming) {
-		return fmt.Errorf(
-			"credential profile name %q conflicts with existing normalized profile %q; "+
-				"remove the existing profile with 'asc auth logout --name %q' and retry, "+
-				"or re-run 'asc auth login' with --name %q to overwrite it",
-			originalName,
-			normalizedName,
-			normalizedName,
-			normalizedName,
-		)
 	}
 	return nil
 }
@@ -574,9 +612,12 @@ func completeCredentialPayload(payload credentialPayload) bool {
 }
 
 func credentialPayloadsMatch(first, second credentialPayload) bool {
-	if first.KeyID != second.KeyID ||
-		first.IssuerID != second.IssuerID ||
-		config.NormalizeCredentialKeyType(first.KeyType) != config.NormalizeCredentialKeyType(second.KeyType) {
+	firstKeyType := config.NormalizeCredentialKeyType(first.KeyType)
+	secondKeyType := config.NormalizeCredentialKeyType(second.KeyType)
+	if first.KeyID != second.KeyID || firstKeyType != secondKeyType {
+		return false
+	}
+	if firstKeyType != config.CredentialKeyTypeIndividual && first.IssuerID != second.IssuerID {
 		return false
 	}
 
@@ -1118,41 +1159,25 @@ func RemoveCredentials(name string) error {
 	if name == "" {
 		return fmt.Errorf("credential name is required")
 	}
-	err := removeFromKeychain(name)
-	if err == nil {
-		if configErr := removeFromConfigIfPresent(name); configErr != nil &&
-			!errors.Is(configErr, config.ErrNotFound) &&
-			!errors.Is(configErr, keyring.ErrKeyNotFound) {
-			return configErr
-		}
-		_ = removeFromLegacyKeychain(name)
+	removedCurrent, err := removeNormalizedKeychainEntries(keyringOpener, name, true)
+	if err != nil {
+		return err
+	}
+	removedLegacy, err := removeNormalizedKeychainEntries(legacyKeyringOpener, name, true)
+	if err != nil {
+		return err
+	}
+
+	configErr := removeFromConfigIfPresent(name)
+	if configErr != nil &&
+		!errors.Is(configErr, config.ErrNotFound) &&
+		!errors.Is(configErr, keyring.ErrKeyNotFound) {
+		return configErr
+	}
+	if removedCurrent || removedLegacy || configErr == nil {
 		return clearDefaultNameIf(name)
 	}
-	if isKeyringUnavailable(err) {
-		return removeFromConfigIfPresent(name)
-	}
-	if errors.Is(err, keyring.ErrKeyNotFound) {
-		legacyErr := removeFromLegacyKeychain(name)
-		if legacyErr == nil {
-			if configErr := removeFromConfigIfPresent(name); configErr != nil &&
-				!errors.Is(configErr, config.ErrNotFound) &&
-				!errors.Is(configErr, keyring.ErrKeyNotFound) {
-				return configErr
-			}
-			return clearDefaultNameIf(name)
-		}
-		if isKeyringUnavailable(legacyErr) {
-			return removeFromConfigIfPresent(name)
-		}
-		if errors.Is(legacyErr, keyring.ErrKeyNotFound) {
-			if err := removeFromConfigIfPresent(name); err != nil {
-				return err
-			}
-			return nil
-		}
-		return legacyErr
-	}
-	return err
+	return configErr
 }
 
 // RemoveAllCredentials removes all stored credentials

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -564,7 +564,13 @@ func completeCredentialPayload(payload credentialPayload) bool {
 		_, err := LoadPrivateKeyFromPEM([]byte(payload.PrivateKeyPEM))
 		return err == nil
 	}
-	return strings.TrimSpace(payload.PrivateKeyPath) != ""
+	if strings.TrimSpace(payload.PrivateKeyPath) == "" {
+		return false
+	}
+	// A path-only entry is usable only if resolution's loader can read and
+	// parse the referenced key file.
+	_, err := LoadPrivateKey(payload.PrivateKeyPath)
+	return err == nil
 }
 
 func credentialPayloadsMatch(first, second credentialPayload) bool {

--- a/internal/auth/keychain.go
+++ b/internal/auth/keychain.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -400,14 +401,8 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	}
 
 	if err := storeInKeychain(name, payload); err == nil {
-		if originalName != name {
-			if err := removeFromKeychain(originalName); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
-				return fmt.Errorf("remove pre-normalized keychain credential %q: %w", originalName, err)
-			}
-			if err := removeFromLegacyKeychain(originalName); err != nil &&
-				!errors.Is(err, keyring.ErrKeyNotFound) && !isKeyringUnavailable(err) {
-				return fmt.Errorf("remove pre-normalized legacy keychain credential %q: %w", originalName, err)
-			}
+		if err := removePreNormalizedKeychainEntries(name, originalName); err != nil {
+			return err
 		}
 		// Successfully stored in keychain - remove matching config entry for security
 		if err := removeFromConfigIfPresent(name); err != nil && !errors.Is(err, config.ErrNotFound) {
@@ -420,6 +415,59 @@ func StoreCredentialsWithKeyType(name, keyID, issuerID, keyPath, keyType string)
 	}
 
 	return storeInConfig(name, payload)
+}
+
+// removePreNormalizedKeychainEntries removes stored spellings whose trimmed
+// form equals the just-stored canonical profile name. Sweeping both keychains
+// on every successful store keeps canonical-name logins effective at clearing
+// orphaned pre-normalized entries, which RemoveCredentials cannot target
+// because it trims its argument.
+func removePreNormalizedKeychainEntries(normalizedName, originalName string) error {
+	variants := make(map[string]struct{})
+	if originalName != normalizedName {
+		variants[originalName] = struct{}{}
+	}
+	collectPreNormalizedKeychainNames(keyringOpener, normalizedName, variants)
+	collectPreNormalizedKeychainNames(legacyKeyringOpener, normalizedName, variants)
+
+	names := make([]string, 0, len(variants))
+	for variant := range variants {
+		names = append(names, variant)
+	}
+	sort.Strings(names)
+	for _, variant := range names {
+		if err := removeFromKeychain(variant); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+			return fmt.Errorf("remove pre-normalized keychain credential %q: %w", variant, err)
+		}
+		if err := removeFromLegacyKeychain(variant); err != nil &&
+			!errors.Is(err, keyring.ErrKeyNotFound) && !isKeyringUnavailable(err) {
+			return fmt.Errorf("remove pre-normalized legacy keychain credential %q: %w", variant, err)
+		}
+	}
+	return nil
+}
+
+// collectPreNormalizedKeychainNames gathers stored profile names that trim to
+// the canonical name. Enumeration is best-effort: failures leave the
+// deterministic originalName cleanup contract intact.
+func collectPreNormalizedKeychainNames(opener func() (keyring.Keyring, error), normalizedName string, variants map[string]struct{}) {
+	kr, err := opener()
+	if err != nil {
+		return
+	}
+	keys, err := kr.Keys()
+	if err != nil {
+		return
+	}
+	for _, key := range keys {
+		if !strings.HasPrefix(key, keyringItemPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(key, keyringItemPrefix)
+		if name != normalizedName && strings.TrimSpace(name) == normalizedName {
+			variants[name] = struct{}{}
+		}
+	}
 }
 
 func rejectNormalizedCredentialCollision(originalName, normalizedName string, incoming credentialPayload) error {

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1674,6 +1674,47 @@ func TestStoreCredentials_RejectsDistinctNormalizedProfileCollisionBeforeMutatio
 	}
 }
 
+func TestStoreCredentials_RetryCompletesPartialLegacyCleanup(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "OLDKEY", "OLDISSUER", "/tmp/OldAuthKey.p8")
+
+	previousLegacy := legacyKeyringOpener
+	transientLegacy := &transientRemoveFailingKeyring{
+		inner:             legacyKr,
+		remainingFailures: 1,
+		err:               errors.New("legacy keyring locked"),
+	}
+	legacyKeyringOpener = func() (keyring.Keyring, error) {
+		return transientLegacy, nil
+	}
+	t.Cleanup(func() { legacyKeyringOpener = previousLegacy })
+
+	firstErr := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8")
+	if firstErr == nil || !strings.Contains(firstErr.Error(), "legacy keyring locked") {
+		t.Fatalf("first StoreCredentials() error = %v, want legacy cleanup failure", firstErr)
+	}
+	if _, err := newKr.Get(keyringKey("spaced")); err != nil {
+		t.Fatalf("canonical credential should survive partial cleanup: %v", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); err != nil {
+		t.Fatalf("legacy credential should remain after failed removal: %v", err)
+	}
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("retry StoreCredentials() error = %v", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("legacy credential after retry error = %v, want ErrKeyNotFound", err)
+	}
+	defaultCreds, err := GetCredentials("")
+	if err != nil {
+		t.Fatalf("GetCredentials(default) error = %v", err)
+	}
+	if defaultCreds.KeyID != "KEY123" || defaultCreds.IssuerID != "ISS456" {
+		t.Fatalf("default credentials after retry = %+v", defaultCreds)
+	}
+}
+
 func TestStoreCredentials_RejectsWhitespaceOnlyProfileName(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 
@@ -2148,6 +2189,29 @@ func (k *removeFailingKeyring) GetMetadata(key string) (keyring.Metadata, error)
 func (k *removeFailingKeyring) Set(item keyring.Item) error { return k.inner.Set(item) }
 func (k *removeFailingKeyring) Remove(string) error         { return k.err }
 func (k *removeFailingKeyring) Keys() ([]string, error)     { return k.inner.Keys() }
+
+type transientRemoveFailingKeyring struct {
+	inner             keyring.Keyring
+	remainingFailures int
+	err               error
+}
+
+func (k *transientRemoveFailingKeyring) Get(key string) (keyring.Item, error) {
+	return k.inner.Get(key)
+}
+
+func (k *transientRemoveFailingKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	return k.inner.GetMetadata(key)
+}
+func (k *transientRemoveFailingKeyring) Set(item keyring.Item) error { return k.inner.Set(item) }
+func (k *transientRemoveFailingKeyring) Remove(key string) error {
+	if k.remainingFailures > 0 {
+		k.remainingFailures--
+		return k.err
+	}
+	return k.inner.Remove(key)
+}
+func (k *transientRemoveFailingKeyring) Keys() ([]string, error) { return k.inner.Keys() }
 
 func TestGetCredentialsWithSource_KeychainAccessDeniedReturnsSentinel(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1660,8 +1660,7 @@ func TestStoreCredentials_RejectsDistinctNormalizedProfileCollisionBeforeMutatio
 
 	err := StoreCredentials("  spaced  ", "NEW", "ISSUER-NEW", "/tmp/new.p8")
 	wantErr := `credential profile name "  spaced  " conflicts with existing normalized profile "spaced"; ` +
-		`remove the existing profile with 'asc auth logout --name "spaced"' and retry, ` +
-		`or re-run 'asc auth login' with --name "spaced" to overwrite it`
+		`remove the existing profile with 'asc auth logout --name "spaced"' and retry`
 	if err == nil || err.Error() != wantErr {
 		t.Fatalf("StoreCredentials() error = %v, want %q", err, wantErr)
 	}
@@ -1679,6 +1678,140 @@ func TestStoreCredentials_RejectsDistinctNormalizedProfileCollisionBeforeMutatio
 	}
 	if _, err := legacyKr.Get(keyringKey("  spaced  ")); err != nil {
 		t.Fatalf("raw legacy credential was removed: %v", err)
+	}
+}
+
+func TestStoreCredentials_RejectsDistinctThirdNormalizedSpellingBeforeMutation(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	keyDir := t.TempDir()
+	canonicalPath := filepath.Join(keyDir, "Canonical.p8")
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	thirdPath := filepath.Join(keyDir, "Third.p8")
+	writeECDSAPEM(t, thirdPath, 0o600, true)
+	incomingPath := filepath.Join(keyDir, "Incoming.p8")
+	writeECDSAPEM(t, incomingPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", canonicalPath)
+	storeCredentialInKeyring(t, legacyKr, "\tspaced ", "THIRD", "ISSUER-THIRD", thirdPath)
+
+	err := StoreCredentials("  spaced  ", "INCOMING", "ISSUER-INCOMING", incomingPath)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with existing normalized profile") {
+		t.Fatalf("StoreCredentials() error = %v, want normalized profile collision", err)
+	}
+
+	canonical, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("canonical credential error: %v", err)
+	}
+	var canonicalPayload credentialPayload
+	if err := json.Unmarshal(canonical.Data, &canonicalPayload); err != nil {
+		t.Fatalf("decode canonical credential: %v", err)
+	}
+	if canonicalPayload.KeyID != "CANONICAL" {
+		t.Fatalf("canonical credential was mutated: %+v", canonicalPayload)
+	}
+	if _, err := legacyKr.Get(keyringKey("\tspaced ")); err != nil {
+		t.Fatalf("third spelling was removed: %v", err)
+	}
+}
+
+func TestStoreCredentials_CanonicalLoginRejectsDistinctNormalizedSpellingBeforeMutation(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	keyDir := t.TempDir()
+	canonicalPath := filepath.Join(keyDir, "Canonical.p8")
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	rawPath := filepath.Join(keyDir, "Raw.p8")
+	writeECDSAPEM(t, rawPath, 0o600, true)
+	incomingPath := filepath.Join(keyDir, "Incoming.p8")
+	writeECDSAPEM(t, incomingPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", canonicalPath)
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "RAW", "ISSUER-RAW", rawPath)
+
+	err := StoreCredentials("spaced", "INCOMING", "ISSUER-INCOMING", incomingPath)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with existing normalized profile") {
+		t.Fatalf("StoreCredentials() error = %v, want normalized profile collision", err)
+	}
+
+	canonical, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("canonical credential error: %v", err)
+	}
+	var canonicalPayload credentialPayload
+	if err := json.Unmarshal(canonical.Data, &canonicalPayload); err != nil {
+		t.Fatalf("decode canonical credential: %v", err)
+	}
+	if canonicalPayload.KeyID != "CANONICAL" {
+		t.Fatalf("canonical credential was mutated: %+v", canonicalPayload)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); err != nil {
+		t.Fatalf("raw credential was removed: %v", err)
+	}
+}
+
+func TestStoreCredentials_UnusableCurrentSpellingDoesNotHideUsableLegacyCollision(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	keyDir := t.TempDir()
+	canonicalPath := filepath.Join(keyDir, "Canonical.p8")
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	legacyPath := filepath.Join(keyDir, "Legacy.p8")
+	writeECDSAPEM(t, legacyPath, 0o600, true)
+	incomingPath := filepath.Join(keyDir, "Incoming.p8")
+	writeECDSAPEM(t, incomingPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", canonicalPath)
+	if err := newKr.Set(keyring.Item{Key: keyringKey("  spaced  "), Data: []byte("not-json")}); err != nil {
+		t.Fatalf("seed unusable current credential: %v", err)
+	}
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "LEGACY", "ISSUER-LEGACY", legacyPath)
+
+	err := StoreCredentials("spaced", "INCOMING", "ISSUER-INCOMING", incomingPath)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with existing normalized profile") {
+		t.Fatalf("StoreCredentials() error = %v, want normalized profile collision", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); err != nil {
+		t.Fatalf("usable legacy credential was removed: %v", err)
+	}
+}
+
+func TestStoreCredentials_IndividualCollisionIgnoresStaleIssuer(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	keyPath := filepath.Join(t.TempDir(), "Individual.p8")
+	writeECDSAPEM(t, keyPath, 0o600, true)
+	privateKeyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read private key: %v", err)
+	}
+	for kr, entry := range map[keyring.Keyring]struct {
+		name     string
+		issuerID string
+	}{
+		newKr:    {name: "spaced", issuerID: "STALE-ISSUER"},
+		legacyKr: {name: "  spaced  ", issuerID: ""},
+	} {
+		item, err := keyringItemForCredential(entry.name, credentialPayload{
+			KeyID:          "INDIVIDUAL-KEY",
+			IssuerID:       entry.issuerID,
+			PrivateKeyPath: keyPath,
+			PrivateKeyPEM:  string(privateKeyPEM),
+			KeyType:        config.CredentialKeyTypeIndividual,
+		})
+		if err != nil {
+			t.Fatalf("credential item: %v", err)
+		}
+		if err := kr.Set(item); err != nil {
+			t.Fatalf("seed credential %q: %v", entry.name, err)
+		}
+	}
+
+	if err := StoreCredentialsWithKeyType(
+		"  spaced  ",
+		"INDIVIDUAL-KEY",
+		"",
+		keyPath,
+		config.CredentialKeyTypeIndividual,
+	); err != nil {
+		t.Fatalf("StoreCredentialsWithKeyType() error: %v", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("equivalent individual credential error = %v, want ErrKeyNotFound", err)
 	}
 }
 
@@ -2326,6 +2459,31 @@ func TestRemoveCredentials_TrimsName(t *testing.T) {
 	}
 	if _, err := newKr.Get(keyringKey("trim-key")); !errors.Is(err, keyring.ErrKeyNotFound) {
 		t.Fatalf("expected credential to be removed, got %v", err)
+	}
+}
+
+func TestRemoveCredentials_RemovesAllNormalizedSpellings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	newKr, legacyKr := withSeparateKeyrings(t)
+
+	storeCredentialInKeyring(t, newKr, "trim-key", "KEY123", "ISS456", "/tmp/AuthKey.p8")
+	storeCredentialInKeyring(t, newKr, "  trim-key  ", "OTHER", "OTHER-ISSUER", "/tmp/Other.p8")
+	storeCredentialInKeyring(t, legacyKr, "\ttrim-key ", "LEGACY", "LEGACY-ISSUER", "/tmp/Legacy.p8")
+
+	if err := RemoveCredentials("trim-key"); err != nil {
+		t.Fatalf("RemoveCredentials() error: %v", err)
+	}
+	for _, check := range []struct {
+		kr   keyring.Keyring
+		name string
+	}{
+		{kr: newKr, name: "trim-key"},
+		{kr: newKr, name: "  trim-key  "},
+		{kr: legacyKr, name: "\ttrim-key "},
+	} {
+		if _, err := check.kr.Get(keyringKey(check.name)); !errors.Is(err, keyring.ErrKeyNotFound) {
+			t.Fatalf("credential %q error = %v, want ErrKeyNotFound", check.name, err)
+		}
 	}
 }
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1782,6 +1782,36 @@ func TestStoreCredentials_ReplacesMalformedPreNormalizedEntry(t *testing.T) {
 	}
 }
 
+func TestStoreCredentials_ReplacesEmptyDecodedPreNormalizedEntry(t *testing.T) {
+	for _, data := range []string{"null", "{}"} {
+		t.Run(data, func(t *testing.T) {
+			newKr, _ := withSeparateKeyrings(t)
+			storeCredentialInKeyring(t, newKr, "spaced", "OLD", "OLD-ISSUER", "/tmp/Old.p8")
+			if err := newKr.Set(keyring.Item{Key: keyringKey("  spaced  "), Data: []byte(data)}); err != nil {
+				t.Fatalf("seed empty keyring entry: %v", err)
+			}
+
+			if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+				t.Fatalf("StoreCredentials() error = %v", err)
+			}
+			if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+				t.Fatalf("empty raw credential error = %v, want ErrKeyNotFound", err)
+			}
+			item, err := newKr.Get(keyringKey("spaced"))
+			if err != nil {
+				t.Fatalf("normalized credential error = %v", err)
+			}
+			var payload credentialPayload
+			if err := json.Unmarshal(item.Data, &payload); err != nil {
+				t.Fatalf("decode normalized credential: %v", err)
+			}
+			if payload.KeyID != "KEY123" {
+				t.Fatalf("normalized credential = %+v", payload)
+			}
+		})
+	}
+}
+
 func TestStoreCredentials_RejectsWhitespaceOnlyProfileName(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1929,6 +1929,41 @@ func TestStoreCredentials_ReplacesCanonicalEntryWithValidPathAndInvalidEmbeddedK
 	}
 }
 
+func TestStoreCredentials_CanonicalNameLoginCleansOrphanedPaddedEntries(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", "/tmp/canonical.p8")
+	storeCredentialInKeyring(t, newKr, "  spaced  ", "RAW", "ISSUER-RAW", "/tmp/raw.p8")
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "RAW", "ISSUER-RAW", "/tmp/raw.p8")
+	storeCredentialInKeyring(t, legacyKr, "\tspaced ", "RAW-LEGACY", "ISSUER-RAW-LEGACY", "/tmp/raw-legacy.p8")
+
+	// Logging in with the canonical name is the advertised collision
+	// remediation, so it must also clear orphaned pre-normalized entries
+	// that RemoveCredentials cannot target.
+	if err := StoreCredentials("spaced", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("legacy raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("\tspaced ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("legacy tabbed credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error: %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.KeyID != "KEY123" {
+		t.Fatalf("normalized credential = %+v", payload)
+	}
+}
+
 func TestStoreCredentials_CleansRawEntryWhenCanonicalLacksPEMEnrichment(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1593,6 +1593,7 @@ func TestStoreCredentialsFallbackToConfig(t *testing.T) {
 
 func TestStoreCredentials_TrimsKeychainProfileNameBeforeSelectingDefault(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, newKr, "  spaced  ", "OLDKEY", "OLDISSUER", "/tmp/OldAuthKey.p8")
 
 	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
 		t.Fatalf("StoreCredentials() error: %v", err)
@@ -1621,6 +1622,22 @@ func TestStoreCredentials_TrimsKeychainProfileNameBeforeSelectingDefault(t *test
 		if strings.Contains(item, "  spaced  ") {
 			t.Fatalf("expected keychain profile key to use trimmed name, got %q", item)
 		}
+	}
+}
+
+func TestStoreCredentials_RejectsWhitespaceOnlyProfileName(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+
+	err := StoreCredentials("   ", "KEY123", "ISS456", "/tmp/AuthKey.p8")
+	if err == nil || err.Error() != "credential name is required" {
+		t.Fatalf("StoreCredentials() error = %v, want credential name is required", err)
+	}
+	items, keysErr := newKr.Keys()
+	if keysErr != nil {
+		t.Fatalf("keychain Keys() error: %v", keysErr)
+	}
+	if len(items) != 0 {
+		t.Fatalf("keychain items = %q, want none", items)
 	}
 }
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1650,8 +1650,13 @@ func TestStoreCredentials_RemovesPreNormalizedProfileFromLegacyKeychain(t *testi
 
 func TestStoreCredentials_RejectsDistinctNormalizedProfileCollisionBeforeMutation(t *testing.T) {
 	newKr, legacyKr := withSeparateKeyrings(t)
-	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", "/tmp/canonical.p8")
-	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "RAW", "ISSUER-RAW", "/tmp/raw.p8")
+	keyDir := t.TempDir()
+	canonicalPath := filepath.Join(keyDir, "Canonical.p8")
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	rawPath := filepath.Join(keyDir, "Raw.p8")
+	writeECDSAPEM(t, rawPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", canonicalPath)
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "RAW", "ISSUER-RAW", rawPath)
 
 	err := StoreCredentials("  spaced  ", "NEW", "ISSUER-NEW", "/tmp/new.p8")
 	wantErr := `credential profile name "  spaced  " conflicts with existing normalized profile "spaced"; ` +
@@ -1925,6 +1930,35 @@ func TestStoreCredentials_ReplacesCanonicalEntryWithValidPathAndInvalidEmbeddedK
 		t.Fatalf("decode normalized credential: %v", err)
 	}
 	if payload.KeyID != "KEY123" {
+		t.Fatalf("normalized credential = %+v", payload)
+	}
+}
+
+func TestStoreCredentials_ReplacesRawEntryWithUnloadableKeyPath(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	canonicalPath := filepath.Join(t.TempDir(), "Canonical.p8")
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", canonicalPath)
+	// The raw entry has complete IDs but its key file was deleted, so
+	// credential resolution cannot authenticate with it; it must not stay
+	// collision-authoritative and block a padded-name login.
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "RAW", "ISSUER-RAW", filepath.Join(t.TempDir(), "Deleted.p8"))
+
+	if err := StoreCredentials("  spaced  ", "NEW", "ISSUER-NEW", "/tmp/new.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("legacy raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error: %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.KeyID != "NEW" {
 		t.Fatalf("normalized credential = %+v", payload)
 	}
 }

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1591,6 +1591,39 @@ func TestStoreCredentialsFallbackToConfig(t *testing.T) {
 	}
 }
 
+func TestStoreCredentials_TrimsKeychainProfileNameBeforeSelectingDefault(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+
+	creds, err := GetCredentials("spaced")
+	if err != nil {
+		t.Fatalf("GetCredentials(trimmed profile) error: %v", err)
+	}
+	if creds.KeyID != "KEY123" || creds.IssuerID != "ISS456" {
+		t.Fatalf("expected trimmed keychain profile credentials, got %+v", creds)
+	}
+	defaultCreds, err := GetCredentials("")
+	if err != nil {
+		t.Fatalf("GetCredentials(default) error: %v", err)
+	}
+	if defaultCreds.KeyID != "KEY123" || defaultCreds.IssuerID != "ISS456" {
+		t.Fatalf("expected trimmed profile to remain default, got %+v", defaultCreds)
+	}
+
+	items, err := newKr.Keys()
+	if err != nil {
+		t.Fatalf("keychain Keys() error: %v", err)
+	}
+	for _, item := range items {
+		if strings.Contains(item, "  spaced  ") {
+			t.Fatalf("expected keychain profile key to use trimmed name, got %q", item)
+		}
+	}
+}
+
 func TestStoreCredentials_RemovesStaleGlobalCredentialWhenLocalConfigActive(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "0")
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1962,6 +1962,103 @@ func TestStoreCredentials_NormalizedPreflightPreservesUnavailableKeyringFallback
 	}
 }
 
+func TestStoreCredentials_UnavailablePreflightDoesNotResumeKeychainMutation(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "0")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	keyDir := t.TempDir()
+	existingPath := filepath.Join(keyDir, "Existing.p8")
+	writeECDSAPEM(t, existingPath, 0o600, true)
+	incomingPath := filepath.Join(keyDir, "Incoming.p8")
+	writeECDSAPEM(t, incomingPath, 0o600, true)
+
+	inner := keyring.NewArrayKeyring([]keyring.Item{})
+	storeCredentialInKeyring(t, inner, "spaced", "EXISTING", "EXISTING-ISSUER", existingPath)
+	storeCredentialInKeyring(t, inner, "  spaced  ", "CONFLICT", "CONFLICT-ISSUER", existingPath)
+	flaky := &transientKeysFailingKeyring{
+		inner:             inner,
+		remainingFailures: 1,
+		err:               keyring.ErrNoAvailImpl,
+	}
+	previousCurrent := keyringOpener
+	previousLegacy := legacyKeyringOpener
+	keyringOpener = func() (keyring.Keyring, error) { return flaky, nil }
+	legacyKeyringOpener = func() (keyring.Keyring, error) { return nil, keyring.ErrNoAvailImpl }
+	t.Cleanup(func() {
+		keyringOpener = previousCurrent
+		legacyKeyringOpener = previousLegacy
+	})
+
+	if err := StoreCredentials("  spaced  ", "INCOMING", "INCOMING-ISSUER", incomingPath); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	for _, name := range []string{"spaced", "  spaced  "} {
+		if _, err := inner.Get(keyringKey(name)); err != nil {
+			t.Fatalf("keychain credential %q should remain after unavailable preflight: %v", name, err)
+		}
+	}
+	item, err := inner.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("get canonical keychain credential: %v", err)
+	}
+	var stored credentialPayload
+	if err := json.Unmarshal(item.Data, &stored); err != nil {
+		t.Fatalf("decode canonical keychain credential: %v", err)
+	}
+	if stored.KeyID != "EXISTING" {
+		t.Fatalf("canonical keychain KeyID = %q, want EXISTING", stored.KeyID)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load() error: %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].Name != "spaced" || cfg.Keys[0].KeyID != "INCOMING" {
+		t.Fatalf("fallback credentials = %+v", cfg.Keys)
+	}
+}
+
+func TestStoreCredentials_LegacyUnavailableDoesNotBypassCurrentKeychain(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "0")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	keyDir := t.TempDir()
+	existingPath := filepath.Join(keyDir, "Existing.p8")
+	writeECDSAPEM(t, existingPath, 0o600, true)
+	incomingPath := filepath.Join(keyDir, "Incoming.p8")
+	writeECDSAPEM(t, incomingPath, 0o600, true)
+
+	current := keyring.NewArrayKeyring([]keyring.Item{})
+	storeCredentialInKeyring(t, current, "spaced", "EXISTING", "EXISTING-ISSUER", existingPath)
+	previousCurrent := keyringOpener
+	previousLegacy := legacyKeyringOpener
+	keyringOpener = func() (keyring.Keyring, error) { return current, nil }
+	legacyKeyringOpener = func() (keyring.Keyring, error) { return nil, keyring.ErrNoAvailImpl }
+	t.Cleanup(func() {
+		keyringOpener = previousCurrent
+		legacyKeyringOpener = previousLegacy
+	})
+
+	if err := StoreCredentials("spaced", "INCOMING", "INCOMING-ISSUER", incomingPath); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	item, err := current.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("get current keychain credential: %v", err)
+	}
+	var stored credentialPayload
+	if err := json.Unmarshal(item.Data, &stored); err != nil {
+		t.Fatalf("decode current keychain credential: %v", err)
+	}
+	if stored.KeyID != "INCOMING" {
+		t.Fatalf("current keychain KeyID = %q, want INCOMING", stored.KeyID)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load() error: %v", err)
+	}
+	if len(cfg.Keys) != 0 {
+		t.Fatalf("config credentials = %+v, want none", cfg.Keys)
+	}
+}
+
 func TestStoreCredentials_ReplacesMalformedPreNormalizedEntry(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 	if err := newKr.Set(keyring.Item{Key: keyringKey("  spaced  "), Data: []byte("not-json")}); err != nil {
@@ -2551,6 +2648,112 @@ func TestRemoveCredentials_RemovesAllNormalizedSpellings(t *testing.T) {
 	}
 }
 
+func TestRemoveCredentials_PreservesCurrentWhenLegacyListingFails(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, newKr, "trim-key", "KEY123", "ISS456", "/tmp/AuthKey.p8")
+
+	previousLegacy := legacyKeyringOpener
+	legacyKeyringOpener = func() (keyring.Keyring, error) {
+		return failingKeyring{err: errors.New("legacy keyring locked")}, nil
+	}
+	t.Cleanup(func() { legacyKeyringOpener = previousLegacy })
+
+	err := RemoveCredentials("trim-key")
+	if err == nil || !strings.Contains(err.Error(), "legacy keyring locked") {
+		t.Fatalf("RemoveCredentials() error = %v, want legacy listing failure", err)
+	}
+	if _, err := newKr.Get(keyringKey("trim-key")); err != nil {
+		t.Fatalf("current credential should remain after legacy listing failure: %v", err)
+	}
+}
+
+func TestRemoveCredentials_UnavailableCurrentDoesNotMutateOtherStores(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "0")
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("ASC_CONFIG_PATH", configPath)
+	current := keyring.NewArrayKeyring([]keyring.Item{})
+	legacy := keyring.NewArrayKeyring([]keyring.Item{})
+	storeCredentialInKeyring(t, current, "trim-key", "CURRENT", "CURRENT-ISSUER", "/tmp/Current.p8")
+	storeCredentialInKeyring(t, legacy, "trim-key", "LEGACY", "LEGACY-ISSUER", "/tmp/Legacy.p8")
+	if err := config.SaveAt(configPath, &config.Config{
+		DefaultKeyName: "trim-key",
+		Keys: []config.Credential{{
+			Name:           "trim-key",
+			KeyID:          "CONFIG",
+			IssuerID:       "CONFIG-ISSUER",
+			PrivateKeyPath: "/tmp/Config.p8",
+		}},
+	}); err != nil {
+		t.Fatalf("config.SaveAt() error: %v", err)
+	}
+
+	flakyCurrent := &transientKeysFailingKeyring{
+		inner:             current,
+		remainingFailures: 1,
+		err:               keyring.ErrNoAvailImpl,
+	}
+	previousCurrent := keyringOpener
+	previousLegacy := legacyKeyringOpener
+	keyringOpener = func() (keyring.Keyring, error) { return flakyCurrent, nil }
+	legacyKeyringOpener = func() (keyring.Keyring, error) { return legacy, nil }
+	t.Cleanup(func() {
+		keyringOpener = previousCurrent
+		legacyKeyringOpener = previousLegacy
+	})
+
+	err := RemoveCredentials("trim-key")
+	if err == nil || !isKeyringUnavailable(err) {
+		t.Fatalf("RemoveCredentials() error = %v, want keyring unavailable", err)
+	}
+	for source, kr := range map[string]keyring.Keyring{"current": current, "legacy": legacy} {
+		if _, err := kr.Get(keyringKey("trim-key")); err != nil {
+			t.Fatalf("%s credential should remain after unavailable preflight: %v", source, err)
+		}
+	}
+	cfg, err := config.LoadAt(configPath)
+	if err != nil {
+		t.Fatalf("config.LoadAt() error: %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].KeyID != "CONFIG" || cfg.DefaultKeyName != "trim-key" {
+		t.Fatalf("config changed after unavailable preflight: %+v", cfg)
+	}
+}
+
+func TestRemoveCredentials_RestoresEarlierConfigWhenLaterPathFails(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	overridePath := filepath.Join(t.TempDir(), "override", "config.json")
+	t.Setenv("ASC_CONFIG_PATH", overridePath)
+	if err := config.SaveAt(overridePath, &config.Config{
+		DefaultKeyName: "trim-key",
+		Keys: []config.Credential{{
+			Name:           "trim-key",
+			KeyID:          "CONFIG",
+			IssuerID:       "CONFIG-ISSUER",
+			PrivateKeyPath: "/tmp/Config.p8",
+		}},
+	}); err != nil {
+		t.Fatalf("config.SaveAt(override) error: %v", err)
+	}
+	globalPath := filepath.Join(homeDir, ".asc", "config.json")
+	if err := os.MkdirAll(globalPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(global config path) error: %v", err)
+	}
+
+	err := RemoveCredentials("trim-key")
+	if err == nil {
+		t.Fatal("RemoveCredentials() error = nil, want later config path failure")
+	}
+	cfg, err := config.LoadAt(overridePath)
+	if err != nil {
+		t.Fatalf("config.LoadAt(override) error: %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].KeyID != "CONFIG" || cfg.DefaultKeyName != "trim-key" {
+		t.Fatalf("override config changed after later path failure: %+v", cfg)
+	}
+}
+
 func TestRemoveCredentials_ClearsStoredKeychainMetadata(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	newKr, _ := withSeparateKeyrings(t)
@@ -2590,6 +2793,7 @@ func TestRemoveCredentials_MissingReturnsErr(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")
 	t.Setenv("ASC_CONFIG_PATH", configPath)
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 
 	previous := keyringOpener
 	previousLegacy := legacyKeyringOpener
@@ -2805,6 +3009,29 @@ func (k *nthRemoveFailingKeyring) Remove(key string) error {
 	return k.inner.Remove(key)
 }
 func (k *nthRemoveFailingKeyring) Keys() ([]string, error) { return k.inner.Keys() }
+
+type transientKeysFailingKeyring struct {
+	inner             keyring.Keyring
+	remainingFailures int
+	err               error
+}
+
+func (k *transientKeysFailingKeyring) Get(key string) (keyring.Item, error) {
+	return k.inner.Get(key)
+}
+
+func (k *transientKeysFailingKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	return k.inner.GetMetadata(key)
+}
+func (k *transientKeysFailingKeyring) Set(item keyring.Item) error { return k.inner.Set(item) }
+func (k *transientKeysFailingKeyring) Remove(key string) error     { return k.inner.Remove(key) }
+func (k *transientKeysFailingKeyring) Keys() ([]string, error) {
+	if k.remainingFailures > 0 {
+		k.remainingFailures--
+		return nil, k.err
+	}
+	return k.inner.Keys()
+}
 
 func TestGetCredentialsWithSource_KeychainAccessDeniedReturnsSentinel(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1817,6 +1817,7 @@ func TestStoreCredentials_ReplacesIncompletePreNormalizedEntry(t *testing.T) {
 		`{"key_id":"BROKEN"}`,
 		`{"key_id":"BROKEN","issuer_id":"ISSUER"}`,
 		`{"key_id":"BROKEN","private_key_path":"/tmp/Broken.p8"}`,
+		`{"key_id":"BROKEN","issuer_id":"ISSUER","private_key_path":"   "}`,
 		`{"key_id":"BROKEN","issuer_id":"ISSUER","private_key_path":"/tmp/Broken.p8","key_type":"unsupported"}`,
 	} {
 		t.Run(data, func(t *testing.T) {
@@ -1844,6 +1845,34 @@ func TestStoreCredentials_ReplacesIncompletePreNormalizedEntry(t *testing.T) {
 				t.Fatalf("normalized credential = %+v", payload)
 			}
 		})
+	}
+}
+
+func TestStoreCredentials_CleansRawEntryWhenCanonicalLacksPEMEnrichment(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")
+	if err := os.WriteFile(keyPath, []byte("PRIVATE KEY"), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	storeCredentialInKeyring(t, newKr, "spaced", "KEY123", "ISS456", keyPath)
+	storeCredentialInKeyring(t, newKr, "  spaced  ", "OTHER", "OTHER-ISSUER", "/tmp/Other.p8")
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", keyPath); err != nil {
+		t.Fatalf("StoreCredentials() error = %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error = %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.PrivateKeyPEM != "PRIVATE KEY" {
+		t.Fatalf("normalized credential PEM = %q, want enrichment", payload.PrivateKeyPEM)
 	}
 }
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1812,6 +1812,41 @@ func TestStoreCredentials_ReplacesEmptyDecodedPreNormalizedEntry(t *testing.T) {
 	}
 }
 
+func TestStoreCredentials_ReplacesIncompletePreNormalizedEntry(t *testing.T) {
+	for _, data := range []string{
+		`{"key_id":"BROKEN"}`,
+		`{"key_id":"BROKEN","issuer_id":"ISSUER"}`,
+		`{"key_id":"BROKEN","private_key_path":"/tmp/Broken.p8"}`,
+		`{"key_id":"BROKEN","issuer_id":"ISSUER","private_key_path":"/tmp/Broken.p8","key_type":"unsupported"}`,
+	} {
+		t.Run(data, func(t *testing.T) {
+			newKr, _ := withSeparateKeyrings(t)
+			storeCredentialInKeyring(t, newKr, "spaced", "OLD", "OLD-ISSUER", "/tmp/Old.p8")
+			if err := newKr.Set(keyring.Item{Key: keyringKey("  spaced  "), Data: []byte(data)}); err != nil {
+				t.Fatalf("seed incomplete keyring entry: %v", err)
+			}
+
+			if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+				t.Fatalf("StoreCredentials() error = %v", err)
+			}
+			if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+				t.Fatalf("incomplete raw credential error = %v, want ErrKeyNotFound", err)
+			}
+			item, err := newKr.Get(keyringKey("spaced"))
+			if err != nil {
+				t.Fatalf("normalized credential error = %v", err)
+			}
+			var payload credentialPayload
+			if err := json.Unmarshal(item.Data, &payload); err != nil {
+				t.Fatalf("decode normalized credential: %v", err)
+			}
+			if payload.KeyID != "KEY123" {
+				t.Fatalf("normalized credential = %+v", payload)
+			}
+		})
+	}
+}
+
 func TestStoreCredentials_RejectsWhitespaceOnlyProfileName(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1884,6 +1884,48 @@ func TestStoreCredentials_ReplacesPreNormalizedEntryWithInvalidEmbeddedKey(t *te
 	}
 }
 
+func TestStoreCredentials_ReplacesCanonicalEntryWithValidPathAndInvalidEmbeddedKey(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	canonicalPath := filepath.Join(t.TempDir(), "Canonical.p8")
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	// Credential resolution prefers the embedded PEM over the key path, so
+	// this canonical entry is unusable at auth time despite its valid path
+	// and must not be collision-authoritative.
+	broken := credentialPayload{
+		KeyID:          "BROKEN",
+		IssuerID:       "BROKEN-ISSUER",
+		PrivateKeyPath: canonicalPath,
+		PrivateKeyPEM:  "not-pem",
+		KeyType:        config.CredentialKeyTypeTeam,
+	}
+	data, err := json.Marshal(broken)
+	if err != nil {
+		t.Fatalf("encode invalid embedded-key credential: %v", err)
+	}
+	if err := newKr.Set(keyring.Item{Key: keyringKey("spaced"), Data: data}); err != nil {
+		t.Fatalf("seed invalid embedded-key credential: %v", err)
+	}
+	storeCredentialInKeyring(t, newKr, "  spaced  ", "RAW", "ISSUER-RAW", "/tmp/raw.p8")
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error: %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.KeyID != "KEY123" {
+		t.Fatalf("normalized credential = %+v", payload)
+	}
+}
+
 func TestStoreCredentials_CleansRawEntryWhenCanonicalLacksPEMEnrichment(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1715,6 +1715,73 @@ func TestStoreCredentials_RetryCompletesPartialLegacyCleanup(t *testing.T) {
 	}
 }
 
+func TestStoreCredentials_NormalizedCollisionUsesCurrentKeyringPrecedence(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, newKr, "spaced", "KEY123", "ISS456", "/tmp/AuthKey.p8")
+	storeCredentialInKeyring(t, newKr, "  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8")
+	storeCredentialInKeyring(t, legacyKr, "spaced", "STALE", "STALE-ISSUER", "/tmp/Stale.p8")
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error = %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("raw current credential error = %v, want ErrKeyNotFound", err)
+	}
+}
+
+func TestStoreCredentials_NormalizedPreflightPreservesUnavailableKeyringFallback(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "0")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	previousCurrent := keyringOpener
+	previousLegacy := legacyKeyringOpener
+	keyringOpener = func() (keyring.Keyring, error) {
+		return failingKeyring{err: keyring.ErrNoAvailImpl}, nil
+	}
+	legacyKeyringOpener = func() (keyring.Keyring, error) {
+		return nil, keyring.ErrNoAvailImpl
+	}
+	t.Cleanup(func() {
+		keyringOpener = previousCurrent
+		legacyKeyringOpener = previousLegacy
+	})
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error = %v", err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0].Name != "spaced" || cfg.Keys[0].KeyID != "KEY123" {
+		t.Fatalf("fallback credentials = %+v", cfg.Keys)
+	}
+}
+
+func TestStoreCredentials_ReplacesMalformedPreNormalizedEntry(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	if err := newKr.Set(keyring.Item{Key: keyringKey("  spaced  "), Data: []byte("not-json")}); err != nil {
+		t.Fatalf("seed malformed keyring entry: %v", err)
+	}
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error = %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("malformed raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error = %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.KeyID != "KEY123" {
+		t.Fatalf("normalized credential = %+v", payload)
+	}
+}
+
 func TestStoreCredentials_RejectsWhitespaceOnlyProfileName(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1625,6 +1625,55 @@ func TestStoreCredentials_TrimsKeychainProfileNameBeforeSelectingDefault(t *test
 	}
 }
 
+func TestStoreCredentials_RemovesPreNormalizedProfileFromLegacyKeychain(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "OLDKEY", "OLDISSUER", "/tmp/OldAuthKey.p8")
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("legacy raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error: %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.KeyID != "KEY123" || payload.IssuerID != "ISS456" {
+		t.Fatalf("normalized payload = %+v", payload)
+	}
+}
+
+func TestStoreCredentials_RejectsDistinctNormalizedProfileCollisionBeforeMutation(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", "/tmp/canonical.p8")
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "RAW", "ISSUER-RAW", "/tmp/raw.p8")
+
+	err := StoreCredentials("  spaced  ", "NEW", "ISSUER-NEW", "/tmp/new.p8")
+	if err == nil || !strings.Contains(err.Error(), "conflicts with existing normalized profile") {
+		t.Fatalf("StoreCredentials() error = %v, want normalized-profile collision", err)
+	}
+
+	canonical, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("canonical credential error: %v", err)
+	}
+	var canonicalPayload credentialPayload
+	if err := json.Unmarshal(canonical.Data, &canonicalPayload); err != nil {
+		t.Fatalf("decode canonical credential: %v", err)
+	}
+	if canonicalPayload.KeyID != "CANONICAL" {
+		t.Fatalf("canonical credential was mutated: %+v", canonicalPayload)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); err != nil {
+		t.Fatalf("raw legacy credential was removed: %v", err)
+	}
+}
+
 func TestStoreCredentials_RejectsWhitespaceOnlyProfileName(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1654,8 +1654,11 @@ func TestStoreCredentials_RejectsDistinctNormalizedProfileCollisionBeforeMutatio
 	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "RAW", "ISSUER-RAW", "/tmp/raw.p8")
 
 	err := StoreCredentials("  spaced  ", "NEW", "ISSUER-NEW", "/tmp/new.p8")
-	if err == nil || !strings.Contains(err.Error(), "conflicts with existing normalized profile") {
-		t.Fatalf("StoreCredentials() error = %v, want normalized-profile collision", err)
+	wantErr := `credential profile name "  spaced  " conflicts with existing normalized profile "spaced"; ` +
+		`remove the existing profile with 'asc auth logout --name "spaced"' and retry, ` +
+		`or re-run 'asc auth login' with --name "spaced" to overwrite it`
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("StoreCredentials() error = %v, want %q", err, wantErr)
 	}
 
 	canonical, err := newKr.Get(keyringKey("spaced"))

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1817,7 +1818,12 @@ func TestStoreCredentials_IndividualCollisionIgnoresStaleIssuer(t *testing.T) {
 
 func TestStoreCredentials_RetryCompletesPartialLegacyCleanup(t *testing.T) {
 	newKr, legacyKr := withSeparateKeyrings(t)
-	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "OLDKEY", "OLDISSUER", "/tmp/OldAuthKey.p8")
+	keyDir := t.TempDir()
+	oldPath := filepath.Join(keyDir, "OldAuthKey.p8")
+	writeECDSAPEM(t, oldPath, 0o600, true)
+	newPath := filepath.Join(keyDir, "AuthKey.p8")
+	writeECDSAPEM(t, newPath, 0o600, true)
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "OLDKEY", "OLDISSUER", oldPath)
 
 	previousLegacy := legacyKeyringOpener
 	transientLegacy := &transientRemoveFailingKeyring{
@@ -1830,18 +1836,18 @@ func TestStoreCredentials_RetryCompletesPartialLegacyCleanup(t *testing.T) {
 	}
 	t.Cleanup(func() { legacyKeyringOpener = previousLegacy })
 
-	firstErr := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8")
+	firstErr := StoreCredentials("  spaced  ", "KEY123", "ISS456", newPath)
 	if firstErr == nil || !strings.Contains(firstErr.Error(), "legacy keyring locked") {
 		t.Fatalf("first StoreCredentials() error = %v, want legacy cleanup failure", firstErr)
 	}
-	if _, err := newKr.Get(keyringKey("spaced")); err != nil {
-		t.Fatalf("canonical credential should survive partial cleanup: %v", err)
+	if _, err := newKr.Get(keyringKey("spaced")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("canonical credential after rollback error = %v, want ErrKeyNotFound", err)
 	}
 	if _, err := legacyKr.Get(keyringKey("  spaced  ")); err != nil {
 		t.Fatalf("legacy credential should remain after failed removal: %v", err)
 	}
 
-	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", newPath); err != nil {
 		t.Fatalf("retry StoreCredentials() error = %v", err)
 	}
 	if _, err := legacyKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
@@ -1853,6 +1859,64 @@ func TestStoreCredentials_RetryCompletesPartialLegacyCleanup(t *testing.T) {
 	}
 	if defaultCreds.KeyID != "KEY123" || defaultCreds.IssuerID != "ISS456" {
 		t.Fatalf("default credentials after retry = %+v", defaultCreds)
+	}
+}
+
+func TestStoreCredentials_RestoresEarlierVariantsWhenLaterCleanupFails(t *testing.T) {
+	newKr, legacyKr := withSeparateKeyrings(t)
+	keyDir := t.TempDir()
+	oldPath := filepath.Join(keyDir, "OldAuthKey.p8")
+	writeECDSAPEM(t, oldPath, 0o600, true)
+	newPath := filepath.Join(keyDir, "AuthKey.p8")
+	writeECDSAPEM(t, newPath, 0o600, true)
+	storeCredentialInKeyring(t, legacyKr, "  spaced", "OLDKEY", "OLDISSUER", oldPath)
+	storeCredentialInKeyring(t, legacyKr, " spaced ", "OLDKEY", "OLDISSUER", oldPath)
+
+	previousLegacy := legacyKeyringOpener
+	failingLegacy := &nthRemoveFailingKeyring{
+		inner:      legacyKr,
+		failOnCall: 2,
+		err:        errors.New("legacy keyring locked"),
+	}
+	legacyKeyringOpener = func() (keyring.Keyring, error) {
+		return failingLegacy, nil
+	}
+	t.Cleanup(func() { legacyKeyringOpener = previousLegacy })
+
+	err := StoreCredentials("spaced", "KEY123", "ISS456", newPath)
+	if err == nil || !strings.Contains(err.Error(), "legacy keyring locked") {
+		t.Fatalf("StoreCredentials() error = %v, want legacy cleanup failure", err)
+	}
+	if _, err := newKr.Get(keyringKey("spaced")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("canonical credential after rollback error = %v, want ErrKeyNotFound", err)
+	}
+	for _, name := range []string{"  spaced", " spaced "} {
+		if _, err := legacyKr.Get(keyringKey(name)); err != nil {
+			t.Fatalf("legacy credential %q should be restored after failed cleanup: %v", name, err)
+		}
+	}
+}
+
+func TestStoreCredentials_IgnoresPathOnlyCollisionWithInsecurePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not enforce Unix private-key permission bits")
+	}
+	newKr, legacyKr := withSeparateKeyrings(t)
+	keyDir := t.TempDir()
+	canonicalPath := filepath.Join(keyDir, "Canonical.p8")
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	insecurePath := filepath.Join(keyDir, "Insecure.p8")
+	writeECDSAPEM(t, insecurePath, 0o644, true)
+	incomingPath := filepath.Join(keyDir, "Incoming.p8")
+	writeECDSAPEM(t, incomingPath, 0o600, true)
+	storeCredentialInKeyring(t, newKr, "spaced", "CANONICAL", "ISSUER-CANONICAL", canonicalPath)
+	storeCredentialInKeyring(t, legacyKr, "  spaced  ", "INSECURE", "ISSUER-INSECURE", insecurePath)
+
+	if err := StoreCredentials("  spaced  ", "INCOMING", "ISSUER-INCOMING", incomingPath); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	if _, err := legacyKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("unusable legacy credential error = %v, want ErrKeyNotFound", err)
 	}
 }
 
@@ -2717,6 +2781,30 @@ func (k *transientRemoveFailingKeyring) Remove(key string) error {
 	return k.inner.Remove(key)
 }
 func (k *transientRemoveFailingKeyring) Keys() ([]string, error) { return k.inner.Keys() }
+
+type nthRemoveFailingKeyring struct {
+	inner       keyring.Keyring
+	removeCalls int
+	failOnCall  int
+	err         error
+}
+
+func (k *nthRemoveFailingKeyring) Get(key string) (keyring.Item, error) {
+	return k.inner.Get(key)
+}
+
+func (k *nthRemoveFailingKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	return k.inner.GetMetadata(key)
+}
+func (k *nthRemoveFailingKeyring) Set(item keyring.Item) error { return k.inner.Set(item) }
+func (k *nthRemoveFailingKeyring) Remove(key string) error {
+	k.removeCalls++
+	if k.removeCalls == k.failOnCall {
+		return k.err
+	}
+	return k.inner.Remove(key)
+}
+func (k *nthRemoveFailingKeyring) Keys() ([]string, error) { return k.inner.Keys() }
 
 func TestGetCredentialsWithSource_KeychainAccessDeniedReturnsSentinel(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1881,10 +1881,14 @@ func TestStoreCredentials_CleansRawEntryWhenCanonicalKeyWasRelocated(t *testing.
 	keyDir := t.TempDir()
 	canonicalPath := filepath.Join(keyDir, "Original.p8")
 	relocatedPath := filepath.Join(keyDir, "Relocated.p8")
-	for _, path := range []string{canonicalPath, relocatedPath} {
-		if err := os.WriteFile(path, []byte("SAME PRIVATE KEY"), 0o600); err != nil {
-			t.Fatalf("write private key %q: %v", path, err)
-		}
+	writeECDSAPEM(t, canonicalPath, 0o600, true)
+	canonicalPEM, err := os.ReadFile(canonicalPath)
+	if err != nil {
+		t.Fatalf("read canonical private key: %v", err)
+	}
+	relocatedPEM := append(append([]byte(nil), canonicalPEM...), '\n')
+	if err := os.WriteFile(relocatedPath, relocatedPEM, 0o600); err != nil {
+		t.Fatalf("write relocated private key: %v", err)
 	}
 	storeCredentialInKeyring(t, newKr, "spaced", "KEY123", "ISS456", canonicalPath)
 	storeCredentialInKeyring(t, newKr, "  spaced  ", "OTHER", "OTHER-ISSUER", "/tmp/Other.p8")
@@ -1903,7 +1907,7 @@ func TestStoreCredentials_CleansRawEntryWhenCanonicalKeyWasRelocated(t *testing.
 	if err := json.Unmarshal(item.Data, &payload); err != nil {
 		t.Fatalf("decode normalized credential: %v", err)
 	}
-	if payload.PrivateKeyPath != relocatedPath || payload.PrivateKeyPEM != "SAME PRIVATE KEY" {
+	if payload.PrivateKeyPath != relocatedPath || payload.PrivateKeyPEM != string(relocatedPEM) {
 		t.Fatalf("normalized credential = %+v, want relocated key enrichment", payload)
 	}
 }

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1848,6 +1848,42 @@ func TestStoreCredentials_ReplacesIncompletePreNormalizedEntry(t *testing.T) {
 	}
 }
 
+func TestStoreCredentials_ReplacesPreNormalizedEntryWithInvalidEmbeddedKey(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	storeCredentialInKeyring(t, newKr, "spaced", "OLD", "OLD-ISSUER", "/tmp/Old.p8")
+	invalid := credentialPayload{
+		KeyID:         "BROKEN",
+		IssuerID:      "BROKEN-ISSUER",
+		PrivateKeyPEM: "not-pem",
+		KeyType:       config.CredentialKeyTypeTeam,
+	}
+	data, err := json.Marshal(invalid)
+	if err != nil {
+		t.Fatalf("encode invalid embedded-key credential: %v", err)
+	}
+	if err := newKr.Set(keyring.Item{Key: keyringKey("  spaced  "), Data: data}); err != nil {
+		t.Fatalf("seed invalid embedded-key credential: %v", err)
+	}
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", "/tmp/AuthKey.p8"); err != nil {
+		t.Fatalf("StoreCredentials() error: %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("invalid raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error: %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.KeyID != "KEY123" {
+		t.Fatalf("normalized credential = %+v", payload)
+	}
+}
+
 func TestStoreCredentials_CleansRawEntryWhenCanonicalLacksPEMEnrichment(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 	keyPath := filepath.Join(t.TempDir(), "AuthKey.p8")

--- a/internal/auth/keychain_test.go
+++ b/internal/auth/keychain_test.go
@@ -1876,6 +1876,38 @@ func TestStoreCredentials_CleansRawEntryWhenCanonicalLacksPEMEnrichment(t *testi
 	}
 }
 
+func TestStoreCredentials_CleansRawEntryWhenCanonicalKeyWasRelocated(t *testing.T) {
+	newKr, _ := withSeparateKeyrings(t)
+	keyDir := t.TempDir()
+	canonicalPath := filepath.Join(keyDir, "Original.p8")
+	relocatedPath := filepath.Join(keyDir, "Relocated.p8")
+	for _, path := range []string{canonicalPath, relocatedPath} {
+		if err := os.WriteFile(path, []byte("SAME PRIVATE KEY"), 0o600); err != nil {
+			t.Fatalf("write private key %q: %v", path, err)
+		}
+	}
+	storeCredentialInKeyring(t, newKr, "spaced", "KEY123", "ISS456", canonicalPath)
+	storeCredentialInKeyring(t, newKr, "  spaced  ", "OTHER", "OTHER-ISSUER", "/tmp/Other.p8")
+
+	if err := StoreCredentials("  spaced  ", "KEY123", "ISS456", relocatedPath); err != nil {
+		t.Fatalf("StoreCredentials() error = %v", err)
+	}
+	if _, err := newKr.Get(keyringKey("  spaced  ")); !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("raw credential error = %v, want ErrKeyNotFound", err)
+	}
+	item, err := newKr.Get(keyringKey("spaced"))
+	if err != nil {
+		t.Fatalf("normalized credential error = %v", err)
+	}
+	var payload credentialPayload
+	if err := json.Unmarshal(item.Data, &payload); err != nil {
+		t.Fatalf("decode normalized credential: %v", err)
+	}
+	if payload.PrivateKeyPath != relocatedPath || payload.PrivateKeyPEM != "SAME PRIVATE KEY" {
+		t.Fatalf("normalized credential = %+v, want relocated key enrichment", payload)
+	}
+}
+
 func TestStoreCredentials_RejectsWhitespaceOnlyProfileName(t *testing.T) {
 	newKr, _ := withSeparateKeyrings(t)
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -621,7 +621,7 @@ so commands continue to work even if the original .p8 file is removed.`,
 				}
 			}
 
-			fmt.Printf("Successfully registered API key '%s'\n", *name)
+			fmt.Printf("Successfully registered API key '%s'\n", strings.TrimSpace(*name))
 			return nil
 		},
 	}

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -654,6 +654,44 @@ func TestAuthLoginCommand(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("success message echoes normalized name", func(t *testing.T) {
+		withTempRepo(t, func(repo string) {
+			keyPath := writeTempECDSAKeyFile(t)
+			cmd := AuthLoginCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--name", "  spaced  ",
+				"--key-id", "KEY",
+				"--issuer-id", "ISS",
+				"--private-key", keyPath,
+				"--bypass-keychain",
+				"--local",
+				"--skip-validation",
+			}); err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			stdout, _ := captureAuthOutput(t, func() {
+				if err := cmd.Exec(context.Background(), []string{}); err != nil {
+					t.Fatalf("Exec() error: %v", err)
+				}
+			})
+			if !strings.Contains(stdout, "Successfully registered API key 'spaced'") {
+				t.Fatalf("expected normalized profile name in success message, got %q", stdout)
+			}
+			if strings.Contains(stdout, "'  spaced  '") {
+				t.Fatalf("success message echoed pre-normalized name: %q", stdout)
+			}
+
+			cfgPath := filepath.Join(repo, ".asc", "config.json")
+			cfg, err := config.LoadAt(cfgPath)
+			if err != nil {
+				t.Fatalf("LoadAt() error: %v", err)
+			}
+			if cfg.DefaultKeyName != "spaced" {
+				t.Fatalf("DefaultKeyName = %q, want spaced", cfg.DefaultKeyName)
+			}
+		})
+	})
 }
 
 func assertAuthDiagnostic(t *testing.T, err error, code shared.DiagnosticCode, parameter string) {


### PR DESCRIPTION
## Summary

- trim profile names before keychain/config storage
- keep the stored key, default-profile pointer, and later lookup identity consistent
- add regression coverage for explicit and default lookup of whitespace-padded names

## Validation

- RED reproduced: stored credentials were unreachable by trimmed/default lookup
- focused and full internal/auth tests
- focused auth race tests
- full `ASC_BYPASS_KEYCHAIN=1 make test`
- normal pre-commit docs, format, lint, and short repository suite

The staged 5.0 logout confirmation transition is unchanged. No live App Store Connect mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile names are trimmed of surrounding whitespace when credentials are saved.
  * Blank or whitespace-only profile names are rejected without saving credentials.
  * Default credential selection and retrieval consistently use the cleaned profile name.
  * Legacy entries with untrimmed names are cleaned up when replaced.
  * Conflicting credentials under equivalent profile names are rejected safely before changes are made.
  * Matching duplicate entries and malformed legacy entries are handled safely during cleanup.
  * Current credentials take precedence, with configuration fallback when keychain access is unavailable.
  * Credentials containing private keys are correctly compared when resolving duplicate profile names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->