### PR TITLE
fix(reports): reject symlinked file parents

### DIFF
--- a/internal/cli/shared/report_helpers.go
+++ b/internal/cli/shared/report_helpers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
 // ResolveVendorNumber resolves the vendor number for reports.
@@ -58,28 +59,12 @@ func ResolveReportOutputPaths(outputPath, defaultCompressed, decompressedExt str
 
 // WriteStreamToFile writes a reader to a file securely.
 func WriteStreamToFile(path string, reader io.Reader) (int64, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return 0, err
-	}
-	file, err := OpenNewFileNoFollow(path, 0o600)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return 0, fmt.Errorf("output file already exists: %w", err)
-		}
-		return 0, err
-	}
-	defer file.Close()
-
-	written, err := io.Copy(file, reader)
-	if err != nil {
-		return 0, err
-	}
-	return written, file.Sync()
+	return createNewOutputFile(path, reader)
 }
 
 // DecompressGzipFile inflates a gzip file to the destination path.
 func DecompressGzipFile(sourcePath, destPath string) (int64, error) {
-	in, err := OpenExistingNoFollow(sourcePath)
+	in, err := rootfs.OpenFile(sourcePath)
 	if err != nil {
 		return 0, err
 	}
@@ -91,21 +76,53 @@ func DecompressGzipFile(sourcePath, destPath string) (int64, error) {
 	}
 	defer reader.Close()
 
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return 0, err
-	}
-	out, err := OpenNewFileNoFollow(destPath, 0o600)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return 0, fmt.Errorf("output file already exists: %w", err)
-		}
-		return 0, err
-	}
-	defer out.Close()
+	return createNewOutputFile(destPath, reader)
+}
 
-	written, err := io.Copy(out, reader)
+// createNewOutputFile writes a complete stream below the filesystem root. The
+// rooted traversal rejects symlinks in every parent component, and atomic
+// no-replace publication keeps a failed stream from leaving a partial output.
+func createNewOutputFile(path string, reader io.Reader) (int64, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return 0, fmt.Errorf("resolve output path %q: %w", path, err)
+	}
+	rootPath := filepath.VolumeName(absolute) + string(filepath.Separator)
+	workingDir, _ := os.Getwd()
+	for _, candidate := range []string{workingDir, os.TempDir()} {
+		candidate, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		candidate = filepath.Clean(candidate)
+		if !pathWithinOutputRoot(candidate, absolute) {
+			continue
+		}
+		if len(candidate) > len(rootPath) {
+			rootPath = candidate
+		}
+	}
+	root, err := rootfs.New(rootPath)
 	if err != nil {
 		return 0, err
 	}
-	return written, out.Sync()
+	defer root.Close()
+
+	relative, err := filepath.Rel(root.Path(), absolute)
+	if err != nil {
+		return 0, fmt.Errorf("resolve output path %q: %w", path, err)
+	}
+	written, err := root.CreateNewFrom(relative, reader, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		return 0, fmt.Errorf("output file already exists: %w", err)
+	}
+	return written, err
+}
+
+func pathWithinOutputRoot(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
 }

--- a/internal/cli/shared/report_helpers_test.go
+++ b/internal/cli/shared/report_helpers_test.go
@@ -1,0 +1,94 @@
+package shared
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteStreamToFileRejectsSymlinkedParent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	output := filepath.Join(root, "output")
+	if err := os.Mkdir(output, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	link := filepath.Join(output, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	destination := filepath.Join(link, "artifact.bin")
+	if _, err := WriteStreamToFile(destination, bytes.NewBufferString("payload")); err == nil {
+		t.Fatal("WriteStreamToFile() succeeded through a symlinked parent")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "artifact.bin")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside destination stat error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestDecompressGzipFileRejectsSymlinkedOutputParent(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.gz")
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write([]byte("payload")); err != nil {
+		t.Fatalf("gzip.Write() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("gzip.Close() error = %v", err)
+	}
+	if err := os.WriteFile(source, compressed.Bytes(), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	outside := t.TempDir()
+	output := filepath.Join(root, "output")
+	if err := os.Mkdir(output, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	link := filepath.Join(output, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	destination := filepath.Join(link, "artifact.txt")
+	if _, err := DecompressGzipFile(source, destination); err == nil {
+		t.Fatal("DecompressGzipFile() succeeded through a symlinked output parent")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "artifact.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside destination stat error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestDecompressGzipFileRejectsSymlinkedSourceParent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	source := filepath.Join(outside, "source.gz")
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write([]byte("payload")); err != nil {
+		t.Fatalf("gzip.Write() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("gzip.Close() error = %v", err)
+	}
+	if err := os.WriteFile(source, compressed.Bytes(), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	link := filepath.Join(root, "source-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	destination := filepath.Join(root, "artifact.txt")
+	if _, err := DecompressGzipFile(filepath.Join(link, "source.gz"), destination); err == nil {
+		t.Fatal("DecompressGzipFile() read through a symlinked source parent")
+	}
+	if _, err := os.Stat(destination); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("destination stat error = %v, want os.ErrNotExist", err)
+	}
+}


### PR DESCRIPTION
## Summary

- open compressed report inputs through rooted, no-follow traversal
- publish streamed and decompressed outputs atomically without following parent symlinks
- preserve create-only/no-overwrite behavior and avoid partial destination files
- cover symlinked input and output parents

## Release audit evidence

The previous final-component-only checks rejected a symlink at the file itself but allowed a symlink in a parent directory, so report downloads or decompression could cross the intended output path.

## Validation

- deterministic RED tests for streamed output, gzip source, and decompressed output parent symlinks
- focused and race `internal/cli/shared` tests
- normal pre-commit hook: command docs, format, golangci-lint, short suite
- `ASC_BYPASS_KEYCHAIN=1 make test`

No live App Store Connect calls or mutations were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report file handling to prevent path traversal and unsafe symlink access.
  * Prevented incomplete files from being left behind when report output fails.
  * Preserved clear errors when an output file already exists.
  * Improved the safety of gzip report processing for source and destination paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->