### PR TITLE
fix(json): preserve sparse resource attribute presence

### DIFF
--- a/internal/asc/types/resources.go
+++ b/internal/asc/types/resources.go
@@ -204,6 +204,71 @@ type Resource[T any] struct {
 	Attributes    T               `json:"attributes"`
 	Relationships json.RawMessage `json:"relationships,omitempty"`
 	Links         json.RawMessage `json:"links,omitempty"`
+
+	attributesDecoded bool
+	attributesPresent bool
+	attributesNull    bool
+}
+
+// UnmarshalJSON records whether attributes was absent, null, or present so
+// sparse JSON:API responses can be rendered without inventing an attributes
+// object that Apple did not return.
+func (r *Resource[T]) UnmarshalJSON(data []byte) error {
+	var decoded struct {
+		Type          ResourceType    `json:"type"`
+		ID            string          `json:"id"`
+		Attributes    json.RawMessage `json:"attributes"`
+		Relationships json.RawMessage `json:"relationships,omitempty"`
+		Links         json.RawMessage `json:"links,omitempty"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	*r = Resource[T]{
+		Type:              decoded.Type,
+		ID:                decoded.ID,
+		Relationships:     decoded.Relationships,
+		Links:             decoded.Links,
+		attributesDecoded: true,
+		attributesPresent: decoded.Attributes != nil,
+		attributesNull:    bytes.Equal(bytes.TrimSpace(decoded.Attributes), []byte("null")),
+	}
+	if !r.attributesPresent || r.attributesNull {
+		return nil
+	}
+	return json.Unmarshal(decoded.Attributes, &r.Attributes)
+}
+
+// MarshalJSON preserves decoded attribute presence while keeping the existing
+// behavior for resources constructed directly by callers.
+func (r Resource[T]) MarshalJSON() ([]byte, error) {
+	var attributes json.RawMessage
+	if !r.attributesDecoded || r.attributesPresent {
+		if r.attributesNull {
+			attributes = json.RawMessage("null")
+		} else {
+			encoded, err := json.Marshal(r.Attributes)
+			if err != nil {
+				return nil, err
+			}
+			attributes = encoded
+		}
+	}
+
+	return json.Marshal(struct {
+		Type          ResourceType    `json:"type"`
+		ID            string          `json:"id"`
+		Attributes    json.RawMessage `json:"attributes,omitempty"`
+		Relationships json.RawMessage `json:"relationships,omitempty"`
+		Links         json.RawMessage `json:"links,omitempty"`
+	}{
+		Type:          r.Type,
+		ID:            r.ID,
+		Attributes:    attributes,
+		Relationships: r.Relationships,
+		Links:         r.Links,
+	})
 }
 
 // Response is a generic ASC API response wrapper.

--- a/internal/asc/types/resources_test.go
+++ b/internal/asc/types/resources_test.go
@@ -55,6 +55,84 @@ func TestResponseGetMeta(t *testing.T) {
 	}
 }
 
+func TestResourcePreservesDecodedAttributesPresence(t *testing.T) {
+	type attributes struct {
+		Name string `json:"name,omitempty"`
+	}
+
+	tests := []struct {
+		name       string
+		input      string
+		want       string
+		attributes bool
+	}{
+		{
+			name:       "absent",
+			input:      `{"type":"apps","id":"app-1"}`,
+			want:       `{"type":"apps","id":"app-1"}`,
+			attributes: false,
+		},
+		{
+			name:       "null",
+			input:      `{"type":"apps","id":"app-1","attributes":null}`,
+			want:       `{"type":"apps","id":"app-1","attributes":null}`,
+			attributes: true,
+		},
+		{
+			name:       "empty object",
+			input:      `{"type":"apps","id":"app-1","attributes":{}}`,
+			want:       `{"type":"apps","id":"app-1","attributes":{}}`,
+			attributes: true,
+		},
+		{
+			name:       "sparse object",
+			input:      `{"type":"apps","id":"app-1","attributes":{"name":"Example"}}`,
+			want:       `{"type":"apps","id":"app-1","attributes":{"name":"Example"}}`,
+			attributes: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var resource Resource[attributes]
+			if err := json.Unmarshal([]byte(tc.input), &resource); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got, err := json.Marshal(resource)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("output = %s, want %s", got, tc.want)
+			}
+
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(got, &fields); err != nil {
+				t.Fatalf("decode output: %v", err)
+			}
+			_, present := fields["attributes"]
+			if present != tc.attributes {
+				t.Fatalf("attributes present = %t, want %t", present, tc.attributes)
+			}
+		})
+	}
+}
+
+func TestResourceConstructedByCallerKeepsAttributes(t *testing.T) {
+	resource := Resource[struct{}]{
+		Type:       ResourceTypeApps,
+		ID:         "app-1",
+		Attributes: struct{}{},
+	}
+	got, err := json.Marshal(resource)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(got) != `{"type":"apps","id":"app-1","attributes":{}}` {
+		t.Fatalf("output = %s", got)
+	}
+}
+
 func TestLinkagesResponseAccessors(t *testing.T) {
 	r := &LinkagesResponse{
 		Data: []ResourceData{


### PR DESCRIPTION
## Summary

- preserve the difference between omitted, null, and empty `attributes` in decoded JSON:API resources
- keep the existing output for resources constructed directly by callers
- cover absent, null, empty-object, and sparse-object round trips

## Why

Sparse fieldsets can return relationship-only resources without an `attributes` member. The generic resource wrapper previously re-encoded those responses with an `attributes` object Apple never sent, which broke the CLI contract for unmodified collection output.

## Validation

- `go test ./internal/asc/types ./internal/asc`
- repository pre-commit checks: command docs, format, lint, and short test suite
- `git diff --check`

No live App Store Connect calls or mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the distinction between absent, `null`, empty, and populated resource attributes when reading and writing JSON.
  * Maintained empty attributes for resources created directly by callers.

* **Tests**
  * Added coverage for JSON round-tripping across all supported attribute states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->