### PR TITLE
fix(upload): reject zero-length asset operations

### DIFF
--- a/internal/asc/assets_upload.go
+++ b/internal/asc/assets_upload.go
@@ -63,6 +63,9 @@ func UploadAssetFromFile(ctx context.Context, file *os.File, fileSize int64, ope
 		if op.Offset < 0 || op.Length < 0 {
 			return fmt.Errorf("upload operation %d has negative offset/length", i)
 		}
+		if op.Length <= 0 {
+			return fmt.Errorf("upload operation %d has non-positive length", i)
+		}
 		if op.Offset+op.Length > fileSize {
 			return fmt.Errorf("upload operation %d exceeds file size", i)
 		}

--- a/internal/asc/assets_upload.go
+++ b/internal/asc/assets_upload.go
@@ -69,7 +69,9 @@ func UploadAssetFromFile(ctx context.Context, file *os.File, fileSize int64, ope
 		if op.Offset+op.Length > fileSize {
 			return fmt.Errorf("upload operation %d exceeds file size", i)
 		}
+	}
 
+	for i, op := range operations {
 		if err := executeUploadOperation(ctx, file, uploadTask{index: i, op: op}, uploadOpts); err != nil {
 			return err
 		}

--- a/internal/asc/assets_upload_test.go
+++ b/internal/asc/assets_upload_test.go
@@ -221,6 +221,29 @@ func TestUploadAssetFromFileRejectsNonPositiveLengthBeforeUpload(t *testing.T) {
 	}
 }
 
+func TestUploadAssetFromFilePreflightsAllOperationsBeforeUpload(t *testing.T) {
+	file := createTempAssetFile(t, []byte("abcdef"))
+	defer file.Close()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	err := UploadAssetFromFile(context.Background(), file, 6, []UploadOperation{
+		{Method: http.MethodPut, URL: server.URL + "/part1", Length: 3, Offset: 0},
+		{Method: http.MethodPut, URL: server.URL + "/part2", Length: 0, Offset: 3},
+	})
+	if err == nil || !strings.Contains(err.Error(), "upload operation 1 has non-positive length") {
+		t.Fatalf("UploadAssetFromFile() error = %v, want non-positive length for operation 1", err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("expected no upload requests after preflight failure, got %d", got)
+	}
+}
+
 func TestUploadAssetFromFileUsesUploadTimeoutEnv(t *testing.T) {
 	t.Setenv("ASC_TIMEOUT", "10ms")
 	t.Setenv("ASC_TIMEOUT_SECONDS", "")

--- a/internal/asc/assets_upload_test.go
+++ b/internal/asc/assets_upload_test.go
@@ -184,6 +184,43 @@ func TestUploadAssetFromFileUploadsChunks(t *testing.T) {
 	}
 }
 
+func TestUploadAssetFromFileRejectsNonPositiveLengthBeforeUpload(t *testing.T) {
+	file := createTempAssetFile(t, []byte("abc"))
+	defer file.Close()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name   string
+		length int64
+		want   string
+	}{
+		{name: "zero", length: 0, want: "non-positive length"},
+		{name: "negative", length: -1, want: "negative offset/length"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := calls.Load()
+			err := UploadAssetFromFile(context.Background(), file, 3, []UploadOperation{{
+				Method: http.MethodPut,
+				URL:    server.URL + "/part",
+				Length: tt.length,
+			}})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("UploadAssetFromFile() error = %v, want %q", err, tt.want)
+			}
+			if got := calls.Load(); got != before {
+				t.Fatalf("expected no upload requests, got %d new request(s)", got-before)
+			}
+		})
+	}
+}
+
 func TestUploadAssetFromFileUsesUploadTimeoutEnv(t *testing.T) {
 	t.Setenv("ASC_TIMEOUT", "10ms")
 	t.Setenv("ASC_TIMEOUT_SECONDS", "")


### PR DESCRIPTION
## Summary

- reject zero-length server-provided asset upload operations before issuing a request
- preserve the existing validation for negative ranges and oversized chunks
- cover zero and negative operation lengths with no-request regressions

## Why

`UploadAssetFromFile` rejected negative operation lengths but allowed zero-length reservations through to the upload request. The shared upload executor already treats non-positive lengths as invalid, so the legacy asset path now enforces the same contract.

## Validation

- focused `internal/asc` upload tests
- adjacent asset, app event, in-app purchase, and subscription upload tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook (`go test -short ./...`)

No live App Store Connect mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Upload operations with zero or negative lengths are now rejected before processing.
  - Prevents invalid upload requests from being sent when any operation is invalid.

- **Tests**
  - Added coverage for invalid upload lengths and complete preflight validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->