### PR TITLE
fix(cli): sanitize usage diagnostics for terminal output

### DIFF
--- a/cmd/terminal_diagnostic_test.go
+++ b/cmd/terminal_diagnostic_test.go
@@ -38,6 +38,25 @@ func TestRun_UnknownFlagSanitizesUnicodeTerminalControlsAndInvalidUTF8(t *testin
 	assertSafeTerminalDiagnostic(t, stderr, "Error: unknown flag `--evil31m \ufffdtail` for `asc builds list`\n")
 }
 
+func TestRun_UsageErrorSanitizesCommandArguments(t *testing.T) {
+	resetReportFlags(t)
+
+	hostile := "bad\x1b[31m\r\ncommand"
+	stdout, stderr := captureCommandOutput(t, func() {
+		if code := Run([]string{"analytics", "compare", hostile}, "1.0.0"); code != ExitUsage {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitUsage)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	assertSafeTerminalDiagnostic(t, stderr, "Error: unexpected argument(s): bad[31m  command\n")
+	if strings.ContainsAny(stderr, "\x1b\r") {
+		t.Fatalf("stderr contains raw terminal control bytes: %q", stderr)
+	}
+}
+
 func assertSafeTerminalDiagnostic(t *testing.T, stderr, wantLine string) {
 	t.Helper()
 

--- a/internal/cli/shared/errors.go
+++ b/internal/cli/shared/errors.go
@@ -213,7 +213,7 @@ func IsValidationError(err error) bool {
 // UsageError prints a CLI validation error and returns flag.ErrHelp so callers
 // map the failure to usage exit code semantics.
 func UsageError(message string) error {
-	trimmed := strings.TrimSpace(message)
+	trimmed := strings.TrimSpace(SanitizeTerminal(message))
 	if trimmed != "" {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", trimmed)
 	}

--- a/internal/cli/shared/errors_test.go
+++ b/internal/cli/shared/errors_test.go
@@ -27,6 +27,24 @@ func TestUsageErrorPreservesValidationMessage(t *testing.T) {
 	}
 }
 
+func TestUsageErrorSanitizesTerminalControls(t *testing.T) {
+	var usageErr error
+	_, stderr := captureOutput(t, func() {
+		usageErr = UsageError("bad\x1b[31m\r\ncommand")
+	})
+
+	const wantMessage = "bad[31m  command"
+	if got := usageErr.Error(); got != wantMessage {
+		t.Fatalf("UsageError().Error() = %q, want %q", got, wantMessage)
+	}
+	if !errors.Is(usageErr, flag.ErrHelp) {
+		t.Fatalf("UsageError() should unwrap to flag.ErrHelp, got %v", usageErr)
+	}
+	if got, want := stderr, "Error: "+wantMessage+"\n"; got != want {
+		t.Fatalf("UsageError() stderr = %q, want %q", got, want)
+	}
+}
+
 func TestNewReportedUsageErrorPreservesUsageClassificationWithoutHelp(t *testing.T) {
 	err := NewReportedUsageError(UsageErrorInvalidValue, "invalid value for --territory")
 


### PR DESCRIPTION
## Summary

- sanitize command-level usage diagnostics before writing them to the terminal
- remove escape and carriage-return controls while preserving readable argument context
- cover the shared UsageError boundary and a full `analytics compare` invocation

## Why

Parser diagnostics already sanitize hostile terminal input, but command-level validation could still echo raw control bytes from positional arguments. That allowed an invalid operand to alter terminal rendering even though the command correctly returned a usage error.

## Validation

- focused shared error tests
- black-box terminal diagnostic regression
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook (`go test -short ./...`)

No live App Store Connect requests were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage-error messages by removing terminal control sequences and normalizing carriage returns and newlines.
  * Prevented malformed or hidden terminal output when command arguments contain escape characters.
  * Preserved expected exit codes, output behavior, and help-error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->