### PR TITLE
apps wall: add takt - car glance

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1661,6 +1661,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ce/6a/7e/ce6a7e31-0c22-1d6d-20e6-5fb7e5b16171/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "takt - car glance",
+    "link": "https://apps.apple.com/us/app/takt-car-glance/id6799290528?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/8f/6a/ae/8f6aaef7-9f39-5dbe-3573-439b29d12f1a/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Tamloot",
     "link": "https://apps.apple.com/il/app/tamloot/id6758220887",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/26/a3/f7/26a3f7f9-3cb6-dc8e-fcbd-0fc93630dd4c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `takt - car glance` to the Wall of Apps

## Entry

- App ID: 6799290528
- App: takt - car glance
- Link: https://apps.apple.com/us/app/takt-car-glance/id6799290528?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the takt - car glance app to the application directory.
  * Included its App Store link and icon for easy discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->