### PR TITLE
fix(testflight): preserve tester metric payloads

### DIFF
--- a/internal/asc/beta_recruitment.go
+++ b/internal/asc/beta_recruitment.go
@@ -109,6 +109,14 @@ func (r *BetaGroupTesterUsagesResponse) GetLinks() *Links {
 	return &r.Links
 }
 
+// GetMeta returns the raw metadata field for pagination warnings.
+func (r *BetaGroupTesterUsagesResponse) GetMeta() json.RawMessage {
+	if r == nil {
+		return nil
+	}
+	return r.Meta
+}
+
 // GetData returns the metric data for aggregation.
 func (r *BetaGroupTesterUsagesResponse) GetData() any {
 	if r == nil {

--- a/internal/asc/beta_recruitment.go
+++ b/internal/asc/beta_recruitment.go
@@ -1,5 +1,11 @@
 package asc
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
 // BetaRecruitmentCriteriaAttributes describes beta recruitment criteria metadata.
 type BetaRecruitmentCriteriaAttributes struct {
 	LastModifiedDate             string                        `json:"lastModifiedDate,omitempty"`
@@ -86,4 +92,137 @@ type BetaGroupMetricAttributes map[string]any
 type BetaGroupPublicLinkUsagesResponse = Response[BetaGroupMetricAttributes]
 
 // BetaGroupTesterUsagesResponse is the response from beta tester usage metrics.
-type BetaGroupTesterUsagesResponse = Response[BetaGroupMetricAttributes]
+// The metric endpoint returns data-point objects rather than JSON:API resource
+// objects, so it has a dedicated envelope instead of Response[T].
+type BetaGroupTesterUsagesResponse struct {
+	Data     []BetaGroupTesterUsage `json:"data"`
+	Links    Links                  `json:"links"`
+	Included json.RawMessage        `json:"included,omitempty"`
+	Meta     json.RawMessage        `json:"meta,omitempty"`
+}
+
+// GetLinks returns the links field for pagination.
+func (r *BetaGroupTesterUsagesResponse) GetLinks() *Links {
+	if r == nil {
+		return nil
+	}
+	return &r.Links
+}
+
+// GetData returns the metric data for aggregation.
+func (r *BetaGroupTesterUsagesResponse) GetData() any {
+	if r == nil {
+		return nil
+	}
+	return r.Data
+}
+
+// BetaGroupTesterUsage is one metric series returned by the group tester
+// usage endpoint. The raw item is retained so JSON output remains faithful to
+// Apple's response while table output can use typed metric fields.
+type BetaGroupTesterUsage struct {
+	Type       string                          `json:"type,omitempty"`
+	ID         string                          `json:"id,omitempty"`
+	DataPoints []BetaGroupTesterUsageDataPoint `json:"dataPoints,omitempty"`
+	Dimensions *BetaGroupTesterUsageDimensions `json:"dimensions,omitempty"`
+	raw        json.RawMessage
+}
+
+func (m *BetaGroupTesterUsage) UnmarshalJSON(data []byte) error {
+	type metricAlias BetaGroupTesterUsage
+	var decoded metricAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	decoded.raw = append(decoded.raw[:0], data...)
+	*m = BetaGroupTesterUsage(decoded)
+	return nil
+}
+
+func (m BetaGroupTesterUsage) MarshalJSON() ([]byte, error) {
+	if len(m.raw) > 0 {
+		return m.raw, nil
+	}
+	type metricAlias BetaGroupTesterUsage
+	return json.Marshal(metricAlias(m))
+}
+
+// BetaGroupTesterUsageDataPoint is one time interval in a metric series.
+type BetaGroupTesterUsageDataPoint struct {
+	Start  string                     `json:"start,omitempty"`
+	End    string                     `json:"end,omitempty"`
+	Values BetaGroupTesterUsageValues `json:"values,omitempty"`
+}
+
+// BetaGroupTesterUsageValues contains the counts Apple reports for a data point.
+type BetaGroupTesterUsageValues struct {
+	CrashCount    *int `json:"crashCount,omitempty"`
+	SessionCount  *int `json:"sessionCount,omitempty"`
+	FeedbackCount *int `json:"feedbackCount,omitempty"`
+}
+
+// BetaGroupTesterUsageDimensions identifies the tester represented by a metric series.
+type BetaGroupTesterUsageDimensions struct {
+	BetaTesters *BetaGroupTesterUsageDimension `json:"betaTesters,omitempty"`
+}
+
+// BetaGroupTesterUsageDimension describes a grouped metric dimension.
+type BetaGroupTesterUsageDimension struct {
+	Data  *BetaGroupTesterUsageDimensionData  `json:"data,omitempty"`
+	Links *BetaGroupTesterUsageDimensionLinks `json:"links,omitempty"`
+}
+
+// BetaGroupTesterUsageDimensionLinks contains links for a metric dimension.
+type BetaGroupTesterUsageDimensionLinks struct {
+	GroupBy string `json:"groupBy,omitempty"`
+	Related string `json:"related,omitempty"`
+}
+
+// BetaGroupTesterUsageDimensionData accepts both the string shape in Apple's
+// schema and the resource identifier object returned by current responses.
+type BetaGroupTesterUsageDimensionData struct {
+	Type string `json:"type,omitempty"`
+	ID   string `json:"id,omitempty"`
+	raw  json.RawMessage
+}
+
+func (d *BetaGroupTesterUsageDimensionData) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) {
+		*d = BetaGroupTesterUsageDimensionData{}
+		return nil
+	}
+
+	var identifier string
+	if err := json.Unmarshal(trimmed, &identifier); err == nil {
+		d.ID = identifier
+		d.Type = ""
+		d.raw = append(d.raw[:0], trimmed...)
+		return nil
+	}
+
+	var resource struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	}
+	if err := json.Unmarshal(trimmed, &resource); err != nil {
+		return fmt.Errorf("betaTesters.data must be a string or object: %w", err)
+	}
+	d.Type = resource.Type
+	d.ID = resource.ID
+	d.raw = append(d.raw[:0], trimmed...)
+	return nil
+}
+
+func (d BetaGroupTesterUsageDimensionData) MarshalJSON() ([]byte, error) {
+	if len(d.raw) > 0 {
+		return d.raw, nil
+	}
+	if d.Type != "" {
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			ID   string `json:"id,omitempty"`
+		}{Type: d.Type, ID: d.ID})
+	}
+	return json.Marshal(d.ID)
+}

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -10267,7 +10267,7 @@ func TestGetBetaGroupPublicLinkUsages(t *testing.T) {
 }
 
 func TestGetBetaGroupTesterUsages(t *testing.T) {
-	response := jsonResponse(http.StatusOK, `{"data":[{"type":"betaGroupMetrics","id":"metric-1","attributes":{"testerCount":12}}]}`)
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"appsBetaTesterUsages","dataPoints":[{"start":"2026-08-01T00:00:00Z","end":"2026-08-02T00:00:00Z","values":{"sessionCount":12,"crashCount":1,"feedbackCount":2}}],"dimensions":{"betaTesters":{"data":{"type":"betaTesters","id":"tester-1"}}}}],"links":{"self":"https://api.example.test/metrics"}}`)
 	client := newTestClient(t, func(req *http.Request) {
 		if req.Method != http.MethodGet {
 			t.Fatalf("expected GET, got %s", req.Method)
@@ -10281,8 +10281,22 @@ func TestGetBetaGroupTesterUsages(t *testing.T) {
 		assertAuthorized(t, req)
 	}, response)
 
-	if _, err := client.GetBetaGroupTesterUsages(context.Background(), "group-1"); err != nil {
+	metrics, err := client.GetBetaGroupTesterUsages(context.Background(), "group-1")
+	if err != nil {
 		t.Fatalf("GetBetaGroupTesterUsages() error: %v", err)
+	}
+	if len(metrics.Data) != 1 || len(metrics.Data[0].DataPoints) != 1 || metrics.Data[0].Dimensions == nil || metrics.Data[0].Dimensions.BetaTesters == nil || metrics.Data[0].Dimensions.BetaTesters.Data == nil || metrics.Data[0].Dimensions.BetaTesters.Data.ID != "tester-1" {
+		t.Fatalf("unexpected decoded metrics: %+v", metrics)
+	}
+}
+
+func TestBetaGroupTesterUsageDimensionDataAcceptsSchemaString(t *testing.T) {
+	var response BetaGroupTesterUsagesResponse
+	if err := json.Unmarshal([]byte(`{"data":[{"dimensions":{"betaTesters":{"data":"tester-1"}}}],"links":{}}`), &response); err != nil {
+		t.Fatalf("unexpected schema-shaped response error: %v", err)
+	}
+	if response.Data[0].Dimensions.BetaTesters.Data.ID != "tester-1" {
+		t.Fatalf("unexpected tester ID: %+v", response.Data[0].Dimensions.BetaTesters.Data)
 	}
 }
 

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -246,6 +246,7 @@ func registerAllOutputRenderers() {
 	registerRows(betaRecruitmentCriteriaRows)
 	registerRows(betaRecruitmentCriteriaDeleteResultRows)
 	registerResponseDataRows(betaGroupMetricsRows)
+	registerRows(betaGroupTesterUsagesRows)
 	registerRowsWithSingleResourceAdapter(sandboxTestersRows)
 	registerRowsWithSingleResourceAdapter(bundleIDCapabilitiesRows)
 	registerRows(localizationDownloadResultRows)

--- a/internal/asc/output_testflight.go
+++ b/internal/asc/output_testflight.go
@@ -162,3 +162,32 @@ func betaGroupMetricsRows(items []Resource[BetaGroupMetricAttributes]) ([]string
 	}
 	return headers, rows
 }
+
+func betaGroupTesterUsagesRows(resp *BetaGroupTesterUsagesResponse) ([]string, [][]string) {
+	headers := []string{"Tester ID", "Start", "End", "Sessions", "Crashes", "Feedback"}
+	rows := make([][]string, 0, len(resp.Data))
+	for _, metric := range resp.Data {
+		testerID := ""
+		if metric.Dimensions != nil && metric.Dimensions.BetaTesters != nil && metric.Dimensions.BetaTesters.Data != nil {
+			testerID = metric.Dimensions.BetaTesters.Data.ID
+		}
+		for _, point := range metric.DataPoints {
+			rows = append(rows, []string{
+				testerID,
+				point.Start,
+				point.End,
+				formatBetaGroupMetricCount(point.Values.SessionCount),
+				formatBetaGroupMetricCount(point.Values.CrashCount),
+				formatBetaGroupMetricCount(point.Values.FeedbackCount),
+			})
+		}
+	}
+	return headers, rows
+}
+
+func formatBetaGroupMetricCount(value *int) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *value)
+}

--- a/internal/cli/cmdtest/testflight_metrics_output_test.go
+++ b/internal/cli/cmdtest/testflight_metrics_output_test.go
@@ -10,6 +10,30 @@ import (
 	"testing"
 )
 
+const groupTesterMetricsFixture = `{
+	"data":[
+		{
+			"type":"appsBetaTesterUsages",
+			"dataPoints":[{
+				"start":"2026-08-01T00:00:00Z",
+				"end":"2026-08-02T00:00:00Z",
+				"values":{"sessionCount":12,"crashCount":1,"feedbackCount":2}
+			}],
+			"dimensions":{"betaTesters":{"data":{"type":"betaTesters","id":"tester-1"}}}
+		},
+		{
+			"type":"appsBetaTesterUsages",
+			"dataPoints":[{
+				"start":"2026-08-02T00:00:00Z",
+				"end":"2026-08-03T00:00:00Z",
+				"values":{"sessionCount":3,"crashCount":0,"feedbackCount":1}
+			}],
+			"dimensions":{"betaTesters":{"data":{"type":"betaTesters","id":"tester-2"}}}
+		}
+	],
+	"links":{"self":"https://api.example.test/v1/betaGroups/group-1/metrics/betaTesterUsages?groupBy=betaTesters"}
+}`
+
 func TestTestFlightMetricsPublicLinkOutput(t *testing.T) {
 	setupAuth(t)
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
@@ -82,7 +106,7 @@ func TestTestFlightMetricsTestersOutput(t *testing.T) {
 		if req.URL.Query().Get("groupBy") != "betaTesters" {
 			t.Fatalf("expected groupBy=betaTesters, got %q", req.URL.Query().Get("groupBy"))
 		}
-		body := `{"data":[{"type":"betaGroupTesterUsages","id":"tester-usage-1"}]}`
+		body := groupTesterMetricsFixture
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(body)),
@@ -108,13 +132,41 @@ func TestTestFlightMetricsTestersOutput(t *testing.T) {
 
 	var out struct {
 		Data []struct {
-			ID string `json:"id"`
+			Type       string `json:"type"`
+			DataPoints []struct {
+				Start  string `json:"start"`
+				End    string `json:"end"`
+				Values struct {
+					SessionCount  int `json:"sessionCount"`
+					CrashCount    int `json:"crashCount"`
+					FeedbackCount int `json:"feedbackCount"`
+				} `json:"values"`
+			} `json:"dataPoints"`
+			Dimensions struct {
+				BetaTesters struct {
+					Data struct {
+						Type string `json:"type"`
+						ID   string `json:"id"`
+					} `json:"data"`
+				} `json:"betaTesters"`
+			} `json:"dimensions"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
 		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
 	}
-	if len(out.Data) != 1 || out.Data[0].ID != "tester-usage-1" {
+	if len(out.Data) != 2 {
+		t.Fatalf("unexpected output data length: %+v", out)
+	}
+	first := out.Data[0]
+	if first.Type != "appsBetaTesterUsages" || len(first.DataPoints) != 1 || first.Dimensions.BetaTesters.Data.Type != "betaTesters" || first.Dimensions.BetaTesters.Data.ID != "tester-1" {
+		t.Fatalf("unexpected first metric: %+v", first)
+	}
+	point := first.DataPoints[0]
+	if point.Start != "2026-08-01T00:00:00Z" || point.End != "2026-08-02T00:00:00Z" || point.Values.SessionCount != 12 || point.Values.CrashCount != 1 || point.Values.FeedbackCount != 2 {
+		t.Fatalf("unexpected first metric data point: %+v", point)
+	}
+	if out.Data[1].Dimensions.BetaTesters.Data.ID != "tester-2" {
 		t.Fatalf("unexpected output: %+v", out)
 	}
 }
@@ -138,7 +190,7 @@ func TestTestFlightMetricsTestersTableOutput(t *testing.T) {
 		if req.URL.Query().Get("groupBy") != "betaTesters" {
 			t.Fatalf("expected groupBy=betaTesters, got %q", req.URL.Query().Get("groupBy"))
 		}
-		body := `{"data":[{"type":"betaGroupTesterUsages","id":"tester-table-1","attributes":{"betaTesters":42}}]}`
+		body := groupTesterMetricsFixture
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(body)),
@@ -161,8 +213,137 @@ func TestTestFlightMetricsTestersTableOutput(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, "tester-table-1") {
-		t.Fatalf("expected table output to contain tester usage id, got %q", stdout)
+	for _, want := range []string{"Tester ID", "Start", "End", "Sessions", "Crashes", "Feedback", "tester-1", "2026-08-01T00:00:00Z", "12", "1", "2", "tester-2", "3", "0"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected table output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTestFlightMetricsTestersMarkdownOutput(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/betaGroups/group-1/metrics/betaTesterUsages" {
+			t.Fatalf("expected path /v1/betaGroups/group-1/metrics/betaTesterUsages, got %s", req.URL.Path)
+		}
+		if req.URL.Query().Get("groupBy") != "betaTesters" {
+			t.Fatalf("expected groupBy=betaTesters, got %q", req.URL.Query().Get("groupBy"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(groupTesterMetricsFixture)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "group-testers", "--group", "group-1", "--output", "markdown"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	for _, want := range []string{"| Tester ID", "| Start", "| Sessions", "| tester-1", "| 12", "| tester-2", "| 3"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected Markdown output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
+func TestTestFlightMetricsTestersEmptyResponse(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":[],"links":{"self":"https://api.example.test/metrics"}}`)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "group-testers", "--group", "group-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var out struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if len(out.Data) != 0 {
+		t.Fatalf("expected empty data, got %+v", out.Data)
+	}
+}
+
+func TestTestFlightMetricsTestersMalformedResponse(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"data":[{"type":"appsBetaTesterUsages","dimensions":{"betaTesters":{"data":42}}}],"links":{"self":"https://api.example.test/metrics"}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "group-testers", "--group", "group-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if runErr == nil {
+		t.Fatal("expected malformed response error")
+	}
+	if !strings.Contains(runErr.Error(), "testflight metrics group-testers: failed to fetch") || !strings.Contains(runErr.Error(), "betaTesters.data") {
+		t.Fatalf("unexpected malformed response error: %v", runErr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("expected no output for malformed response, stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 

--- a/internal/cli/cmdtest/testflight_metrics_pagination_signals_test.go
+++ b/internal/cli/cmdtest/testflight_metrics_pagination_signals_test.go
@@ -54,6 +54,51 @@ func TestTestFlightMetricsAppTestersSinglePageWarnsOnMorePages(t *testing.T) {
 	}
 }
 
+func TestTestFlightMetricsGroupTestersSinglePageWarnsWithPagingTotal(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/betaGroups/group-1/metrics/betaTesterUsages" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if req.URL.Query().Get("groupBy") != "betaTesters" {
+			t.Fatalf("expected groupBy=betaTesters, got %q", req.URL.Query().Get("groupBy"))
+		}
+		body := `{"data":[{"type":"appsBetaTesterUsages","dataPoints":[{"start":"2026-08-01T00:00:00Z","end":"2026-08-02T00:00:00Z","values":{"sessionCount":12}}],"dimensions":{"betaTesters":{"data":{"type":"betaTesters","id":"tester-1"}}}}],"links":{"next":"https://api.example.test/v1/betaGroups/group-1/metrics/betaTesterUsages?cursor=next"},"meta":{"paging":{"total":7,"limit":1}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"testflight", "metrics", "group-testers", "--group", "group-1"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"tester-1"`) {
+		t.Fatalf("expected metric data in stdout, got %q", stdout)
+	}
+	wantWarning := "Warning: showing 1 of 7 results; more pages exist (use --paginate or --next where supported)\n"
+	if stderr != wantWarning {
+		t.Fatalf("stderr = %q, want %q", stderr, wantWarning)
+	}
+}
+
 func TestTestFlightMetricsResolveTestersMergesIncludedAcrossPages(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 	t.Setenv("ASC_APP_ID", "")


### PR DESCRIPTION
## Summary

- decode beta tester usage metrics using Apple's metric data-point envelope instead of JSON:API resource attributes
- preserve the original metric objects for faithful JSON output
- render tester IDs, time ranges, sessions, crashes, and feedback in table and Markdown output

## Why

`testflight metrics group-testers` previously exited successfully while rendering blank IDs and null attributes. Apple returns `dataPoints` and `dimensions` at the metric-object level, so the generic JSON:API `Response[T]` model silently discarded the useful payload.

## Compatibility

- JSON retains Apple's metric object shape
- the dimension decoder accepts both Apple's observed resource-identifier object and the documented string form
- empty responses and malformed dimensions are covered

## Validation

- focused client and command tests
- JSON, table, and Markdown renderer tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- serialized commit hook (`GOMAXPROCS=1 go test -short ./...`)

The response fixture was scrubbed; no live App Store Connect mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added beta tester usage metrics, including session, crash, and feedback counts.
  - Added table, Markdown, and JSON output with time intervals and tester IDs.
  - Added support for multiple API response formats and nullable metric values.
  - Added paging information and warnings when additional results are available.

- **Bug Fixes**
  - Improved handling of empty, malformed, and schema-variable metrics responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->