### PR TITLE
feat(app-events): expose list query controls

### DIFF
--- a/commands/app-events.mdx
+++ b/commands/app-events.mdx
@@ -28,15 +28,41 @@ asc app-events list --app "APP_ID"
 
 **Optional Flags:**
 
+* `--event-state` - Filter by lifecycle state(s), comma-separated: `DRAFT`,
+  `READY_FOR_REVIEW`, `WAITING_FOR_REVIEW`, `IN_REVIEW`, `REJECTED`,
+  `ACCEPTED`, `APPROVED`, `PUBLISHED`, `PAST`, `ARCHIVED`
+* `--id` - Filter by app event ID(s), comma-separated
+* `--fields` - Sparse fields for app events: `referenceName`, `badge`,
+  `eventState`, `deepLink`, `purchaseRequirement`, `primaryLocale`, `priority`,
+  `purpose`, `territorySchedules`, `archivedTerritorySchedules`, `localizations`
+* `--localization-fields` - Sparse fields for included localizations: `locale`,
+  `name`, `shortDescription`, `longDescription`, `appEvent`,
+  `appEventScreenshots`, `appEventVideoClips`
+* `--include` - Related resources to include: `localizations`
+* `--localizations-limit` - Maximum included localizations (1-50); requires
+  `--include localizations`
 * `--limit` - Results per page (1-200)
 * `--paginate` - Fetch all pages
 * `--next` - Pagination URL
+
+The query controls are experimental and follow the App Store Connect endpoint
+schema. `--localization-fields` also requires `--include localizations`. Do not
+combine query controls with `--next`, because a continuation URL already carries
+the query that produced it; `--app` remains compatible with `--next` for existing
+pagination scripts.
 
 **Example:**
 
 ```bash  theme={null}
 # List all events
 asc app-events list --app "123456789"
+
+# List published events with their localizations
+asc app-events list \
+  --app "123456789" \
+  --event-state PUBLISHED \
+  --include localizations \
+  --localizations-limit 10
 
 # Fetch all pages
 asc app-events list \

--- a/internal/asc/app_events.go
+++ b/internal/asc/app_events.go
@@ -2,6 +2,7 @@ package asc
 
 import (
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -235,6 +236,12 @@ type AppEventVideoClipsOption func(*appEventVideoClipsQuery)
 
 type appEventsQuery struct {
 	listQuery
+	states             []string
+	ids                []string
+	fields             []string
+	localizationFields []string
+	include            []string
+	localizationsLimit int
 }
 
 type appEventLocalizationsQuery struct {
@@ -263,6 +270,50 @@ func WithAppEventsNextURL(next string) AppEventsOption {
 	return func(q *appEventsQuery) {
 		if strings.TrimSpace(next) != "" {
 			q.nextURL = strings.TrimSpace(next)
+		}
+	}
+}
+
+// WithAppEventsStates filters app events by lifecycle state(s).
+func WithAppEventsStates(states []string) AppEventsOption {
+	return func(q *appEventsQuery) {
+		q.states = normalizeUpperList(states)
+	}
+}
+
+// WithAppEventsIDs filters app events by ID(s).
+func WithAppEventsIDs(ids []string) AppEventsOption {
+	return func(q *appEventsQuery) {
+		q.ids = normalizeList(ids)
+	}
+}
+
+// WithAppEventsFields sets fields[appEvents] for app event responses.
+func WithAppEventsFields(fields []string) AppEventsOption {
+	return func(q *appEventsQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
+// WithAppEventsLocalizationFields sets fields[appEventLocalizations] for included localizations.
+func WithAppEventsLocalizationFields(fields []string) AppEventsOption {
+	return func(q *appEventsQuery) {
+		q.localizationFields = normalizeList(fields)
+	}
+}
+
+// WithAppEventsInclude includes related resources in app event responses.
+func WithAppEventsInclude(include []string) AppEventsOption {
+	return func(q *appEventsQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithAppEventsLocalizationsLimit sets the maximum number of included localizations.
+func WithAppEventsLocalizationsLimit(limit int) AppEventsOption {
+	return func(q *appEventsQuery) {
+		if limit > 0 {
+			q.localizationsLimit = limit
 		}
 	}
 }
@@ -323,7 +374,15 @@ func WithAppEventVideoClipsNextURL(next string) AppEventVideoClipsOption {
 
 func buildAppEventsQuery(query *appEventsQuery) string {
 	values := url.Values{}
+	addCSV(values, "filter[eventState]", query.states)
+	addCSV(values, "filter[id]", query.ids)
+	addCSV(values, "fields[appEvents]", query.fields)
+	addCSV(values, "fields[appEventLocalizations]", query.localizationFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
+	if query.localizationsLimit > 0 {
+		values.Set("limit[localizations]", strconv.Itoa(query.localizationsLimit))
+	}
 	return values.Encode()
 }
 

--- a/internal/asc/client_app_events_test.go
+++ b/internal/asc/client_app_events_test.go
@@ -80,6 +80,47 @@ func TestGetAppEvents_WithLimit(t *testing.T) {
 	}
 }
 
+func TestGetAppEvents_WithQueryOptions(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-123/appEvents" {
+			t.Fatalf("expected path /v1/apps/app-123/appEvents, got %s", req.URL.Path)
+		}
+		want := map[string]string{
+			"filter[eventState]":            "APPROVED,ARCHIVED",
+			"filter[id]":                    "event-1,event-2",
+			"fields[appEvents]":             "referenceName,eventState,localizations",
+			"fields[appEventLocalizations]": "locale,name",
+			"include":                       "localizations",
+			"limit[localizations]":          "10",
+			"limit":                         "25",
+		}
+		for key, expected := range want {
+			if got := req.URL.Query().Get(key); got != expected {
+				t.Errorf("query[%q] = %q, want %q", key, got, expected)
+			}
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppEvents(
+		context.Background(),
+		"app-123",
+		WithAppEventsStates([]string{"APPROVED", "ARCHIVED"}),
+		WithAppEventsIDs([]string{"event-1", "event-2"}),
+		WithAppEventsFields([]string{"referenceName", "eventState", "localizations"}),
+		WithAppEventsLocalizationFields([]string{"locale", "name"}),
+		WithAppEventsInclude([]string{"localizations"}),
+		WithAppEventsLocalizationsLimit(10),
+		WithAppEventsLimit(25),
+	); err != nil {
+		t.Fatalf("GetAppEvents() error: %v", err)
+	}
+}
+
 func TestGetAppEvents_UsesNextURL(t *testing.T) {
 	next := "https://api.appstoreconnect.apple.com/v1/apps/app-123/appEvents?cursor=abc"
 	response := jsonResponse(http.StatusOK, `{"data":[]}`)

--- a/internal/cli/app_events/app_events.go
+++ b/internal/cli/app_events/app_events.go
@@ -57,6 +57,12 @@ func AppEventsListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	eventState := fs.String("event-state", "", "[experimental] Filter by lifecycle state(s), comma-separated: "+strings.Join(appEventStateList(), ", "))
+	ids := fs.String("id", "", "[experimental] Filter by app event ID(s), comma-separated")
+	fields := fs.String("fields", "", "[experimental] Fields to include: "+strings.Join(appEventFieldsList(), ", "))
+	localizationFields := fs.String("localization-fields", "", "[experimental] Fields to include for localizations: "+strings.Join(appEventLocalizationFieldsList(), ", "))
+	include := fs.String("include", "", "[experimental] Include related resources: "+strings.Join(appEventIncludeList(), ", "))
+	localizationsLimit := fs.Int("localizations-limit", 0, "[experimental] Maximum included localizations (1-50)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -70,15 +76,57 @@ func AppEventsListCommand() *ffcli.Command {
 
 Examples:
   asc app-events list --app "APP_ID"
+  asc app-events list --app "APP_ID" --event-state PUBLISHED --include localizations --localizations-limit 10
   asc app-events list --app "APP_ID" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			if *limit != 0 && (*limit < 1 || *limit > 200) {
-				return fmt.Errorf("app-events list: --limit must be between 1 and 200")
-			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("app-events list: %w", err)
+			}
+			if err := shared.RejectNextFlagConflicts(
+				fs,
+				*next,
+				"app-events list",
+				"app",
+				"event-state",
+				"id",
+				"fields",
+				"localization-fields",
+				"include",
+				"localizations-limit",
+				"limit",
+			); err != nil {
+				return err
+			}
+			if *limit != 0 && (*limit < 1 || *limit > 200) {
+				return shared.UsageErrorf("app-events list: --limit must be between 1 and 200")
+			}
+			if *localizationsLimit != 0 && (*localizationsLimit < 1 || *localizationsLimit > 50) {
+				return shared.UsageErrorf("app-events list: --localizations-limit must be between 1 and 50")
+			}
+
+			stateValues, err := normalizeAppEventStates(*eventState)
+			if err != nil {
+				return shared.UsageErrorf("app-events list: %v", err)
+			}
+			fieldValues, err := shared.NormalizeSelection(*fields, appEventFieldsList(), "--fields")
+			if err != nil {
+				return shared.UsageErrorf("app-events list: %v", err)
+			}
+			localizationFieldValues, err := shared.NormalizeSelection(*localizationFields, appEventLocalizationFieldsList(), "--localization-fields")
+			if err != nil {
+				return shared.UsageErrorf("app-events list: %v", err)
+			}
+			includeValues, err := shared.NormalizeSelection(*include, appEventIncludeList(), "--include")
+			if err != nil {
+				return shared.UsageErrorf("app-events list: %v", err)
+			}
+			if len(localizationFieldValues) > 0 && !shared.HasInclude(includeValues, "localizations") {
+				return shared.UsageError("app-events list: --localization-fields requires --include localizations")
+			}
+			if *localizationsLimit > 0 && !shared.HasInclude(includeValues, "localizations") {
+				return shared.UsageError("app-events list: --localizations-limit requires --include localizations")
 			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
@@ -96,6 +144,12 @@ Examples:
 			defer cancel()
 
 			opts := []asc.AppEventsOption{
+				asc.WithAppEventsStates(stateValues),
+				asc.WithAppEventsIDs(shared.SplitCSV(*ids)),
+				asc.WithAppEventsFields(fieldValues),
+				asc.WithAppEventsLocalizationFields(localizationFieldValues),
+				asc.WithAppEventsInclude(includeValues),
+				asc.WithAppEventsLocalizationsLimit(*localizationsLimit),
 				asc.WithAppEventsLimit(*limit),
 				asc.WithAppEventsNextURL(*next),
 			}

--- a/internal/cli/app_events/app_events.go
+++ b/internal/cli/app_events/app_events.go
@@ -88,7 +88,6 @@ Examples:
 				fs,
 				*next,
 				"app-events list",
-				"app",
 				"event-state",
 				"id",
 				"fields",
@@ -99,10 +98,16 @@ Examples:
 			); err != nil {
 				return err
 			}
+			localizationsLimitProvided := false
+			fs.Visit(func(f *flag.Flag) {
+				if f.Name == "localizations-limit" {
+					localizationsLimitProvided = true
+				}
+			})
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return shared.UsageErrorf("app-events list: --limit must be between 1 and 200")
 			}
-			if *localizationsLimit != 0 && (*localizationsLimit < 1 || *localizationsLimit > 50) {
+			if localizationsLimitProvided && (*localizationsLimit < 1 || *localizationsLimit > 50) {
 				return shared.UsageErrorf("app-events list: --localizations-limit must be between 1 and 50")
 			}
 

--- a/internal/cli/app_events/app_events.go
+++ b/internal/cli/app_events/app_events.go
@@ -94,7 +94,6 @@ Examples:
 				"localization-fields",
 				"include",
 				"localizations-limit",
-				"limit",
 			); err != nil {
 				return err
 			}

--- a/internal/cli/app_events/app_events.go
+++ b/internal/cli/app_events/app_events.go
@@ -98,12 +98,24 @@ Examples:
 			); err != nil {
 				return err
 			}
-			localizationsLimitProvided := false
-			fs.Visit(func(f *flag.Flag) {
-				if f.Name == "localizations-limit" {
-					localizationsLimitProvided = true
+			for _, selection := range []struct {
+				name  string
+				value string
+			}{
+				{name: "event-state", value: *eventState},
+				{name: "id", value: *ids},
+				{name: "fields", value: *fields},
+				{name: "localization-fields", value: *localizationFields},
+				{name: "include", value: *include},
+			} {
+				if !appEventFlagWasProvided(fs, selection.name) {
+					continue
 				}
-			})
+				if err := validateAppEventCSV(selection.value, "--"+selection.name); err != nil {
+					return shared.UsageErrorf("app-events list: %v", err)
+				}
+			}
+			localizationsLimitProvided := appEventFlagWasProvided(fs, "localizations-limit")
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
 				return shared.UsageErrorf("app-events list: --limit must be between 1 and 200")
 			}

--- a/internal/cli/app_events/query_flags.go
+++ b/internal/cli/app_events/query_flags.go
@@ -1,11 +1,32 @@
 package app_events
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
+
+func appEventFlagWasProvided(fs *flag.FlagSet, name string) bool {
+	provided := false
+	fs.Visit(func(f *flag.Flag) {
+		provided = provided || f.Name == name
+	})
+	return provided
+}
+
+func validateAppEventCSV(value, flagName string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s must not be empty", flagName)
+	}
+	for _, item := range strings.Split(value, ",") {
+		if strings.TrimSpace(item) == "" {
+			return fmt.Errorf("%s must not contain empty values", flagName)
+		}
+	}
+	return nil
+}
 
 func normalizeAppEventStates(value string) ([]string, error) {
 	values := shared.SplitCSVUpper(value)

--- a/internal/cli/app_events/query_flags.go
+++ b/internal/cli/app_events/query_flags.go
@@ -1,0 +1,77 @@
+package app_events
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func normalizeAppEventStates(value string) ([]string, error) {
+	values := shared.SplitCSVUpper(value)
+	if len(values) == 0 {
+		return nil, nil
+	}
+	for _, value := range values {
+		if !containsString(appEventStateList(), value) {
+			return nil, fmt.Errorf("--event-state must be one of: %s", strings.Join(appEventStateList(), ", "))
+		}
+	}
+	return values, nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func appEventStateList() []string {
+	return []string{
+		"DRAFT",
+		"READY_FOR_REVIEW",
+		"WAITING_FOR_REVIEW",
+		"IN_REVIEW",
+		"REJECTED",
+		"ACCEPTED",
+		"APPROVED",
+		"PUBLISHED",
+		"PAST",
+		"ARCHIVED",
+	}
+}
+
+func appEventFieldsList() []string {
+	return []string{
+		"referenceName",
+		"badge",
+		"eventState",
+		"deepLink",
+		"purchaseRequirement",
+		"primaryLocale",
+		"priority",
+		"purpose",
+		"territorySchedules",
+		"archivedTerritorySchedules",
+		"localizations",
+	}
+}
+
+func appEventLocalizationFieldsList() []string {
+	return []string{
+		"locale",
+		"name",
+		"shortDescription",
+		"longDescription",
+		"appEvent",
+		"appEventScreenshots",
+		"appEventVideoClips",
+	}
+}
+
+func appEventIncludeList() []string {
+	return []string{"localizations"}
+}

--- a/internal/cli/cmdtest/app_events_query_surface_test.go
+++ b/internal/cli/cmdtest/app_events_query_surface_test.go
@@ -139,9 +139,39 @@ func TestAppEventsListQuerySurfaceRejectsInvalidValuesBeforeAuth(t *testing.T) {
 			want: "--event-state",
 		},
 		{
+			name: "event state explicitly empty",
+			args: []string{"--event-state", ""},
+			want: "--event-state must not be empty",
+		},
+		{
+			name: "event state contains empty value",
+			args: []string{"--event-state", "APPROVED,"},
+			want: "--event-state must not contain empty values",
+		},
+		{
+			name: "id explicitly empty",
+			args: []string{"--id", ""},
+			want: "--id must not be empty",
+		},
+		{
+			name: "id contains empty value",
+			args: []string{"--id", "event-1,"},
+			want: "--id must not contain empty values",
+		},
+		{
 			name: "event fields",
 			args: []string{"--fields", "notAField"},
 			want: "--fields",
+		},
+		{
+			name: "event fields explicitly empty",
+			args: []string{"--fields", "  "},
+			want: "--fields must not be empty",
+		},
+		{
+			name: "event fields contains empty value",
+			args: []string{"--fields", "referenceName,,eventState"},
+			want: "--fields must not contain empty values",
 		},
 		{
 			name: "localization fields",
@@ -149,9 +179,29 @@ func TestAppEventsListQuerySurfaceRejectsInvalidValuesBeforeAuth(t *testing.T) {
 			want: "--localization-fields",
 		},
 		{
+			name: "localization fields explicitly empty",
+			args: []string{"--localization-fields", ""},
+			want: "--localization-fields must not be empty",
+		},
+		{
+			name: "localization fields contains empty value",
+			args: []string{"--localization-fields", "locale,,name"},
+			want: "--localization-fields must not contain empty values",
+		},
+		{
 			name: "include",
 			args: []string{"--include", "notARelationship"},
 			want: "--include",
+		},
+		{
+			name: "include explicitly empty",
+			args: []string{"--include", ""},
+			want: "--include must not be empty",
+		},
+		{
+			name: "include contains empty value",
+			args: []string{"--include", "localizations,"},
+			want: "--include must not contain empty values",
 		},
 		{
 			name: "localization limit",

--- a/internal/cli/cmdtest/app_events_query_surface_test.go
+++ b/internal/cli/cmdtest/app_events_query_surface_test.go
@@ -1,0 +1,244 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type appEventsListQueryCapture struct {
+	calls int
+	path  string
+	query url.Values
+}
+
+func appEventsListQueryStub(t *testing.T) *appEventsListQueryCapture {
+	t.Helper()
+
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	captured := &appEventsListQueryCapture{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		captured.calls++
+		captured.path = req.URL.Path
+		captured.query = req.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[],"links":{"next":""}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Scheme != "https" || req.URL.Host != "api.appstoreconnect.apple.com" {
+			t.Errorf("request URL = %s, want official App Store Connect host", req.URL.String())
+		}
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
+
+	return captured
+}
+
+func runAppEventsListQuerySurface(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	return stdout, stderr, runErr
+}
+
+func TestAppEventsListQuerySurfaceEmitsSupportedParameters(t *testing.T) {
+	captured := appEventsListQueryStub(t)
+
+	stdout, stderr, err := runAppEventsListQuerySurface(
+		t,
+		"app-events", "list",
+		"--app", "app-123",
+		"--event-state", "approved,archived",
+		"--id", "event-1,event-2",
+		"--fields", "referenceName,eventState,localizations",
+		"--localization-fields", "locale,name",
+		"--include", "localizations",
+		"--localizations-limit", "10",
+		"--limit", "25",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("run error: %v (stderr=%q)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if captured.path != "/v1/apps/app-123/appEvents" {
+		t.Fatalf("path = %q, want /v1/apps/app-123/appEvents", captured.path)
+	}
+	want := url.Values{
+		"filter[eventState]":            {"APPROVED,ARCHIVED"},
+		"filter[id]":                    {"event-1,event-2"},
+		"fields[appEvents]":             {"referenceName,eventState,localizations"},
+		"fields[appEventLocalizations]": {"locale,name"},
+		"include":                       {"localizations"},
+		"limit[localizations]":          {"10"},
+		"limit":                         {"25"},
+	}
+	if got := captured.query.Encode(); got != want.Encode() {
+		t.Fatalf("query = %q, want %q", got, want.Encode())
+	}
+	if !strings.Contains(stdout, `"data":[]`) {
+		t.Fatalf("stdout = %q, want empty data envelope", stdout)
+	}
+}
+
+func TestAppEventsListQuerySurfaceRejectsInvalidValuesBeforeAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "event state",
+			args: []string{"--event-state", "NOT_A_STATE"},
+			want: "--event-state",
+		},
+		{
+			name: "event fields",
+			args: []string{"--fields", "notAField"},
+			want: "--fields",
+		},
+		{
+			name: "localization fields",
+			args: []string{"--localization-fields", "notAField"},
+			want: "--localization-fields",
+		},
+		{
+			name: "include",
+			args: []string{"--include", "notARelationship"},
+			want: "--include",
+		},
+		{
+			name: "localization limit",
+			args: []string{"--localizations-limit", "51"},
+			want: "--localizations-limit",
+		},
+		{
+			name: "localization fields require include",
+			args: []string{"--localization-fields", "locale"},
+			want: "--localization-fields requires --include localizations",
+		},
+		{
+			name: "localization limit requires include",
+			args: []string{"--localizations-limit", "10"},
+			want: "--localizations-limit requires --include localizations",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during validation")
+			}))
+
+			stdout, stderr := captureOutput(t, func() {
+				code := rootcmd.Run(append([]string{"app-events", "list", "--app", "app-123"}, test.args...), "1.2.3")
+				if code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, test.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, test.want)
+			}
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before query validation")
+			}
+		})
+	}
+}
+
+func TestAppEventsListQuerySurfaceRejectsNextConflictsBeforeAuth(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-123/appEvents?cursor=next"
+	tests := []struct {
+		name  string
+		flag  string
+		value string
+	}{
+		{name: "app", flag: "--app", value: "app-123"},
+		{name: "event state", flag: "--event-state", value: "APPROVED"},
+		{name: "id", flag: "--id", value: "event-1"},
+		{name: "fields", flag: "--fields", value: "referenceName"},
+		{name: "localization fields", flag: "--localization-fields", value: "locale"},
+		{name: "include", flag: "--include", value: "localizations"},
+		{name: "localization limit", flag: "--localizations-limit", value: "10"},
+		{name: "limit", flag: "--limit", value: "10"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during validation")
+			}))
+
+			args := []string{"app-events", "list", "--next", nextURL, test.flag, test.value}
+			stdout, stderr := captureOutput(t, func() {
+				code := rootcmd.Run(args, "1.2.3")
+				if code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			want := "app-events list: --next cannot be combined with " + test.flag
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("stderr = %q, want %q", stderr, want)
+			}
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before --next conflict validation")
+			}
+		})
+	}
+}

--- a/internal/cli/cmdtest/app_events_query_surface_test.go
+++ b/internal/cli/cmdtest/app_events_query_surface_test.go
@@ -265,7 +265,6 @@ func TestAppEventsListQuerySurfaceRejectsNextConflictsBeforeAuth(t *testing.T) {
 		{name: "localization fields", flag: "--localization-fields", value: "locale"},
 		{name: "include", flag: "--include", value: "localizations"},
 		{name: "localization limit", flag: "--localizations-limit", value: "10"},
-		{name: "limit", flag: "--limit", value: "10"},
 	}
 
 	for _, test := range tests {
@@ -306,6 +305,7 @@ func TestAppEventsListQuerySurfaceAllowsAppWithNextAndUsesOpaqueURL(t *testing.T
 		"app-events", "list",
 		"--app", "app-123",
 		"--next", nextURL,
+		"--limit", "10",
 		"--output", "json",
 	)
 	if err != nil {

--- a/internal/cli/cmdtest/app_events_query_surface_test.go
+++ b/internal/cli/cmdtest/app_events_query_surface_test.go
@@ -156,7 +156,12 @@ func TestAppEventsListQuerySurfaceRejectsInvalidValuesBeforeAuth(t *testing.T) {
 		{
 			name: "localization limit",
 			args: []string{"--localizations-limit", "51"},
-			want: "--localizations-limit",
+			want: "--localizations-limit must be between 1 and 50",
+		},
+		{
+			name: "explicit zero localization limit",
+			args: []string{"--localizations-limit", "0"},
+			want: "--localizations-limit must be between 1 and 50",
 		},
 		{
 			name: "localization fields require include",
@@ -204,7 +209,6 @@ func TestAppEventsListQuerySurfaceRejectsNextConflictsBeforeAuth(t *testing.T) {
 		flag  string
 		value string
 	}{
-		{name: "app", flag: "--app", value: "app-123"},
 		{name: "event state", flag: "--event-state", value: "APPROVED"},
 		{name: "id", flag: "--id", value: "event-1"},
 		{name: "fields", flag: "--fields", value: "referenceName"},
@@ -240,5 +244,41 @@ func TestAppEventsListQuerySurfaceRejectsNextConflictsBeforeAuth(t *testing.T) {
 				t.Fatal("client factory ran before --next conflict validation")
 			}
 		})
+	}
+}
+
+func TestAppEventsListQuerySurfaceAllowsAppWithNextAndUsesOpaqueURL(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-123/appEvents?cursor=opaque&limit=42&unexpected=kept"
+	captured := appEventsListQueryStub(t)
+
+	stdout, stderr, err := runAppEventsListQuerySurface(
+		t,
+		"app-events", "list",
+		"--app", "app-123",
+		"--next", nextURL,
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("run error: %v (stderr=%q)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if captured.calls != 1 {
+		t.Fatalf("request count = %d, want 1", captured.calls)
+	}
+	if captured.path != "/v1/apps/app-123/appEvents" {
+		t.Fatalf("path = %q, want /v1/apps/app-123/appEvents", captured.path)
+	}
+	want := url.Values{
+		"cursor":     {"opaque"},
+		"limit":      {"42"},
+		"unexpected": {"kept"},
+	}
+	if got := captured.query.Encode(); got != want.Encode() {
+		t.Fatalf("query = %q, want opaque next query %q", got, want.Encode())
+	}
+	if !strings.Contains(stdout, `"data":[]`) {
+		t.Fatalf("stdout = %q, want response from next URL", stdout)
 	}
 }


### PR DESCRIPTION
## Summary
- add experimental lifecycle and ID filters to `app-events list`
- expose sparse fields, localization inclusion, and included-localization limits
- reject cursor/query conflicts before authentication and validate endpoint enums locally

## Tests
- `make build`
- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- pre-commit hook (`go test -short ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental filters for app event states and IDs.
  * Added event and localization field selection, related-resource inclusion, and localization limits.
  * Extended `app-events list` with query options, pagination controls, and usage examples.

* **Bug Fixes**
  * Added validation for unsupported values, localization requirements, invalid limits, and conflicting pagination settings.
  * Improved pagination-link handling when combined with app selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->