### PR TITLE
apps wall: add Baby Sleep Sounds - Dozy

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -105,6 +105,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/03/45/5a/03455ad1-896f-c341-6d38-13bab0c40e8b/AppIcon-0-1x_U007epad-0-1-P3-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Baby Sleep Sounds - Dozy",
+    "link": "https://apps.apple.com/us/app/baby-sleep-sounds-dozy/id6747475875?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/51/a2/ba/51a2babe-ae87-6425-508c-fb303753debb/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Beauty Fonts - Font Keyboard",
     "link": "https://apps.apple.com/us/app/beauty-fonts-font-keyboard/id1438854446?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ce/85/c5/ce85c50d-e009-34b8-96f1-924e6881a364/AppIcon-0-0-1x_U007epad-0-1-0-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Baby Sleep Sounds - Dozy` to the Wall of Apps

## Entry

- App ID: 6747475875
- App: Baby Sleep Sounds - Dozy
- Link: https://apps.apple.com/us/app/baby-sleep-sounds-dozy/id6747475875?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Baby Sleep Sounds - Dozy to the application directory, including its App Store link and icon.
  * Added Focus & Streak: That One Thing with its App Store link and icon.
  * Added Quit Caffeine: Stop Coffee with its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->