### PR TITLE
apps wall: add MultiPods Audio

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -967,6 +967,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/c5/ec/37/c5ec371e-e920-33ec-1541-74d05fc067c2/app-icon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "MultiPods Audio",
+    "link": "https://apps.apple.com/us/app/multipods-audio/id6766111375?mt=12&uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/85/12/63/8512639f-60c5-e662-6fb4-0f1214d6a3a1/AppIcon-0-0-85-220-0-5-0-2x-P3.png/512x512bb.png"
+  },
+  {
     "app": "murmur: ai interview roleplay",
     "link": "https://apps.apple.com/us/app/murmur-ai-interview-roleplay/id6755495030?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a6/6f/1d/a66f1dd5-40fb-a7e8-f089-53f1790e67d7/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `MultiPods Audio` to the Wall of Apps

## Entry

- App ID: 6766111375
- App: MultiPods Audio
- Link: https://apps.apple.com/us/app/multipods-audio/id6766111375?mt=12&uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MultiPods Audio to the application listing, including its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->