### PR TITLE
fix(itunes): honor ratings histogram cancellation

### DIFF
--- a/internal/itunes/client_test.go
+++ b/internal/itunes/client_test.go
@@ -3,6 +3,8 @@ package itunes
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -204,6 +206,50 @@ func TestGetRatings_HistogramFailureIsNonFatal(t *testing.T) {
 	}
 	if len(ratings.Histogram) != 0 {
 		t.Fatalf("expected empty histogram on failure, got %v", ratings.Histogram)
+	}
+}
+
+func TestGetRatings_PropagatesHistogramCancellation(t *testing.T) {
+	lookupBody := `{"resultCount":1,"results":[{"trackId":123,"trackName":"Canceled Histogram","averageUserRating":4.0,"userRatingCount":10}]}`
+	histogramStarted := make(chan struct{})
+	client := &Client{
+		BaseURL: "https://example.test",
+		HTTPClient: &http.Client{Transport: ratingsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/lookup":
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(lookupBody)), Request: req}, nil
+			case "/us/customer-reviews/id123":
+				close(histogramStarted)
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			default:
+				return nil, fmt.Errorf("unexpected request path %s", req.URL.Path)
+			}
+		})},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := client.GetRatings(ctx, "123", "us")
+		resultCh <- err
+	}()
+
+	select {
+	case <-histogramStarted:
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for histogram request")
+	}
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("GetRatings() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for GetRatings()")
 	}
 }
 

--- a/internal/itunes/ratings.go
+++ b/internal/itunes/ratings.go
@@ -78,7 +78,14 @@ func (c *Client) GetRatings(ctx context.Context, appID, country string) (*AppRat
 	}
 
 	// Histogram scraping is best-effort and must remain non-fatal.
-	_ = c.fetchHistogram(ctx, appID, normalizedCountry, ratings)
+	if err := c.fetchHistogram(ctx, appID, normalizedCountry, ratings); err != nil {
+		// A best-effort auxiliary request may fail for storefront reasons, but
+		// it must not turn an explicit caller cancellation into a successful
+		// ratings response.
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+	}
 	return ratings, nil
 }
 


### PR DESCRIPTION
## Summary

- propagate explicit caller cancellation from the best-effort public ratings histogram fetch
- keep storefront failures and histogram deadlines non-fatal
- cover cancellation and the existing best-effort compatibility boundary

## Release audit evidence

Before this change, canceling the request after the lookup succeeded could still return a successful ratings result. The regression test failed with a nil error instead of `context.Canceled`.

## Validation

- focused `internal/itunes` tests
- `go test -race ./internal/itunes`
- `go test -race ./internal/web ./internal/cli/web`
- normal pre-commit hook: command docs, format, golangci-lint, short suite
- `ASC_BYPASS_KEYCHAIN=1 make test`

No live App Store Connect calls or mutations were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellation during ratings histogram retrieval is now correctly reported as a canceled request.
  * Other non-critical histogram retrieval errors continue to be handled without interrupting ratings results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->