### PR TITLE
apps wall: add Otis — A friend to your stocks

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1062,6 +1062,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/01/c5/6b/01c56bf4-5653-758b-8eb0-e4253687f800/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Otis — A friend to your stocks",
+    "link": "https://apps.apple.com/us/app/otis-a-friend-to-your-stocks/id6766045265?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/24/e3/57/24e3572d-cb12-9163-09b1-099d3e997dfd/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "P2P View",
     "link": "https://apps.apple.com/us/app/p2p-view/id1643919225?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/f3/cc/c0/f3ccc01d-a2ab-5a17-13d7-5095b55763cc/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Otis — A friend to your stocks` to the Wall of Apps

## Entry

- App ID: 6766045265
- App: Otis — A friend to your stocks
- Link: https://apps.apple.com/us/app/otis-a-friend-to-your-stocks/id6766045265?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Otis — A friend to your stocks to the app directory, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->