### PR TITLE
apps wall: add Ordsnok - Snoop for words

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1062,6 +1062,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/01/c5/6b/01c56bf4-5653-758b-8eb0-e4253687f800/AppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Ordsnok - Snoop for words",
+    "link": "https://apps.apple.com/us/app/ordsnok-snoop-for-words/id6797599523?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/94/bb/c5/94bbc530-63d7-d7a6-ee19-32109782919c/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Otis — A friend to your stocks",
     "link": "https://apps.apple.com/us/app/otis-a-friend-to-your-stocks/id6766045265?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/24/e3/57/24e3572d-cb12-9163-09b1-099d3e997dfd/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Ordsnok - Snoop for words` to the Wall of Apps

## Entry

- App ID: 6797599523
- App: Ordsnok - Snoop for words
- Link: https://apps.apple.com/us/app/ordsnok-snoop-for-words/id6797599523?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Ordsnok – Snoop for Words app to the applications list.
  * Included its App Store link and app icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->