### PR TITLE
fix(users): confirm visible app replacement

### DIFF
--- a/commands/users.mdx
+++ b/commands/users.mdx
@@ -69,7 +69,7 @@ Update a user:
 
 ```bash  theme={null}
 asc users update --id "USER_ID" --roles "ADMIN"
-asc users update --id "USER_ID" --roles "DEVELOPER" --visible-app "APP_ID"
+asc users update --id "USER_ID" --roles "DEVELOPER" --visible-app "APP_ID" --confirm
 ```
 
 **Flags:**
@@ -77,6 +77,7 @@ asc users update --id "USER_ID" --roles "DEVELOPER" --visible-app "APP_ID"
 * `--id` - User ID (required)
 * `--roles` - Comma-separated role IDs (required)
 * `--visible-app` - Comma-separated app IDs for visible apps
+* `--confirm` - Confirm replacing the user's existing visible-app relationship (required with `--visible-app`)
 * `--output` - Output format: `json`, `table`, `markdown`
 * `--pretty` - Pretty-print JSON output
 
@@ -282,7 +283,8 @@ asc users update --id "USER_ID" --roles "APP_MANAGER"
 asc users update \
   --id "USER_ID" \
   --roles "DEVELOPER" \
-  --visible-app "123456789,987654321"
+  --visible-app "123456789,987654321" \
+  --confirm
 ```
 
 ### List All Admins

--- a/internal/cli/cmdtest/users_update_visible_apps_test.go
+++ b/internal/cli/cmdtest/users_update_visible_apps_test.go
@@ -221,7 +221,7 @@ func TestUsersUpdateConfirmRequiresVisibleAppsBeforeHTTP(t *testing.T) {
 		exitCode = rootcmd.Run([]string{
 			"users", "update",
 			"--id", "user-1",
-			"--roles", "developer",
+			"--roles", "access_to_reports",
 			"--confirm",
 			"--output", "json",
 		}, "1.2.3")

--- a/internal/cli/cmdtest/users_update_visible_apps_test.go
+++ b/internal/cli/cmdtest/users_update_visible_apps_test.go
@@ -245,6 +245,47 @@ func TestUsersUpdateConfirmRequiresVisibleAppsBeforeHTTP(t *testing.T) {
 	}
 }
 
+func TestUsersUpdateExplicitFalseConfirmRequiresVisibleAppsBeforeHTTP(t *testing.T) {
+	var mu sync.Mutex
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	setUsersUpdateTestClient(t, server)
+
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{
+			"users", "update",
+			"--id", "user-1",
+			"--roles", "access_to_reports",
+			"--confirm=false",
+			"--output", "json",
+		}, "1.2.3")
+	})
+
+	mu.Lock()
+	gotRequestCount := requestCount
+	mu.Unlock()
+
+	if exitCode != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", exitCode, rootcmd.ExitUsage, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "Error: --confirm requires --visible-app\n" {
+		t.Fatalf("stderr = %q, want stray-confirm diagnostic", stderr)
+	}
+	if gotRequestCount != 0 {
+		t.Fatalf("request count = %d, want zero without visible apps", gotRequestCount)
+	}
+}
+
 func TestUsersUpdateRejectedRequestDoesNotChangeAccess(t *testing.T) {
 	type accessState struct {
 		Role       string

--- a/internal/cli/cmdtest/users_update_visible_apps_test.go
+++ b/internal/cli/cmdtest/users_update_visible_apps_test.go
@@ -204,6 +204,47 @@ func TestUsersUpdateVisibleAppsRequiresConfirmBeforeHTTP(t *testing.T) {
 	}
 }
 
+func TestUsersUpdateConfirmRequiresVisibleAppsBeforeHTTP(t *testing.T) {
+	var mu sync.Mutex
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	setUsersUpdateTestClient(t, server)
+
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{
+			"users", "update",
+			"--id", "user-1",
+			"--roles", "developer",
+			"--confirm",
+			"--output", "json",
+		}, "1.2.3")
+	})
+
+	mu.Lock()
+	gotRequestCount := requestCount
+	mu.Unlock()
+
+	if exitCode != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", exitCode, rootcmd.ExitUsage, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "Error: --confirm requires --visible-app\n" {
+		t.Fatalf("stderr = %q, want stray-confirm diagnostic", stderr)
+	}
+	if gotRequestCount != 0 {
+		t.Fatalf("request count = %d, want zero without visible apps", gotRequestCount)
+	}
+}
+
 func TestUsersUpdateRejectedRequestDoesNotChangeAccess(t *testing.T) {
 	type accessState struct {
 		Role       string

--- a/internal/cli/cmdtest/users_update_visible_apps_test.go
+++ b/internal/cli/cmdtest/users_update_visible_apps_test.go
@@ -58,6 +58,7 @@ func TestUsersUpdateSendsRolesAndVisibleAppsInOneRequest(t *testing.T) {
 			"--id", "user-1",
 			"--roles", "developer",
 			"--visible-app", "app-2, app-1",
+			"--confirm",
 			"--output", "json",
 		}, "1.2.3")
 	})
@@ -102,6 +103,107 @@ func TestUsersUpdateSendsRolesAndVisibleAppsInOneRequest(t *testing.T) {
 	}
 }
 
+func TestUsersUpdateRolesOnlyDoesNotRequireConfirm(t *testing.T) {
+	var mu sync.Mutex
+	requestCount := 0
+	var payload asc.UserUpdateRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPatch || req.URL.Path != "/v1/users/user-1" {
+			http.NotFound(w, req)
+			return
+		}
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"type":"users","id":"user-1","attributes":{"roles":["DEVELOPER"],"allAppsVisible":true,"provisioningAllowed":false}},"links":{}}`))
+	}))
+	defer server.Close()
+	setUsersUpdateTestClient(t, server)
+
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{
+			"users", "update",
+			"--id", "user-1",
+			"--roles", "developer",
+			"--output", "json",
+		}, "1.2.3")
+	})
+
+	mu.Lock()
+	gotRequestCount := requestCount
+	gotPayload := payload
+	mu.Unlock()
+
+	if exitCode != rootcmd.ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", exitCode, rootcmd.ExitSuccess, stdout, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if gotRequestCount != 1 {
+		t.Fatalf("request count = %d, want one user PATCH", gotRequestCount)
+	}
+	if gotPayload.Data.Relationships != nil {
+		t.Fatalf("relationships = %+v, want omitted", gotPayload.Data.Relationships)
+	}
+	if gotPayload.Data.Attributes == nil || !reflect.DeepEqual(gotPayload.Data.Attributes.Roles, []string{"DEVELOPER"}) {
+		t.Fatalf("attributes = %+v, want DEVELOPER roles", gotPayload.Data.Attributes)
+	}
+	if gotPayload.Data.Attributes.AllAppsVisible != nil {
+		t.Fatalf("allAppsVisible = %v, want omitted", gotPayload.Data.Attributes.AllAppsVisible)
+	}
+	if !strings.Contains(stdout, `"id":"user-1"`) {
+		t.Fatalf("stdout = %q, want user response", stdout)
+	}
+}
+
+func TestUsersUpdateVisibleAppsRequiresConfirmBeforeHTTP(t *testing.T) {
+	var mu sync.Mutex
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	setUsersUpdateTestClient(t, server)
+
+	var exitCode int
+	stdout, stderr := captureOutput(t, func() {
+		exitCode = rootcmd.Run([]string{
+			"users", "update",
+			"--id", "user-1",
+			"--roles", "developer",
+			"--visible-app", "app-1",
+			"--output", "json",
+		}, "1.2.3")
+	})
+
+	mu.Lock()
+	gotRequestCount := requestCount
+	mu.Unlock()
+
+	if exitCode != rootcmd.ExitUsage {
+		t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", exitCode, rootcmd.ExitUsage, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if stderr != "Error: --confirm is required when --visible-app is set\n" {
+		t.Fatalf("stderr = %q, want missing-confirm diagnostic", stderr)
+	}
+	if gotRequestCount != 0 {
+		t.Fatalf("request count = %d, want zero before confirmation", gotRequestCount)
+	}
+}
+
 func TestUsersUpdateRejectedRequestDoesNotChangeAccess(t *testing.T) {
 	type accessState struct {
 		Role       string
@@ -143,6 +245,7 @@ func TestUsersUpdateRejectedRequestDoesNotChangeAccess(t *testing.T) {
 			"--id", "user-1",
 			"--roles", "developer",
 			"--visible-app", "app-after",
+			"--confirm",
 			"--output", "json",
 		}, "1.2.3")
 	})

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -195,7 +195,7 @@ func UsersUpdateCommand() *ffcli.Command {
 	id := fs.String("id", "", "User ID")
 	roles := shared.BindOnceCSVFlag(fs, "roles", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
 	visibleApps := shared.BindOnceCSVFlag(fs, "visible-app", "Comma-separated app IDs for visible apps")
-	confirm := fs.Bool("confirm", false, "Confirm replacing visible apps (required with --visible-app)")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm replacing visible apps (required with --visible-app)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -230,6 +230,15 @@ Examples:
 			warnDeprecatedUserRoles(roleValues)
 
 			visibleAppIDs := shared.SplitCSV(visibleApps.String())
+			if len(visibleAppIDs) == 0 && *confirm {
+				message := "--confirm requires --visible-app"
+				fmt.Fprintln(os.Stderr, "Error:", message)
+				return shared.WithDiagnostic(
+					shared.NewReportedUsageError(shared.UsageErrorInvalidValue, message),
+					shared.DiagnosticConflictingInput,
+					"--confirm",
+				)
+			}
 			if len(visibleAppIDs) > 0 && !*confirm {
 				message := "--confirm is required when --visible-app is set"
 				fmt.Fprintln(os.Stderr, "Error:", message)

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -195,17 +195,21 @@ func UsersUpdateCommand() *ffcli.Command {
 	id := fs.String("id", "", "User ID")
 	roles := shared.BindOnceCSVFlag(fs, "roles", "Comma-separated UserRole values: "+strings.Join(userRoleList(), ", "))
 	visibleApps := shared.BindOnceCSVFlag(fs, "visible-app", "Comma-separated app IDs for visible apps")
+	confirm := fs.Bool("confirm", false, "Confirm replacing visible apps (required with --visible-app)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
 		Name:       "update",
-		ShortUsage: "asc users update --id USER_ID --roles ROLE_ID[,ROLE_ID...] [--visible-app APP_ID[,APP_ID...]]",
+		ShortUsage: "asc users update --id USER_ID --roles ROLE_ID[,ROLE_ID...] [--visible-app APP_ID[,APP_ID...]] [--confirm]",
 		ShortHelp:  "Update a user.",
 		LongHelp: `Update a user by ID.
 
+The --visible-app list replaces the user's existing visible-app relationship;
+use --confirm when --visible-app is supplied.
+
 Examples:
   asc users update --id "USER_ID" --roles "ADMIN"
-  asc users update --id "USER_ID" --roles "ADMIN" --visible-app "APP_ID"`,
+  asc users update --id "USER_ID" --roles "ADMIN" --visible-app "APP_ID" --confirm`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -226,6 +230,15 @@ Examples:
 			warnDeprecatedUserRoles(roleValues)
 
 			visibleAppIDs := shared.SplitCSV(visibleApps.String())
+			if len(visibleAppIDs) > 0 && !*confirm {
+				message := "--confirm is required when --visible-app is set"
+				fmt.Fprintln(os.Stderr, "Error:", message)
+				return shared.WithDiagnostic(
+					shared.NewReportedUsageError(shared.UsageErrorMissingRequired, message),
+					shared.DiagnosticRequiredInputMissing,
+					"--confirm",
+				)
+			}
 
 			client, err := shared.GetASCClient()
 			if err != nil {

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -227,8 +227,6 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: --roles is required")
 				return shared.MissingRequiredUsageError("--roles")
 			}
-			warnDeprecatedUserRoles(roleValues)
-
 			visibleAppIDs := shared.SplitCSV(visibleApps.String())
 			if len(visibleAppIDs) == 0 && *confirm {
 				message := "--confirm requires --visible-app"
@@ -248,6 +246,7 @@ Examples:
 					"--confirm",
 				)
 			}
+			warnDeprecatedUserRoles(roleValues)
 
 			client, err := shared.GetASCClient()
 			if err != nil {

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -228,7 +228,13 @@ Examples:
 				return shared.MissingRequiredUsageError("--roles")
 			}
 			visibleAppIDs := shared.SplitCSV(visibleApps.String())
-			if len(visibleAppIDs) == 0 && *confirm {
+			confirmSet := false
+			fs.Visit(func(parsed *flag.Flag) {
+				if parsed.Name == "confirm" {
+					confirmSet = true
+				}
+			})
+			if len(visibleAppIDs) == 0 && confirmSet {
 				message := "--confirm requires --visible-app"
 				fmt.Fprintln(os.Stderr, "Error:", message)
 				return shared.WithDiagnostic(


### PR DESCRIPTION
## Summary

- require `--confirm` when `users update` receives `--visible-app`
- explain that the supplied list replaces the user's existing visible-app relationship
- preserve roles-only updates without confirmation and reject missing confirmation before HTTP

## Why

Apple treats `visibleApps` as a complete relationship replacement and the request also sets `allAppsVisible=false`. Supplying a partial list can therefore narrow a user's account access. The CLI now makes that destructive scope explicit.

## Validation

- focused users update command tests
- `make build`
- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook (`go test -short ./...`)

No live App Store Connect mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--confirm` safeguard when changing visible-app assignments with `users update`.
  - Roles-only updates continue without requiring confirmation.
  - Updated command help to clarify the experimental flag and replacement behavior.

- **Bug Fixes**
  - Prevented visible-app updates from sending requests when confirmation is missing.
  - Rejected `--confirm`, including explicit `--confirm=false`, without `--visible-app`.
  - Ensured rejected updates do not alter access settings.

- **Documentation**
  - Updated user update examples to include confirmation for visible-app changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->