### PR TITLE
fix(analytics): paginate reports from continuation URLs

### DIFF
--- a/commands/analytics.mdx
+++ b/commands/analytics.mdx
@@ -155,8 +155,8 @@ asc analytics view --request-id "REQUEST_ID"
 * `--granularity` - Filter instances by `DAILY`, `WEEKLY`, or `MONTHLY` (comma-separated)
 * `--include-segments` - Include download URLs for report segments
 * `--limit` - Results per page (1-200)
-* `--paginate` - Fetch all reports (recommended with `--processing-date`)
-* `--next` - Pagination URL
+* `--paginate` - Fetch all reports (recommended with `--processing-date` or `--next`)
+* `--next` - Report-page `links.next` URL; combine with `--paginate` to resume and fetch every remaining page
 
 **Examples:**
 
@@ -179,6 +179,11 @@ asc analytics view \
 asc analytics view \
   --request-id "REQUEST_ID" \
   --instance-id "INSTANCE_ID"
+
+# Resume from a saved report-page link and fetch the remaining pages
+asc analytics view \
+  --next "<links.next>" \
+  --paginate
 ```
 
 ### Download Report Data

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -17,7 +17,7 @@ Quirks and tips for specific App Store Connect API endpoints.
 - Although Apple's current Sales Reports documentation describes `YYYY-MM-DD` for non-daily dates, the live endpoint requires `YYYY-MM` for monthly reports and `YYYY` for yearly reports. The CLI accepts either form and reduces full monthly or yearly dates to those live period identifiers before the request.
 - Vendor number comes from Sales and Trends → Reports URL (`vendorNumber=...`)
 - Sales Reports validates the complete report type/subtype/frequency/version tuple against Apple's endpoint table. Although the current table lists `SUBSCRIPTION` `1_3`, live verification in PR #1842 proved `1_4` succeeds and is required by some accounts, so both are accepted and `1_4` remains the default.
-- Use `--paginate` with `asc analytics view --processing-date` to search every report page; the CLI forwards the value as `filter[processingDate]` when fetching instances
+- Use `--paginate` with `asc analytics view --processing-date` to search every report page; the CLI forwards the value as `filter[processingDate]` when fetching instances. To resume from a saved report-page `links.next` URL, pass it with `--next <links.next> --paginate`.
 - Use `--granularity "DAILY,WEEKLY,MONTHLY"` with `asc analytics view` to filter instances by one or more documented granularities
 - Long analytics runs may require raising `ASC_TIMEOUT`
 

--- a/internal/cli/analytics/analytics_helpers.go
+++ b/internal/cli/analytics/analytics_helpers.go
@@ -304,18 +304,11 @@ func fetchAnalyticsReports(ctx context.Context, client *asc.Client, requestID st
 		seen  = make(map[string]bool)
 	)
 
-	if strings.TrimSpace(next) != "" {
-		resp, err := getAnalyticsReportsPage(ctx, client, requestID, asc.WithAnalyticsReportsNextURL(next))
-		if err != nil {
-			return nil, asc.Links{}, err
-		}
-		return resp.Data, resp.Links, nil
-	}
-
 	if limit <= 0 {
 		limit = analyticsMaxLimit
 	}
-	nextURL := ""
+	nextURL := strings.TrimSpace(next)
+	firstPage := true
 	for {
 		var resp *asc.AnalyticsReportsResponse
 		var err error
@@ -331,11 +324,14 @@ func fetchAnalyticsReports(ctx context.Context, client *asc.Client, requestID st
 		if err != nil {
 			return nil, asc.Links{}, err
 		}
-		if links.Self == "" {
+		if firstPage && nextURL != "" {
+			links = resp.Links
+		} else if links.Self == "" {
 			links.Self = resp.Links.Self
 		}
 		all = append(all, resp.Data...)
 		links.Next = resp.Links.Next
+		firstPage = false
 		if !paginate || resp.Links.Next == "" {
 			break
 		}

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -362,7 +362,7 @@ func AnalyticsViewCommand() *ffcli.Command {
 	includeSegments := fs.Bool("include-segments", false, "Include report segments with download URLs")
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
-	paginate := fs.Bool("paginate", false, "Paginate all reports (recommended with --processing-date)")
+	paginate := fs.Bool("paginate", false, "Paginate all reports (recommended with --processing-date or --next)")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -373,13 +373,17 @@ func AnalyticsViewCommand() *ffcli.Command {
 
 The --processing-date and --granularity filters are sent to App Store Connect
 when fetching report instances. Granularity accepts DAILY, WEEKLY, and MONTHLY.
+Use --next with a report-page links.next URL to resume from that page. Combine
+--next with --paginate to fetch every remaining report page; without
+--paginate, only the supplied page is fetched.
 
 Examples:
   asc analytics view --request-id "REQUEST_ID"
   asc analytics view --request-id "REQUEST_ID" --include-segments
   asc analytics view --request-id "REQUEST_ID" --instance-id "INSTANCE_ID"
   asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-20" --paginate
-  asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-20" --granularity "DAILY,WEEKLY" --paginate`,
+  asc analytics view --request-id "REQUEST_ID" --processing-date "2024-01-20" --granularity "DAILY,WEEKLY" --paginate
+  asc analytics view --next "<links.next>" --paginate`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/analytics/analytics_requests.go
+++ b/internal/cli/analytics/analytics_requests.go
@@ -435,7 +435,7 @@ Examples:
 				return fmt.Errorf("analytics view: %w", err)
 			}
 
-			paginateReports := strings.TrimSpace(*next) == "" && (strings.TrimSpace(*instanceID) != "" || *paginate)
+			paginateReports := *paginate || (strings.TrimSpace(*next) == "" && strings.TrimSpace(*instanceID) != "")
 			reports, links, err := fetchAnalyticsReports(ctx, client, strings.TrimSpace(*requestID), *limit, *next, paginateReports)
 			if err != nil {
 				return fmt.Errorf("analytics view: failed to fetch reports: %w", err)

--- a/internal/cli/cmdtest/analytics_next_validation_test.go
+++ b/internal/cli/cmdtest/analytics_next_validation_test.go
@@ -332,3 +332,88 @@ func TestAnalyticsViewPaginateFromNextWithoutRequestID(t *testing.T) {
 		t.Fatalf("expected report and instance IDs in output, got %q", stdout)
 	}
 }
+
+func TestAnalyticsViewPaginateFromNextFollowsReportPages(t *testing.T) {
+	setupAuth(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	const (
+		firstReportsURL    = "https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports?cursor=AQ&limit=200"
+		secondReportsURL   = "https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports?cursor=BQ&limit=200"
+		firstInstancesURL  = "https://api.appstoreconnect.apple.com/v1/analyticsReports/analytics-report-next-1/instances?limit=200"
+		secondInstancesURL = "https://api.appstoreconnect.apple.com/v1/analyticsReports/analytics-report-next-2/instances?limit=200"
+	)
+
+	requestCount := 0
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		var body string
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.String() != firstReportsURL {
+				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
+			}
+			body = `{"data":[{"type":"analyticsReports","id":"analytics-report-next-1","attributes":{"name":"Retention","category":"APP_USAGE","granularity":"DAILY"}}],"links":{"first":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports","prev":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports?cursor=9w","next":"` + secondReportsURL + `"}}`
+		case 2:
+			if req.Method != http.MethodGet || req.URL.String() != secondReportsURL {
+				t.Fatalf("unexpected second request: %s %s", req.Method, req.URL.String())
+			}
+			body = `{"data":[{"type":"analyticsReports","id":"analytics-report-next-2","attributes":{"name":"Acquisition","category":"APP_STORE","granularity":"DAILY"}}],"links":{"next":""}}`
+		case 3:
+			if req.Method != http.MethodGet || req.URL.String() != firstInstancesURL {
+				t.Fatalf("unexpected third request: %s %s", req.Method, req.URL.String())
+			}
+			body = `{"data":[{"type":"analyticsReportInstances","id":"analytics-instance-next-1","attributes":{"reportDate":"2024-01-01","processingDate":"2024-01-02T00:00:00Z","granularity":"DAILY","version":"1"}}],"links":{"next":""}}`
+		case 4:
+			if req.Method != http.MethodGet || req.URL.String() != secondInstancesURL {
+				t.Fatalf("unexpected fourth request: %s %s", req.Method, req.URL.String())
+			}
+			body = `{"data":[{"type":"analyticsReportInstances","id":"analytics-instance-next-2","attributes":{"reportDate":"2024-01-03","processingDate":"2024-01-04T00:00:00Z","granularity":"DAILY","version":"1"}}],"links":{"next":""}}`
+		default:
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	setAnalyticsTimeoutTestClient(t, transport)
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"analytics", "view", "--paginate", "--next", firstReportsURL}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := root.Run(context.Background()); err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if requestCount != 4 {
+		t.Fatalf("request count = %d, want 4", requestCount)
+	}
+	for _, link := range []string{
+		`"first":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports"`,
+		`"prev":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports?cursor=9w"`,
+	} {
+		if !strings.Contains(stdout, link) {
+			t.Fatalf("expected output to contain %q, got %q", link, stdout)
+		}
+	}
+	for _, id := range []string{
+		"analytics-report-next-1",
+		"analytics-report-next-2",
+		"analytics-instance-next-1",
+		"analytics-instance-next-2",
+	} {
+		if !strings.Contains(stdout, `"id":"`+id+`"`) {
+			t.Fatalf("expected output to contain %q, got %q", id, stdout)
+		}
+	}
+}

--- a/internal/cli/cmdtest/analytics_next_validation_test.go
+++ b/internal/cli/cmdtest/analytics_next_validation_test.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 func runAnalyticsInvalidNextURLCases(
@@ -344,41 +350,75 @@ func TestAnalyticsViewPaginateFromNextFollowsReportPages(t *testing.T) {
 		secondInstancesURL = "https://api.appstoreconnect.apple.com/v1/analyticsReports/analytics-report-next-2/instances?limit=200"
 	)
 
+	pages := []struct {
+		url  string
+		body string
+	}{
+		{
+			url:  firstReportsURL,
+			body: `{"data":[{"type":"analyticsReports","id":"analytics-report-next-1","attributes":{"name":"Retention","category":"APP_USAGE","granularity":"DAILY"}}],"links":{"first":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports","prev":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports?cursor=9w","next":"` + secondReportsURL + `"}}`,
+		},
+		{
+			url:  secondReportsURL,
+			body: `{"data":[{"type":"analyticsReports","id":"analytics-report-next-2","attributes":{"name":"Acquisition","category":"APP_STORE","granularity":"DAILY"}}],"links":{"next":""}}`,
+		},
+		{
+			url:  firstInstancesURL,
+			body: `{"data":[{"type":"analyticsReportInstances","id":"analytics-instance-next-1","attributes":{"reportDate":"2024-01-01","processingDate":"2024-01-02T00:00:00Z","granularity":"DAILY","version":"1"}}],"links":{"next":""}}`,
+		},
+		{
+			url:  secondInstancesURL,
+			body: `{"data":[{"type":"analyticsReportInstances","id":"analytics-instance-next-2","attributes":{"reportDate":"2024-01-03","processingDate":"2024-01-04T00:00:00Z","granularity":"DAILY","version":"1"}}],"links":{"next":""}}`,
+		},
+	}
+
 	requestCount := 0
-	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requestCount++
-		var body string
-		switch requestCount {
-		case 1:
-			if req.Method != http.MethodGet || req.URL.String() != firstReportsURL {
-				t.Fatalf("unexpected first request: %s %s", req.Method, req.URL.String())
-			}
-			body = `{"data":[{"type":"analyticsReports","id":"analytics-report-next-1","attributes":{"name":"Retention","category":"APP_USAGE","granularity":"DAILY"}}],"links":{"first":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports","prev":"https://api.appstoreconnect.apple.com/v1/analyticsReportRequests/request-1/reports?cursor=9w","next":"` + secondReportsURL + `"}}`
-		case 2:
-			if req.Method != http.MethodGet || req.URL.String() != secondReportsURL {
-				t.Fatalf("unexpected second request: %s %s", req.Method, req.URL.String())
-			}
-			body = `{"data":[{"type":"analyticsReports","id":"analytics-report-next-2","attributes":{"name":"Acquisition","category":"APP_STORE","granularity":"DAILY"}}],"links":{"next":""}}`
-		case 3:
-			if req.Method != http.MethodGet || req.URL.String() != firstInstancesURL {
-				t.Fatalf("unexpected third request: %s %s", req.Method, req.URL.String())
-			}
-			body = `{"data":[{"type":"analyticsReportInstances","id":"analytics-instance-next-1","attributes":{"reportDate":"2024-01-01","processingDate":"2024-01-02T00:00:00Z","granularity":"DAILY","version":"1"}}],"links":{"next":""}}`
-		case 4:
-			if req.Method != http.MethodGet || req.URL.String() != secondInstancesURL {
-				t.Fatalf("unexpected fourth request: %s %s", req.Method, req.URL.String())
-			}
-			body = `{"data":[{"type":"analyticsReportInstances","id":"analytics-instance-next-2","attributes":{"reportDate":"2024-01-03","processingDate":"2024-01-04T00:00:00Z","granularity":"DAILY","version":"1"}}],"links":{"next":""}}`
-		default:
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if requestCount < 1 || requestCount > len(pages) {
 			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
 		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-		}, nil
+		expectedURL, err := url.Parse(pages[requestCount-1].url)
+		if err != nil {
+			t.Fatalf("parse expected URL: %v", err)
+		}
+		if req.Method != http.MethodGet || req.URL.RequestURI() != expectedURL.RequestURI() {
+			t.Fatalf("unexpected server request: %s %s", req.Method, req.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, pages[requestCount-1].body)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount > len(pages) {
+			t.Fatalf("unexpected extra request: %s %s", req.Method, req.URL.String())
+		}
+		if req.Method != http.MethodGet || req.URL.String() != pages[requestCount-1].url {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		routed := req.Clone(req.Context())
+		routed.URL.Scheme = serverURL.Scheme
+		routed.URL.Host = serverURL.Host
+		routed.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(routed)
 	})
-	setAnalyticsTimeoutTestClient(t, transport)
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create analytics pagination test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
 
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)


### PR DESCRIPTION
## Summary

- continue paginating analytics reports when `--next` supplies the first report page
- keep the supplied continuation URL authoritative for the initial request
- preserve first-page navigation links while aggregating reports and instances

## Why

`analytics view --next URL --paginate` fetched only the supplied page because the presence of `--next` disabled report pagination. A valid next link in that response was ignored, so the command returned an incomplete report set despite the explicit pagination request.

## Validation

- two-page command regression covering reports and report instances
- focused and adjacent analytics tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook (`go test -short ./...`)

No live App Store Connect mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed analytics pagination when using `--paginate` with `--next`.
  - Analytics views now retrieve all subsequent report pages and associated instances.
  - Preserved pagination links and result ordering across fetched pages.

- **Documentation**
  - Clarified how to resume pagination using a saved `links.next` URL.
  - Added guidance and examples for combining `--next` with `--paginate`, or fetching a single page.

- **Tests**
  - Added coverage validating multi-page analytics reports, instance retrieval, pagination links, and request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->