### PR TITLE
fix(xcode): accept project paths with trailing separators

### DIFF
--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -202,7 +202,7 @@ type BumpVersionResult struct {
 }
 
 func resolvedProjectDir(projectDir string) string {
-	projectDir = filepath.Clean(projectDir)
+	projectDir = trimTrailingPathSeparators(projectDir)
 	if projectDir == "" {
 		return "."
 	}
@@ -730,7 +730,7 @@ func findXcodeproj(projectDir string) (string, error) {
 	if projectDir == "" {
 		projectDir = "."
 	}
-	projectDir = filepath.Clean(projectDir)
+	projectDir = trimTrailingPathSeparators(projectDir)
 	if strings.HasSuffix(projectDir, ".xcodeproj") {
 		info, err := os.Stat(projectDir)
 		if err != nil {
@@ -760,6 +760,14 @@ func findXcodeproj(projectDir string) (string, error) {
 	default:
 		return "", fmt.Errorf("multiple .xcodeproj found in %s (%s); use --project to pick one", projectDir, strings.Join(matches, ", "))
 	}
+}
+
+func trimTrailingPathSeparators(path string) string {
+	minimumLength := len(filepath.VolumeName(path)) + 1
+	for len(path) > minimumLength && os.IsPathSeparator(path[len(path)-1]) {
+		path = path[:len(path)-1]
+	}
+	return path
 }
 
 // isVariableReference checks if a value is an Xcode variable like $(MARKETING_VERSION).

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -202,6 +202,7 @@ type BumpVersionResult struct {
 }
 
 func resolvedProjectDir(projectDir string) string {
+	projectDir = filepath.Clean(projectDir)
 	if projectDir == "" {
 		return "."
 	}
@@ -729,6 +730,7 @@ func findXcodeproj(projectDir string) (string, error) {
 	if projectDir == "" {
 		projectDir = "."
 	}
+	projectDir = filepath.Clean(projectDir)
 	if strings.HasSuffix(projectDir, ".xcodeproj") {
 		info, err := os.Stat(projectDir)
 		if err != nil {

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -207,7 +207,9 @@ func resolvedProjectDir(projectDir string) string {
 		return "."
 	}
 	if strings.HasSuffix(projectDir, ".xcodeproj") {
-		projectDir = resolveExistingProjectPath(projectDir)
+		if resolved, err := resolveProjectParentTraversal(projectDir); err == nil {
+			projectDir = resolved
+		}
 		return filepath.Dir(projectDir)
 	}
 	return projectDir
@@ -740,9 +742,18 @@ func findXcodeproj(projectDir string) (string, error) {
 		if !info.IsDir() {
 			return "", fmt.Errorf("%s is not an .xcodeproj directory", projectDir)
 		}
-		return resolveExistingProjectPath(projectDir), nil
+		resolved, err := resolveProjectParentTraversal(projectDir)
+		if err != nil {
+			return "", fmt.Errorf("resolve Xcode project path %s: %w", projectDir, err)
+		}
+		return resolved, nil
 	}
 
+	resolvedProjectDir, err := resolveProjectParentTraversal(projectDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve Xcode project directory %s: %w", projectDir, err)
+	}
+	projectDir = resolvedProjectDir
 	entries, err := os.ReadDir(projectDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to read project directory: %w", err)
@@ -757,28 +768,35 @@ func findXcodeproj(projectDir string) (string, error) {
 	case 0:
 		return "", fmt.Errorf("no .xcodeproj found in %s", projectDir)
 	case 1:
-		return resolveExistingProjectPath(filepath.Join(projectDir, matches[0])), nil
+		return filepath.Join(projectDir, matches[0]), nil
 	default:
 		return "", fmt.Errorf("multiple .xcodeproj found in %s (%s); use --project to pick one", projectDir, strings.Join(matches, ", "))
 	}
 }
 
-func resolveExistingProjectPath(path string) string {
-	containsParentTraversal := false
-	for _, component := range strings.Split(filepath.ToSlash(path), "/") {
+func resolveProjectParentTraversal(path string) (string, error) {
+	slashPath := filepath.ToSlash(path)
+	components := strings.Split(slashPath, "/")
+	lastParent := -1
+	for index, component := range components {
 		if component == ".." {
-			containsParentTraversal = true
-			break
+			lastParent = index
 		}
 	}
-	if !containsParentTraversal {
-		return path
+	if lastParent == -1 {
+		return path, nil
 	}
-	resolved, err := filepath.EvalSymlinks(path)
+
+	prefix := filepath.FromSlash(strings.Join(components[:lastParent+1], "/"))
+	resolvedPrefix, err := filepath.EvalSymlinks(prefix)
 	if err != nil {
-		return path
+		return "", err
 	}
-	return resolved
+	suffix := filepath.FromSlash(strings.Join(components[lastParent+1:], "/"))
+	if suffix == "" {
+		return resolvedPrefix, nil
+	}
+	return filepath.Join(resolvedPrefix, suffix), nil
 }
 
 func trimTrailingPathSeparators(path string) string {

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -207,6 +207,7 @@ func resolvedProjectDir(projectDir string) string {
 		return "."
 	}
 	if strings.HasSuffix(projectDir, ".xcodeproj") {
+		projectDir = resolveExistingProjectPath(projectDir)
 		return filepath.Dir(projectDir)
 	}
 	return projectDir
@@ -739,7 +740,7 @@ func findXcodeproj(projectDir string) (string, error) {
 		if !info.IsDir() {
 			return "", fmt.Errorf("%s is not an .xcodeproj directory", projectDir)
 		}
-		return projectDir, nil
+		return resolveExistingProjectPath(projectDir), nil
 	}
 
 	entries, err := os.ReadDir(projectDir)
@@ -756,10 +757,28 @@ func findXcodeproj(projectDir string) (string, error) {
 	case 0:
 		return "", fmt.Errorf("no .xcodeproj found in %s", projectDir)
 	case 1:
-		return filepath.Join(projectDir, matches[0]), nil
+		return resolveExistingProjectPath(filepath.Join(projectDir, matches[0])), nil
 	default:
 		return "", fmt.Errorf("multiple .xcodeproj found in %s (%s); use --project to pick one", projectDir, strings.Join(matches, ", "))
 	}
+}
+
+func resolveExistingProjectPath(path string) string {
+	containsParentTraversal := false
+	for _, component := range strings.Split(filepath.ToSlash(path), "/") {
+		if component == ".." {
+			containsParentTraversal = true
+			break
+		}
+	}
+	if !containsParentTraversal {
+		return path
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	return resolved
 }
 
 func trimTrailingPathSeparators(path string) string {

--- a/internal/xcode/version_test.go
+++ b/internal/xcode/version_test.go
@@ -301,7 +301,10 @@ func TestFindXcodeprojPreservesSymlinkParentTraversal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("findXcodeproj() error = %v", err)
 	}
-	want := strings.TrimSuffix(input, string(os.PathSeparator))
+	want, err := filepath.EvalSymlinks(projectPath)
+	if err != nil {
+		t.Fatalf("resolve project path: %v", err)
+	}
 	if got != want {
 		t.Fatalf("findXcodeproj() = %q, want %q", got, want)
 	}

--- a/internal/xcode/version_test.go
+++ b/internal/xcode/version_test.go
@@ -313,6 +313,75 @@ func TestFindXcodeprojPreservesSymlinkParentTraversal(t *testing.T) {
 	}
 }
 
+func TestFindXcodeprojResolvesDirectoryTraversalBeforeJoiningProject(t *testing.T) {
+	tempDir := t.TempDir()
+	realDir := filepath.Join(tempDir, "real")
+	childDir := filepath.Join(realDir, "child")
+	realProject := filepath.Join(realDir, "App.xcodeproj")
+	siblingProject := filepath.Join(tempDir, "App.xcodeproj")
+	for _, path := range []string{childDir, realProject, siblingProject} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	linkPath := filepath.Join(tempDir, "link")
+	if err := os.Symlink(childDir, linkPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got, err := findXcodeproj(linkPath + string(os.PathSeparator) + "..")
+	if err != nil {
+		t.Fatalf("findXcodeproj() error = %v", err)
+	}
+	want, err := filepath.EvalSymlinks(realProject)
+	if err != nil {
+		t.Fatalf("resolve real project: %v", err)
+	}
+	if got != want {
+		t.Fatalf("findXcodeproj() = %q, want %q", got, want)
+	}
+}
+
+func TestFindXcodeprojPreservesProjectSymlinkAfterParentTraversal(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tempDir, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	targetProject := filepath.Join(t.TempDir(), "Target.xcodeproj")
+	if err := os.Mkdir(targetProject, 0o755); err != nil {
+		t.Fatalf("mkdir target project: %v", err)
+	}
+	aliasProject := filepath.Join(tempDir, "Alias.xcodeproj")
+	if err := os.Symlink(targetProject, aliasProject); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	separator := string(os.PathSeparator)
+	input := filepath.Join(tempDir, "sub") + separator + ".." + separator + "Alias.xcodeproj" + separator
+	got, err := findXcodeproj(input)
+	if err != nil {
+		t.Fatalf("findXcodeproj() error = %v", err)
+	}
+	info, err := os.Lstat(got)
+	if err != nil {
+		t.Fatalf("lstat selected project: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("findXcodeproj() = %q, want selected project symlink", got)
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("resolve selected project: %v", err)
+	}
+	wantTarget, err := filepath.EvalSymlinks(targetProject)
+	if err != nil {
+		t.Fatalf("resolve target project: %v", err)
+	}
+	if resolvedTarget != wantTarget {
+		t.Fatalf("selected project target = %q, want %q", resolvedTarget, wantTarget)
+	}
+}
+
 func TestFindXcodeprojDoesNotRetargetTrailingWhitespaceProjectPath(t *testing.T) {
 	tempDir := t.TempDir()
 	exactProject := filepath.Join(tempDir, "Foo.xcodeproj")

--- a/internal/xcode/version_test.go
+++ b/internal/xcode/version_test.go
@@ -279,6 +279,37 @@ func TestResolvedProjectDirNormalizesExplicitProjectPathWithTrailingSeparator(t 
 	}
 }
 
+func TestFindXcodeprojPreservesSymlinkParentTraversal(t *testing.T) {
+	tempDir := t.TempDir()
+	realDir := filepath.Join(tempDir, "real")
+	childDir := filepath.Join(realDir, "child")
+	projectPath := filepath.Join(realDir, "App.xcodeproj")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	if err := os.Mkdir(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	linkPath := filepath.Join(tempDir, "link")
+	if err := os.Symlink(childDir, linkPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	separator := string(os.PathSeparator)
+	input := linkPath + separator + ".." + separator + "App.xcodeproj" + separator
+	got, err := findXcodeproj(input)
+	if err != nil {
+		t.Fatalf("findXcodeproj() error = %v", err)
+	}
+	want := strings.TrimSuffix(input, string(os.PathSeparator))
+	if got != want {
+		t.Fatalf("findXcodeproj() = %q, want %q", got, want)
+	}
+	if gotDir := resolvedProjectDir(input); gotDir != filepath.Dir(want) {
+		t.Fatalf("resolvedProjectDir() = %q, want %q", gotDir, filepath.Dir(want))
+	}
+}
+
 func TestFindXcodeprojDoesNotRetargetTrailingWhitespaceProjectPath(t *testing.T) {
 	tempDir := t.TempDir()
 	exactProject := filepath.Join(tempDir, "Foo.xcodeproj")

--- a/internal/xcode/version_test.go
+++ b/internal/xcode/version_test.go
@@ -254,6 +254,31 @@ func TestFindXcodeprojAcceptsExplicitProjectPath(t *testing.T) {
 	}
 }
 
+func TestFindXcodeprojAcceptsExplicitProjectPathWithTrailingSeparator(t *testing.T) {
+	tempDir := t.TempDir()
+	projectPath := filepath.Join(tempDir, "App.xcodeproj")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	got, err := findXcodeproj(projectPath + string(os.PathSeparator))
+	if err != nil {
+		t.Fatalf("expected trailing separator project path to succeed, got %v", err)
+	}
+	if got != projectPath {
+		t.Fatalf("findXcodeproj() = %q, want %q", got, projectPath)
+	}
+}
+
+func TestResolvedProjectDirNormalizesExplicitProjectPathWithTrailingSeparator(t *testing.T) {
+	projectPath := filepath.Join(t.TempDir(), "App.xcodeproj")
+	got := resolvedProjectDir(projectPath + string(os.PathSeparator))
+	want := filepath.Dir(projectPath)
+	if got != want {
+		t.Fatalf("resolvedProjectDir() = %q, want %q", got, want)
+	}
+}
+
 func TestFindXcodeprojDoesNotRetargetTrailingWhitespaceProjectPath(t *testing.T) {
 	tempDir := t.TempDir()
 	exactProject := filepath.Join(tempDir, "Foo.xcodeproj")


### PR DESCRIPTION
## Summary

- normalize explicit project paths before detecting the `.xcodeproj` suffix
- resolve legacy project working directories from the normalized path
- cover both direct project discovery and legacy directory resolution

## Release audit evidence

`--project App.xcodeproj/` was treated as a directory to scan rather than the explicitly selected project, and the legacy helper could receive the project bundle itself as its working directory.

## Validation

- focused `internal/xcode` tests and race tests
- `make build`
- normal pre-commit hook: command docs, format, golangci-lint, short suite
- `ASC_BYPASS_KEYCHAIN=1 make test`

No live App Store Connect calls or mutations were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Xcode project paths with trailing separators.
  - Preserved symlink-based parent directory traversal during project discovery.
  - Ensured project paths resolve consistently when locating projects and parent directories.
  - Preserved usable paths when symlink resolution is unavailable.
  - Improved error context when project path resolution fails.
  - Preserved selected project symlinks and filesystem root paths during path normalization.

- **Tests**
  - Added coverage for trailing separators, symlinked parent directories, project symlinks, and path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->