### PR TITLE
apps wall: add Quit Caffeine: Stop Coffee

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1266,6 +1266,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/57/73/ae/5773ae23-b9f6-362c-893f-c2d85e59e916/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Quit Caffeine: Stop Coffee",
+    "link": "https://apps.apple.com/us/app/quit-caffeine-stop-coffee/id6756549120?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f0/b8/ba/f0b8bad8-af2d-10f9-e8a6-1c2e421736a1/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "QuitNicPouches Pouch Tracker",
     "link": "https://apps.apple.com/us/app/quitnicpouches-pouch-tracker/id6753104415?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/99/f4/3b/99f43be3-8cd4-448c-26db-bbe190492794/AppIcon-0-0-1x_U007ephone-0-1-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Quit Caffeine: Stop Coffee` to the Wall of Apps

## Entry

- App ID: 6756549120
- App: Quit Caffeine: Stop Coffee
- Link: https://apps.apple.com/us/app/quit-caffeine-stop-coffee/id6756549120?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Quit Caffeine: Stop Coffee” app to the app directory, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->