### PR TITLE
fix(cli): keep known flag parse errors concise

### DIFF
--- a/cmd/parse_diagnostics_test.go
+++ b/cmd/parse_diagnostics_test.go
@@ -165,6 +165,26 @@ func TestRunRootFlagParseFailureUsesRightmostMixedMarker(t *testing.T) {
 	}
 }
 
+func TestRunRepeatedCustomFlagReasonDoesNotReplaceParserSuffix(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"reviews", "--stars", "1", "--stars", "2 for flag -version: x", "view",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc reviews --help") {
+		t.Fatalf("stderr = %q, want reviews group help guidance", stderr)
+	}
+	if strings.Contains(stderr, "asc reviews view --help") {
+		t.Fatalf("stderr = %q, reason text must not replace the parser suffix", stderr)
+	}
+}
+
 func TestRunParseFailurePreservesJSONAndJUnitContracts(t *testing.T) {
 	resetReportFlags(t)
 	stdout, stderr := captureCommandOutput(t, func() {

--- a/cmd/parse_diagnostics_test.go
+++ b/cmd/parse_diagnostics_test.go
@@ -111,6 +111,24 @@ func TestRunRepeatedFlagNameParseFailurePointsToFailingLeaf(t *testing.T) {
 	}
 }
 
+func TestRunEarlierRepeatedFlagParseFailureKeepsEarlierOwner(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"--version=maybe", "builds", "list", "--version", "1.2.3"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc --help") {
+		t.Fatalf("stderr = %q, want root help guidance", stderr)
+	}
+	if strings.Contains(stderr, "asc builds list --help") {
+		t.Fatalf("stderr = %q, later flag must not replace failing root owner", stderr)
+	}
+}
+
 func TestRunRootFlagParseFailureIgnoresFlagMarkerInsideInvalidValue(t *testing.T) {
 	resetReportFlags(t)
 	stdout, stderr := captureCommandOutput(t, func() {
@@ -126,6 +144,24 @@ func TestRunRootFlagParseFailureIgnoresFlagMarkerInsideInvalidValue(t *testing.T
 	}
 	if strings.Contains(stderr, "asc builds list --help") {
 		t.Fatalf("stderr = %q, must not point to leaf help for a root flag", stderr)
+	}
+}
+
+func TestRunRootFlagParseFailureUsesRightmostMixedMarker(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"--strict-auth=foo for flag -limit: x", "builds", "list"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc --help") {
+		t.Fatalf("stderr = %q, want root help guidance", stderr)
+	}
+	if strings.Contains(stderr, "asc builds list --help") {
+		t.Fatalf("stderr = %q, embedded marker must not replace the diagnostic suffix", stderr)
 	}
 }
 

--- a/cmd/parse_diagnostics_test.go
+++ b/cmd/parse_diagnostics_test.go
@@ -75,6 +75,42 @@ func TestRunRootFlagParseFailurePointsToRootHelp(t *testing.T) {
 	}
 }
 
+func TestRunIntermediateFlagParseFailurePointsToOwningGroupHelp(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"reviews", "--limit", "nope", "view"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc reviews --help") {
+		t.Fatalf("stderr = %q, want reviews group help guidance", stderr)
+	}
+	if strings.Contains(stderr, "asc reviews view --help") {
+		t.Fatalf("stderr = %q, must not point to leaf help for a group flag", stderr)
+	}
+}
+
+func TestRunRootFlagParseFailureIgnoresFlagMarkerInsideInvalidValue(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"--strict-auth=foo for -other", "builds", "list"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc --help") {
+		t.Fatalf("stderr = %q, want root help guidance", stderr)
+	}
+	if strings.Contains(stderr, "asc builds list --help") {
+		t.Fatalf("stderr = %q, must not point to leaf help for a root flag", stderr)
+	}
+}
+
 func TestRunParseFailurePreservesJSONAndJUnitContracts(t *testing.T) {
 	resetReportFlags(t)
 	stdout, stderr := captureCommandOutput(t, func() {

--- a/cmd/parse_diagnostics_test.go
+++ b/cmd/parse_diagnostics_test.go
@@ -185,6 +185,26 @@ func TestRunRepeatedCustomFlagReasonDoesNotReplaceParserSuffix(t *testing.T) {
 	}
 }
 
+func TestRunRepeatedFlagValuePointsToFailingLeaf(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"reviews", "--stars", "1", "list", "--stars", "2", "--stars", "1",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc reviews list --help") {
+		t.Fatalf("stderr = %q, want reviews list help guidance", stderr)
+	}
+	if strings.Contains(stderr, "\n  asc reviews --help") {
+		t.Fatalf("stderr = %q, earlier equal value must not replace the failing leaf owner", stderr)
+	}
+}
+
 func TestRunParseFailurePreservesJSONAndJUnitContracts(t *testing.T) {
 	resetReportFlags(t)
 	stdout, stderr := captureCommandOutput(t, func() {

--- a/cmd/parse_diagnostics_test.go
+++ b/cmd/parse_diagnostics_test.go
@@ -57,6 +57,24 @@ func TestRunKnownFlagParseFailuresAreConcise(t *testing.T) {
 	}
 }
 
+func TestRunRootFlagParseFailurePointsToRootHelp(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"--strict-auth=not-a-bool", "builds", "list"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc --help") {
+		t.Fatalf("stderr = %q, want root help guidance", stderr)
+	}
+	if strings.Contains(stderr, "asc builds list --help") {
+		t.Fatalf("stderr = %q, must not point to leaf help for a root flag", stderr)
+	}
+}
+
 func TestRunParseFailurePreservesJSONAndJUnitContracts(t *testing.T) {
 	resetReportFlags(t)
 	stdout, stderr := captureCommandOutput(t, func() {

--- a/cmd/parse_diagnostics_test.go
+++ b/cmd/parse_diagnostics_test.go
@@ -93,6 +93,24 @@ func TestRunIntermediateFlagParseFailurePointsToOwningGroupHelp(t *testing.T) {
 	}
 }
 
+func TestRunRepeatedFlagNameParseFailurePointsToFailingLeaf(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"--profile", "work", "signing", "run", "--profile"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "asc signing run --help") {
+		t.Fatalf("stderr = %q, want signing run help guidance", stderr)
+	}
+	if strings.Contains(stderr, "\n  asc --help") {
+		t.Fatalf("stderr = %q, must not point to root help for the leaf flag", stderr)
+	}
+}
+
 func TestRunRootFlagParseFailureIgnoresFlagMarkerInsideInvalidValue(t *testing.T) {
 	resetReportFlags(t)
 	stdout, stderr := captureCommandOutput(t, func() {

--- a/cmd/parse_diagnostics_test.go
+++ b/cmd/parse_diagnostics_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+)
+
+func TestRunKnownFlagParseFailuresAreConcise(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "invalid value",
+			args: []string{"builds", "list", "--limit", "nope"},
+			want: `invalid value "nope" for flag -limit: parse error`,
+		},
+		{
+			name: "missing value",
+			args: []string{"builds", "list", "--limit"},
+			want: "flag needs an argument: -limit",
+		},
+		{
+			name: "invalid boolean",
+			args: []string{"builds", "list", "--paginate", "nope"},
+			want: `invalid boolean value "nope" for -paginate: parse error`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resetReportFlags(t)
+			stdout, stderr := captureCommandOutput(t, func() {
+				if code := Run(test.args, "1.0.0"); code != ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+				}
+			})
+
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			want := "Error: " + test.want + "\nFor help:\n  asc builds list --help\n"
+			if stderr != want {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
+			}
+			if strings.Contains(stderr, "DESCRIPTION") || strings.Contains(stderr, "USAGE") || strings.Contains(stderr, "FLAGS") {
+				t.Fatalf("parse failure dumped command help: %q", stderr)
+			}
+		})
+	}
+}
+
+func TestRunParseFailurePreservesJSONAndJUnitContracts(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"builds", "list", "--output", "json", "--limit", "nope"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("JSON parse failure wrote stdout = %q, want empty", stdout)
+	}
+	if !strings.HasPrefix(stderr, "Error: invalid value") || !strings.Contains(stderr, "asc builds list --help") {
+		t.Fatalf("unexpected JSON parse diagnostic: %q", stderr)
+	}
+
+	resetReportFlags(t)
+	reportPath := filepath.Join(t.TempDir(), "parse.xml")
+	stdout, stderr = captureCommandOutput(t, func() {
+		if code := Run([]string{
+			"--report", "junit", "--report-file", reportPath,
+			"builds", "list", "--limit", "nope",
+		}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("JUnit parse failure wrote stdout = %q, want empty", stdout)
+	}
+	if !strings.HasPrefix(stderr, "Error: invalid value") || !strings.Contains(stderr, "asc builds list --help") {
+		t.Fatalf("unexpected JUnit parse diagnostic: %q", stderr)
+	}
+	if _, err := os.Stat(reportPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("generic parse failures must preserve the no-report contract, stat error = %v", err)
+	}
+}
+
+func TestRunExplicitHelpStillUsesStdout(t *testing.T) {
+	resetReportFlags(t)
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"builds", "list", "--help"}, "1.0.0"); code != ExitSuccess {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
+		}
+	})
+	if !strings.Contains(stdout, "DESCRIPTION") || !strings.Contains(stdout, "--paginate") {
+		t.Fatalf("explicit help stdout = %q, want full command help", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("explicit help stderr = %q, want empty", stderr)
+	}
+}
+
+func TestRunKnownFlagParseFailureDoesNotChangeUsageClassification(t *testing.T) {
+	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+	var gotExit int
+	emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+		gotExit = exitCode
+		if eventContext.FailureStage != telemetry.FailureStageParse || eventContext.OutcomeKind != telemetry.OutcomeUsageError {
+			t.Errorf("telemetry context = %+v, want parse usage failure", eventContext)
+		}
+	}
+
+	_, _ = captureCommandOutput(t, func() {
+		if code := Run([]string{"builds", "list", "--limit", "nope"}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+	if gotExit != ExitUsage {
+		t.Fatalf("telemetry exit code = %d, want %d", gotExit, ExitUsage)
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -485,7 +485,7 @@ func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput str
 
 func parseFailureFlagName(parseOutput string) string {
 	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
-	markerIndex, marker := rightmostParseFailureMarker(firstLine)
+	markerIndex, marker := parseFailureMarker(firstLine)
 	if markerIndex == -1 {
 		return ""
 	}
@@ -496,11 +496,15 @@ func parseFailureFlagName(parseOutput string) string {
 
 func parseFailureInvalidValue(parseOutput string) (string, bool) {
 	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
-	markerIndex, _ := rightmostParseFailureMarker(firstLine)
+	markerIndex, _ := parseFailureMarker(firstLine)
 	if markerIndex == -1 {
 		return "", false
 	}
-	prefix := strings.TrimSpace(firstLine[:markerIndex])
+	return invalidValueFromDiagnosticPrefix(firstLine[:markerIndex])
+}
+
+func invalidValueFromDiagnosticPrefix(prefix string) (string, bool) {
+	prefix = strings.TrimSpace(prefix)
 	for _, diagnosticPrefix := range []string{"invalid boolean value ", "invalid value "} {
 		quotedValue, found := strings.CutPrefix(prefix, diagnosticPrefix)
 		if !found {
@@ -512,7 +516,29 @@ func parseFailureInvalidValue(parseOutput string) (string, bool) {
 	return "", false
 }
 
-func rightmostParseFailureMarker(firstLine string) (int, string) {
+func parseFailureMarker(firstLine string) (int, string) {
+	if strings.HasPrefix(firstLine, "invalid boolean value ") || strings.HasPrefix(firstLine, "invalid value ") {
+		bestIndex := -1
+		bestMarker := ""
+		for _, marker := range []string{" for flag -", " for -"} {
+			searchFrom := 0
+			for searchFrom < len(firstLine) {
+				relativeIndex := strings.Index(firstLine[searchFrom:], marker)
+				if relativeIndex == -1 {
+					break
+				}
+				markerIndex := searchFrom + relativeIndex
+				if _, valid := invalidValueFromDiagnosticPrefix(firstLine[:markerIndex]); valid &&
+					(bestIndex == -1 || markerIndex < bestIndex) {
+					bestIndex = markerIndex
+					bestMarker = marker
+				}
+				searchFrom = markerIndex + len(marker)
+			}
+		}
+		return bestIndex, bestMarker
+	}
+
 	rightmostIndex := -1
 	rightmostMarker := ""
 	for _, marker := range []string{" for flag -", " for -", "argument: -"} {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,7 +46,7 @@ func Run(args []string, versionInfo string) int {
 	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stopSignals()
 
-	parseOutput := &bytes.Buffer{}
+	parseOutput := &parseOutputBuffer{}
 	restoreFlagOutputs := prepareFlagParsing(root, args, parseOutput)
 	parseErr := root.Parse(args)
 	restoreFlagOutputs()
@@ -78,7 +78,7 @@ func Run(args []string, versionInfo string) int {
 		} else if strings.HasPrefix(badFlagSyntax, "bad flag syntax:") {
 			fmt.Fprintf(os.Stderr, "Error: %s\nFor help:\n  asc --help\n", shared.SanitizeTerminal(badFlagSyntax))
 		} else {
-			printParseFailure(parseErr, parseOutput.String(), analysis, parseFailureHelpCommand(root, args, parseOutput.String()))
+			printParseFailure(parseErr, parseOutput.String(), analysis, parseFailureHelpCommand(root, args, parseOutput.String(), parseOutput.owner))
 		}
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
@@ -434,7 +434,10 @@ func printParseFailure(parseErr error, parseOutput string, analysis invocationAn
 	}
 }
 
-func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput string) string {
+func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput, parseOwner string) string {
+	if parseOwner != "" {
+		return parseOwner
+	}
 	flagName := parseFailureFlagName(parseOutput)
 	invalidValue, hasInvalidValue := parseFailureInvalidValue(parseOutput)
 	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
@@ -572,12 +575,30 @@ func emitImmediateTelemetry(
 	emitTelemetry(getCommandName(root, args), versionInfo, 0, ExitUsage, eventContext)
 }
 
-func prepareFlagParsing(command *ffcli.Command, args []string, output *bytes.Buffer) func() {
+type parseOutputBuffer struct {
+	bytes.Buffer
+	owner string
+}
+
+type scopedParseWriter struct {
+	output *parseOutputBuffer
+	owner  string
+}
+
+func (w scopedParseWriter) Write(data []byte) (int, error) {
+	if len(data) > 0 {
+		w.output.owner = w.owner
+	}
+	return w.output.Write(data)
+}
+
+func prepareFlagParsing(command *ffcli.Command, args []string, output *parseOutputBuffer) func() {
 	type preparedFlagSet struct {
 		flagSet *flag.FlagSet
 		output  io.Writer
 	}
 	prepared := []preparedFlagSet{}
+	path := []string{command.Name}
 
 	for command != nil {
 		if command.FlagSet == nil {
@@ -588,7 +609,7 @@ func prepareFlagParsing(command *ffcli.Command, args []string, output *bytes.Buf
 			output:  command.FlagSet.Output(),
 		})
 		command.FlagSet.Init(command.FlagSet.Name(), flag.ContinueOnError)
-		command.FlagSet.SetOutput(output)
+		command.FlagSet.SetOutput(scopedParseWriter{output: output, owner: strings.Join(path, " ")})
 
 		var next *ffcli.Command
 		var remaining []string
@@ -600,6 +621,7 @@ func prepareFlagParsing(command *ffcli.Command, args []string, output *bytes.Buf
 			}
 			if sub := findDirectSubcommand(command, token); sub != nil {
 				next = sub
+				path = append(path, sub.Name)
 				remaining = args[i+1:]
 				break
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -436,17 +436,22 @@ func printParseFailure(parseErr error, parseOutput string, analysis invocationAn
 
 func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput string) string {
 	flagName := parseFailureFlagName(parseOutput)
+	command := root
+	path := []string{root.Name}
 	for index := 0; flagName != "" && index < len(args); {
 		token := args[index]
-		if findDirectSubcommand(root, token) != nil {
-			break
+		if subcommand := findDirectSubcommand(command, token); subcommand != nil {
+			command = subcommand
+			path = append(path, subcommand.Name)
+			index++
+			continue
 		}
 		trimmed := strings.TrimLeft(token, "-")
 		name, _ := splitFlagToken(trimmed)
-		if name == flagName && root.FlagSet.Lookup(name) != nil {
-			return root.Name
+		if name == flagName && command.FlagSet.Lookup(name) != nil {
+			return strings.Join(path, " ")
 		}
-		next, consumed := consumeFlagToken(root.FlagSet, token, args, index)
+		next, consumed := consumeFlagToken(command.FlagSet, token, args, index)
 		if !consumed {
 			break
 		}
@@ -458,10 +463,11 @@ func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput str
 func parseFailureFlagName(parseOutput string) string {
 	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
 	for _, marker := range []string{" for flag -", " for -", "argument: -"} {
-		_, remainder, found := strings.Cut(firstLine, marker)
-		if !found {
+		markerIndex := strings.LastIndex(firstLine, marker)
+		if markerIndex == -1 {
 			continue
 		}
+		remainder := firstLine[markerIndex+len(marker):]
 		name, _, _ := strings.Cut(remainder, ":")
 		return strings.TrimSpace(name)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,7 +78,7 @@ func Run(args []string, versionInfo string) int {
 		} else if strings.HasPrefix(badFlagSyntax, "bad flag syntax:") {
 			fmt.Fprintf(os.Stderr, "Error: %s\nFor help:\n  asc --help\n", shared.SanitizeTerminal(badFlagSyntax))
 		} else {
-			printParseFailure(parseErr, parseOutput.String(), analysis, parseFailureHelpCommand(root, args, parseOutput.String(), parseOutput.owner))
+			printParseFailure(parseErr, parseOutput.String(), analysis, parseFailureHelpCommand(root, args, parseOutput.owner))
 		}
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
@@ -434,123 +434,16 @@ func printParseFailure(parseErr error, parseOutput string, analysis invocationAn
 	}
 }
 
-func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput, parseOwner string) string {
+// parseFailureHelpCommand names the command whose help a parse failure should
+// point to. The scoped parse writers record which command's flag set produced
+// diagnostics during Parse; when nothing was written there is no diagnostic to
+// attribute, so the help target falls back to the deepest command named by the
+// invocation.
+func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOwner string) string {
 	if parseOwner != "" {
 		return parseOwner
 	}
-	flagName := parseFailureFlagName(parseOutput)
-	invalidValue, hasInvalidValue := parseFailureInvalidValue(parseOutput)
-	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
-	missingArgument := strings.HasPrefix(firstLine, "flag needs an argument:")
-	command := root
-	path := []string{root.Name}
-	owner := ""
-	for index := 0; flagName != "" && index < len(args); {
-		token := args[index]
-		if subcommand := findDirectSubcommand(command, token); subcommand != nil {
-			command = subcommand
-			path = append(path, subcommand.Name)
-			index++
-			continue
-		}
-		trimmed := strings.TrimLeft(token, "-")
-		name, hasInlineValue := splitFlagToken(trimmed)
-		if name == flagName && command.FlagSet.Lookup(name) != nil {
-			currentOwner := strings.Join(path, " ")
-			if owner == "" {
-				owner = currentOwner
-			}
-			if hasInvalidValue {
-				providedValue := ""
-				if hasInlineValue {
-					_, providedValue, _ = strings.Cut(trimmed, "=")
-				} else if index+1 < len(args) {
-					providedValue = args[index+1]
-				}
-				if providedValue == invalidValue {
-					return currentOwner
-				}
-			} else if missingArgument && !hasInlineValue && index+1 >= len(args) {
-				return currentOwner
-			}
-		}
-		next, consumed := consumeFlagToken(command.FlagSet, token, args, index)
-		if !consumed {
-			break
-		}
-		index = next
-	}
-	if owner != "" {
-		return owner
-	}
 	return getCommandName(root, args)
-}
-
-func parseFailureFlagName(parseOutput string) string {
-	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
-	markerIndex, marker := parseFailureMarker(firstLine)
-	if markerIndex == -1 {
-		return ""
-	}
-	remainder := firstLine[markerIndex+len(marker):]
-	name, _, _ := strings.Cut(remainder, ":")
-	return strings.TrimSpace(name)
-}
-
-func parseFailureInvalidValue(parseOutput string) (string, bool) {
-	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
-	markerIndex, _ := parseFailureMarker(firstLine)
-	if markerIndex == -1 {
-		return "", false
-	}
-	return invalidValueFromDiagnosticPrefix(firstLine[:markerIndex])
-}
-
-func invalidValueFromDiagnosticPrefix(prefix string) (string, bool) {
-	prefix = strings.TrimSpace(prefix)
-	for _, diagnosticPrefix := range []string{"invalid boolean value ", "invalid value "} {
-		quotedValue, found := strings.CutPrefix(prefix, diagnosticPrefix)
-		if !found {
-			continue
-		}
-		value, err := strconv.Unquote(quotedValue)
-		return value, err == nil
-	}
-	return "", false
-}
-
-func parseFailureMarker(firstLine string) (int, string) {
-	if strings.HasPrefix(firstLine, "invalid boolean value ") || strings.HasPrefix(firstLine, "invalid value ") {
-		bestIndex := -1
-		bestMarker := ""
-		for _, marker := range []string{" for flag -", " for -"} {
-			searchFrom := 0
-			for searchFrom < len(firstLine) {
-				relativeIndex := strings.Index(firstLine[searchFrom:], marker)
-				if relativeIndex == -1 {
-					break
-				}
-				markerIndex := searchFrom + relativeIndex
-				if _, valid := invalidValueFromDiagnosticPrefix(firstLine[:markerIndex]); valid &&
-					(bestIndex == -1 || markerIndex < bestIndex) {
-					bestIndex = markerIndex
-					bestMarker = marker
-				}
-				searchFrom = markerIndex + len(marker)
-			}
-		}
-		return bestIndex, bestMarker
-	}
-
-	rightmostIndex := -1
-	rightmostMarker := ""
-	for _, marker := range []string{" for flag -", " for -", "argument: -"} {
-		if markerIndex := strings.LastIndex(firstLine, marker); markerIndex > rightmostIndex {
-			rightmostIndex = markerIndex
-			rightmostMarker = marker
-		}
-	}
-	return rightmostIndex, rightmostMarker
 }
 
 func isUnknownFlagParseFailure(parseErr error, parseOutput string) bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,7 +78,7 @@ func Run(args []string, versionInfo string) int {
 		} else if strings.HasPrefix(badFlagSyntax, "bad flag syntax:") {
 			fmt.Fprintf(os.Stderr, "Error: %s\nFor help:\n  asc --help\n", shared.SanitizeTerminal(badFlagSyntax))
 		} else {
-			printParseFailure(parseErr, parseOutput.String(), analysis, getCommandName(root, args))
+			printParseFailure(parseErr, parseOutput.String(), analysis, parseFailureHelpCommand(root, args, parseOutput.String()))
 		}
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
@@ -432,6 +432,40 @@ func printParseFailure(parseErr error, parseOutput string, analysis invocationAn
 	if parseOutput != "" {
 		fmt.Fprint(os.Stderr, parseOutput)
 	}
+}
+
+func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput string) string {
+	flagName := parseFailureFlagName(parseOutput)
+	for index := 0; flagName != "" && index < len(args); {
+		token := args[index]
+		if findDirectSubcommand(root, token) != nil {
+			break
+		}
+		trimmed := strings.TrimLeft(token, "-")
+		name, _ := splitFlagToken(trimmed)
+		if name == flagName && root.FlagSet.Lookup(name) != nil {
+			return root.Name
+		}
+		next, consumed := consumeFlagToken(root.FlagSet, token, args, index)
+		if !consumed {
+			break
+		}
+		index = next
+	}
+	return getCommandName(root, args)
+}
+
+func parseFailureFlagName(parseOutput string) string {
+	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
+	for _, marker := range []string{" for flag -", " for -", "argument: -"} {
+		_, remainder, found := strings.Cut(firstLine, marker)
+		if !found {
+			continue
+		}
+		name, _, _ := strings.Cut(remainder, ":")
+		return strings.TrimSpace(name)
+	}
+	return ""
 }
 
 func isUnknownFlagParseFailure(parseErr error, parseOutput string) bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -436,6 +436,9 @@ func printParseFailure(parseErr error, parseOutput string, analysis invocationAn
 
 func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput string) string {
 	flagName := parseFailureFlagName(parseOutput)
+	invalidValue, hasInvalidValue := parseFailureInvalidValue(parseOutput)
+	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
+	missingArgument := strings.HasPrefix(firstLine, "flag needs an argument:")
 	command := root
 	path := []string{root.Name}
 	owner := ""
@@ -448,9 +451,25 @@ func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput str
 			continue
 		}
 		trimmed := strings.TrimLeft(token, "-")
-		name, _ := splitFlagToken(trimmed)
+		name, hasInlineValue := splitFlagToken(trimmed)
 		if name == flagName && command.FlagSet.Lookup(name) != nil {
-			owner = strings.Join(path, " ")
+			currentOwner := strings.Join(path, " ")
+			if owner == "" {
+				owner = currentOwner
+			}
+			if hasInvalidValue {
+				providedValue := ""
+				if hasInlineValue {
+					_, providedValue, _ = strings.Cut(trimmed, "=")
+				} else if index+1 < len(args) {
+					providedValue = args[index+1]
+				}
+				if providedValue == invalidValue {
+					return currentOwner
+				}
+			} else if missingArgument && !hasInlineValue && index+1 >= len(args) {
+				return currentOwner
+			}
 		}
 		next, consumed := consumeFlagToken(command.FlagSet, token, args, index)
 		if !consumed {
@@ -466,16 +485,43 @@ func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput str
 
 func parseFailureFlagName(parseOutput string) string {
 	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
-	for _, marker := range []string{" for flag -", " for -", "argument: -"} {
-		markerIndex := strings.LastIndex(firstLine, marker)
-		if markerIndex == -1 {
+	markerIndex, marker := rightmostParseFailureMarker(firstLine)
+	if markerIndex == -1 {
+		return ""
+	}
+	remainder := firstLine[markerIndex+len(marker):]
+	name, _, _ := strings.Cut(remainder, ":")
+	return strings.TrimSpace(name)
+}
+
+func parseFailureInvalidValue(parseOutput string) (string, bool) {
+	firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
+	markerIndex, _ := rightmostParseFailureMarker(firstLine)
+	if markerIndex == -1 {
+		return "", false
+	}
+	prefix := strings.TrimSpace(firstLine[:markerIndex])
+	for _, diagnosticPrefix := range []string{"invalid boolean value ", "invalid value "} {
+		quotedValue, found := strings.CutPrefix(prefix, diagnosticPrefix)
+		if !found {
 			continue
 		}
-		remainder := firstLine[markerIndex+len(marker):]
-		name, _, _ := strings.Cut(remainder, ":")
-		return strings.TrimSpace(name)
+		value, err := strconv.Unquote(quotedValue)
+		return value, err == nil
 	}
-	return ""
+	return "", false
+}
+
+func rightmostParseFailureMarker(firstLine string) (int, string) {
+	rightmostIndex := -1
+	rightmostMarker := ""
+	for _, marker := range []string{" for flag -", " for -", "argument: -"} {
+		if markerIndex := strings.LastIndex(firstLine, marker); markerIndex > rightmostIndex {
+			rightmostIndex = markerIndex
+			rightmostMarker = marker
+		}
+	}
+	return rightmostIndex, rightmostMarker
 }
 
 func isUnknownFlagParseFailure(parseErr error, parseOutput string) bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -438,6 +438,7 @@ func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput str
 	flagName := parseFailureFlagName(parseOutput)
 	command := root
 	path := []string{root.Name}
+	owner := ""
 	for index := 0; flagName != "" && index < len(args); {
 		token := args[index]
 		if subcommand := findDirectSubcommand(command, token); subcommand != nil {
@@ -449,13 +450,16 @@ func parseFailureHelpCommand(root *ffcli.Command, args []string, parseOutput str
 		trimmed := strings.TrimLeft(token, "-")
 		name, _ := splitFlagToken(trimmed)
 		if name == flagName && command.FlagSet.Lookup(name) != nil {
-			return strings.Join(path, " ")
+			owner = strings.Join(path, " ")
 		}
 		next, consumed := consumeFlagToken(command.FlagSet, token, args, index)
 		if !consumed {
 			break
 		}
 		index = next
+	}
+	if owner != "" {
+		return owner
 	}
 	return getCommandName(root, args)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,7 +78,7 @@ func Run(args []string, versionInfo string) int {
 		} else if strings.HasPrefix(badFlagSyntax, "bad flag syntax:") {
 			fmt.Fprintf(os.Stderr, "Error: %s\nFor help:\n  asc --help\n", shared.SanitizeTerminal(badFlagSyntax))
 		} else {
-			printParseFailure(parseErr, parseOutput.String(), analysis)
+			printParseFailure(parseErr, parseOutput.String(), analysis, getCommandName(root, args))
 		}
 		// Every non-help error returned by command-tree parsing is invalid usage,
 		// including NoExecError cases that do not write flag output.
@@ -404,10 +404,18 @@ func requestedHelp(root *ffcli.Command, args []string) bool {
 	return false
 }
 
-func printParseFailure(parseErr error, parseOutput string, analysis invocationAnalysis) {
+func printParseFailure(parseErr error, parseOutput string, analysis invocationAnalysis, commandName string) {
 	if !analysis.unknownFlag || !isUnknownFlagParseFailure(parseErr, parseOutput) {
 		if parseOutput != "" {
-			fmt.Fprint(os.Stderr, parseOutput)
+			firstLine, _, _ := strings.Cut(strings.TrimSpace(parseOutput), "\n")
+			if firstLine != "" {
+				fmt.Fprintf(
+					os.Stderr,
+					"Error: %s\nFor help:\n  %s --help\n",
+					shared.SanitizeTerminal(firstLine),
+					commandName,
+				)
+			}
 			return
 		}
 		fmt.Fprint(os.Stderr, errfmt.FormatStderr(parseErr))

--- a/internal/cli/cmdtest/once_csv_repeated_flag_contract_test.go
+++ b/internal/cli/cmdtest/once_csv_repeated_flag_contract_test.go
@@ -42,9 +42,9 @@ func TestRepeatedCSVFlagRejectedEndToEnd(t *testing.T) {
 
 	// The rejection is a flag parse failure, not a help request: `--help` exits
 	// 0 and starts with the usage banner, so the first stderr line has to be the
-	// flag error itself.
+	// concise flag error itself.
 	firstLine, _, _ := strings.Cut(stderr, "\n")
-	wantFirstLine := fmt.Sprintf("invalid value %q for flag -certificate: %s", "CERT_B", wantMessage)
+	wantFirstLine := fmt.Sprintf("Error: invalid value %q for flag -certificate: %s", "CERT_B", wantMessage)
 	if firstLine != wantFirstLine {
 		t.Fatalf("first stderr line = %q, want %q", firstLine, wantFirstLine)
 	}


### PR DESCRIPTION
## Summary

- print only the concrete parser error plus a scoped help command for known-flag value failures
- preserve explicit help on stdout, usage exit code 2, JSON behavior, JUnit behavior, and telemetry classification
- cover invalid values, missing values, malformed booleans, and repeated CSV flags

## Release audit evidence

Known flags with an invalid or missing value printed their parse error followed by the command's entire DESCRIPTION/USAGE/EXAMPLES/FLAGS page. Unknown flags already used concise diagnostics.

## Validation

- deterministic RED tests for invalid integer, missing value, and malformed boolean
- focused and race `cmd` tests
- focused command-level compatibility tests
- normal pre-commit hook: command docs, format, golangci-lint, short suite
- `ASC_BYPASS_KEYCHAIN=1 make test`

No live App Store Connect calls or mutations were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line error messages for invalid options with concise, sanitized output.
  * Added accurate, command-specific help hints for parse failures, including nested commands.
  * Correctly identifies the relevant option when invalid values contain flag-like text.
  * Preserved JSON and JUnit output behavior and no-report handling for parse errors.
  * Kept explicit help output on standard output and maintained existing usage classifications.
  * Standardized duplicate certificate flag errors with an `Error:` prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->