### PR TITLE
fix(subscriptions): reconcile setup price mutations

### DIFF
--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -1871,3 +1871,223 @@ func TestSubscriptionsSetupNormalizesTerritories(t *testing.T) {
 		t.Fatalf("expected 9 setup requests, got %d", requestCount)
 	}
 }
+
+func TestSubscriptionsSetupReconcilesAppliedEOFWithoutReplay(t *testing.T) {
+	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureAppliedEOF)
+}
+
+func TestSubscriptionsSetupReconcilesAppliedEOFAfterDelayedVisibility(t *testing.T) {
+	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureAppliedDelayedEOF)
+}
+
+func TestSubscriptionsSetupReconcilesApplied5xxWithoutReplay(t *testing.T) {
+	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureApplied5xx)
+}
+
+func TestSubscriptionsSetupDoesNotReplayUnappliedAmbiguousPricePatch(t *testing.T) {
+	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureUnappliedEOF)
+}
+
+func TestSubscriptionsSetupPreservesDeterministicPricePatchFailure(t *testing.T) {
+	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureDeterministic)
+}
+
+func TestSubscriptionsSetupReportsVerificationFailureAfterReconciledPricePatch(t *testing.T) {
+	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureVerification)
+}
+
+type subscriptionsSetupPriceFailureMode string
+
+const (
+	subscriptionsSetupPriceFailureAppliedEOF        subscriptionsSetupPriceFailureMode = "applied-eof"
+	subscriptionsSetupPriceFailureAppliedDelayedEOF subscriptionsSetupPriceFailureMode = "applied-delayed-eof"
+	subscriptionsSetupPriceFailureApplied5xx        subscriptionsSetupPriceFailureMode = "applied-5xx"
+	subscriptionsSetupPriceFailureUnappliedEOF      subscriptionsSetupPriceFailureMode = "unapplied-eof"
+	subscriptionsSetupPriceFailureDeterministic     subscriptionsSetupPriceFailureMode = "deterministic"
+	subscriptionsSetupPriceFailureVerification      subscriptionsSetupPriceFailureMode = "verification"
+)
+
+func runSubscriptionsSetupPriceFailureCase(t *testing.T, mode subscriptionsSetupPriceFailureMode) {
+	t.Helper()
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	patchAttempts := 0
+	matrixReads := 0
+	applied := false
+	verify := mode == subscriptionsSetupPriceFailureVerification
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		respond := func(status int, body string) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_, _ = io.WriteString(w, body)
+		}
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1/subscriptions":
+			respond(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-1","attributes":{"name":"Pro Monthly","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"READY_TO_SUBMIT"}}],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/prices" && req.URL.Query().Get("filter[planType]") == "":
+			respond(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionPricePoints/pp-usa/equalizations":
+			respond(http.StatusOK, `{"data":[{"type":"subscriptionPricePoints","id":"pp-can","attributes":{"customerPrice":"4.99"},"relationships":{"territory":{"data":{"type":"territories","id":"CAN"}}}}],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/subscriptionAvailability":
+			respond(http.StatusOK, `{"data":{"type":"subscriptionAvailabilities","id":"availability-1","attributes":{"availableInNewTerritories":false}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionAvailabilities/availability-1/availableTerritories":
+			respond(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/prices" && req.URL.Query().Get("filter[planType]") == "UPFRONT":
+			matrixReads++
+			if applied && (mode != subscriptionsSetupPriceFailureAppliedDelayedEOF || matrixReads != 2) {
+				respond(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-can","attributes":{"startDate":"2026-08-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-can"}},"territory":{"data":{"type":"territories","id":"CAN"}}}},{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2026-08-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`)
+				return
+			}
+			respond(http.StatusOK, `{"data":[],"links":{"next":""}}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/subscriptions/sub-1":
+			patchAttempts++
+			var payload asc.SubscriptionUpdateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode matrix PATCH payload: %v", err)
+			}
+			if len(payload.Included) != 2 {
+				t.Fatalf("expected complete USA/CAN matrix, got %+v", payload.Included)
+			}
+			territories := make(map[string]bool, len(payload.Included))
+			for _, included := range payload.Included {
+				if included.Attributes == nil || included.Attributes.PlanType != asc.SubscriptionPlanTypeUpfront || included.Relationships.Territory == nil {
+					t.Fatalf("expected each matrix row to include UPFRONT plan and territory, got %+v", included)
+				}
+				territories[included.Relationships.Territory.Data.ID] = true
+			}
+			if !territories["USA"] || !territories["CAN"] {
+				t.Fatalf("expected USA and CAN matrix territories, got %v", territories)
+			}
+			if mode == subscriptionsSetupPriceFailureAppliedEOF || mode == subscriptionsSetupPriceFailureAppliedDelayedEOF || mode == subscriptionsSetupPriceFailureApplied5xx || mode == subscriptionsSetupPriceFailureVerification {
+				applied = true
+			}
+			switch mode {
+			case subscriptionsSetupPriceFailureAppliedEOF, subscriptionsSetupPriceFailureAppliedDelayedEOF, subscriptionsSetupPriceFailureUnappliedEOF, subscriptionsSetupPriceFailureVerification:
+				panic(http.ErrAbortHandler)
+			case subscriptionsSetupPriceFailureApplied5xx:
+				respond(http.StatusBadGateway, `{"errors":[{"status":"502","code":"SERVER_ERROR","title":"Bad Gateway","detail":"upstream unavailable"}]}`)
+			case subscriptionsSetupPriceFailureDeterministic:
+				respond(http.StatusUnprocessableEntity, `{"errors":[{"status":"422","code":"INVALID_PRICE","title":"Invalid price","detail":"price matrix rejected"}]}`)
+			default:
+				t.Fatalf("unhandled price failure mode %q", mode)
+			}
+		case verify && req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptionGroups/group-1":
+			respond(http.StatusOK, `{"data":{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"Pro"}}}`)
+		case verify && req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1":
+			respond(http.StatusOK, `{"data":{"type":"subscriptions","id":"sub-1","attributes":{"name":"Unexpected Name","productId":"com.example.pro.monthly","subscriptionPeriod":"ONE_MONTH","state":"READY_TO_SUBMIT"}}}`)
+		default:
+			t.Fatalf("unexpected request in %s case: %s %s?%s", mode, req.Method, req.URL.Path, req.URL.RawQuery)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create setup test client: %v", err)
+	}
+	t.Cleanup(subscriptionscli.SetSetupClientFactory(func() (*asc.Client, error) {
+		return client, nil
+	}))
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	args := []string{
+		"subscriptions", "setup",
+		"--group-id", "group-1",
+		"--reference-name", "Pro Monthly",
+		"--product-id", "com.example.pro.monthly",
+		"--subscription-period", "ONE_MONTH",
+		"--price-point-id", "pp-usa",
+		"--price-territory", "USA",
+		"--start-date", "2026-08-01",
+		"--output", "json",
+	}
+	if !verify {
+		args = append(args, "--no-verify")
+	}
+
+	var runErr error
+	var result subscriptionsSetupOutput
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse setup result: %v\nstdout=%q", err, stdout)
+	}
+
+	switch mode {
+	case subscriptionsSetupPriceFailureAppliedEOF, subscriptionsSetupPriceFailureAppliedDelayedEOF, subscriptionsSetupPriceFailureApplied5xx:
+		if runErr != nil || result.Status != "ok" {
+			t.Fatalf("expected reconciled setup success, err=%v result=%+v", runErr, result)
+		}
+		foundPriceStep := false
+		for _, step := range result.Steps {
+			if step.Name == "set_price" {
+				foundPriceStep = true
+				if step.Status != "completed" || step.Message != "materialized complete price matrix across 2 territories" {
+					t.Fatalf("unexpected reconciled set_price step: %+v", step)
+				}
+			}
+		}
+		if !foundPriceStep {
+			t.Fatalf("expected completed set_price step, got %+v", result.Steps)
+		}
+		if result.Verification.Status != "skipped" {
+			t.Fatalf("expected skipped verification, got %+v", result.Verification)
+		}
+	case subscriptionsSetupPriceFailureUnappliedEOF:
+		if runErr == nil || result.Status != "error" || result.FailedStep != "set_price" {
+			t.Fatalf("expected unreconciled set_price failure, err=%v result=%+v", runErr, result)
+		}
+	case subscriptionsSetupPriceFailureDeterministic:
+		if runErr == nil || result.Status != "error" || result.FailedStep != "set_price" {
+			t.Fatalf("expected deterministic set_price failure, err=%v result=%+v", runErr, result)
+		}
+		if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.HTTPStatusToExitCode(http.StatusUnprocessableEntity) {
+			t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.HTTPStatusToExitCode(http.StatusUnprocessableEntity), runErr)
+		}
+	case subscriptionsSetupPriceFailureVerification:
+		if runErr == nil || result.Status != "error" || result.FailedStep != "verify_state" || result.Verification.Status != "failed" {
+			t.Fatalf("expected final verification failure, err=%v result=%+v", runErr, result)
+		}
+	}
+
+	if patchAttempts != 1 {
+		t.Fatalf("expected exactly one matrix PATCH in %s case, got %d", mode, patchAttempts)
+	}
+	wantMatrixReads := 1
+	switch mode {
+	case subscriptionsSetupPriceFailureAppliedDelayedEOF, subscriptionsSetupPriceFailureUnappliedEOF:
+		wantMatrixReads = 3
+	case subscriptionsSetupPriceFailureAppliedEOF, subscriptionsSetupPriceFailureApplied5xx, subscriptionsSetupPriceFailureVerification:
+		wantMatrixReads = 2
+	}
+	if matrixReads != wantMatrixReads {
+		t.Fatalf("expected %d filtered matrix reads in %s case, got %d", wantMatrixReads, mode, matrixReads)
+	}
+}

--- a/internal/cli/cmdtest/subscriptions_setup_test.go
+++ b/internal/cli/cmdtest/subscriptions_setup_test.go
@@ -1896,15 +1896,20 @@ func TestSubscriptionsSetupReportsVerificationFailureAfterReconciledPricePatch(t
 	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureVerification)
 }
 
+func TestSubscriptionsSetupDoesNotInferForcedRepairFromUnchangedMatrix(t *testing.T) {
+	runSubscriptionsSetupPriceFailureCase(t, subscriptionsSetupPriceFailureForcedRepairUnchanged)
+}
+
 type subscriptionsSetupPriceFailureMode string
 
 const (
-	subscriptionsSetupPriceFailureAppliedEOF        subscriptionsSetupPriceFailureMode = "applied-eof"
-	subscriptionsSetupPriceFailureAppliedDelayedEOF subscriptionsSetupPriceFailureMode = "applied-delayed-eof"
-	subscriptionsSetupPriceFailureApplied5xx        subscriptionsSetupPriceFailureMode = "applied-5xx"
-	subscriptionsSetupPriceFailureUnappliedEOF      subscriptionsSetupPriceFailureMode = "unapplied-eof"
-	subscriptionsSetupPriceFailureDeterministic     subscriptionsSetupPriceFailureMode = "deterministic"
-	subscriptionsSetupPriceFailureVerification      subscriptionsSetupPriceFailureMode = "verification"
+	subscriptionsSetupPriceFailureAppliedEOF            subscriptionsSetupPriceFailureMode = "applied-eof"
+	subscriptionsSetupPriceFailureAppliedDelayedEOF     subscriptionsSetupPriceFailureMode = "applied-delayed-eof"
+	subscriptionsSetupPriceFailureApplied5xx            subscriptionsSetupPriceFailureMode = "applied-5xx"
+	subscriptionsSetupPriceFailureUnappliedEOF          subscriptionsSetupPriceFailureMode = "unapplied-eof"
+	subscriptionsSetupPriceFailureDeterministic         subscriptionsSetupPriceFailureMode = "deterministic"
+	subscriptionsSetupPriceFailureVerification          subscriptionsSetupPriceFailureMode = "verification"
+	subscriptionsSetupPriceFailureForcedRepairUnchanged subscriptionsSetupPriceFailureMode = "forced-repair-unchanged"
 )
 
 func runSubscriptionsSetupPriceFailureCase(t *testing.T, mode subscriptionsSetupPriceFailureMode) {
@@ -1938,6 +1943,10 @@ func runSubscriptionsSetupPriceFailureCase(t *testing.T, mode subscriptionsSetup
 			respond(http.StatusOK, `{"data":[{"type":"territories","id":"USA"}],"links":{"next":""}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/subscriptions/sub-1/prices" && req.URL.Query().Get("filter[planType]") == "UPFRONT":
 			matrixReads++
+			if mode == subscriptionsSetupPriceFailureForcedRepairUnchanged {
+				respond(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-can","attributes":{"startDate":"2026-08-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-can"}},"territory":{"data":{"type":"territories","id":"CAN"}}}},{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2026-08-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`)
+				return
+			}
 			if applied && (mode != subscriptionsSetupPriceFailureAppliedDelayedEOF || matrixReads != 2) {
 				respond(http.StatusOK, `{"data":[{"type":"subscriptionPrices","id":"price-can","attributes":{"startDate":"2026-08-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-can"}},"territory":{"data":{"type":"territories","id":"CAN"}}}},{"type":"subscriptionPrices","id":"price-usa","attributes":{"startDate":"2026-08-01","planType":"UPFRONT"},"relationships":{"subscriptionPricePoint":{"data":{"type":"subscriptionPricePoints","id":"pp-usa"}},"territory":{"data":{"type":"territories","id":"USA"}}}}],"links":{"next":""}}`)
 				return
@@ -1966,7 +1975,7 @@ func runSubscriptionsSetupPriceFailureCase(t *testing.T, mode subscriptionsSetup
 				applied = true
 			}
 			switch mode {
-			case subscriptionsSetupPriceFailureAppliedEOF, subscriptionsSetupPriceFailureAppliedDelayedEOF, subscriptionsSetupPriceFailureUnappliedEOF, subscriptionsSetupPriceFailureVerification:
+			case subscriptionsSetupPriceFailureAppliedEOF, subscriptionsSetupPriceFailureAppliedDelayedEOF, subscriptionsSetupPriceFailureUnappliedEOF, subscriptionsSetupPriceFailureVerification, subscriptionsSetupPriceFailureForcedRepairUnchanged:
 				panic(http.ErrAbortHandler)
 			case subscriptionsSetupPriceFailureApplied5xx:
 				respond(http.StatusBadGateway, `{"errors":[{"status":"502","code":"SERVER_ERROR","title":"Bad Gateway","detail":"upstream unavailable"}]}`)
@@ -2024,6 +2033,9 @@ func runSubscriptionsSetupPriceFailureCase(t *testing.T, mode subscriptionsSetup
 	if !verify {
 		args = append(args, "--no-verify")
 	}
+	if mode == subscriptionsSetupPriceFailureForcedRepairUnchanged {
+		args = append(args, "--repair")
+	}
 
 	var runErr error
 	var result subscriptionsSetupOutput
@@ -2060,7 +2072,7 @@ func runSubscriptionsSetupPriceFailureCase(t *testing.T, mode subscriptionsSetup
 		if result.Verification.Status != "skipped" {
 			t.Fatalf("expected skipped verification, got %+v", result.Verification)
 		}
-	case subscriptionsSetupPriceFailureUnappliedEOF:
+	case subscriptionsSetupPriceFailureUnappliedEOF, subscriptionsSetupPriceFailureForcedRepairUnchanged:
 		if runErr == nil || result.Status != "error" || result.FailedStep != "set_price" {
 			t.Fatalf("expected unreconciled set_price failure, err=%v result=%+v", runErr, result)
 		}
@@ -2082,7 +2094,7 @@ func runSubscriptionsSetupPriceFailureCase(t *testing.T, mode subscriptionsSetup
 	}
 	wantMatrixReads := 1
 	switch mode {
-	case subscriptionsSetupPriceFailureAppliedDelayedEOF, subscriptionsSetupPriceFailureUnappliedEOF:
+	case subscriptionsSetupPriceFailureAppliedDelayedEOF, subscriptionsSetupPriceFailureUnappliedEOF, subscriptionsSetupPriceFailureForcedRepairUnchanged:
 		wantMatrixReads = 3
 	case subscriptionsSetupPriceFailureAppliedEOF, subscriptionsSetupPriceFailureApplied5xx, subscriptionsSetupPriceFailureVerification:
 		wantMatrixReads = 2

--- a/internal/cli/shared/reconciled_mutation.go
+++ b/internal/cli/shared/reconciled_mutation.go
@@ -79,7 +79,7 @@ func runReconciledMutation[T any](
 			if retry >= retryOpts.MaxRetries {
 				return zero, "", mutationErr
 			}
-			if err := sleepForMutationRetry(ctx, mutationRetryDelay(retryOpts, retry, mutationErr)); err != nil {
+			if err := sleepForMutationRetry(ctx, mutationReadbackDelay(retryOpts, retry, mutationErr)); err != nil {
 				return zero, "", err
 			}
 
@@ -156,6 +156,14 @@ func mutationRetryDelay(opts asc.RetryOptions, retry int, err error) time.Durati
 		delay *= time.Duration(1 << retry)
 	}
 	if opts.MaxDelay > 0 && (delay > opts.MaxDelay || delay <= 0) {
+		return opts.MaxDelay
+	}
+	return delay
+}
+
+func mutationReadbackDelay(opts asc.RetryOptions, retry int, err error) time.Duration {
+	delay := mutationRetryDelay(opts, retry, err)
+	if opts.MaxDelay > 0 && delay > opts.MaxDelay {
 		return opts.MaxDelay
 	}
 	return delay

--- a/internal/cli/shared/reconciled_mutation.go
+++ b/internal/cli/shared/reconciled_mutation.go
@@ -28,6 +28,28 @@ func RunReconciledMutation[T any](
 	mutate func(context.Context) (T, error),
 	readback func(context.Context) (T, bool, error),
 ) (T, ReconciledMutationStatus, error) {
+	return runReconciledMutation(ctx, mutate, readback, true)
+}
+
+// RunReconciledMutationNoReplay executes an ambiguous mutation once and uses
+// immediate and one delayed readback to determine whether that attempt
+// applied. It never replays a mutation after a negative readback.
+// Deterministic failures are returned directly so strict API errors keep their
+// existing classification.
+func RunReconciledMutationNoReplay[T any](
+	ctx context.Context,
+	mutate func(context.Context) (T, error),
+	readback func(context.Context) (T, bool, error),
+) (T, ReconciledMutationStatus, error) {
+	return runReconciledMutation(ctx, mutate, readback, false)
+}
+
+func runReconciledMutation[T any](
+	ctx context.Context,
+	mutate func(context.Context) (T, error),
+	readback func(context.Context) (T, bool, error),
+	replay bool,
+) (T, ReconciledMutationStatus, error) {
 	var zero T
 	if err := ctx.Err(); err != nil {
 		return zero, "", err
@@ -42,6 +64,9 @@ func RunReconciledMutation[T any](
 		if err := ctx.Err(); err != nil {
 			return zero, "", err
 		}
+		if !replay && !isAmbiguousMutationError(ctx, mutationErr) {
+			return zero, "", mutationErr
+		}
 
 		value, matches, readErr := runMutationReadback(ctx, readback)
 		if readErr != nil {
@@ -49,6 +74,23 @@ func RunReconciledMutation[T any](
 		}
 		if matches {
 			return value, ReconciledMutationRecovered, nil
+		}
+		if !replay {
+			if retry >= retryOpts.MaxRetries {
+				return zero, "", mutationErr
+			}
+			if err := sleepForMutationRetry(ctx, mutationRetryDelay(retryOpts, retry, mutationErr)); err != nil {
+				return zero, "", err
+			}
+
+			value, matches, readErr = runMutationReadback(ctx, readback)
+			if readErr != nil {
+				return zero, "", fmt.Errorf("mutation and pre-retry readback failed: %w", errors.Join(mutationErr, readErr))
+			}
+			if matches {
+				return value, ReconciledMutationRecovered, nil
+			}
+			return zero, "", mutationErr
 		}
 		if isRateLimitRejection(mutationErr) || !IsTransientMutationError(ctx, mutationErr) || retry >= retryOpts.MaxRetries {
 			return zero, "", mutationErr
@@ -66,6 +108,10 @@ func RunReconciledMutation[T any](
 			return value, ReconciledMutationRecovered, nil
 		}
 	}
+}
+
+func isAmbiguousMutationError(parent context.Context, err error) bool {
+	return !isRateLimitRejection(err) && IsTransientMutationError(parent, err)
 }
 
 func isRateLimitRejection(err error) bool {

--- a/internal/cli/shared/reconciled_mutation_test.go
+++ b/internal/cli/shared/reconciled_mutation_test.go
@@ -37,6 +37,103 @@ func TestRunReconciledMutationReadsAgainBeforeReplay(t *testing.T) {
 	}
 }
 
+func TestRunReconciledMutationNoReplayStopsAfterNegativeReadback(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	mutations := 0
+	readbacks := 0
+	_, _, err := RunReconciledMutationNoReplay(
+		context.Background(),
+		func(context.Context) (string, error) {
+			mutations++
+			return "", &asc.RetryableError{Err: &asc.APIError{StatusCode: http.StatusBadGateway}}
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "", false, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected ambiguous mutation error, got nil")
+	}
+	if mutations != 1 || readbacks != 2 {
+		t.Fatalf("expected one mutation and two readbacks without replay, got mutations=%d readbacks=%d", mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationNoReplayRecoversOnDelayedReadback(t *testing.T) {
+	t.Setenv("ASC_MAX_RETRIES", "1")
+	t.Setenv("ASC_BASE_DELAY", "1ms")
+	t.Setenv("ASC_MAX_DELAY", "1ms")
+
+	mutations := 0
+	readbacks := 0
+	value, status, err := RunReconciledMutationNoReplay(
+		context.Background(),
+		func(context.Context) (string, error) {
+			mutations++
+			return "", &asc.RetryableError{Err: &asc.APIError{StatusCode: http.StatusBadGateway}}
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "subscription-id", readbacks == 2, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("RunReconciledMutationNoReplay() error: %v", err)
+	}
+	if value != "subscription-id" || status != ReconciledMutationRecovered || mutations != 1 || readbacks != 2 {
+		t.Fatalf("unexpected delayed recovery: value=%q status=%q mutations=%d readbacks=%d", value, status, mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationNoReplayPreservesDeterministicFailure(t *testing.T) {
+	mutations := 0
+	readbacks := 0
+	wantErr := &asc.APIError{StatusCode: http.StatusUnprocessableEntity, Code: "INVALID_PRICE"}
+	_, _, err := RunReconciledMutationNoReplay(
+		context.Background(),
+		func(context.Context) (string, error) {
+			mutations++
+			return "", wantErr
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "", false, nil
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected original deterministic error, got %v", err)
+	}
+	if mutations != 1 || readbacks != 0 {
+		t.Fatalf("expected one mutation and no readback for deterministic failure, got mutations=%d readbacks=%d", mutations, readbacks)
+	}
+}
+
+func TestRunReconciledMutationNoReplayDoesNotReadRateLimitRejection(t *testing.T) {
+	mutations := 0
+	readbacks := 0
+	_, _, err := RunReconciledMutationNoReplay(
+		context.Background(),
+		func(context.Context) (string, error) {
+			mutations++
+			return "", &asc.RetryableError{Err: &asc.APIError{Code: "RATE_LIMIT_EXCEEDED", StatusCode: http.StatusTooManyRequests}}
+		},
+		func(context.Context) (string, bool, error) {
+			readbacks++
+			return "", false, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected rate-limit error, got nil")
+	}
+	if mutations != 1 || readbacks != 0 {
+		t.Fatalf("expected one mutation and no readback for rate-limit rejection, got mutations=%d readbacks=%d", mutations, readbacks)
+	}
+}
+
 func TestRunReconciledMutationDoesNotRetryRateLimitRejection(t *testing.T) {
 	t.Setenv("ASC_MAX_RETRIES", "1")
 	t.Setenv("ASC_BASE_DELAY", "1ms")

--- a/internal/cli/shared/reconciled_mutation_test.go
+++ b/internal/cli/shared/reconciled_mutation_test.go
@@ -134,6 +134,18 @@ func TestRunReconciledMutationNoReplayDoesNotReadRateLimitRejection(t *testing.T
 	}
 }
 
+func TestMutationReadbackDelayCapsRetryAfter(t *testing.T) {
+	opts := asc.RetryOptions{BaseDelay: time.Millisecond, MaxDelay: 5 * time.Millisecond}
+	err := &asc.RetryableError{
+		RetryAfter: time.Hour,
+		Err:        &asc.APIError{StatusCode: http.StatusBadGateway},
+	}
+
+	if got := mutationReadbackDelay(opts, 0, err); got != opts.MaxDelay {
+		t.Fatalf("mutationReadbackDelay() = %s, want %s", got, opts.MaxDelay)
+	}
+}
+
 func TestRunReconciledMutationDoesNotRetryRateLimitRejection(t *testing.T) {
 	t.Setenv("ASC_MAX_RETRIES", "1")
 	t.Setenv("ASC_BASE_DELAY", "1ms")

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -1400,29 +1400,46 @@ func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client
 	if err != nil {
 		return nil, false, err
 	}
-	complete := true
-	for _, target := range matrix {
-		resolved := subscriptionPriceImportResolvedRow{
-			territoryID:  target.TerritoryID,
-			pricePointID: target.PricePointID,
-			startDate:    strings.TrimSpace(attrs.StartDate),
-			planType:     attrs.PlanType,
-		}
-		if !subscriptionSetupPriceStateMatches(state, resolved) {
-			complete = false
-			break
-		}
-	}
-	if complete && !repair {
+	if subscriptionSetupPriceMatrixMatches(state, matrix) && !repair {
 		return territories, false, nil
 	}
-	priceCtx, priceCancel := shared.ContextWithTimeout(ctx)
-	_, err = client.SetSubscriptionPriceMatrix(priceCtx, subscriptionID, matrix)
-	priceCancel()
+	// The complete matrix PATCH may apply before a transport/5xx response is
+	// observed, so reconcile its exact state without replaying the write.
+	_, _, err = shared.RunReconciledMutationNoReplay(
+		ctx,
+		func(requestCtx context.Context) (struct{}, error) {
+			_, mutationErr := client.SetSubscriptionPriceMatrix(requestCtx, subscriptionID, matrix)
+			return struct{}{}, mutationErr
+		},
+		func(readbackCtx context.Context) (struct{}, bool, error) {
+			readbackState, readbackErr := fetchSubscriptionPriceImportState(readbackCtx, client, subscriptionID)
+			if readbackErr != nil {
+				return struct{}{}, false, readbackErr
+			}
+			return struct{}{}, subscriptionSetupPriceMatrixMatches(readbackState, matrix), nil
+		},
+	)
 	if err != nil {
 		return nil, false, err
 	}
 	return territories, true, nil
+}
+
+func subscriptionSetupPriceMatrixMatches(index *subscriptionPriceImportStateIndex, matrix []asc.SubscriptionInlinePrice) bool {
+	if index == nil {
+		return false
+	}
+	for _, target := range matrix {
+		if !subscriptionSetupPriceStateMatches(index, subscriptionPriceImportResolvedRow{
+			territoryID:  target.TerritoryID,
+			pricePointID: target.PricePointID,
+			startDate:    strings.TrimSpace(target.Attributes.StartDate),
+			planType:     target.Attributes.PlanType,
+		}) {
+			return false
+		}
+	}
+	return true
 }
 
 // subscriptionSetupPriceStateMatches accepts an omitted start date only when

--- a/internal/cli/subscriptions/setup.go
+++ b/internal/cli/subscriptions/setup.go
@@ -1400,7 +1400,8 @@ func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client
 	if err != nil {
 		return nil, false, err
 	}
-	if subscriptionSetupPriceMatrixMatches(state, matrix) && !repair {
+	preMutationMatched := subscriptionSetupPriceMatrixMatches(state, matrix)
+	if preMutationMatched && !repair {
 		return territories, false, nil
 	}
 	// The complete matrix PATCH may apply before a transport/5xx response is
@@ -1416,7 +1417,8 @@ func ensureSubscriptionsSetupPriceMatrix(ctx context.Context, client *asc.Client
 			if readbackErr != nil {
 				return struct{}{}, false, readbackErr
 			}
-			return struct{}{}, subscriptionSetupPriceMatrixMatches(readbackState, matrix), nil
+			matches := subscriptionSetupPriceMatrixMatches(readbackState, matrix)
+			return struct{}{}, matches && (!repair || !preMutationMatched), nil
 		},
 	)
 	if err != nil {

--- a/internal/cli/subscriptions/setup_test.go
+++ b/internal/cli/subscriptions/setup_test.go
@@ -122,6 +122,22 @@ func TestSubscriptionSetupPriceStateMatchesAllowsOmittedStartDate(t *testing.T) 
 	}
 }
 
+func TestSubscriptionSetupPriceMatrixMatchesUsesCoverageSemantics(t *testing.T) {
+	index := &subscriptionPriceImportStateIndex{states: []subscriptionPriceImportState{
+		{territoryID: "CAN", pricePointID: "pp-can", startDate: "2026-08-01", planType: asc.SubscriptionPlanTypeUpfront},
+		{territoryID: "JPN", pricePointID: "pp-historical", startDate: "2026-07-01", planType: asc.SubscriptionPlanTypeUpfront},
+		{territoryID: "USA", pricePointID: "pp-usa", startDate: "2026-08-01", planType: asc.SubscriptionPlanTypeUpfront},
+	}}
+	matrix := []asc.SubscriptionInlinePrice{
+		{TerritoryID: "CAN", PricePointID: "pp-can", Attributes: asc.SubscriptionPriceCreateAttributes{StartDate: "2026-08-01", PlanType: asc.SubscriptionPlanTypeUpfront}},
+		{TerritoryID: "USA", PricePointID: "pp-usa", Attributes: asc.SubscriptionPriceCreateAttributes{StartDate: "2026-08-01", PlanType: asc.SubscriptionPlanTypeUpfront}},
+	}
+
+	if !subscriptionSetupPriceMatrixMatches(index, matrix) {
+		t.Fatal("expected requested matrix coverage to match while retaining an extra historical row")
+	}
+}
+
 func TestSubscriptionSetupStateIsComplete(t *testing.T) {
 	for _, state := range []string{"READY_TO_SUBMIT", "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "APPROVED"} {
 		if !subscriptionSetupStateIsComplete(state) {


### PR DESCRIPTION
## Summary
- reconcile ambiguous complete price-matrix PATCH failures through immediate and delayed state readback
- never replay the matrix PATCH after an EOF, timeout, or retryable server response
- preserve deterministic API errors and final setup verification behavior

## Why
`subscriptions setup` sends the complete territory price matrix in one PATCH. If App Store Connect applies that PATCH but the response is lost or returns ambiguously, replaying the full mutation risks duplicate or conflicting pricing state. The setup flow now reads back the requested matrix and only continues when every requested row is visible.

## Tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook: docs, format, lint, `go test -short ./...`

Regression coverage includes applied EOF, delayed visibility, applied 5xx, unapplied EOF, deterministic 422, verification failure, and exact one-PATCH assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription setup now recognizes when requested pricing is already complete and avoids unnecessary updates.
  * Added repair handling for incomplete or mismatched pricing data.
  * Failed pricing updates now use immediate and delayed checks to determine whether changes were applied.

* **Bug Fixes**
  * Improved handling of ambiguous, deterministic, and rate-limit failures.
  * Prevented duplicate retries when a repair operation confirms no change occurred.
  * Preserved historical pricing rows while validating requested territories and attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->