### PR TITLE
docs: the app-scoped builds endpoint hides the latest build

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -100,6 +100,11 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - `--api-debug` and `ASC_DEBUG=api` log each response's raw `X-Rate-Limit` value to stderr without changing stdout.
 - Some endpoints return 403 when the API key role lacks permission (e.g., finance reports, reviews).
 
+## Builds
+
+- `GET /v1/apps/{id}/builds` has no documented default order and rejects `sort` with 400 `PARAMETER_ERROR.ILLEGAL`; with `limit=1` it can return a weeks-stale build that reads as "latest". Use the top-level collection instead: `GET /v1/builds?filter[app]={id}&sort=-uploadedDate&limit=1`.
+- General shape of the trap: a relationship endpoint (`/v1/{parent}/{id}/{children}`) and its top-level collection (`/v1/{children}?filter[{parent}]=`) accept different query parameters, so a `sort` or `filter` that works on one can 400 on the other.
+
 ## Devices
 
 - No DELETE endpoint; devices can only be enabled/disabled via PATCH.


### PR DESCRIPTION
## Summary

Adds a Builds section to `docs/API_NOTES.md` documenting a trap hit while benchmarking raw API calls against `asc`:

- `GET /v1/apps/{id}/builds?limit=1` returned a five-week-stale build (build 9 of 28) with nothing indicating the order is arbitrary, and adding `sort=-uploadedDate` fails with 400 `PARAMETER_ERROR.ILLEGAL` — that endpoint rejects `sort` outright.
- The reliable query is the top-level collection: `GET /v1/builds?filter[app]={id}&sort=-uploadedDate&limit=1`.
- Generalized note: relationship endpoints and their top-level collections accept different query parameters, matching the existing guidance in AGENTS.md ("related top-level and relationship endpoints often differ").

`asc status` and `asc builds` already do the right thing — this is documentation for anyone validating endpoints per the develop-asc-change flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reliably retrieving app builds when relationship endpoint results may be unordered or stale.
  * Documented query parameter differences between relationship and top-level build collection endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->