### PR TITLE
apps wall: add Convusic

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -274,6 +274,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4d/84/49/4d84498d-802a-03b0-262f-bc80aa2c0f1a/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg"
   },
   {
+    "app": "Convusic",
+    "link": "https://apps.apple.com/us/app/convusic/id1591366129?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/40/b9/d8/40b9d80c-b3e5-79e4-1fc6-44f04efc95c4/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Cruisea: Real-time Tracking",
     "link": "https://apps.apple.com/us/app/cruisea-real-time-tracking/id6755068162?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ad/6c/03/ad6c0376-c349-cdee-bfac-c7882f57a4d7/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Convusic` to the Wall of Apps

## Entry

- App ID: 1591366129
- App: Convusic
- Link: https://apps.apple.com/us/app/convusic/id1591366129?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Convusic to the applications list.
  * Included its App Store link and app icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->