### PR TITLE
apps wall: add Focus & Streak: That One Thing

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -538,6 +538,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a8/1c/5f/a81c5f95-aeea-6b4a-08c2-f1e029af022c/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"
   },
   {
+    "app": "Focus & Streak: That One Thing",
+    "link": "https://apps.apple.com/us/app/focus-streak-that-one-thing/id6746286274?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/eb/f0/cc/ebf0ccfc-7693-db0a-0e4a-2fa5851cbca3/AppIcon_Cream-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Focus Rail: Pomodoro Timer",
     "link": "https://apps.apple.com/us/app/focus-rail-pomodoro-timer/id6758016543?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7d/f9/0e/7df90e3f-3a37-c70c-7bf9-cb3cc9c0f16d/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Focus & Streak: That One Thing` to the Wall of Apps

## Entry

- App ID: 6746286274
- App: Focus & Streak: That One Thing
- Link: https://apps.apple.com/us/app/focus-streak-that-one-thing/id6746286274?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Focus & Streak: That One Thing to the application listing, including its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->