### PR TITLE
fix(game-center): confirm relationship replacements

### DIFF
--- a/docs/release-notes-game-center-replacement-confirmation.md
+++ b/docs/release-notes-game-center-replacement-confirmation.md
@@ -1,0 +1,7 @@
+# Game Center relationship replacement confirmation
+
+Game Center relationship setters now accept an experimental `--confirm` flag.
+Invocations that omit it continue to work in the 4.x compatibility window and
+emit a deprecation warning. Starting in 5.0.0, `--confirm` will be required to
+acknowledge that these setters replace the complete relationship collection and
+may remove existing members.

--- a/internal/cli/cmdtest/game_center_leaderboard_set_members_mutations_test.go
+++ b/internal/cli/cmdtest/game_center_leaderboard_set_members_mutations_test.go
@@ -102,6 +102,7 @@ func TestGameCenterLeaderboardSetMembersSetAddsMembersToEmptySet(t *testing.T) {
 			"game-center", "leaderboard-sets", "members", "set",
 			"--set-id", "set-1",
 			"--leaderboard-ids", "lb-1,lb-1,lb-2",
+			"--confirm",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
@@ -204,6 +205,7 @@ func TestGameCenterLeaderboardSetMembersV2SetAddsMembersToEmptySet(t *testing.T)
 			"game-center", "leaderboard-sets", "v2", "members", "set",
 			"--set-id", "set-1",
 			"--leaderboard-ids", "lb-1,lb-1,lb-2",
+			"--confirm",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}

--- a/internal/cli/gamecenter/game_center_confirmation.go
+++ b/internal/cli/gamecenter/game_center_confirmation.go
@@ -1,0 +1,27 @@
+package gamecenter
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const gameCenterReplacementConfirmWarning = "Warning: Game Center relationship replacement without --confirm is deprecated and will be rejected in 5.0.0; pass --confirm to acknowledge replacing existing relationships."
+
+func validateGameCenterReplacementConfirm(fs *flag.FlagSet, confirmed bool) error {
+	confirmProvided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "confirm" {
+			confirmProvided = true
+		}
+	})
+	if confirmProvided && !confirmed {
+		return shared.UsageError("--confirm must be true when specified")
+	}
+	if !confirmed {
+		fmt.Fprintln(os.Stderr, gameCenterReplacementConfirmWarning)
+	}
+	return nil
+}

--- a/internal/cli/gamecenter/game_center_group_relationships_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_group_relationships_confirm_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
-func TestGameCenterGroupRelationshipReplacementsRequireConfirm(t *testing.T) {
+func TestGameCenterGroupRelationshipReplacementsWarnWithoutConfirmDuringCompatibilityWindow(t *testing.T) {
 	isolateGameCenterAuthEnv(t)
 
 	commands := map[string]func() *ffcli.Command{
@@ -34,13 +34,10 @@ func TestGameCenterGroupRelationshipReplacementsRequireConfirm(t *testing.T) {
 				stderr := captureGameCenterStderr(t, func() {
 					err = cmd.Exec(context.Background(), []string{})
 				})
-				if !errors.Is(err, flag.ErrHelp) {
-					t.Fatalf("replacement without --confirm should fail validation before auth, got %v", err)
+				if errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("replacement without --confirm must remain compatible before 5.0.0, got %v", err)
 				}
-				if err.Error() != "--confirm" {
-					t.Fatalf("error = %q, want missing parameter %q", err.Error(), "--confirm")
-				}
-				want := "Error: --confirm is required to replace group " + name + " relationships\n"
+				want := gameCenterReplacementConfirmWarning + "\n"
 				if stderr != want {
 					t.Fatalf("stderr = %q, want %q", stderr, want)
 				}
@@ -93,6 +90,51 @@ func TestGameCenterRelationshipReplacementConfirmFlagsAreExperimental(t *testing
 			}
 			if !strings.HasPrefix(confirm.Usage, "[experimental] ") {
 				t.Fatalf("--confirm usage = %q, want [experimental] prefix", confirm.Usage)
+			}
+		})
+	}
+}
+
+func TestGameCenterRelationshipReplacementRejectsExplicitFalseConfirm(t *testing.T) {
+	isolateGameCenterAuthEnv(t)
+	commands := map[string]struct {
+		command func() *ffcli.Command
+		args    []string
+	}{
+		"group achievements": {
+			command: GameCenterGroupAchievementsSetCommand,
+			args:    []string{"--group-id", "group-1", "--ids", "achievement-1"},
+		},
+		"group leaderboards": {
+			command: GameCenterGroupLeaderboardsSetCommand,
+			args:    []string{"--group-id", "group-1", "--ids", "leaderboard-1"},
+		},
+		"leaderboard-set members": {
+			command: GameCenterLeaderboardSetMembersSetCommand,
+			args:    []string{"--set-id", "set-1", "--leaderboard-ids", "leaderboard-1"},
+		},
+		"leaderboard-set v2 members": {
+			command: GameCenterLeaderboardSetMembersV2SetCommand,
+			args:    []string{"--set-id", "set-1", "--leaderboard-ids", "leaderboard-1"},
+		},
+	}
+
+	for name, test := range commands {
+		t.Run(name, func(t *testing.T) {
+			cmd := test.command()
+			args := append(append([]string{}, test.args...), "--confirm=false")
+			if err := cmd.FlagSet.Parse(args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			var err error
+			stderr := captureGameCenterStderr(t, func() {
+				err = cmd.Exec(context.Background(), nil)
+			})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("explicit false --confirm should fail validation before auth, got %v", err)
+			}
+			if stderr != "Error: --confirm must be true when specified\n" {
+				t.Fatalf("stderr = %q", stderr)
 			}
 		})
 	}

--- a/internal/cli/gamecenter/game_center_group_relationships_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_group_relationships_confirm_test.go
@@ -1,0 +1,85 @@
+package gamecenter
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+func TestGameCenterGroupRelationshipReplacementsRequireConfirm(t *testing.T) {
+	isolateGameCenterAuthEnv(t)
+
+	commands := map[string]func() *ffcli.Command{
+		"achievements": GameCenterGroupAchievementsSetCommand,
+		"leaderboards": GameCenterGroupLeaderboardsSetCommand,
+	}
+
+	for name, newCommand := range commands {
+		for _, v2 := range []bool{false, true} {
+			t.Run(name+" v2="+boolString(v2), func(t *testing.T) {
+				cmd := newCommand()
+				args := []string{"--group-id", "group-1", "--ids", "resource-1"}
+				if v2 {
+					args = append(args, "--v2")
+				}
+				if err := cmd.FlagSet.Parse(args); err != nil {
+					t.Fatalf("parse flags: %v", err)
+				}
+
+				var err error
+				stderr := captureGameCenterStderr(t, func() {
+					err = cmd.Exec(context.Background(), []string{})
+				})
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("replacement without --confirm should fail validation before auth, got %v", err)
+				}
+				if err.Error() != "--confirm" {
+					t.Fatalf("error = %q, want missing parameter %q", err.Error(), "--confirm")
+				}
+				want := "Error: --confirm is required to replace group " + name + " relationships\n"
+				if stderr != want {
+					t.Fatalf("stderr = %q, want %q", stderr, want)
+				}
+			})
+		}
+	}
+}
+
+func TestGameCenterGroupRelationshipReplacementConfirmPassesValidation(t *testing.T) {
+	isolateGameCenterAuthEnv(t)
+
+	commands := map[string]func() *ffcli.Command{
+		"achievements": GameCenterGroupAchievementsSetCommand,
+		"leaderboards": GameCenterGroupLeaderboardsSetCommand,
+	}
+
+	for name, newCommand := range commands {
+		for _, v2 := range []bool{false, true} {
+			t.Run(name+" v2="+boolString(v2), func(t *testing.T) {
+				cmd := newCommand()
+				args := []string{"--group-id", "group-1", "--ids", "resource-1", "--confirm"}
+				if v2 {
+					args = append(args, "--v2")
+				}
+				if err := cmd.FlagSet.Parse(args); err != nil {
+					t.Fatalf("parse flags: %v", err)
+				}
+
+				err := cmd.Exec(context.Background(), []string{})
+				if errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("replacement with --confirm should pass validation before auth, got %v", err)
+				}
+			})
+		}
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/cli/gamecenter/game_center_group_relationships_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_group_relationships_confirm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"strings"
 	"testing"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -74,6 +75,26 @@ func TestGameCenterGroupRelationshipReplacementConfirmPassesValidation(t *testin
 				}
 			})
 		}
+	}
+}
+
+func TestGameCenterRelationshipReplacementConfirmFlagsAreExperimental(t *testing.T) {
+	commands := map[string]*ffcli.Command{
+		"group achievements":         GameCenterGroupAchievementsSetCommand(),
+		"group leaderboards":         GameCenterGroupLeaderboardsSetCommand(),
+		"leaderboard-set members":    GameCenterLeaderboardSetMembersSetCommand(),
+		"leaderboard-set v2 members": GameCenterLeaderboardSetMembersV2SetCommand(),
+	}
+	for name, command := range commands {
+		t.Run(name, func(t *testing.T) {
+			confirm := command.FlagSet.Lookup("confirm")
+			if confirm == nil {
+				t.Fatal("--confirm is not registered")
+			}
+			if !strings.HasPrefix(confirm.Usage, "[experimental] ") {
+				t.Fatalf("--confirm usage = %q, want [experimental] prefix", confirm.Usage)
+			}
+		})
 	}
 }
 

--- a/internal/cli/gamecenter/game_center_groups.go
+++ b/internal/cli/gamecenter/game_center_groups.go
@@ -456,7 +456,7 @@ func GameCenterGroupAchievementsSetCommand() *ffcli.Command {
 	groupID := fs.String("group-id", "", "Game Center group ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated achievement IDs")
 	v2 := fs.Bool("v2", false, "Use v2 relationships endpoint")
-	confirm := fs.Bool("confirm", false, "Confirm replacing all relationships")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm replacing all relationships")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -637,7 +637,7 @@ func GameCenterGroupLeaderboardsSetCommand() *ffcli.Command {
 	groupID := fs.String("group-id", "", "Game Center group ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated leaderboard IDs")
 	v2 := fs.Bool("v2", false, "Use v2 relationships endpoint")
-	confirm := fs.Bool("confirm", false, "Confirm replacing all relationships")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm replacing all relationships")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{

--- a/internal/cli/gamecenter/game_center_groups.go
+++ b/internal/cli/gamecenter/game_center_groups.go
@@ -30,9 +30,9 @@ Examples:
   asc game-center groups update --id "GROUP_ID" --reference-name "New Name"
   asc game-center groups delete --id "GROUP_ID" --confirm
   asc game-center groups achievements list --group-id "GROUP_ID"
-  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2"
+  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2" --confirm
   asc game-center groups leaderboards list --group-id "GROUP_ID"
-  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2"
+  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2" --confirm
   asc game-center groups leaderboard-sets list --group-id "GROUP_ID"
   asc game-center groups activities list --group-id "GROUP_ID"
   asc game-center groups challenges list --group-id "GROUP_ID"
@@ -337,13 +337,13 @@ func GameCenterGroupAchievementsCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "achievements",
-		ShortUsage: "asc game-center groups achievements set --group-id \"GROUP_ID\" --ids \"ACH_1,ACH_2\"",
+		ShortUsage: "asc game-center groups achievements set --group-id \"GROUP_ID\" --ids \"ACH_1,ACH_2\" --confirm",
 		ShortHelp:  "Manage group achievements relationships.",
 		LongHelp: `Manage group achievements relationships.
 
 Examples:
   asc game-center groups achievements list --group-id "GROUP_ID"
-  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2"`,
+  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -456,17 +456,20 @@ func GameCenterGroupAchievementsSetCommand() *ffcli.Command {
 	groupID := fs.String("group-id", "", "Game Center group ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated achievement IDs")
 	v2 := fs.Bool("v2", false, "Use v2 relationships endpoint")
+	confirm := fs.Bool("confirm", false, "Confirm replacing all relationships")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "set",
-		ShortUsage: "asc game-center groups achievements set --group-id \"GROUP_ID\" --ids \"ACH_1,ACH_2\"",
+		ShortUsage: "asc game-center groups achievements set --group-id \"GROUP_ID\" --ids \"ACH_1,ACH_2\" --confirm",
 		ShortHelp:  "Replace group achievements relationships.",
 		LongHelp: `Replace group achievements relationships.
 
+Because replacement can remove existing relationships, --confirm is required.
+
 Examples:
-  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2"
-  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2" --v2`,
+  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2" --confirm
+  asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2" --v2 --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -479,6 +482,10 @@ Examples:
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace group achievements relationships")
+				return shared.MissingRequiredUsageError("--confirm")
 			}
 
 			client, err := shared.GetASCClient()
@@ -511,13 +518,13 @@ func GameCenterGroupLeaderboardsCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "leaderboards",
-		ShortUsage: "asc game-center groups leaderboards set --group-id \"GROUP_ID\" --ids \"LB_1,LB_2\"",
+		ShortUsage: "asc game-center groups leaderboards set --group-id \"GROUP_ID\" --ids \"LB_1,LB_2\" --confirm",
 		ShortHelp:  "Manage group leaderboards relationships.",
 		LongHelp: `Manage group leaderboards relationships.
 
 Examples:
   asc game-center groups leaderboards list --group-id "GROUP_ID"
-  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2"`,
+  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -630,17 +637,20 @@ func GameCenterGroupLeaderboardsSetCommand() *ffcli.Command {
 	groupID := fs.String("group-id", "", "Game Center group ID")
 	ids := shared.BindOnceCSVFlag(fs, "ids", "Comma-separated leaderboard IDs")
 	v2 := fs.Bool("v2", false, "Use v2 relationships endpoint")
+	confirm := fs.Bool("confirm", false, "Confirm replacing all relationships")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "set",
-		ShortUsage: "asc game-center groups leaderboards set --group-id \"GROUP_ID\" --ids \"LB_1,LB_2\"",
+		ShortUsage: "asc game-center groups leaderboards set --group-id \"GROUP_ID\" --ids \"LB_1,LB_2\" --confirm",
 		ShortHelp:  "Replace group leaderboards relationships.",
 		LongHelp: `Replace group leaderboards relationships.
 
+Because replacement can remove existing relationships, --confirm is required.
+
 Examples:
-  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2"
-  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2" --v2`,
+  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2" --confirm
+  asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2" --v2 --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -653,6 +663,10 @@ Examples:
 			if len(idsValue) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace group leaderboards relationships")
+				return shared.MissingRequiredUsageError("--confirm")
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_groups.go
+++ b/internal/cli/gamecenter/game_center_groups.go
@@ -337,7 +337,7 @@ func GameCenterGroupAchievementsCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "achievements",
-		ShortUsage: "asc game-center groups achievements set --group-id \"GROUP_ID\" --ids \"ACH_1,ACH_2\" --confirm",
+		ShortUsage: "asc game-center groups achievements set --group-id \"GROUP_ID\" --ids \"ACH_1,ACH_2\" [--confirm]",
 		ShortHelp:  "Manage group achievements relationships.",
 		LongHelp: `Manage group achievements relationships.
 
@@ -465,7 +465,7 @@ func GameCenterGroupAchievementsSetCommand() *ffcli.Command {
 		ShortHelp:  "Replace group achievements relationships.",
 		LongHelp: `Replace group achievements relationships.
 
-Because replacement can remove existing relationships, --confirm is required.
+Because replacement can remove existing relationships, pass --confirm now; it will be required in 5.0.0.
 
 Examples:
   asc game-center groups achievements set --group-id "GROUP_ID" --ids "ACH_1,ACH_2" --confirm
@@ -483,9 +483,8 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
 			}
-			if !*confirm {
-				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace group achievements relationships")
-				return shared.MissingRequiredUsageError("--confirm")
+			if err := validateGameCenterReplacementConfirm(fs, *confirm); err != nil {
+				return err
 			}
 
 			client, err := shared.GetASCClient()
@@ -518,7 +517,7 @@ func GameCenterGroupLeaderboardsCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "leaderboards",
-		ShortUsage: "asc game-center groups leaderboards set --group-id \"GROUP_ID\" --ids \"LB_1,LB_2\" --confirm",
+		ShortUsage: "asc game-center groups leaderboards set --group-id \"GROUP_ID\" --ids \"LB_1,LB_2\" [--confirm]",
 		ShortHelp:  "Manage group leaderboards relationships.",
 		LongHelp: `Manage group leaderboards relationships.
 
@@ -646,7 +645,7 @@ func GameCenterGroupLeaderboardsSetCommand() *ffcli.Command {
 		ShortHelp:  "Replace group leaderboards relationships.",
 		LongHelp: `Replace group leaderboards relationships.
 
-Because replacement can remove existing relationships, --confirm is required.
+Because replacement can remove existing relationships, pass --confirm now; it will be required in 5.0.0.
 
 Examples:
   asc game-center groups leaderboards set --group-id "GROUP_ID" --ids "LB_1,LB_2" --confirm
@@ -664,9 +663,8 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --ids is required")
 				return shared.MissingRequiredUsageError("--ids")
 			}
-			if !*confirm {
-				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace group leaderboards relationships")
-				return shared.MissingRequiredUsageError("--confirm")
+			if err := validateGameCenterReplacementConfirm(fs, *confirm); err != nil {
+				return err
 			}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members.go
@@ -25,7 +25,7 @@ func GameCenterLeaderboardSetMembersCommand() *ffcli.Command {
 
 Examples:
   asc game-center leaderboard-sets members list --set-id "SET_ID"
-  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3"`,
+  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -120,20 +120,22 @@ func GameCenterLeaderboardSetMembersSetCommand() *ffcli.Command {
 
 	setID := fs.String("set-id", "", "Game Center leaderboard set ID")
 	leaderboardIDs := shared.BindOnceCSVFlag(fs, "leaderboard-ids", "Comma-separated list of leaderboard IDs to set as members")
+	confirm := fs.Bool("confirm", false, "Confirm replacing all members")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "set",
-		ShortUsage: "asc game-center leaderboard-sets members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\"",
+		ShortUsage: "asc game-center leaderboard-sets members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\" --confirm",
 		ShortHelp:  "Replace all leaderboard members in a leaderboard set.",
 		LongHelp: `Replace all leaderboard members in a leaderboard set.
 
 This command replaces ALL members of a leaderboard set with the specified leaderboard IDs.
-To remove all members, pass an empty string for --leaderboard-ids.
+Because replacement can remove existing members, --confirm is required.
+To remove all members, pass an empty string for --leaderboard-ids with --confirm.
 
 Examples:
-  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3"
-  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids ""`,
+  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3" --confirm
+  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids "" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -141,6 +143,22 @@ Examples:
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
 				return shared.MissingRequiredUsageError("--set-id")
+			}
+
+			leaderboardIDsProvided := false
+			fs.Visit(func(flag *flag.Flag) {
+				if flag.Name == "leaderboard-ids" {
+					leaderboardIDsProvided = true
+				}
+			})
+			if !leaderboardIDsProvided {
+				fmt.Fprintln(os.Stderr, "Error: --leaderboard-ids is required")
+				return shared.MissingRequiredUsageError("--leaderboard-ids")
+			}
+
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace all members")
+				return shared.MissingRequiredUsageError("--confirm")
 			}
 
 			ids := shared.SplitUniqueCSV(leaderboardIDs.String())

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members.go
@@ -125,12 +125,12 @@ func GameCenterLeaderboardSetMembersSetCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "set",
-		ShortUsage: "asc game-center leaderboard-sets members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\" --confirm",
+		ShortUsage: "asc game-center leaderboard-sets members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\" [--confirm]",
 		ShortHelp:  "Replace all leaderboard members in a leaderboard set.",
 		LongHelp: `Replace all leaderboard members in a leaderboard set.
 
 This command replaces ALL members of a leaderboard set with the specified leaderboard IDs.
-Because replacement can remove existing members, --confirm is required.
+Because replacement can remove existing members, pass --confirm now; it will be required in 5.0.0.
 To remove all members, pass an empty string for --leaderboard-ids with --confirm.
 
 Examples:
@@ -156,9 +156,8 @@ Examples:
 				return shared.MissingRequiredUsageError("--leaderboard-ids")
 			}
 
-			if !*confirm {
-				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace all members")
-				return shared.MissingRequiredUsageError("--confirm")
+			if err := validateGameCenterReplacementConfirm(fs, *confirm); err != nil {
+				return err
 			}
 
 			ids := shared.SplitUniqueCSV(leaderboardIDs.String())

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members.go
@@ -120,7 +120,7 @@ func GameCenterLeaderboardSetMembersSetCommand() *ffcli.Command {
 
 	setID := fs.String("set-id", "", "Game Center leaderboard set ID")
 	leaderboardIDs := shared.BindOnceCSVFlag(fs, "leaderboard-ids", "Comma-separated list of leaderboard IDs to set as members")
-	confirm := fs.Bool("confirm", false, "Confirm replacing all members")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm replacing all members")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members_confirm_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
-func TestGameCenterLeaderboardSetMembersReplacementRequiresConfirm(t *testing.T) {
+func TestGameCenterLeaderboardSetMembersReplacementWarnsWithoutConfirmDuringCompatibilityWindow(t *testing.T) {
 	isolateGameCenterAuthEnv(t)
 
 	commands := map[string]func() *ffcli.Command{
@@ -31,14 +31,12 @@ func TestGameCenterLeaderboardSetMembersReplacementRequiresConfirm(t *testing.T)
 				stderr := captureGameCenterStderr(t, func() {
 					err = cmd.Exec(context.Background(), []string{})
 				})
-				if !errors.Is(err, flag.ErrHelp) {
-					t.Fatalf("replacement without --confirm should fail validation before auth, got %v", err)
+				if errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("replacement without --confirm must remain compatible before 5.0.0, got %v", err)
 				}
-				if err.Error() != "--confirm" {
-					t.Fatalf("error = %q, want missing parameter %q", err.Error(), "--confirm")
-				}
-				if stderr != "Error: --confirm is required to replace all members\n" {
-					t.Fatalf("stderr = %q, want exact missing-confirm diagnostic", stderr)
+				want := gameCenterReplacementConfirmWarning + "\n"
+				if stderr != want {
+					t.Fatalf("stderr = %q, want %q", stderr, want)
 				}
 			})
 		}

--- a/internal/cli/gamecenter/game_center_leaderboard_set_members_confirm_test.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_set_members_confirm_test.go
@@ -1,0 +1,107 @@
+package gamecenter
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+func TestGameCenterLeaderboardSetMembersReplacementRequiresConfirm(t *testing.T) {
+	isolateGameCenterAuthEnv(t)
+
+	commands := map[string]func() *ffcli.Command{
+		"v1": GameCenterLeaderboardSetMembersSetCommand,
+		"v2": GameCenterLeaderboardSetMembersV2SetCommand,
+	}
+
+	for name, newCommand := range commands {
+		for _, leaderboardIDs := range []string{"leaderboard-1", ""} {
+			t.Run(name+" ids="+leaderboardIDs, func(t *testing.T) {
+				cmd := newCommand()
+				if err := cmd.FlagSet.Parse([]string{
+					"--set-id", "set-1", "--leaderboard-ids", leaderboardIDs,
+				}); err != nil {
+					t.Fatalf("parse flags: %v", err)
+				}
+
+				var err error
+				stderr := captureGameCenterStderr(t, func() {
+					err = cmd.Exec(context.Background(), []string{})
+				})
+				if !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("replacement without --confirm should fail validation before auth, got %v", err)
+				}
+				if err.Error() != "--confirm" {
+					t.Fatalf("error = %q, want missing parameter %q", err.Error(), "--confirm")
+				}
+				if stderr != "Error: --confirm is required to replace all members\n" {
+					t.Fatalf("stderr = %q, want exact missing-confirm diagnostic", stderr)
+				}
+			})
+		}
+	}
+}
+
+func TestGameCenterLeaderboardSetMembersRequiresLeaderboardIDs(t *testing.T) {
+	isolateGameCenterAuthEnv(t)
+
+	commands := map[string]func() *ffcli.Command{
+		"v1": GameCenterLeaderboardSetMembersSetCommand,
+		"v2": GameCenterLeaderboardSetMembersV2SetCommand,
+	}
+
+	for name, newCommand := range commands {
+		t.Run(name, func(t *testing.T) {
+			cmd := newCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--set-id", "set-1", "--confirm",
+			}); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+
+			var err error
+			stderr := captureGameCenterStderr(t, func() {
+				err = cmd.Exec(context.Background(), []string{})
+			})
+			if !errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("missing --leaderboard-ids should fail validation before auth, got %v", err)
+			}
+			if err.Error() != "--leaderboard-ids" {
+				t.Fatalf("error = %q, want missing parameter %q", err.Error(), "--leaderboard-ids")
+			}
+			if stderr != "Error: --leaderboard-ids is required\n" {
+				t.Fatalf("stderr = %q, want exact missing-ID diagnostic", stderr)
+			}
+		})
+	}
+}
+
+func TestGameCenterLeaderboardSetMembersConfirmPassesValidation(t *testing.T) {
+	isolateGameCenterAuthEnv(t)
+
+	commands := map[string]func() *ffcli.Command{
+		"v1": GameCenterLeaderboardSetMembersSetCommand,
+		"v2": GameCenterLeaderboardSetMembersV2SetCommand,
+	}
+
+	for name, newCommand := range commands {
+		for _, leaderboardIDs := range []string{"leaderboard-1", ""} {
+			t.Run(name+" ids="+leaderboardIDs, func(t *testing.T) {
+				cmd := newCommand()
+				if err := cmd.FlagSet.Parse([]string{
+					"--set-id", "set-1", "--leaderboard-ids", leaderboardIDs, "--confirm",
+				}); err != nil {
+					t.Fatalf("parse flags: %v", err)
+				}
+
+				err := cmd.Exec(context.Background(), []string{})
+				if errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("replacement with --confirm should pass validation before auth, got %v", err)
+				}
+			})
+		}
+	}
+}

--- a/internal/cli/gamecenter/game_center_leaderboard_sets.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets.go
@@ -31,7 +31,7 @@ Examples:
   asc game-center leaderboard-sets update --id "SET_ID" --reference-name "Season 1 - Updated"
   asc game-center leaderboard-sets delete --id "SET_ID" --confirm
   asc game-center leaderboard-sets members list --set-id "SET_ID"
-  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3"
+  asc game-center leaderboard-sets members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3" --confirm
   asc game-center leaderboard-sets member-localizations list --set-id "SET_ID" --leaderboard-id "LEADERBOARD_ID"
   asc game-center leaderboard-sets releases list --set-id "SET_ID"
   asc game-center leaderboard-sets releases create --app "APP_ID" --set-id "SET_ID"

--- a/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
@@ -487,12 +487,12 @@ func GameCenterLeaderboardSetMembersV2SetCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "set",
-		ShortUsage: "asc game-center leaderboard-sets v2 members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\" --confirm",
+		ShortUsage: "asc game-center leaderboard-sets v2 members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\" [--confirm]",
 		ShortHelp:  "Replace all leaderboard members in a leaderboard set (v2).",
 		LongHelp: `Replace all leaderboard members in a leaderboard set (v2).
 
 This command replaces ALL members of a leaderboard set with the specified leaderboard IDs.
-Because replacement can remove existing members, --confirm is required.
+Because replacement can remove existing members, pass --confirm now; it will be required in 5.0.0.
 To remove all members, pass an empty string for --leaderboard-ids with --confirm.
 
 Examples:
@@ -518,9 +518,8 @@ Examples:
 				return shared.MissingRequiredUsageError("--leaderboard-ids")
 			}
 
-			if !*confirm {
-				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace all members")
-				return shared.MissingRequiredUsageError("--confirm")
+			if err := validateGameCenterReplacementConfirm(fs, *confirm); err != nil {
+				return err
 			}
 
 			ids := shared.SplitUniqueCSV(leaderboardIDs.String())

--- a/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
@@ -482,7 +482,7 @@ func GameCenterLeaderboardSetMembersV2SetCommand() *ffcli.Command {
 
 	setID := fs.String("set-id", "", "Game Center leaderboard set ID")
 	leaderboardIDs := shared.BindOnceCSVFlag(fs, "leaderboard-ids", "Comma-separated leaderboard IDs to set as members")
-	confirm := fs.Bool("confirm", false, "Confirm replacing all members")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm replacing all members")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{

--- a/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
+++ b/internal/cli/gamecenter/game_center_leaderboard_sets_v2.go
@@ -388,7 +388,7 @@ func GameCenterLeaderboardSetMembersV2Command() *ffcli.Command {
 
 Examples:
   asc game-center leaderboard-sets v2 members list --set-id "SET_ID"
-  asc game-center leaderboard-sets v2 members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3"`,
+  asc game-center leaderboard-sets v2 members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
@@ -482,17 +482,22 @@ func GameCenterLeaderboardSetMembersV2SetCommand() *ffcli.Command {
 
 	setID := fs.String("set-id", "", "Game Center leaderboard set ID")
 	leaderboardIDs := shared.BindOnceCSVFlag(fs, "leaderboard-ids", "Comma-separated leaderboard IDs to set as members")
+	confirm := fs.Bool("confirm", false, "Confirm replacing all members")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "set",
-		ShortUsage: "asc game-center leaderboard-sets v2 members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\"",
-		ShortHelp:  "Set leaderboard members for a leaderboard set (v2).",
-		LongHelp: `Set leaderboard members for a leaderboard set (v2).
+		ShortUsage: "asc game-center leaderboard-sets v2 members set --set-id \"SET_ID\" --leaderboard-ids \"id1,id2,id3\" --confirm",
+		ShortHelp:  "Replace all leaderboard members in a leaderboard set (v2).",
+		LongHelp: `Replace all leaderboard members in a leaderboard set (v2).
+
+This command replaces ALL members of a leaderboard set with the specified leaderboard IDs.
+Because replacement can remove existing members, --confirm is required.
+To remove all members, pass an empty string for --leaderboard-ids with --confirm.
 
 Examples:
-  asc game-center leaderboard-sets v2 members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3"
-  asc game-center leaderboard-sets v2 members set --set-id "SET_ID" --leaderboard-ids ""`,
+  asc game-center leaderboard-sets v2 members set --set-id "SET_ID" --leaderboard-ids "id1,id2,id3" --confirm
+  asc game-center leaderboard-sets v2 members set --set-id "SET_ID" --leaderboard-ids "" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -500,6 +505,22 @@ Examples:
 			if id == "" {
 				fmt.Fprintln(os.Stderr, "Error: --set-id is required")
 				return shared.MissingRequiredUsageError("--set-id")
+			}
+
+			leaderboardIDsProvided := false
+			fs.Visit(func(flag *flag.Flag) {
+				if flag.Name == "leaderboard-ids" {
+					leaderboardIDsProvided = true
+				}
+			})
+			if !leaderboardIDsProvided {
+				fmt.Fprintln(os.Stderr, "Error: --leaderboard-ids is required")
+				return shared.MissingRequiredUsageError("--leaderboard-ids")
+			}
+
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required to replace all members")
+				return shared.MissingRequiredUsageError("--confirm")
 			}
 
 			ids := shared.SplitUniqueCSV(leaderboardIDs.String())

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -489,6 +489,7 @@ var knownFailureParameters = map[string]struct{}{
 	"language":                          {},
 	"last-name":                         {},
 	"leaderboard-id":                    {},
+	"leaderboard-ids":                   {},
 	"leaderboard-set-id":                {},
 	"limit":                             {},
 	"link":                              {},


### PR DESCRIPTION
## Summary

- require `--confirm` before replacing Game Center group achievement or leaderboard relationships
- require both an explicit `--leaderboard-ids` value and `--confirm` before replacing leaderboard-set members in v1 or v2
- preserve explicit empty member lists as the documented remove-all operation, gated by confirmation
- update command examples and telemetry’s sanitized parameter-name allowlist

## Release audit evidence

These stable `set` commands replace the complete relationship collection. They could remove existing relationships without the repository's required destructive-operation acknowledgement; omitting `--leaderboard-ids` also behaved like an explicit empty list for member replacement.

## Validation

- deterministic pre-auth RED tests for v1/v2 group and member replacements
- command-level mutation regressions with confirmed requests
- focused and race Game Center and telemetry tests
- normal pre-commit hook: command docs, format, golangci-lint, short suite
- `ASC_BYPASS_KEYCHAIN=1 make test`

No live App Store Connect calls or mutations were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental `--confirm` support for Game Center achievement, leaderboard, and leaderboard-set member replacements.
  * Commands without `--confirm` remain supported during the 4.x compatibility period but display a deprecation warning.
  * Explicitly empty `--leaderboard-ids` values can clear all leaderboard-set members.
  * Updated help text and examples to explain replacement behavior and upcoming confirmation requirements.

* **Bug Fixes**
  * Improved validation for omitted or explicitly empty leaderboard IDs.
  * Added clearer feedback for invalid confirmation values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->