### PR TITLE
fix(app-clips): reject repeated CSV mutation flags

### DIFF
--- a/internal/cli/appclips/advanced_experiences.go
+++ b/internal/cli/appclips/advanced_experiences.go
@@ -232,7 +232,7 @@ func AppClipAdvancedExperiencesCreateCommand() *ffcli.Command {
 	action := fs.String("action", "", "Action (OPEN, VIEW, PLAY)")
 	category := fs.String("category", "", "Business category")
 	headerImageID := fs.String("header-image-id", "", "Header image ID")
-	localizationIDs := fs.String("localization-id", "", "Existing localization ID(s), comma-separated")
+	localizationIDs := shared.BindOnceCSVFlag(fs, "localization-id", "Existing localization ID(s), comma-separated")
 	var inlineLocalizationJSON inlineLocalizationFlag
 	fs.Var(&inlineLocalizationJSON, "inline-localization", "Inline localization as JSON with language, title, and optional subtitle (repeatable)")
 	language := fs.String("language", "", "Inline localization language (use with --title)")
@@ -287,7 +287,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--header-image-id")
 			}
 
-			localizationValues := shared.SplitCSV(*localizationIDs)
+			localizationValues := shared.SplitCSV(localizationIDs.String())
 			languageValue := strings.TrimSpace(*language)
 			titleValue := strings.TrimSpace(*title)
 			subtitleValue := strings.TrimSpace(*subtitle)
@@ -397,7 +397,7 @@ func AppClipAdvancedExperiencesUpdateCommand() *ffcli.Command {
 	isPoweredBy := fs.Bool("is-powered-by", false, "Powered by your app")
 	removed := fs.Bool("removed", false, "Mark the experience as removed")
 	headerImageID := fs.String("header-image-id", "", "Header image ID")
-	localizationIDs := fs.String("localization-id", "", "Localization ID(s), comma-separated")
+	localizationIDs := shared.BindOnceCSVFlag(fs, "localization-id", "Localization ID(s), comma-separated")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -472,7 +472,7 @@ Examples:
 			requestCtx, cancel := shared.ContextWithTimeout(ctx)
 			defer cancel()
 
-			resp, err := client.UpdateAppClipAdvancedExperience(requestCtx, experienceValue, attrs, *appClipID, *headerImageID, shared.SplitCSV(*localizationIDs))
+			resp, err := client.UpdateAppClipAdvancedExperience(requestCtx, experienceValue, attrs, *appClipID, *headerImageID, shared.SplitCSV(localizationIDs.String()))
 			if err != nil {
 				return fmt.Errorf("app-clips advanced-experiences update: failed to update: %w", err)
 			}

--- a/internal/cli/appclips/invocations.go
+++ b/internal/cli/appclips/invocations.go
@@ -177,7 +177,7 @@ func AppClipInvocationsCreateCommand() *ffcli.Command {
 
 	buildBundleID := fs.String("build-bundle-id", "", "Build bundle ID")
 	url := fs.String("url", "", "Invocation URL")
-	localizationIDs := fs.String("localization-id", "", "Existing localization ID(s), comma-separated")
+	localizationIDs := shared.BindOnceCSVFlag(fs, "localization-id", "Existing localization ID(s), comma-separated")
 	locale := fs.String("locale", "", "Inline localization locale (use with --title)")
 	title := fs.String("title", "", "Inline localization title (use with --locale)")
 	output := shared.BindOutputFlags(fs)
@@ -208,7 +208,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--url")
 			}
 
-			localizationValues := shared.SplitCSV(*localizationIDs)
+			localizationValues := shared.SplitCSV(localizationIDs.String())
 			localeValue := strings.TrimSpace(*locale)
 			titleValue := strings.TrimSpace(*title)
 			if titleValue != "" && localeValue == "" {

--- a/internal/cli/appclips/review_details.go
+++ b/internal/cli/appclips/review_details.go
@@ -87,7 +87,7 @@ func AppClipReviewDetailsCreateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("create", flag.ExitOnError)
 
 	experienceID := fs.String("experience-id", "", "Default experience ID")
-	urls := fs.String("url", "", "Invocation URL(s), comma-separated")
+	urls := shared.BindOnceCSVFlag(fs, "url", "Invocation URL(s), comma-separated")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -107,7 +107,7 @@ Examples:
 				return shared.MissingRequiredUsageError("--experience-id")
 			}
 
-			urlValues := shared.SplitCSV(*urls)
+			urlValues := shared.SplitCSV(urls.String())
 			if len(urlValues) == 0 {
 				fmt.Fprintln(os.Stderr, "Error: --url is required")
 				return shared.MissingRequiredUsageError("--url")
@@ -137,7 +137,7 @@ func AppClipReviewDetailsUpdateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 
 	detailID := fs.String("id", "", "Review detail ID")
-	urls := fs.String("url", "", "Invocation URL(s), comma-separated")
+	urls := shared.BindOnceCSVFlag(fs, "url", "Invocation URL(s), comma-separated")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -166,7 +166,7 @@ Examples:
 				return shared.MissingRequiredUsageError("")
 			}
 
-			urlValues := shared.SplitCSV(*urls)
+			urlValues := shared.SplitCSV(urls.String())
 			attrs := &asc.AppClipAppStoreReviewDetailUpdateAttributes{InvocationURLs: urlValues}
 
 			client, err := shared.GetASCClient()

--- a/internal/cli/cmdtest/appclips_repeatable_csv_test.go
+++ b/internal/cli/cmdtest/appclips_repeatable_csv_test.go
@@ -1,0 +1,227 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestAppClipsMutationsRejectRepeatedCSVFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flagName string
+	}{
+		{
+			name: "review details create urls",
+			args: []string{
+				"app-clips", "review-details", "create",
+				"--experience-id", "experience-1",
+				"--url", "https://example.com/one",
+				"--url", "https://example.com/two",
+			},
+			flagName: "url",
+		},
+		{
+			name: "review details update urls",
+			args: []string{
+				"app-clips", "review-details", "update",
+				"--id", "detail-1",
+				"--url", "https://example.com/one",
+				"--url", "https://example.com/two",
+			},
+			flagName: "url",
+		},
+		{
+			name: "invocation localization ids",
+			args: []string{
+				"app-clips", "invocations", "create",
+				"--build-bundle-id", "bundle-1",
+				"--url", "https://example.com/clip",
+				"--localization-id", "loc-1",
+				"--localization-id", "loc-2",
+			},
+			flagName: "localization-id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			factoryCalls := 0
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				factoryCalls++
+				return nil, errors.New("unexpected client creation")
+			})
+			t.Cleanup(restore)
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := cmd.Run(test.args, "1.2.3"); code != cmd.ExitUsage {
+					t.Fatalf("Run() exit code = %d, want %d", code, cmd.ExitUsage)
+				}
+			})
+
+			if factoryCalls != 0 {
+				t.Fatalf("client factory calls = %d, want 0 before repeated-flag rejection", factoryCalls)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			want := "--" + test.flagName + " specified multiple times"
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("stderr = %q, want repeated-flag diagnostic containing %q", stderr, want)
+			}
+		})
+	}
+}
+
+func TestAppClipsReviewDetailsCSVValuesPreserveOrder(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		method string
+		path   string
+		status int
+	}{
+		{
+			name: "create",
+			args: []string{
+				"app-clips", "review-details", "create",
+				"--experience-id", "experience-1",
+				"--url", "https://example.com/one,https://example.com/two",
+			},
+			method: http.MethodPost,
+			path:   "/v1/appClipAppStoreReviewDetails",
+			status: http.StatusCreated,
+		},
+		{
+			name: "update",
+			args: []string{
+				"app-clips", "review-details", "update",
+				"--id", "detail-1",
+				"--url", "https://example.com/one,https://example.com/two",
+			},
+			method: http.MethodPatch,
+			path:   "/v1/appClipAppStoreReviewDetails/detail-1",
+			status: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keyPath := t.TempDir() + "/AuthKey.p8"
+			writeECDSAPEM(t, keyPath)
+			client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", keyPath, &http.Client{
+				Transport: appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.Method != test.method || req.URL.Path != test.path {
+						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+					}
+
+					var payload struct {
+						Data struct {
+							Attributes struct {
+								InvocationURLs []string `json:"invocationUrls"`
+							} `json:"attributes"`
+						} `json:"data"`
+					}
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode request: %v", err)
+					}
+					want := []string{"https://example.com/one", "https://example.com/two"}
+					if len(payload.Data.Attributes.InvocationURLs) != len(want) {
+						t.Fatalf("invocation URL count = %d, want %d", len(payload.Data.Attributes.InvocationURLs), len(want))
+					}
+					for index, value := range want {
+						if payload.Data.Attributes.InvocationURLs[index] != value {
+							t.Fatalf("invocation URL %d = %q, want %q", index, payload.Data.Attributes.InvocationURLs[index], value)
+						}
+					}
+					return jsonResponse(test.status, `{"data":{"type":"appClipAppStoreReviewDetails","id":"detail-1","attributes":{"invocationUrls":["https://example.com/one","https://example.com/two"]}}}`)
+				}),
+			})
+			if err != nil {
+				t.Fatalf("new client: %v", err)
+			}
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				return client, nil
+			})
+			t.Cleanup(restore)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if !strings.Contains(stdout, `"id":"detail-1"`) {
+				t.Fatalf("expected detail ID in stdout, got %q", stdout)
+			}
+		})
+	}
+}
+
+func TestAppClipsInvocationsCreateCSVValuesRemainCompatible(t *testing.T) {
+	client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", func() string {
+		path := t.TempDir() + "/AuthKey.p8"
+		writeECDSAPEM(t, path)
+		return path
+	}(), &http.Client{
+		Transport: appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppClipInvocations" {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+			var payload asc.BetaAppClipInvocationCreateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			ids := payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data
+			if len(ids) != 2 || ids[0].ID != "loc-1" || ids[1].ID != "loc-2" {
+				t.Fatalf("localization IDs = %#v, want loc-1, loc-2", ids)
+			}
+			return jsonResponse(http.StatusCreated, `{"data":{"type":"betaAppClipInvocations","id":"inv-1","attributes":{"url":"https://example.com/clip"}}}`)
+		}),
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	})
+	t.Cleanup(restore)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{
+			"app-clips", "invocations", "create",
+			"--build-bundle-id", "bundle-1",
+			"--url", "https://example.com/clip",
+			"--localization-id", "loc-1,loc-2",
+		}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"inv-1"`) {
+		t.Fatalf("expected invocation ID in stdout, got %q", stdout)
+	}
+}

--- a/internal/cli/cmdtest/appclips_repeatable_csv_test.go
+++ b/internal/cli/cmdtest/appclips_repeatable_csv_test.go
@@ -53,6 +53,30 @@ func TestAppClipsMutationsRejectRepeatedCSVFlags(t *testing.T) {
 			},
 			flagName: "localization-id",
 		},
+		{
+			name: "advanced experience create localization ids",
+			args: []string{
+				"app-clips", "advanced-experiences", "create",
+				"--app-clip-id", "clip-1",
+				"--link", "https://example.com/clip",
+				"--default-language", "EN",
+				"--is-powered-by",
+				"--header-image-id", "image-1",
+				"--localization-id", "loc-1",
+				"--localization-id", "loc-2",
+			},
+			flagName: "localization-id",
+		},
+		{
+			name: "advanced experience update localization ids",
+			args: []string{
+				"app-clips", "advanced-experiences", "update",
+				"--experience-id", "experience-1",
+				"--localization-id", "loc-1",
+				"--localization-id", "loc-2",
+			},
+			flagName: "localization-id",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/appclips_repeatable_csv_test.go
+++ b/internal/cli/cmdtest/appclips_repeatable_csv_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -116,36 +118,39 @@ func TestAppClipsReviewDetailsCSVValuesPreserveOrder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != test.method || req.URL.Path != test.path {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+				}
+
+				var payload struct {
+					Data struct {
+						Attributes struct {
+							InvocationURLs []string `json:"invocationUrls"`
+						} `json:"attributes"`
+					} `json:"data"`
+				}
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				want := []string{"https://example.com/one", "https://example.com/two"}
+				if len(payload.Data.Attributes.InvocationURLs) != len(want) {
+					t.Fatalf("invocation URL count = %d, want %d", len(payload.Data.Attributes.InvocationURLs), len(want))
+				}
+				for index, value := range want {
+					if payload.Data.Attributes.InvocationURLs[index] != value {
+						t.Fatalf("invocation URL %d = %q, want %q", index, payload.Data.Attributes.InvocationURLs[index], value)
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(test.status)
+				_, _ = io.WriteString(w, `{"data":{"type":"appClipAppStoreReviewDetails","id":"detail-1","attributes":{"invocationUrls":["https://example.com/one","https://example.com/two"]}}}`)
+			}))
+			t.Cleanup(server.Close)
+
 			keyPath := t.TempDir() + "/AuthKey.p8"
 			writeECDSAPEM(t, keyPath)
-			client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", keyPath, &http.Client{
-				Transport: appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-					if req.Method != test.method || req.URL.Path != test.path {
-						t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-					}
-
-					var payload struct {
-						Data struct {
-							Attributes struct {
-								InvocationURLs []string `json:"invocationUrls"`
-							} `json:"attributes"`
-						} `json:"data"`
-					}
-					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-						t.Fatalf("decode request: %v", err)
-					}
-					want := []string{"https://example.com/one", "https://example.com/two"}
-					if len(payload.Data.Attributes.InvocationURLs) != len(want) {
-						t.Fatalf("invocation URL count = %d, want %d", len(payload.Data.Attributes.InvocationURLs), len(want))
-					}
-					for index, value := range want {
-						if payload.Data.Attributes.InvocationURLs[index] != value {
-							t.Fatalf("invocation URL %d = %q, want %q", index, payload.Data.Attributes.InvocationURLs[index], value)
-						}
-					}
-					return jsonResponse(test.status, `{"data":{"type":"appClipAppStoreReviewDetails","id":"detail-1","attributes":{"invocationUrls":["https://example.com/one","https://example.com/two"]}}}`)
-				}),
-			})
+			client, err := newAppClipsTestServerClient(t, server, keyPath)
 			if err != nil {
 				t.Fatalf("new client: %v", err)
 			}
@@ -175,26 +180,27 @@ func TestAppClipsReviewDetailsCSVValuesPreserveOrder(t *testing.T) {
 }
 
 func TestAppClipsInvocationsCreateCSVValuesRemainCompatible(t *testing.T) {
-	client, err := asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", func() string {
-		path := t.TempDir() + "/AuthKey.p8"
-		writeECDSAPEM(t, path)
-		return path
-	}(), &http.Client{
-		Transport: appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppClipInvocations" {
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-			var payload asc.BetaAppClipInvocationCreateRequest
-			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode request: %v", err)
-			}
-			ids := payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data
-			if len(ids) != 2 || ids[0].ID != "loc-1" || ids[1].ID != "loc-2" {
-				t.Fatalf("localization IDs = %#v, want loc-1, loc-2", ids)
-			}
-			return jsonResponse(http.StatusCreated, `{"data":{"type":"betaAppClipInvocations","id":"inv-1","attributes":{"url":"https://example.com/clip"}}}`)
-		}),
-	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v1/betaAppClipInvocations" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		var payload asc.BetaAppClipInvocationCreateRequest
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		ids := payload.Data.Relationships.BetaAppClipInvocationLocalizations.Data
+		if len(ids) != 2 || ids[0].ID != "loc-1" || ids[1].ID != "loc-2" {
+			t.Fatalf("localization IDs = %#v, want loc-1, loc-2", ids)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"data":{"type":"betaAppClipInvocations","id":"inv-1","attributes":{"url":"https://example.com/clip"}}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	keyPath := t.TempDir() + "/AuthKey.p8"
+	writeECDSAPEM(t, keyPath)
+	client, err := newAppClipsTestServerClient(t, server, keyPath)
 	if err != nil {
 		t.Fatalf("new client: %v", err)
 	}
@@ -224,4 +230,19 @@ func TestAppClipsInvocationsCreateCSVValuesRemainCompatible(t *testing.T) {
 	if !strings.Contains(stdout, `"id":"inv-1"`) {
 		t.Fatalf("expected invocation ID in stdout, got %q", stdout)
 	}
+}
+
+func newAppClipsTestServerClient(t *testing.T, server *httptest.Server, keyPath string) (*asc.Client, error) {
+	t.Helper()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		return nil, err
+	}
+	transport := appClipsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	return asc.NewClientWithHTTPClient("TEST_KEY", "TEST_ISSUER", keyPath, &http.Client{Transport: transport})
 }


### PR DESCRIPTION
## Summary

- reject repeated `--url` occurrences for App Clip review-detail mutations
- reject repeated `--localization-id` occurrences for beta App Clip invocation creation
- preserve existing single-occurrence and comma-separated input behavior

## Why

These mutation flags were backed by plain string values. Repeating a flag silently replaced its earlier value before CSV parsing, so a request could omit resources the caller supplied. The commands now use the repository's strict repeatable-CSV binding and fail before client creation.

## Validation

- focused App Clips command tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook checks

No live App Store Connect mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App Clips commands now accept multiple localization IDs and invocation URLs as comma-separated values, including advanced experience and review detail operations.
  * Existing comma-separated input remains supported, with values processed in the order provided.

* **Bug Fixes**
  * Repeated CSV options are rejected with a clear usage error before any request is made.

* **Tests**
  * Added coverage for CSV compatibility, ordering, validation, request handling, and clean command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->