### PR TITLE
fix(builds): reject filters combined with next cursor

### DIFF
--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -627,6 +627,27 @@ Examples:
 				if strings.TrimSpace(*sort) != "" {
 					return shared.UsageError("builds list: --next cannot be combined with --sort")
 				}
+				if platformValue != "" {
+					return shared.UsageError("builds list: --next cannot be combined with --platform")
+				}
+				if len(processingStateValues) > 0 {
+					return shared.UsageError("builds list: --next cannot be combined with --processing-state")
+				}
+				if versionValue != "" {
+					return shared.UsageError("builds list: --next cannot be combined with --version")
+				}
+				if buildNumberValue != "" {
+					return shared.UsageError("builds list: --next cannot be combined with --build-number")
+				}
+				if *limit != 0 {
+					return shared.UsageError("builds list: --next cannot be combined with --limit")
+				}
+				if *excludeExpired {
+					return shared.UsageError("builds list: --next cannot be combined with --exclude-expired")
+				}
+				if *notExpired {
+					return shared.UsageError("builds list: --next cannot be combined with --not-expired")
+				}
 			}
 
 			betaReviewStateValues, err := normalizeBuildsListBetaReviewStates(*betaReviewState)

--- a/internal/cli/builds/builds_commands.go
+++ b/internal/cli/builds/builds_commands.go
@@ -617,37 +617,14 @@ Examples:
 
 			// A links.next URL already carries the query that produced it, and
 			// GetBuilds follows it verbatim, so these flags would be discarded.
-			if nextValue != "" {
-				if strings.TrimSpace(*betaReviewState) != "" {
-					return shared.UsageError("builds list: --next cannot be combined with --beta-review-state")
-				}
-				if strings.TrimSpace(*include) != "" {
-					return shared.UsageError("builds list: --next cannot be combined with --include")
-				}
-				if strings.TrimSpace(*sort) != "" {
-					return shared.UsageError("builds list: --next cannot be combined with --sort")
-				}
-				if platformValue != "" {
-					return shared.UsageError("builds list: --next cannot be combined with --platform")
-				}
-				if len(processingStateValues) > 0 {
-					return shared.UsageError("builds list: --next cannot be combined with --processing-state")
-				}
-				if versionValue != "" {
-					return shared.UsageError("builds list: --next cannot be combined with --version")
-				}
-				if buildNumberValue != "" {
-					return shared.UsageError("builds list: --next cannot be combined with --build-number")
-				}
-				if *limit != 0 {
-					return shared.UsageError("builds list: --next cannot be combined with --limit")
-				}
-				if *excludeExpired {
-					return shared.UsageError("builds list: --next cannot be combined with --exclude-expired")
-				}
-				if *notExpired {
-					return shared.UsageError("builds list: --next cannot be combined with --not-expired")
-				}
+			if err := shared.RejectNextFlagConflicts(
+				fs,
+				nextValue,
+				"builds list",
+				"beta-review-state", "include", "sort", "platform", "processing-state",
+				"version", "build-number", "limit", "exclude-expired", "not-expired",
+			); err != nil {
+				return err
 			}
 
 			betaReviewStateValues, err := normalizeBuildsListBetaReviewStates(*betaReviewState)

--- a/internal/cli/cmdtest/builds_list_edge_test.go
+++ b/internal/cli/cmdtest/builds_list_edge_test.go
@@ -186,59 +186,32 @@ func TestBuildsListVersionLookupPaginatesAndUsesAllPreReleaseVersions(t *testing
 	}
 }
 
-func TestBuildsListNextURLIgnoresVersionFilters(t *testing.T) {
-	setupAuth(t)
-	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
-	t.Setenv("ASC_APP_ID", "")
+func TestBuildsListNextWithPaginateStillFollowsCursor(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/builds?cursor=AQ&filter%5Bapp%5D=123456789&include=preReleaseVersion"
+	captured := buildsListQuerySurfaceStub(t)
 
-	const nextURL = "https://api.appstoreconnect.apple.com/v1/builds?cursor=AQ"
-
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
-	requestCount := 0
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requestCount++
-		if requestCount != 1 {
-			t.Fatalf("unexpected request count %d", requestCount)
-		}
-		if req.Method != http.MethodGet {
-			t.Fatalf("expected GET, got %s", req.Method)
-		}
-		if req.URL.String() != nextURL {
-			t.Fatalf("expected next URL %q, got %q", nextURL, req.URL.String())
-		}
-		body := `{"data":[{"type":"builds","id":"build-next"}],"links":{"next":""}}`
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
-	})
-
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-
-	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{
-			"builds", "list",
-			"--next", nextURL,
-			"--version", "1.2.3",
-			"--build-number", "77",
-		}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		if err := root.Run(context.Background()); err != nil {
-			t.Fatalf("run error: %v", err)
-		}
-	})
-
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
+	stdout, stderr, err := runBuildsListQuerySurface(
+		t,
+		"builds", "list",
+		"--next", nextURL,
+		"--paginate",
+	)
+	if err != nil {
+		t.Fatalf("run error: %v (stderr=%q)", err, stderr)
 	}
-	if !strings.Contains(stdout, `"id":"build-next"`) {
+	if captured.path != "/v1/builds" {
+		t.Fatalf("expected /v1/builds path, got %q", captured.path)
+	}
+	for param, want := range map[string]string{
+		"cursor":      "AQ",
+		"filter[app]": "123456789",
+		"include":     "preReleaseVersion",
+	} {
+		if got := captured.query.Get(param); got != want {
+			t.Fatalf("expected %s=%q on the followed next URL, got %q", param, want, got)
+		}
+	}
+	if !strings.Contains(stdout, `"id":"build-1"`) {
 		t.Fatalf("expected next-page build in output, got %q", stdout)
 	}
 }

--- a/internal/cli/cmdtest/builds_list_lookup_test.go
+++ b/internal/cli/cmdtest/builds_list_lookup_test.go
@@ -228,8 +228,6 @@ func TestBuildsListNextURLSkipsAppLookupForNonNumericApp(t *testing.T) {
 			"builds", "list",
 			"--next", nextURL,
 			"--app", "com.example.lookup",
-			"--version", "1.2.3",
-			"--build-number", "77",
 		}); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}

--- a/internal/cli/cmdtest/builds_list_query_surface_test.go
+++ b/internal/cli/cmdtest/builds_list_query_surface_test.go
@@ -311,6 +311,7 @@ func TestBuildsListRejectsQueryFlagsCombinedWithNext(t *testing.T) {
 		{name: "version", flag: "--version", args: []string{"--version", "1.2.3"}},
 		{name: "build number", flag: "--build-number", args: []string{"--build-number", "77"}},
 		{name: "limit", flag: "--limit", args: []string{"--limit", "10"}},
+		{name: "limit explicit zero", flag: "--limit", args: []string{"--limit", "0"}},
 		{name: "exclude expired", flag: "--exclude-expired", args: []string{"--exclude-expired"}},
 		{name: "not expired alias", flag: "--not-expired", args: []string{"--not-expired"}},
 	} {

--- a/internal/cli/cmdtest/builds_list_query_surface_test.go
+++ b/internal/cli/cmdtest/builds_list_query_surface_test.go
@@ -283,18 +283,32 @@ func TestBuildsListRejectsQueryFlagsCombinedWithNext(t *testing.T) {
 		{name: "beta review state", flag: "--beta-review-state", args: []string{"--beta-review-state", "APPROVED"}},
 		{name: "include", flag: "--include", args: []string{"--include", "betaGroups"}},
 		{name: "sort", flag: "--sort", args: []string{"--sort", "version"}},
+		{name: "platform", flag: "--platform", args: []string{"--platform", "IOS"}},
+		{name: "processing state", flag: "--processing-state", args: []string{"--processing-state", "VALID"}},
+		{name: "version", flag: "--version", args: []string{"--version", "1.2.3"}},
+		{name: "build number", flag: "--build-number", args: []string{"--build-number", "77"}},
+		{name: "limit", flag: "--limit", args: []string{"--limit", "10"}},
+		{name: "exclude expired", flag: "--exclude-expired", args: []string{"--exclude-expired"}},
+		{name: "not expired alias", flag: "--not-expired", args: []string{"--not-expired"}},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			captured := buildsListQuerySurfaceStub(t)
 
 			args := append([]string{"builds", "list", "--next", nextURL}, testCase.args...)
-			_, stderr, err := runBuildsListQuerySurface(t, args...)
+			stdout, stderr, err := runBuildsListQuerySurface(t, args...)
 
 			if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitUsage {
 				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, err)
 			}
-			if !strings.Contains(stderr, "--next cannot be combined with "+testCase.flag) {
-				t.Fatalf("expected stderr to reject %s with --next, got %q", testCase.flag, stderr)
+			wantError := "builds list: --next cannot be combined with " + testCase.flag
+			if err == nil || !errors.Is(err, flag.ErrHelp) || err.Error() != wantError {
+				t.Fatalf("error = %v, want usage error %q", err, wantError)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if firstLine := strings.SplitN(stderr, "\n", 2)[0]; firstLine != "Error: "+wantError {
+				t.Fatalf("expected concise first stderr line %q, got %q", "Error: "+wantError, firstLine)
 			}
 			captured.assertNoRequest(t)
 		})

--- a/internal/cli/cmdtest/builds_list_query_surface_test.go
+++ b/internal/cli/cmdtest/builds_list_query_surface_test.go
@@ -6,12 +6,16 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 // buildsListQuerySurfaceRequest records what the CLI sent, so tests can assert
@@ -22,8 +26,8 @@ type buildsListQuerySurfaceRequest struct {
 	query url.Values
 }
 
-// buildsListQuerySurfaceStub installs a transport that captures the builds
-// request the CLI issues and replies with a minimal envelope.
+// buildsListQuerySurfaceStub installs a server-backed ASC client that captures
+// the builds request the CLI issues and replies with a minimal envelope.
 func buildsListQuerySurfaceStub(t *testing.T) *buildsListQuerySurfaceRequest {
 	t.Helper()
 
@@ -31,24 +35,43 @@ func buildsListQuerySurfaceStub(t *testing.T) *buildsListQuerySurfaceRequest {
 	t.Setenv("ASC_APP_ID", "")
 	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
 
-	originalTransport := http.DefaultTransport
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
-
 	captured := &buildsListQuerySurfaceRequest{}
-
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		captured.calls++
 		captured.path = req.URL.Path
 		captured.query = req.URL.Query()
 		body := `{"data":[{"type":"builds","id":"build-1","attributes":{"version":"42"}}]}`
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Scheme + "://" + req.URL.Host; got != asc.BaseURL {
+			t.Errorf("request origin = %s, want %s", got, asc.BaseURL)
+		}
+		routed := req.Clone(req.Context())
+		routed.URL.Scheme = serverURL.Scheme
+		routed.URL.Host = serverURL.Host
+		routed.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(routed)
 	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
 
 	return captured
 }


### PR DESCRIPTION
## Summary

- reject build filters that cannot affect an Apple `links.next` URL
- cover platform, processing state, version, build number, limit, and expired-build flags
- preserve compatible `--next --paginate` behavior and the existing app-context shortcut

## Why

`GetBuilds` follows `--next` verbatim. These flags were accepted, then silently discarded, which could make an agent believe the returned page had been filtered when it had not. The command now fails with a concise usage error before HTTP.

## Validation

- focused builds and command tests for every rejected flag and alias
- zero-request assertions
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- serialized commit hook (`GOMAXPROCS=1 go test -short ./...`)
- full `make test` was run and only unrelated timing-sensitive tests failed; their focused reruns passed

No live App Store Connect mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `builds list --next` validation by rejecting filters that cannot be applied when following a pagination URL.
  - Prevented conflicting options such as platform, processing state, version, build number, limit, and expiration filters from being silently ignored.
  - Preserved pagination cursors and supported parameters when combining `--next` with `--paginate`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->