### PR TITLE
fix(apps): preserve partial published audits

### DIFF
--- a/internal/asc/output_apps_published.go
+++ b/internal/asc/output_apps_published.go
@@ -1,0 +1,82 @@
+package asc
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// PublishedApp describes an App Store Connect app with live published territory coverage.
+type PublishedApp struct {
+	ID                      string `json:"id"`
+	Name                    string `json:"name"`
+	BundleID                string `json:"bundleId"`
+	SKU                     string `json:"sku"`
+	PrimaryLocale           string `json:"primaryLocale,omitempty"`
+	AvailabilityID          string `json:"availabilityId"`
+	PublishedTerritoryCount int    `json:"publishedTerritoryCount"`
+}
+
+// PublishedAppFailure describes an app whose availability audit could not be completed.
+type PublishedAppFailure struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+// AppsPublishedReport summarizes an account-wide published-app audit, retaining
+// successful rows when individual app audits fail.
+type AppsPublishedReport struct {
+	AuditedAppCount   int                   `json:"auditedAppCount"`
+	PublishedAppCount int                   `json:"publishedAppCount"`
+	Apps              []PublishedApp        `json:"apps"`
+	Failures          []PublishedAppFailure `json:"failures,omitempty"`
+}
+
+func appsPublishedReportTables(report *AppsPublishedReport, render func([]string, [][]string)) error {
+	headers := []string{"ID", "Name", "Bundle ID", "SKU", "Availability ID", "Published Territories"}
+	rows := make([][]string, 0, len(report.Apps))
+	for _, app := range report.Apps {
+		rows = append(rows, []string{
+			app.ID,
+			app.Name,
+			app.BundleID,
+			app.SKU,
+			app.AvailabilityID,
+			strconv.Itoa(app.PublishedTerritoryCount),
+		})
+	}
+	render(headers, rows)
+
+	if len(report.Failures) > 0 {
+		failureRows := make([][]string, 0, len(report.Failures))
+		for _, failure := range report.Failures {
+			failureRows = append(failureRows, []string{failure.ID, failure.Name, failure.Error})
+		}
+		fmt.Fprintln(os.Stdout, "\nFailed app audits:")
+		render([]string{"ID", "Name", "Error"}, failureRows)
+	}
+	fmt.Fprintf(os.Stdout, "\n%s\n", PublishedAppsSummary(*report))
+	return nil
+}
+
+// PublishedAppsSummary returns the human-readable audit totals.
+func PublishedAppsSummary(report AppsPublishedReport) string {
+	summary := fmt.Sprintf(
+		"Audited %d app records; found %d published %s.",
+		report.AuditedAppCount,
+		report.PublishedAppCount,
+		publishedAppLabel(report.PublishedAppCount),
+	)
+	if len(report.Failures) > 0 {
+		summary += fmt.Sprintf(" %d app audit(s) failed.", len(report.Failures))
+	}
+	return summary
+}
+
+func publishedAppLabel(count int) string {
+	if count == 1 {
+		return "app"
+	}
+	return "apps"
+}

--- a/internal/asc/output_apps_published_test.go
+++ b/internal/asc/output_apps_published_test.go
@@ -1,0 +1,70 @@
+package asc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAppsPublishedReportUsesCamelCaseJSONFields(t *testing.T) {
+	report := AppsPublishedReport{
+		AuditedAppCount:   2,
+		PublishedAppCount: 1,
+		Apps: []PublishedApp{{
+			ID:                      "app-1",
+			BundleID:                "com.example.app",
+			AvailabilityID:          "availability-1",
+			PublishedTerritoryCount: 3,
+		}},
+		Failures: []PublishedAppFailure{{ID: "app-2", Error: "request failed"}},
+	}
+
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	for _, want := range []string{"auditedAppCount", "publishedAppCount", "bundleId", "availabilityId", "publishedTerritoryCount", "failures"} {
+		if !strings.Contains(string(encoded), want) {
+			t.Fatalf("JSON output missing camelCase field %q: %s", want, encoded)
+		}
+	}
+}
+
+func TestAppsPublishedReportRegisteredTableAndMarkdownOutput(t *testing.T) {
+	report := &AppsPublishedReport{
+		AuditedAppCount:   2,
+		PublishedAppCount: 1,
+		Apps: []PublishedApp{{
+			ID:                      "app-1",
+			Name:                    "Healthy",
+			BundleID:                "com.example.healthy",
+			SKU:                     "HEALTHY",
+			AvailabilityID:          "availability-1",
+			PublishedTerritoryCount: 2,
+		}},
+		Failures: []PublishedAppFailure{{
+			ID:    "app-2",
+			Name:  "Broken",
+			Error: "request failed",
+		}},
+	}
+
+	ensureOutputRegistryPopulated()
+	if !isRegistryTypeRegistered(typeForPtr[AppsPublishedReport]()) {
+		t.Fatal("AppsPublishedReport is not registered with the output renderer")
+	}
+
+	table := captureStdout(t, func() error { return PrintTable(report) })
+	for _, want := range []string{"Healthy", "Failed app audits:", "Broken", "request failed", "Audited 2 app records; found 1 published app. 1 app audit(s) failed."} {
+		if !strings.Contains(table, want) {
+			t.Fatalf("table output missing %q: %s", want, table)
+		}
+	}
+
+	markdown := captureStdout(t, func() error { return PrintMarkdown(report) })
+	for _, want := range []string{"| Healthy", "Failed app audits:", "| Broken", "| request failed", "Audited 2 app records; found 1 published app. 1 app audit(s) failed."} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("Markdown output missing %q: %s", want, markdown)
+		}
+	}
+}

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -29,6 +29,7 @@ func registerAllOutputRenderers() {
 	registerRowsWithSingleResourceAdapter(reviewsRows)
 	registerRows(customerReviewSummarizationsRows)
 	registerRowsWithSingleResourceAdapter(appsRows)
+	registerDirect(appsPublishedReportTables)
 	registerRows(appRenameResultRows)
 	registerRows(appsWallRows)
 	registerRowsWithSingleResourceAdapter(appClipsRows)

--- a/internal/cli/apps/published.go
+++ b/internal/cli/apps/published.go
@@ -36,11 +36,20 @@ type PublishedApp struct {
 	PublishedTerritoryCount int    `json:"publishedTerritoryCount"`
 }
 
-// AppsPublishedReport summarizes a complete account-wide published-app audit.
+// PublishedAppFailure describes an app whose availability audit could not be completed.
+type PublishedAppFailure struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+// AppsPublishedReport summarizes an account-wide published-app audit, retaining
+// successful rows when individual app audits fail.
 type AppsPublishedReport struct {
-	AuditedAppCount   int            `json:"auditedAppCount"`
-	PublishedAppCount int            `json:"publishedAppCount"`
-	Apps              []PublishedApp `json:"apps"`
+	AuditedAppCount   int                   `json:"auditedAppCount"`
+	PublishedAppCount int                   `json:"publishedAppCount"`
+	Apps              []PublishedApp        `json:"apps"`
+	Failures          []PublishedAppFailure `json:"failures,omitempty"`
 }
 
 // AppsPublishedCommand returns the account-wide published-app audit command.
@@ -83,26 +92,27 @@ Examples:
 				return fmt.Errorf("apps published: fetch apps: %w", err)
 			}
 
-			report, err := auditPublishedApps(requestCtx, client, appsResponse.Data)
-			if err != nil {
-				return fmt.Errorf("apps published: %w", err)
-			}
+			report, auditErr := auditPublishedApps(requestCtx, client, appsResponse.Data)
 			if strings.EqualFold(strings.TrimSpace(*output.Output), "json") {
 				fmt.Fprintf(
 					os.Stderr,
-					"Audited %d app records; found %d published %s.\n",
-					report.AuditedAppCount,
-					report.PublishedAppCount,
-					pluralizeApp(report.PublishedAppCount),
+					"%s\n",
+					publishedAppsSummary(report),
 				)
 			}
-			return shared.PrintOutputWithRenderers(
+			if err := shared.PrintOutputWithRenderers(
 				report,
 				*output.Output,
 				*output.Pretty,
 				func() error { return renderAppsPublishedReport(report, false) },
 				func() error { return renderAppsPublishedReport(report, true) },
-			)
+			); err != nil {
+				return err
+			}
+			if auditErr != nil {
+				return fmt.Errorf("apps published: %w", auditErr)
+			}
+			return nil
 		},
 	}
 }
@@ -171,10 +181,14 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 		close(results)
 	}()
 
-	failures := make([]string, 0)
+	failures := make([]PublishedAppFailure, 0)
 	for result := range results {
 		if result.Err != nil {
-			failures = append(failures, fmt.Sprintf("%s (%s): %v", result.App.Attributes.Name, result.App.ID, result.Err))
+			failures = append(failures, PublishedAppFailure{
+				ID:    result.App.ID,
+				Name:  result.App.Attributes.Name,
+				Error: result.Err.Error(),
+			})
 			continue
 		}
 		if result.TerritoryCount == 0 {
@@ -190,11 +204,6 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 			PublishedTerritoryCount: result.TerritoryCount,
 		})
 	}
-	if len(failures) > 0 {
-		sort.Strings(failures)
-		return AppsPublishedReport{}, fmt.Errorf("audit failed for %d of %d apps: %s", len(failures), len(appResources), strings.Join(failures, "; "))
-	}
-
 	sort.Slice(report.Apps, func(i, j int) bool {
 		left := strings.ToLower(strings.TrimSpace(report.Apps[i].Name))
 		right := strings.ToLower(strings.TrimSpace(report.Apps[j].Name))
@@ -203,8 +212,28 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 		}
 		return report.Apps[i].ID < report.Apps[j].ID
 	})
+	sortPublishedAppFailures(failures)
+	report.Failures = failures
 	report.PublishedAppCount = len(report.Apps)
+	if len(failures) > 0 {
+		details := make([]string, 0, len(failures))
+		for _, failure := range failures {
+			details = append(details, fmt.Sprintf("%s (%s): %s", failure.Name, failure.ID, failure.Error))
+		}
+		return report, fmt.Errorf("audit failed for %d of %d apps: %s", len(failures), len(appResources), strings.Join(details, "; "))
+	}
 	return report, nil
+}
+
+func sortPublishedAppFailures(failures []PublishedAppFailure) {
+	sort.Slice(failures, func(i, j int) bool {
+		left := strings.ToLower(strings.TrimSpace(failures[i].Name))
+		right := strings.ToLower(strings.TrimSpace(failures[j].Name))
+		if left != right {
+			return left < right
+		}
+		return failures[i].ID < failures[j].ID
+	})
 }
 
 // auditPublishedApp returns an app's availability ID and published-territory count.
@@ -289,14 +318,38 @@ func renderAppsPublishedReport(report AppsPublishedReport, markdown bool) error 
 	} else {
 		asc.RenderTable(headers, rows)
 	}
+	if len(report.Failures) > 0 {
+		failureRows := make([][]string, 0, len(report.Failures))
+		for _, failure := range report.Failures {
+			failureRows = append(failureRows, []string{failure.ID, failure.Name, failure.Error})
+		}
+		fmt.Fprintln(os.Stdout, "\nFailed app audits:")
+		failureHeaders := []string{"ID", "Name", "Error"}
+		if markdown {
+			asc.RenderMarkdown(failureHeaders, failureRows)
+		} else {
+			asc.RenderTable(failureHeaders, failureRows)
+		}
+	}
 	fmt.Fprintf(
 		os.Stdout,
-		"\nAudited %d app records; found %d published %s.\n",
+		"\n%s\n",
+		publishedAppsSummary(report),
+	)
+	return nil
+}
+
+func publishedAppsSummary(report AppsPublishedReport) string {
+	summary := fmt.Sprintf(
+		"Audited %d app records; found %d published %s.",
 		report.AuditedAppCount,
 		report.PublishedAppCount,
 		pluralizeApp(report.PublishedAppCount),
 	)
-	return nil
+	if len(report.Failures) > 0 {
+		summary += fmt.Sprintf(" %d app audit(s) failed.", len(report.Failures))
+	}
+	return summary
 }
 
 // pluralizeApp returns the singular or plural app label for a count.

--- a/internal/cli/apps/published.go
+++ b/internal/cli/apps/published.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,33 +23,6 @@ const (
 )
 
 var appsPublishedClientFactory = shared.GetASCClient
-
-// PublishedApp describes an App Store Connect app with live published territory coverage.
-type PublishedApp struct {
-	ID                      string `json:"id"`
-	Name                    string `json:"name"`
-	BundleID                string `json:"bundleId"`
-	SKU                     string `json:"sku"`
-	PrimaryLocale           string `json:"primaryLocale,omitempty"`
-	AvailabilityID          string `json:"availabilityId"`
-	PublishedTerritoryCount int    `json:"publishedTerritoryCount"`
-}
-
-// PublishedAppFailure describes an app whose availability audit could not be completed.
-type PublishedAppFailure struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Error string `json:"error"`
-}
-
-// AppsPublishedReport summarizes an account-wide published-app audit, retaining
-// successful rows when individual app audits fail.
-type AppsPublishedReport struct {
-	AuditedAppCount   int                   `json:"auditedAppCount"`
-	PublishedAppCount int                   `json:"publishedAppCount"`
-	Apps              []PublishedApp        `json:"apps"`
-	Failures          []PublishedAppFailure `json:"failures,omitempty"`
-}
 
 // AppsPublishedCommand returns the account-wide published-app audit command.
 func AppsPublishedCommand() *ffcli.Command {
@@ -97,16 +69,10 @@ Examples:
 				fmt.Fprintf(
 					os.Stderr,
 					"%s\n",
-					publishedAppsSummary(report),
+					asc.PublishedAppsSummary(report),
 				)
 			}
-			if err := shared.PrintOutputWithRenderers(
-				report,
-				*output.Output,
-				*output.Pretty,
-				func() error { return renderAppsPublishedReport(report, false) },
-				func() error { return renderAppsPublishedReport(report, true) },
-			); err != nil {
+			if err := shared.PrintOutput(&report, *output.Output, *output.Pretty); err != nil {
 				return err
 			}
 			if auditErr != nil {
@@ -144,10 +110,10 @@ type publishedAppAuditResult struct {
 }
 
 // auditPublishedApps audits app availability concurrently and returns published apps.
-func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []asc.Resource[asc.AppAttributes]) (AppsPublishedReport, error) {
-	report := AppsPublishedReport{
+func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []asc.Resource[asc.AppAttributes]) (asc.AppsPublishedReport, error) {
+	report := asc.AppsPublishedReport{
 		AuditedAppCount: len(appResources),
-		Apps:            make([]PublishedApp, 0),
+		Apps:            make([]asc.PublishedApp, 0),
 	}
 	if len(appResources) == 0 {
 		return report, nil
@@ -181,10 +147,10 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 		close(results)
 	}()
 
-	failures := make([]PublishedAppFailure, 0)
+	failures := make([]asc.PublishedAppFailure, 0)
 	for result := range results {
 		if result.Err != nil {
-			failures = append(failures, PublishedAppFailure{
+			failures = append(failures, asc.PublishedAppFailure{
 				ID:    result.App.ID,
 				Name:  result.App.Attributes.Name,
 				Error: result.Err.Error(),
@@ -194,7 +160,7 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 		if result.TerritoryCount == 0 {
 			continue
 		}
-		report.Apps = append(report.Apps, PublishedApp{
+		report.Apps = append(report.Apps, asc.PublishedApp{
 			ID:                      result.App.ID,
 			Name:                    result.App.Attributes.Name,
 			BundleID:                result.App.Attributes.BundleID,
@@ -225,7 +191,7 @@ func auditPublishedApps(ctx context.Context, client *asc.Client, appResources []
 	return report, nil
 }
 
-func sortPublishedAppFailures(failures []PublishedAppFailure) {
+func sortPublishedAppFailures(failures []asc.PublishedAppFailure) {
 	sort.Slice(failures, func(i, j int) bool {
 		left := strings.ToLower(strings.TrimSpace(failures[i].Name))
 		right := strings.ToLower(strings.TrimSpace(failures[j].Name))
@@ -297,65 +263,4 @@ func hasAvailableContentStatus(statuses []string) bool {
 		}
 	}
 	return false
-}
-
-// renderAppsPublishedReport writes table or Markdown rows and their audit totals.
-func renderAppsPublishedReport(report AppsPublishedReport, markdown bool) error {
-	headers := []string{"ID", "Name", "Bundle ID", "SKU", "Availability ID", "Published Territories"}
-	rows := make([][]string, 0, len(report.Apps))
-	for _, app := range report.Apps {
-		rows = append(rows, []string{
-			app.ID,
-			app.Name,
-			app.BundleID,
-			app.SKU,
-			app.AvailabilityID,
-			strconv.Itoa(app.PublishedTerritoryCount),
-		})
-	}
-	if markdown {
-		asc.RenderMarkdown(headers, rows)
-	} else {
-		asc.RenderTable(headers, rows)
-	}
-	if len(report.Failures) > 0 {
-		failureRows := make([][]string, 0, len(report.Failures))
-		for _, failure := range report.Failures {
-			failureRows = append(failureRows, []string{failure.ID, failure.Name, failure.Error})
-		}
-		fmt.Fprintln(os.Stdout, "\nFailed app audits:")
-		failureHeaders := []string{"ID", "Name", "Error"}
-		if markdown {
-			asc.RenderMarkdown(failureHeaders, failureRows)
-		} else {
-			asc.RenderTable(failureHeaders, failureRows)
-		}
-	}
-	fmt.Fprintf(
-		os.Stdout,
-		"\n%s\n",
-		publishedAppsSummary(report),
-	)
-	return nil
-}
-
-func publishedAppsSummary(report AppsPublishedReport) string {
-	summary := fmt.Sprintf(
-		"Audited %d app records; found %d published %s.",
-		report.AuditedAppCount,
-		report.PublishedAppCount,
-		pluralizeApp(report.PublishedAppCount),
-	)
-	if len(report.Failures) > 0 {
-		summary += fmt.Sprintf(" %d app audit(s) failed.", len(report.Failures))
-	}
-	return summary
-}
-
-// pluralizeApp returns the singular or plural app label for a count.
-func pluralizeApp(count int) string {
-	if count == 1 {
-		return "app"
-	}
-	return "apps"
 }

--- a/internal/cli/cmdtest/apps_published_test.go
+++ b/internal/cli/cmdtest/apps_published_test.go
@@ -132,34 +132,17 @@ func TestAppsPublishedEmptyAccount(t *testing.T) {
 	}
 }
 
-func TestAppsPublishedAggregatesNamedAppErrorsAndContinues(t *testing.T) {
+func TestAppsPublishedPreservesSuccessfulRowsWhenAnotherAuditFails(t *testing.T) {
 	setupAuth(t)
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 	var healthyAppRead atomic.Int32
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
-			return jsonHTTPResponse(http.StatusOK, `{
-				"data":[
-					{"type":"apps","id":"bad-app","attributes":{"name":"Broken","bundleId":"com.example.broken","sku":"BROKEN"}},
-					{"type":"apps","id":"good-app","attributes":{"name":"Healthy","bundleId":"com.example.healthy","sku":"HEALTHY"}}
-				],"links":{"next":""}
-			}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/bad-app/appAvailabilityV2":
-			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No apps resource exists"}]}`), nil
-		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/good-app/appAvailabilityV2":
-			healthyAppRead.Add(1)
-			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No appAvailabilities resource exists"}]}`), nil
-		default:
-			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
-		}
-	})
+	http.DefaultTransport = publishedAppsPartialFailureTransport(&healthyAppRead)
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
-	stdout, _ := captureOutput(t, func() {
-		if err := root.Parse([]string{"apps", "published"}); err != nil {
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"apps", "published", "--pretty"}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		err := root.Run(context.Background())
@@ -170,11 +153,128 @@ func TestAppsPublishedAggregatesNamedAppErrorsAndContinues(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
-	if stdout != "" {
-		t.Fatalf("expected no partial stdout, got %q", stdout)
+	var report struct {
+		AuditedAppCount   int `json:"auditedAppCount"`
+		PublishedAppCount int `json:"publishedAppCount"`
+		Apps              []struct {
+			ID string `json:"id"`
+		} `json:"apps"`
+		Failures []struct {
+			ID    string `json:"id"`
+			Name  string `json:"name"`
+			Error string `json:"error"`
+		} `json:"failures"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode partial output %q: %v", stdout, err)
+	}
+	if report.AuditedAppCount != 2 || report.PublishedAppCount != 1 || len(report.Apps) != 1 {
+		t.Fatalf("unexpected partial report: %+v", report)
+	}
+	if report.Apps[0].ID != "good-app" {
+		t.Fatalf("unexpected successful app: %+v", report.Apps[0])
+	}
+	if len(report.Failures) != 1 || report.Failures[0].ID != "bad-app" || report.Failures[0].Name != "Broken" || !strings.Contains(report.Failures[0].Error, "No apps resource exists") {
+		t.Fatalf("unexpected failures: %+v", report.Failures)
+	}
+	if !strings.Contains(stderr, "Audited 2 app records; found 1 published app. 1 app audit(s) failed.") {
+		t.Fatalf("unexpected partial summary: %q", stderr)
 	}
 	if healthyAppRead.Load() != 1 {
 		t.Fatalf("healthy app was not audited: %d", healthyAppRead.Load())
+	}
+}
+
+func TestAppsPublishedRendersPartialResultsForHumanFormats(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	for _, format := range []string{"table", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			http.DefaultTransport = publishedAppsPartialFailureTransport(nil)
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{"apps", "published", "--output", format}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err == nil {
+					t.Fatal("expected audit error")
+				}
+			})
+
+			for _, want := range []string{"Healthy", "Failed app audits:", "Broken", "No apps resource exists", "Audited 2 app records; found 1 published app. 1 app audit(s) failed."} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("%s output missing %q: %s", format, want, stdout)
+				}
+			}
+			if strings.Count(stdout, "Audited 2 app records; found 1 published app. 1 app audit(s) failed.") != 1 {
+				t.Fatalf("%s output duplicated summary: %s", format, stdout)
+			}
+			if strings.Count(stdout, "No apps resource exists") != 1 {
+				t.Fatalf("%s output duplicated failure detail: %s", format, stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("%s output unexpectedly wrote diagnostics to stderr: %q", format, stderr)
+			}
+		})
+	}
+}
+
+func TestAppsPublishedOrdersMultipleFailuresDeterministically(t *testing.T) {
+	setupAuth(t)
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"apps","id":"z-failure","attributes":{"name":"Zulu Failure","bundleId":"com.example.zulu","sku":"ZULU"}},
+					{"type":"apps","id":"healthy","attributes":{"name":"Healthy","bundleId":"com.example.healthy","sku":"HEALTHY"}},
+					{"type":"apps","id":"a-failure","attributes":{"name":"Alpha Failure","bundleId":"com.example.alpha","sku":"ALPHA"}}
+				],"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/healthy/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-healthy","attributes":{}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-healthy/territoryAvailabilities":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territoryAvailabilities","id":"territory-healthy","attributes":{"contentStatuses":["AVAILABLE"]}}],"links":{"next":""}}`), nil
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/appAvailabilityV2"):
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No apps resource exists"}]}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		if err := root.Parse([]string{"apps", "published", "--pretty"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected audit error")
+	}
+
+	var report struct {
+		Failures []struct {
+			ID string `json:"id"`
+		} `json:"failures"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode partial output %q: %v", stdout, err)
+	}
+	if len(report.Failures) != 2 || report.Failures[0].ID != "a-failure" || report.Failures[1].ID != "z-failure" {
+		t.Fatalf("failures are not deterministically ordered: %+v", report.Failures)
+	}
+	alphaIndex := strings.Index(runErr.Error(), "Alpha Failure (a-failure)")
+	zuluIndex := strings.Index(runErr.Error(), "Zulu Failure (z-failure)")
+	if alphaIndex < 0 || zuluIndex < 0 || alphaIndex > zuluIndex {
+		t.Fatalf("aggregate error is not deterministically ordered: %v", runErr)
 	}
 }
 
@@ -288,6 +388,31 @@ func publishedAppsTwoAppTransport(t *testing.T) http.RoundTripper {
 			return jsonHTTPResponse(http.StatusOK, fmt.Sprintf(`{"data":{"type":"appAvailabilities","id":"availability-%s","attributes":{"availableInNewTerritories":false}}}`, appID)), nil
 		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/v2/appAvailabilities/availability-"):
 			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territoryAvailabilities","id":"ta-1","attributes":{"available":true,"contentStatuses":["AVAILABLE"]}}],"links":{"next":""}}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+}
+
+func publishedAppsPartialFailureTransport(healthyAppRead *atomic.Int32) http.RoundTripper {
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps":
+			return jsonHTTPResponse(http.StatusOK, `{
+				"data":[
+					{"type":"apps","id":"bad-app","attributes":{"name":"Broken","bundleId":"com.example.broken","sku":"BROKEN"}},
+					{"type":"apps","id":"good-app","attributes":{"name":"Healthy","bundleId":"com.example.healthy","sku":"HEALTHY"}}
+				],"links":{"next":""}
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/bad-app/appAvailabilityV2":
+			return jsonHTTPResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"The specified resource does not exist","detail":"No apps resource exists"}]}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/good-app/appAvailabilityV2":
+			if healthyAppRead != nil {
+				healthyAppRead.Add(1)
+			}
+			return jsonHTTPResponse(http.StatusOK, `{"data":{"type":"appAvailabilities","id":"availability-good","attributes":{}}}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/v2/appAvailabilities/availability-good/territoryAvailabilities":
+			return jsonHTTPResponse(http.StatusOK, `{"data":[{"type":"territoryAvailabilities","id":"territory-good","attributes":{"contentStatuses":["AVAILABLE"]}}],"links":{"next":""}}`), nil
 		default:
 			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
 		}


### PR DESCRIPTION
## Summary

- retain successful `apps published` rows when another app audit fails
- add structured, deterministically ordered failure entries to JSON output
- render failed app audits in table and Markdown while preserving a nonzero exit

## Why

The account-wide audit already continued after an individual app failure, but then discarded every successful result and returned an empty report. Agents could not use the work that completed or identify failures from structured output.

## Compatibility

- failures still produce a nonzero exit and an aggregate error
- `failures` is additive in JSON
- successful output ordering and zero-territory behavior are unchanged

## Validation

- focused and adjacent `apps published` tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `GOMAXPROCS=2 ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook (`go test -short ./...`)

No live App Store Connect mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Published-app audits now preserve successful results when other audits fail.
  * Reports include clear per-app failure details and failure counts.
  * Failed audits are displayed in JSON, table, and Markdown output.
  * Failure results are shown in a consistent, deterministic order.
  * Published-app counts remain available even when some audits fail.

* **Improvements**
  * Published-app reports now provide consistent summaries across supported output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->