### PR TITLE
fix(web): explain missing company name on app create

### DIFF
--- a/internal/cli/web/web_apps_create_shared.go
+++ b/internal/cli/web/web_apps_create_shared.go
@@ -94,6 +94,16 @@ func normalizeAppsCreateRunOptions(opts AppsCreateRunOptions) AppsCreateRunOptio
 	return opts
 }
 
+func explainAppsCreateError(err error) error {
+	if webcore.IsMissingCompanyNameError(err) {
+		return fmt.Errorf(
+			"web apps create failed: Apple requires a company name for this account; retry with --company-name \"Your Company\": %w",
+			err,
+		)
+	}
+	return fmt.Errorf("web apps create failed: %w", err)
+}
+
 func promptAppsCreateFields(opts *AppsCreateRunOptions) error {
 	if opts == nil {
 		return fmt.Errorf("app create options are required")
@@ -416,7 +426,7 @@ func RunAppsCreate(ctx context.Context, opts AppsCreateRunOptions) error {
 				err = errors.Join(err, fmt.Errorf("failed to roll back created bundle id %q: %w", opts.BundleID, rollbackErr))
 			}
 		}
-		return fmt.Errorf("web apps create failed: %w", err)
+		return explainAppsCreateError(err)
 	}
 
 	fmt.Fprintf(os.Stderr, "Created app successfully (id=%s)\n", strings.TrimSpace(app.Data.ID))

--- a/internal/cli/web/web_apps_test.go
+++ b/internal/cli/web/web_apps_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared/errfmt"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
@@ -1222,6 +1223,73 @@ func TestWebAppsCreateRollsBackCreatedBundleIDWhenCreateFails(t *testing.T) {
 	}
 	if !errors.Is(err, createErr) {
 		t.Fatalf("expected wrapped create error, got %v", err)
+	}
+	if deletedBundleID != "com.example.app" {
+		t.Fatalf("expected rollback for bundle id %q, got %q", "com.example.app", deletedBundleID)
+	}
+}
+
+func TestWebAppsCreateMissingCompanyNameProvidesActionableHint(t *testing.T) {
+	origResolveAppCreateSession := resolveAppCreateSessionFn
+	origNewWebClient := newWebClientFn
+	origEnsureBundleID := ensureBundleIDFn
+	origDeleteBundleID := deleteBundleIDFn
+	t.Cleanup(func() {
+		resolveAppCreateSessionFn = origResolveAppCreateSession
+		newWebClientFn = origNewWebClient
+		ensureBundleIDFn = origEnsureBundleID
+		deleteBundleIDFn = origDeleteBundleID
+	})
+
+	const secret = "account-secret-token"
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(`{"errors":[{
+				"title":"The provided entity is missing a required attribute",
+				"detail":"You must provide a value for the attribute 'companyName' with this request",
+				"code":"ENTITY_ERROR.ATTRIBUTE.REQUIRED",
+				"secret":"` + secret + `"
+			}]}`)),
+			Request: req,
+		}, nil
+	})
+	resolveAppCreateSessionFn = func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{Client: &http.Client{Transport: transport}}, "cache", nil
+	}
+	newWebClientFn = webcore.NewClient
+	ensureBundleIDFn = func(ctx context.Context, bundleID, appName, platform string) (bool, error) {
+		return true, nil
+	}
+	deletedBundleID := ""
+	deleteBundleIDFn = func(ctx context.Context, bundleID string) error {
+		deletedBundleID = bundleID
+		return nil
+	}
+	t.Setenv("ASC_WEB_MIN_REQUEST_INTERVAL", "0")
+
+	err := RunAppsCreate(context.Background(), AppsCreateRunOptions{
+		Name:     "My App",
+		BundleID: "com.example.app",
+		SKU:      "SKU123",
+		AppleID:  "user@example.com",
+		Output:   "json",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Apple requires a company name for this account") {
+		t.Fatalf("error = %q, want actionable company-name guidance", err)
+	}
+	if !strings.Contains(err.Error(), "--company-name") {
+		t.Fatalf("error = %q, want --company-name hint", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked raw response body secret: %q", err)
+	}
+	if got := errfmt.FormatStderr(err); !strings.Contains(got, "Error: web apps create failed:") {
+		t.Fatalf("formatted stderr = %q, want command error prefix", got)
 	}
 	if deletedBundleID != "com.example.app" {
 		t.Fatalf("expected rollback for bundle id %q, got %q", "com.example.app", deletedBundleID)

--- a/internal/web/errors.go
+++ b/internal/web/errors.go
@@ -41,6 +41,43 @@ func IsDuplicateAppNameError(err error) bool {
 	return false
 }
 
+// IsMissingCompanyNameError reports whether an internal API error means Apple
+// requires a company name for the app-creation request. The response body is
+// only used for this package-internal classification; APIError.Error keeps it
+// out of user-facing messages.
+func IsMissingCompanyNameError(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr == nil || len(apiErr.rawResponseBody()) == 0 {
+		return false
+	}
+
+	var payload struct {
+		Errors []struct {
+			AttributeName string `json:"attributeName"`
+			Detail        string `json:"detail"`
+			Title         string `json:"title"`
+		} `json:"errors"`
+	}
+	if json.Unmarshal(apiErr.rawResponseBody(), &payload) != nil {
+		return false
+	}
+
+	for _, responseError := range payload.Errors {
+		attributeName := strings.ToLower(strings.TrimSpace(responseError.AttributeName))
+		text := strings.ToLower(strings.TrimSpace(responseError.Title + " " + responseError.Detail))
+		if attributeName == "companyname" &&
+			(strings.Contains(text, "is required") || strings.Contains(text, "required attribute") ||
+				strings.Contains(text, "missing") || strings.Contains(text, "must provide")) {
+			return true
+		}
+		if strings.Contains(text, "missing a required attribute") &&
+			strings.Contains(text, "attribute 'companyname'") {
+			return true
+		}
+	}
+	return false
+}
+
 // IsAlreadyExistsConflict reports whether an internal API error is a 409 caused
 // by an exact already-exists response. It intentionally avoids treating broader
 // "already attached/submitted" wording as idempotent success.

--- a/internal/web/errors_test.go
+++ b/internal/web/errors_test.go
@@ -63,6 +63,73 @@ func TestIsDuplicateAppNameError(t *testing.T) {
 	}
 }
 
+func TestIsMissingCompanyNameError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "required attribute detail",
+			err: &APIError{rawBody: []byte(`{
+				"errors":[{
+					"title":"The provided entity is missing a required attribute",
+					"detail":"You must provide a value for the attribute 'companyName' with this request"
+				}]
+			}`)},
+			want: true,
+		},
+		{
+			name: "required attribute name",
+			err: &APIError{rawBody: []byte(`{
+				"errors":[{
+					"attributeName":"companyName",
+					"detail":"This attribute is required"
+				}]
+			}`)},
+			want: true,
+		},
+		{
+			name: "different required attribute",
+			err: &APIError{rawBody: []byte(`{
+				"errors":[{
+					"attributeName":"sku",
+					"detail":"This attribute is required"
+				}]
+			}`)},
+			want: false,
+		},
+		{
+			name: "company name explicitly optional",
+			err: &APIError{rawBody: []byte(`{
+				"errors":[{
+					"attributeName":"companyName",
+					"detail":"This attribute is not required"
+				}]
+			}`)},
+			want: false,
+		},
+		{
+			name: "malformed body",
+			err:  &APIError{rawBody: []byte(`{"errors":[`)},
+			want: false,
+		},
+		{
+			name: "non api error",
+			err:  errors.New("nope"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsMissingCompanyNameError(tc.err); got != tc.want {
+				t.Fatalf("IsMissingCompanyNameError()=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsAlreadyExistsConflict(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

- recognize Apple's structured missing-`companyName` app-creation response
- tell users to retry with `--company-name` when their account requires it
- preserve bundle-ID rollback, error wrapping, exit behavior, and raw response secrecy

## Why

Some accounts require a company name for web app creation. The command already supports `--company-name`, but the generic create failure did not connect Apple's response to that recovery path.

## Validation

- focused `internal/web` and `internal/cli/web` suites
- matching, nonmatching, malformed, rollback, and response-secrecy tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- commit hook (`GOMAXPROCS=1 go test -short ./...`)
- full `make test` reached an unrelated subscription import timing failure; its exact focused rerun passed

No live App Store Connect mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app creation errors when Apple requires a company name.
  * Added actionable guidance while preventing sensitive response details from appearing in CLI output.
  * Preserved Bundle ID rollback behavior after app creation failures.

* **Tests**
  * Added coverage for company-name validation, malformed responses, unrelated errors, and rollback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->