### PR TITLE
apps wall: add QELM

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1246,6 +1246,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/38/1c/5b/381c5b87-8ab7-7351-138b-0cef5c4d5084/AppIcon-1x_U007ephone-0-1-85-220-0.jpeg/512x512bb.jpg"
   },
   {
+    "app": "QELM",
+    "link": "https://apps.apple.com/us/app/qelm/id6762642772?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/17/10/d6/1710d67e-6275-de37-b0b4-6ff940a4a858/AppIcon-0-0-1x_U007ephone-0-1-P3-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "QontactR",
     "link": "https://apps.apple.com/us/app/qontactr/id1169525139?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/dd/e8/78/dde87816-0e87-d38d-9b0a-a0fc93dfd60e/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `QELM` to the Wall of Apps

## Entry

- App ID: 6762642772
- App: QELM
- Link: https://apps.apple.com/us/app/qelm/id6762642772?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QELM to the application directory with its App Store link and icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->