### PR TITLE
feat(product-pages): expose custom page query controls

### DIFF
--- a/internal/asc/client_product_pages_test.go
+++ b/internal/asc/client_product_pages_test.go
@@ -85,6 +85,47 @@ func TestAppCustomProductPageListEndpoints_WithLimit(t *testing.T) {
 	}
 }
 
+func TestGetAppCustomProductPages_SendsQuerySurface(t *testing.T) {
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/app-1/appCustomProductPages" {
+			t.Fatalf("expected custom product pages path, got %s", req.URL.Path)
+		}
+		query := req.URL.Query()
+		want := map[string]string{
+			"filter[visible]":                      "false,true",
+			"fields[appCustomProductPages]":        "name,visible,app",
+			"fields[apps]":                         "name,bundleId",
+			"fields[appCustomProductPageVersions]": "version,state",
+			"include":                              "app,appCustomProductPageVersions",
+			"limit[appCustomProductPageVersions]":  "25",
+			"limit":                                "10",
+		}
+		for key, expected := range want {
+			if got := query.Get(key); got != expected {
+				t.Fatalf("query[%q] = %q, want %q (full query %s)", key, got, expected, query.Encode())
+			}
+		}
+	}, jsonResponse(http.StatusOK, `{"data":[{"type":"appCustomProductPages","id":"page-1"}]}`))
+
+	_, err := client.GetAppCustomProductPages(
+		context.Background(),
+		"app-1",
+		WithAppCustomProductPagesVisible([]string{"false", "true"}),
+		WithAppCustomProductPagesFields([]string{"name", "visible", "app"}),
+		WithAppCustomProductPagesAppFields([]string{"name", "bundleId"}),
+		WithAppCustomProductPagesVersionFields([]string{"version", "state"}),
+		WithAppCustomProductPagesInclude([]string{"app", "appCustomProductPageVersions"}),
+		WithAppCustomProductPagesVersionsLimit(25),
+		WithAppCustomProductPagesLimit(10),
+	)
+	if err != nil {
+		t.Fatalf("GetAppCustomProductPages() error: %v", err)
+	}
+}
+
 func TestGetAppCustomProductPage_SendsRequest(t *testing.T) {
 	response := jsonResponse(http.StatusOK, `{"data":{"type":"appCustomProductPages","id":"page-1","attributes":{"name":"Summer"}}}`)
 	client := newTestClient(t, func(req *http.Request) {

--- a/internal/asc/client_product_pages_test.go
+++ b/internal/asc/client_product_pages_test.go
@@ -96,7 +96,7 @@ func TestGetAppCustomProductPages_SendsQuerySurface(t *testing.T) {
 		query := req.URL.Query()
 		want := map[string]string{
 			"filter[visible]":                      "false,true",
-			"fields[appCustomProductPages]":        "name,visible,app",
+			"fields[appCustomProductPages]":        "name,visible,app,appCustomProductPageVersions",
 			"fields[apps]":                         "name,bundleId",
 			"fields[appCustomProductPageVersions]": "version,state",
 			"include":                              "app,appCustomProductPageVersions",

--- a/internal/asc/client_query_versions.go
+++ b/internal/asc/client_query_versions.go
@@ -84,6 +84,12 @@ type territoryAgeRatingsQuery struct {
 
 type appCustomProductPagesQuery struct {
 	listQuery
+	visible       []string
+	fields        []string
+	appFields     []string
+	versionFields []string
+	include       []string
+	versionsLimit int
 }
 
 type appCustomProductPageVersionsQuery struct {
@@ -289,7 +295,15 @@ func buildTerritoryAgeRatingsQuery(query *territoryAgeRatingsQuery) string {
 
 func buildAppCustomProductPagesQuery(query *appCustomProductPagesQuery) string {
 	values := url.Values{}
+	addCSV(values, "filter[visible]", query.visible)
+	addCSV(values, "fields[appCustomProductPages]", query.fields)
+	addCSV(values, "fields[apps]", query.appFields)
+	addCSV(values, "fields[appCustomProductPageVersions]", query.versionFields)
+	addCSV(values, "include", query.include)
 	addLimit(values, query.limit)
+	if query.versionsLimit > 0 {
+		values.Set("limit[appCustomProductPageVersions]", strconv.Itoa(query.versionsLimit))
+	}
 	return values.Encode()
 }
 
@@ -989,6 +1003,50 @@ func WithAppCustomProductPagesLimit(limit int) AppCustomProductPagesOption {
 	return func(q *appCustomProductPagesQuery) {
 		if limit > 0 {
 			q.limit = limit
+		}
+	}
+}
+
+// WithAppCustomProductPagesVisible filters custom product pages by visibility.
+func WithAppCustomProductPagesVisible(values []string) AppCustomProductPagesOption {
+	return func(q *appCustomProductPagesQuery) {
+		q.visible = normalizeList(values)
+	}
+}
+
+// WithAppCustomProductPagesFields sets fields[appCustomProductPages] for responses.
+func WithAppCustomProductPagesFields(fields []string) AppCustomProductPagesOption {
+	return func(q *appCustomProductPagesQuery) {
+		q.fields = normalizeList(fields)
+	}
+}
+
+// WithAppCustomProductPagesAppFields sets fields[apps] for included apps.
+func WithAppCustomProductPagesAppFields(fields []string) AppCustomProductPagesOption {
+	return func(q *appCustomProductPagesQuery) {
+		q.appFields = normalizeList(fields)
+	}
+}
+
+// WithAppCustomProductPagesVersionFields sets fields[appCustomProductPageVersions] for included versions.
+func WithAppCustomProductPagesVersionFields(fields []string) AppCustomProductPagesOption {
+	return func(q *appCustomProductPagesQuery) {
+		q.versionFields = normalizeList(fields)
+	}
+}
+
+// WithAppCustomProductPagesInclude sets relationships to include in responses.
+func WithAppCustomProductPagesInclude(include []string) AppCustomProductPagesOption {
+	return func(q *appCustomProductPagesQuery) {
+		q.include = normalizeList(include)
+	}
+}
+
+// WithAppCustomProductPagesVersionsLimit sets the max number of included versions.
+func WithAppCustomProductPagesVersionsLimit(limit int) AppCustomProductPagesOption {
+	return func(q *appCustomProductPagesQuery) {
+		if limit > 0 {
+			q.versionsLimit = limit
 		}
 	}
 }

--- a/internal/asc/client_query_versions.go
+++ b/internal/asc/client_query_versions.go
@@ -295,11 +295,18 @@ func buildTerritoryAgeRatingsQuery(query *territoryAgeRatingsQuery) string {
 
 func buildAppCustomProductPagesQuery(query *appCustomProductPagesQuery) string {
 	values := url.Values{}
+	include := normalizeUniqueList(query.include)
+	fields := normalizeUniqueList(query.fields)
+	if len(fields) > 0 {
+		// A primary sparse fieldset must retain every included relationship or
+		// ASC can omit the linkage and included resource from the response.
+		fields = normalizeUniqueList(append(fields, include...))
+	}
 	addCSV(values, "filter[visible]", query.visible)
-	addCSV(values, "fields[appCustomProductPages]", query.fields)
+	addCSV(values, "fields[appCustomProductPages]", fields)
 	addCSV(values, "fields[apps]", query.appFields)
 	addCSV(values, "fields[appCustomProductPageVersions]", query.versionFields)
-	addCSV(values, "include", query.include)
+	addCSV(values, "include", include)
 	addLimit(values, query.limit)
 	if query.versionsLimit > 0 {
 		values.Set("limit[appCustomProductPageVersions]", strconv.Itoa(query.versionsLimit))

--- a/internal/cli/cmdtest/product_pages_custom_pages_next_validation_phase50_test.go
+++ b/internal/cli/cmdtest/product_pages_custom_pages_next_validation_phase50_test.go
@@ -153,7 +153,7 @@ func TestCustomPagesListPaginateFromNext(t *testing.T) {
 
 	runProductPagesPaginateFromNext(
 		t,
-		[]string{"product-pages", "custom-pages", "list", "--app", "app-1"},
+		[]string{"product-pages", "custom-pages", "list"},
 		firstURL,
 		secondURL,
 		firstBody,

--- a/internal/cli/cmdtest/product_pages_custom_pages_query_test.go
+++ b/internal/cli/cmdtest/product_pages_custom_pages_query_test.go
@@ -59,7 +59,7 @@ func TestCustomPagesListEmitsQuerySurface(t *testing.T) {
 		}
 		want := url.Values{
 			"filter[visible]":                      {"false,true"},
-			"fields[appCustomProductPages]":        {"name,visible,app"},
+			"fields[appCustomProductPages]":        {"name,visible,app,appCustomProductPageVersions"},
 			"fields[apps]":                         {"name,bundleId"},
 			"fields[appCustomProductPageVersions]": {"version,state"},
 			"include":                              {"app,appCustomProductPageVersions"},
@@ -122,7 +122,6 @@ func TestCustomPagesListRejectsNextQueryFlagsBeforeAuth(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "app", args: []string{"--app", "app-1"}, want: "--next cannot be combined with --app"},
 		{name: "visible", args: []string{"--visible", "true"}, want: "--next cannot be combined with --visible"},
 		{name: "fields", args: []string{"--fields", "name"}, want: "--next cannot be combined with --fields"},
 		{name: "app fields", args: []string{"--app-fields", "name"}, want: "--next cannot be combined with --app-fields"},
@@ -161,6 +160,7 @@ func TestCustomPagesListRejectsInvalidQueryValuesBeforeAuth(t *testing.T) {
 		{name: "app fields", args: []string{"--app-fields", "invalid"}, want: "--app-fields must be one of"},
 		{name: "version fields", args: []string{"--version-fields", "invalid"}, want: "--version-fields must be one of"},
 		{name: "include", args: []string{"--include", "invalid"}, want: "--include must be one of"},
+		{name: "versions limit explicitly zero", args: []string{"--versions-limit", "0"}, want: "--versions-limit must be between 1 and 50"},
 		{name: "versions limit", args: []string{"--versions-limit", "51"}, want: "--versions-limit must be between 1 and 50"},
 	}
 
@@ -177,6 +177,37 @@ func TestCustomPagesListRejectsInvalidQueryValuesBeforeAuth(t *testing.T) {
 			assertUsageExit(t, args, "custom-pages list: "+test.want)
 			if clientFactoryCalled {
 				t.Fatal("client factory ran before query validation")
+			}
+		})
+	}
+}
+
+func TestCustomPagesListRejectsExplicitEmptyQueryFlagsBeforeAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "visible empty", args: []string{"--visible", ""}, want: "--visible must not be empty"},
+		{name: "fields empty", args: []string{"--fields", ""}, want: "--fields must not be empty"},
+		{name: "app fields whitespace", args: []string{"--app-fields", " \t"}, want: "--app-fields must not be empty"},
+		{name: "version fields empty", args: []string{"--version-fields", ""}, want: "--version-fields must not be empty"},
+		{name: "include whitespace", args: []string{"--include", " \t"}, want: "--include must not be empty"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during empty-value validation")
+			})
+			defer restore()
+
+			args := append([]string{"product-pages", "custom-pages", "list", "--app", "app-1"}, test.args...)
+			assertUsageExit(t, args, "custom-pages list: "+test.want)
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before empty-value validation")
 			}
 		})
 	}
@@ -280,5 +311,33 @@ func TestCustomPagesListAllowsNextWithoutApp(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"id":"page-next"`) {
 		t.Fatalf("stdout = %q, want page-next", stdout)
+	}
+}
+
+func TestCustomPagesListAllowsNextWithApp(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appCustomProductPages?cursor=opaque%2Btoken&limit=17"
+	installCustomPagesQueryTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v1/apps/app-1/appCustomProductPages" || req.URL.RawQuery != "cursor=opaque%2Btoken&limit=17" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"appCustomProductPages","id":"page-opaque"}],"links":{"next":""}}`)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"product-pages", "custom-pages", "list", "--app", "app-compat", "--next", nextURL, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"page-opaque"`) {
+		t.Fatalf("stdout = %q, want page-opaque", stdout)
 	}
 }

--- a/internal/cli/cmdtest/product_pages_custom_pages_query_test.go
+++ b/internal/cli/cmdtest/product_pages_custom_pages_query_test.go
@@ -189,10 +189,15 @@ func TestCustomPagesListRejectsExplicitEmptyQueryFlagsBeforeAuth(t *testing.T) {
 		want string
 	}{
 		{name: "visible empty", args: []string{"--visible", ""}, want: "--visible must not be empty"},
+		{name: "visible delimiters", args: []string{"--visible", ","}, want: "--visible must not be empty"},
 		{name: "fields empty", args: []string{"--fields", ""}, want: "--fields must not be empty"},
+		{name: "fields delimiters", args: []string{"--fields", ","}, want: "--fields must not be empty"},
 		{name: "app fields whitespace", args: []string{"--app-fields", " \t"}, want: "--app-fields must not be empty"},
+		{name: "app fields delimiters", args: []string{"--app-fields", ","}, want: "--app-fields must not be empty"},
 		{name: "version fields empty", args: []string{"--version-fields", ""}, want: "--version-fields must not be empty"},
+		{name: "version fields delimiters", args: []string{"--version-fields", ","}, want: "--version-fields must not be empty"},
 		{name: "include whitespace", args: []string{"--include", " \t"}, want: "--include must not be empty"},
+		{name: "include delimiters", args: []string{"--include", ","}, want: "--include must not be empty"},
 	}
 
 	for _, test := range tests {

--- a/internal/cli/cmdtest/product_pages_custom_pages_query_test.go
+++ b/internal/cli/cmdtest/product_pages_custom_pages_query_test.go
@@ -1,0 +1,284 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func installCustomPagesQueryTestClient(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = serverURL.Scheme
+		cloned.URL.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(cloned)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		os.Getenv("ASC_KEY_ID"),
+		os.Getenv("ASC_ISSUER_ID"),
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create custom pages query test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
+}
+
+func TestCustomPagesListEmitsQuerySurface(t *testing.T) {
+	installCustomPagesQueryTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/appCustomProductPages" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		want := url.Values{
+			"filter[visible]":                      {"false,true"},
+			"fields[appCustomProductPages]":        {"name,visible,app"},
+			"fields[apps]":                         {"name,bundleId"},
+			"fields[appCustomProductPageVersions]": {"version,state"},
+			"include":                              {"app,appCustomProductPageVersions"},
+			"limit[appCustomProductPageVersions]":  {"25"},
+			"limit":                                {"10"},
+		}
+		if got := req.URL.Query(); got.Encode() != want.Encode() {
+			t.Errorf("query = %q, want %q", got.Encode(), want.Encode())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"appCustomProductPages","id":"page-1"}],"links":{"next":""}}`)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		args := []string{
+			"product-pages", "custom-pages", "list", "--app", "app-1",
+			"--visible", "false,true",
+			"--fields", "name,visible,app",
+			"--app-fields", "name,bundleId",
+			"--version-fields", "version,state",
+			"--include", "app,appCustomProductPageVersions",
+			"--versions-limit", "25",
+			"--limit", "10",
+			"--output", "json",
+		}
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"page-1"`) {
+		t.Fatalf("stdout = %q, want page-1", stdout)
+	}
+}
+
+func TestCustomPagesListQueryFlagsAreExperimental(t *testing.T) {
+	cmd := findCommandByPath(t, "product-pages", "custom-pages", "list")
+	for _, name := range []string{"visible", "fields", "app-fields", "version-fields", "include", "versions-limit"} {
+		flagValue := cmd.FlagSet.Lookup(name)
+		if flagValue == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+		if !strings.HasPrefix(flagValue.Usage, "[experimental] ") {
+			t.Fatalf("--%s usage = %q, want experimental marker", name, flagValue.Usage)
+		}
+	}
+}
+
+func TestCustomPagesListRejectsNextQueryFlagsBeforeAuth(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appCustomProductPages?cursor=next"
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "app", args: []string{"--app", "app-1"}, want: "--next cannot be combined with --app"},
+		{name: "visible", args: []string{"--visible", "true"}, want: "--next cannot be combined with --visible"},
+		{name: "fields", args: []string{"--fields", "name"}, want: "--next cannot be combined with --fields"},
+		{name: "app fields", args: []string{"--app-fields", "name"}, want: "--next cannot be combined with --app-fields"},
+		{name: "version fields", args: []string{"--version-fields", "version"}, want: "--next cannot be combined with --version-fields"},
+		{name: "include", args: []string{"--include", "app"}, want: "--next cannot be combined with --include"},
+		{name: "versions limit", args: []string{"--versions-limit", "10"}, want: "--next cannot be combined with --versions-limit"},
+		{name: "limit", args: []string{"--limit", "10"}, want: "--next cannot be combined with --limit"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during validation")
+			})
+			defer restore()
+
+			args := append([]string{"product-pages", "custom-pages", "list", "--next", nextURL}, test.args...)
+			assertUsageExit(t, args, "custom-pages list: "+test.want)
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before --next conflict validation")
+			}
+		})
+	}
+}
+
+func TestCustomPagesListRejectsInvalidQueryValuesBeforeAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "visible", args: []string{"--visible", "maybe"}, want: "--visible must be true or false"},
+		{name: "page fields", args: []string{"--fields", "name,invalid"}, want: "--fields must be one of"},
+		{name: "app fields", args: []string{"--app-fields", "invalid"}, want: "--app-fields must be one of"},
+		{name: "version fields", args: []string{"--version-fields", "invalid"}, want: "--version-fields must be one of"},
+		{name: "include", args: []string{"--include", "invalid"}, want: "--include must be one of"},
+		{name: "versions limit", args: []string{"--versions-limit", "51"}, want: "--versions-limit must be between 1 and 50"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during validation")
+			})
+			defer restore()
+
+			args := append([]string{"product-pages", "custom-pages", "list", "--app", "app-1"}, test.args...)
+			assertUsageExit(t, args, "custom-pages list: "+test.want)
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before query validation")
+			}
+		})
+	}
+}
+
+func TestCustomPagesListRelationshipFlagsRequireIncludes(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		parameter string
+		want      string
+	}{
+		{
+			name:      "app fields",
+			args:      []string{"--app-fields", "name"},
+			parameter: "--app-fields",
+			want:      "custom-pages list: --app-fields requires --include app",
+		},
+		{
+			name:      "version fields",
+			args:      []string{"--include", "app", "--version-fields", "version"},
+			parameter: "--version-fields",
+			want:      "custom-pages list: --version-fields requires --include appCustomProductPageVersions",
+		},
+		{
+			name:      "versions limit",
+			args:      []string{"--include", "app", "--versions-limit", "10"},
+			parameter: "--versions-limit",
+			want:      "custom-pages list: --versions-limit requires --include appCustomProductPageVersions",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientFactoryCalled := false
+			restore := shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+				clientFactoryCalled = true
+				return nil, errors.New("client factory must not run during relationship validation")
+			})
+			defer restore()
+
+			args := append([]string{"product-pages", "custom-pages", "list", "--app", "app-1"}, test.args...)
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+			if runErr == nil || !shared.IsReportedUsageError(runErr) || errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("run error = %v, want reported usage error without flag.ErrHelp", runErr)
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitUsage)
+			}
+			diagnostic, ok := shared.DiagnosticFromError(runErr)
+			if !ok {
+				t.Fatal("run error is missing validation diagnostic")
+			}
+			if diagnostic.Code != shared.DiagnosticInvalidInput || diagnostic.Parameter != test.parameter {
+				t.Fatalf("diagnostic = %+v, want code %q parameter %q", diagnostic, shared.DiagnosticInvalidInput, test.parameter)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			wantStderr := "Error: " + test.want + "\n"
+			if stderr != wantStderr {
+				t.Fatalf("stderr = %q, want %q", stderr, wantStderr)
+			}
+			if clientFactoryCalled {
+				t.Fatal("client factory ran before relationship validation")
+			}
+		})
+	}
+}
+
+func TestCustomPagesListAllowsNextWithoutApp(t *testing.T) {
+	const nextURL = "https://api.appstoreconnect.apple.com/v1/apps/app-1/appCustomProductPages?cursor=next"
+	installCustomPagesQueryTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v1/apps/app-1/appCustomProductPages" || req.URL.Query().Get("cursor") != "next" {
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"appCustomProductPages","id":"page-next"}],"links":{"next":""}}`)
+	})
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"product-pages", "custom-pages", "list", "--next", nextURL, "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"id":"page-next"`) {
+		t.Fatalf("stdout = %q, want page-next", stdout)
+	}
+}

--- a/internal/cli/productpages/custom_pages.go
+++ b/internal/cli/productpages/custom_pages.go
@@ -51,6 +51,12 @@ func CustomPagesListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("custom-pages list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	visible := fs.String("visible", "", "[experimental] Filter by visibility (true/false), comma-separated")
+	fields := fs.String("fields", "", "[experimental] Custom product page fields: name,url,visible,app,appCustomProductPageVersions")
+	appFields := fs.String("app-fields", "", "[experimental] Included app fields (comma-separated)")
+	versionFields := fs.String("version-fields", "", "[experimental] Included version fields: version,state,deepLink,appCustomProductPage,appCustomProductPageLocalizations")
+	include := fs.String("include", "", "[experimental] Include related resources: app,appCustomProductPageVersions")
+	versionsLimit := fs.Int("versions-limit", 0, "[experimental] Maximum included versions (1-50)")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -58,26 +64,70 @@ func CustomPagesListCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "list",
-		ShortUsage: "asc product-pages custom-pages list --app \"APP_ID\" [flags]",
+		ShortUsage: "asc product-pages custom-pages list [flags]",
 		ShortHelp:  "List custom product pages.",
 		LongHelp: `List custom product pages.
 
 Examples:
   asc product-pages custom-pages list --app "APP_ID"
+  asc product-pages custom-pages list --app "APP_ID" --visible true
+  asc product-pages custom-pages list --app "APP_ID" --include app,appCustomProductPageVersions --versions-limit 10
   asc product-pages custom-pages list --app "APP_ID" --limit 50
-  asc product-pages custom-pages list --app "APP_ID" --paginate`,
+  asc product-pages custom-pages list --app "APP_ID" --paginate
+  asc product-pages custom-pages list --next "<links.next>"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
-			if *limit != 0 && (*limit < 1 || *limit > productPagesMaxLimit) {
-				return fmt.Errorf("custom-pages list: --limit must be between 1 and %d", productPagesMaxLimit)
-			}
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("custom-pages list: %w", err)
 			}
+			if err := shared.RejectNextFlagConflicts(
+				fs,
+				*next,
+				"custom-pages list",
+				"app", "visible", "fields", "app-fields", "version-fields", "include", "versions-limit", "limit",
+			); err != nil {
+				return err
+			}
+			if *limit != 0 && (*limit < 1 || *limit > productPagesMaxLimit) {
+				return fmt.Errorf("custom-pages list: --limit must be between 1 and %d", productPagesMaxLimit)
+			}
+			if *versionsLimit != 0 && (*versionsLimit < 1 || *versionsLimit > customPagesMaxVersionsLimit) {
+				return shared.UsageError(fmt.Sprintf("custom-pages list: --versions-limit must be between 1 and %d", customPagesMaxVersionsLimit))
+			}
+
+			visibleValues, err := normalizeCustomPagesVisible(*visible)
+			if err != nil {
+				return shared.UsageError("custom-pages list: " + err.Error())
+			}
+			pageFields, err := shared.NormalizeSelection(*fields, customPagesFields, "--fields")
+			if err != nil {
+				return shared.UsageError("custom-pages list: " + err.Error())
+			}
+			appFieldValues, err := shared.NormalizeSelection(*appFields, customPagesAppFields, "--app-fields")
+			if err != nil {
+				return shared.UsageError("custom-pages list: " + err.Error())
+			}
+			versionFieldValues, err := shared.NormalizeSelection(*versionFields, customPagesVersionFields, "--version-fields")
+			if err != nil {
+				return shared.UsageError("custom-pages list: " + err.Error())
+			}
+			includeValues, err := shared.NormalizeSelection(*include, customPagesIncludes, "--include")
+			if err != nil {
+				return shared.UsageError("custom-pages list: " + err.Error())
+			}
+			if len(appFieldValues) > 0 && !shared.HasInclude(includeValues, "app") {
+				return customPagesListIncludeRequirementUsageError("--app-fields", "custom-pages list: --app-fields requires --include app")
+			}
+			if len(versionFieldValues) > 0 && !shared.HasInclude(includeValues, "appCustomProductPageVersions") {
+				return customPagesListIncludeRequirementUsageError("--version-fields", "custom-pages list: --version-fields requires --include appCustomProductPageVersions")
+			}
+			if *versionsLimit > 0 && !shared.HasInclude(includeValues, "appCustomProductPageVersions") {
+				return customPagesListIncludeRequirementUsageError("--versions-limit", "custom-pages list: --versions-limit requires --include appCustomProductPageVersions")
+			}
 
 			resolvedAppID := shared.ResolveAppID(*appID)
-			if resolvedAppID == "" {
+			if resolvedAppID == "" && strings.TrimSpace(*next) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
 				return shared.MissingRequiredUsageError("--app")
 			}
@@ -91,19 +141,38 @@ Examples:
 			defer cancel()
 
 			opts := []asc.AppCustomProductPagesOption{
+				asc.WithAppCustomProductPagesVisible(visibleValues),
 				asc.WithAppCustomProductPagesLimit(*limit),
 				asc.WithAppCustomProductPagesNextURL(*next),
 			}
+			if len(pageFields) > 0 {
+				opts = append(opts, asc.WithAppCustomProductPagesFields(pageFields))
+			}
+			if len(appFieldValues) > 0 {
+				opts = append(opts, asc.WithAppCustomProductPagesAppFields(appFieldValues))
+			}
+			if len(versionFieldValues) > 0 {
+				opts = append(opts, asc.WithAppCustomProductPagesVersionFields(versionFieldValues))
+			}
+			if len(includeValues) > 0 {
+				opts = append(opts, asc.WithAppCustomProductPagesInclude(includeValues))
+			}
+			if *versionsLimit > 0 {
+				opts = append(opts, asc.WithAppCustomProductPagesVersionsLimit(*versionsLimit))
+			}
 
 			if *paginate {
-				paginateOpts := append(opts, asc.WithAppCustomProductPagesLimit(productPagesMaxLimit))
+				paginateOpts := append([]asc.AppCustomProductPagesOption{}, opts...)
+				paginateOpts = append(paginateOpts, asc.WithAppCustomProductPagesLimit(productPagesMaxLimit))
 				firstPage, err := client.GetAppCustomProductPages(requestCtx, resolvedAppID, paginateOpts...)
 				if err != nil {
 					return fmt.Errorf("custom-pages list: failed to fetch: %w", err)
 				}
 
 				paginated, err := asc.PaginateAll(requestCtx, firstPage, func(ctx context.Context, nextURL string) (asc.PaginatedResponse, error) {
-					return client.GetAppCustomProductPages(ctx, resolvedAppID, asc.WithAppCustomProductPagesNextURL(nextURL))
+					continuationOpts := append([]asc.AppCustomProductPagesOption{}, opts...)
+					continuationOpts = append(continuationOpts, asc.WithAppCustomProductPagesNextURL(nextURL))
+					return client.GetAppCustomProductPages(ctx, resolvedAppID, continuationOpts...)
 				})
 				if err != nil {
 					return fmt.Errorf("custom-pages list: %w", err)
@@ -120,6 +189,44 @@ Examples:
 			return shared.PrintOutput(resp, *output.Output, *output.Pretty)
 		},
 	}
+}
+
+func customPagesListIncludeRequirementUsageError(parameter, message string) error {
+	fmt.Fprintln(os.Stderr, "Error: "+message)
+	return shared.WithDiagnostic(
+		shared.NewReportedUsageError(shared.UsageErrorInvalidValue, message),
+		shared.DiagnosticInvalidInput,
+		parameter,
+	)
+}
+
+const customPagesMaxVersionsLimit = 50
+
+var (
+	customPagesFields        = []string{"name", "url", "visible", "app", "appCustomProductPageVersions"}
+	customPagesAppFields     = []string{"accessibilityUrl", "name", "bundleId", "sku", "primaryLocale", "isOrEverWasMadeForKids", "subscriptionStatusUrl", "subscriptionStatusUrlVersion", "subscriptionStatusUrlForSandbox", "subscriptionStatusUrlVersionForSandbox", "contentRightsDeclaration", "streamlinedPurchasingEnabled", "accessibilityDeclarations", "appEncryptionDeclarations", "appStoreIcon", "ciProduct", "betaTesters", "betaGroups", "appStoreVersions", "appTags", "preReleaseVersions", "betaAppLocalizations", "builds", "betaLicenseAgreement", "betaAppReviewDetail", "appInfos", "appClips", "appPricePoints", "endUserLicenseAgreement", "appPriceSchedule", "appAvailabilityV2", "inAppPurchases", "subscriptionGroups", "gameCenterEnabledVersions", "perfPowerMetrics", "appCustomProductPages", "inAppPurchasesV2", "promotedPurchases", "appEvents", "reviewSubmissions", "subscriptionGracePeriod", "customerReviews", "customerReviewSummarizations", "gameCenterDetail", "appStoreVersionExperimentsV2", "alternativeDistributionKey", "analyticsReportRequests", "marketplaceSearchDetail", "buildUploads", "backgroundAssets", "betaFeedbackScreenshotSubmissions", "betaFeedbackCrashSubmissions", "searchKeywords", "webhooks", "androidToIosAppMappingDetails"}
+	customPagesVersionFields = []string{"version", "state", "deepLink", "appCustomProductPage", "appCustomProductPageLocalizations"}
+	customPagesIncludes      = []string{"app", "appCustomProductPageVersions"}
+)
+
+func normalizeCustomPagesVisible(value string) ([]string, error) {
+	values := shared.SplitCSV(value)
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	normalized := make([]string, 0, len(values))
+	for _, item := range values {
+		switch strings.ToLower(strings.TrimSpace(item)) {
+		case "true":
+			normalized = append(normalized, "true")
+		case "false":
+			normalized = append(normalized, "false")
+		default:
+			return nil, fmt.Errorf("--visible must be true or false")
+		}
+	}
+	return normalized, nil
 }
 
 // CustomPagesGetCommand returns the custom pages get subcommand.

--- a/internal/cli/productpages/custom_pages.go
+++ b/internal/cli/productpages/custom_pages.go
@@ -85,14 +85,32 @@ Examples:
 				fs,
 				*next,
 				"custom-pages list",
-				"app", "visible", "fields", "app-fields", "version-fields", "include", "versions-limit", "limit",
+				"visible", "fields", "app-fields", "version-fields", "include", "versions-limit", "limit",
 			); err != nil {
 				return err
+			}
+			providedQueryFlags := make(map[string]bool)
+			fs.Visit(func(f *flag.Flag) {
+				providedQueryFlags[f.Name] = true
+			})
+			for _, queryFlag := range []struct {
+				name  string
+				value string
+			}{
+				{name: "visible", value: *visible},
+				{name: "fields", value: *fields},
+				{name: "app-fields", value: *appFields},
+				{name: "version-fields", value: *versionFields},
+				{name: "include", value: *include},
+			} {
+				if providedQueryFlags[queryFlag.name] && strings.TrimSpace(queryFlag.value) == "" {
+					return shared.UsageError(fmt.Sprintf("custom-pages list: --%s must not be empty", queryFlag.name))
+				}
 			}
 			if *limit != 0 && (*limit < 1 || *limit > productPagesMaxLimit) {
 				return fmt.Errorf("custom-pages list: --limit must be between 1 and %d", productPagesMaxLimit)
 			}
-			if *versionsLimit != 0 && (*versionsLimit < 1 || *versionsLimit > customPagesMaxVersionsLimit) {
+			if providedQueryFlags["versions-limit"] && (*versionsLimit < 1 || *versionsLimit > customPagesMaxVersionsLimit) {
 				return shared.UsageError(fmt.Sprintf("custom-pages list: --versions-limit must be between 1 and %d", customPagesMaxVersionsLimit))
 			}
 

--- a/internal/cli/productpages/custom_pages.go
+++ b/internal/cli/productpages/custom_pages.go
@@ -103,7 +103,7 @@ Examples:
 				{name: "version-fields", value: *versionFields},
 				{name: "include", value: *include},
 			} {
-				if providedQueryFlags[queryFlag.name] && strings.TrimSpace(queryFlag.value) == "" {
+				if providedQueryFlags[queryFlag.name] && len(shared.SplitCSV(queryFlag.value)) == 0 {
 					return shared.UsageError(fmt.Sprintf("custom-pages list: --%s must not be empty", queryFlag.name))
 				}
 			}


### PR DESCRIPTION
## Summary
- add experimental visibility filtering and sparse fields to `product-pages custom-pages list`
- expose app/version includes and included-version limits with concise prerequisite diagnostics
- support opaque continuation URLs without requiring `--app` and reject cursor/query conflicts before authentication

## Tests
- `make build`
- `make format`
- `make generate-command-docs`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- pre-commit hook (`go test -short ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced query options to `custom-pages list`, including visibility filters, field selection, relationship inclusion, and version limits.
  * Query options now work consistently across initial and paginated requests.
  * Added validation for incompatible options, required relationships, supported values, and pagination limits.

* **Bug Fixes**
  * Improved diagnostics and validation ordering for invalid query combinations and pagination usage.

* **Tests**
  * Added comprehensive coverage for query construction, validation, authorization behavior, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->