### PR TITLE
fix(signing): guard pagination cycles during fetch

### DIFF
--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -214,6 +214,8 @@ func findCertificates(ctx context.Context, client *asc.Client, profileType, cert
 		links asc.Links
 		next  string
 	)
+	page := 1
+	seenNext := make(map[string]struct{})
 	for {
 		resp, err := client.GetCertificates(
 			ctx,
@@ -228,6 +230,11 @@ func findCertificates(ctx context.Context, client *asc.Client, profileType, cert
 		if strings.TrimSpace(resp.Links.Next) == "" {
 			break
 		}
+		if _, ok := seenNext[resp.Links.Next]; ok {
+			return nil, fmt.Errorf("page %d: %w", page+1, asc.ErrRepeatedPaginationURL)
+		}
+		seenNext[resp.Links.Next] = struct{}{}
+		page++
 		next = resp.Links.Next
 	}
 	if len(all) == 0 {
@@ -453,6 +460,8 @@ func resolveSigningCertificateTypes(profileType, raw string) (string, error) {
 func findActiveProfiles(ctx context.Context, client *asc.Client, bundleIDResourceID, profileType string) ([]asc.Resource[asc.ProfileAttributes], error) {
 	var matches []asc.Resource[asc.ProfileAttributes]
 	next := ""
+	page := 1
+	seenNext := make(map[string]struct{})
 	for {
 		profiles, err := client.GetBundleIDProfiles(
 			ctx,
@@ -475,6 +484,11 @@ func findActiveProfiles(ctx context.Context, client *asc.Client, bundleIDResourc
 		if strings.TrimSpace(profiles.Links.Next) == "" {
 			return matches, nil
 		}
+		if _, ok := seenNext[profiles.Links.Next]; ok {
+			return nil, fmt.Errorf("page %d: %w", page+1, asc.ErrRepeatedPaginationURL)
+		}
+		seenNext[profiles.Links.Next] = struct{}{}
+		page++
 		next = profiles.Links.Next
 	}
 }
@@ -485,6 +499,8 @@ func findProfileCertificates(ctx context.Context, client *asc.Client, profileID,
 		links asc.Links
 		next  string
 	)
+	page := 1
+	seenNext := make(map[string]struct{})
 	for {
 		response, err := client.GetProfileCertificates(
 			ctx,
@@ -499,6 +515,11 @@ func findProfileCertificates(ctx context.Context, client *asc.Client, profileID,
 		if strings.TrimSpace(response.Links.Next) == "" {
 			break
 		}
+		if _, ok := seenNext[response.Links.Next]; ok {
+			return nil, fmt.Errorf("page %d: %w", page+1, asc.ErrRepeatedPaginationURL)
+		}
+		seenNext[response.Links.Next] = struct{}{}
+		page++
 		next = response.Links.Next
 	}
 

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -384,6 +384,163 @@ func TestFindActiveProfilesUseBundleIDRelationship(t *testing.T) {
 	}
 }
 
+func TestSigningFetchPaginationRejectsRepeatedNextURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		response   string
+		fetch      func(context.Context, *asc.Client) error
+		wantSecond string
+	}{
+		{
+			name:     "certificates",
+			path:     "/v1/certificates",
+			response: `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/certificates?cursor=repeat"}}`,
+			fetch: func(ctx context.Context, client *asc.Client) error {
+				_, err := findCertificates(ctx, client, "IOS_APP_STORE", "IOS_DISTRIBUTION")
+				return err
+			},
+			wantSecond: "https://api.appstoreconnect.apple.com/v1/certificates?cursor=repeat",
+		},
+		{
+			name:     "bundle ID profiles",
+			path:     "/v1/bundleIds/bundle-main/profiles",
+			response: `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/bundleIds/bundle-main/profiles?cursor=repeat"}}`,
+			fetch: func(ctx context.Context, client *asc.Client) error {
+				_, err := findActiveProfiles(ctx, client, "bundle-main", "IOS_APP_STORE")
+				return err
+			},
+			wantSecond: "https://api.appstoreconnect.apple.com/v1/bundleIds/bundle-main/profiles?cursor=repeat",
+		},
+		{
+			name:     "profile certificates",
+			path:     "/v1/profiles/profile-main/certificates",
+			response: `{"data":[],"links":{"next":"https://api.appstoreconnect.apple.com/v1/profiles/profile-main/certificates?cursor=repeat"}}`,
+			fetch: func(ctx context.Context, client *asc.Client) error {
+				_, err := findProfileCertificates(ctx, client, "profile-main", "")
+				return err
+			},
+			wantSecond: "https://api.appstoreconnect.apple.com/v1/profiles/profile-main/certificates?cursor=repeat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			requestURLs := []string{}
+			client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+				calls++
+				requestURLs = append(requestURLs, req.URL.String())
+				if req.URL.Path != tt.path {
+					t.Fatalf("request path = %q, want %q", req.URL.Path, tt.path)
+				}
+				if calls <= 2 {
+					return signingFetchJSONResponse(http.StatusOK, tt.response)
+				}
+				return signingFetchJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","detail":"test stop"}]}`)
+			})
+
+			err := tt.fetch(context.Background(), client)
+			if !errors.Is(err, asc.ErrRepeatedPaginationURL) {
+				t.Fatalf("fetch error = %v, want ErrRepeatedPaginationURL", err)
+			}
+			if calls != 2 {
+				t.Fatalf("request count = %d, want 2", calls)
+			}
+			if len(requestURLs) != 2 || requestURLs[1] != tt.wantSecond {
+				t.Fatalf("request URLs = %v, want continuation %q", requestURLs, tt.wantSecond)
+			}
+		})
+	}
+}
+
+func TestSigningFetchPaginationFollowsDistinctNextURLs(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		first      string
+		second     string
+		fetch      func(context.Context, *asc.Client) (int, error)
+		wantSecond string
+	}{
+		{
+			name:   "certificates",
+			path:   "/v1/certificates",
+			first:  `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/certificates?cursor=page-2"}}`,
+			second: `{"data":[{"type":"certificates","id":"cert-2","attributes":{"certificateType":"IOS_DISTRIBUTION"}}],"links":{}}`,
+			fetch: func(ctx context.Context, client *asc.Client) (int, error) {
+				response, err := findCertificates(ctx, client, "IOS_APP_STORE", "IOS_DISTRIBUTION")
+				if err != nil {
+					return 0, err
+				}
+				return len(response.Data), nil
+			},
+			wantSecond: "https://api.appstoreconnect.apple.com/v1/certificates?cursor=page-2",
+		},
+		{
+			name:   "bundle ID profiles",
+			path:   "/v1/bundleIds/bundle-main/profiles",
+			first:  `{"data":[{"type":"profiles","id":"profile-1","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/bundleIds/bundle-main/profiles?cursor=page-2"}}`,
+			second: `{"data":[{"type":"profiles","id":"profile-2","attributes":{"profileType":"IOS_APP_STORE","profileState":"ACTIVE"}}],"links":{}}`,
+			fetch: func(ctx context.Context, client *asc.Client) (int, error) {
+				response, err := findActiveProfiles(ctx, client, "bundle-main", "IOS_APP_STORE")
+				return len(response), err
+			},
+			wantSecond: "https://api.appstoreconnect.apple.com/v1/bundleIds/bundle-main/profiles?cursor=page-2",
+		},
+		{
+			name:   "profile certificates",
+			path:   "/v1/profiles/profile-main/certificates",
+			first:  `{"data":[{"type":"certificates","id":"cert-1","attributes":{"certificateType":"IOS_DISTRIBUTION"}}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/profiles/profile-main/certificates?cursor=page-2"}}`,
+			second: `{"data":[{"type":"certificates","id":"cert-2","attributes":{"certificateType":"IOS_DISTRIBUTION"}}],"links":{}}`,
+			fetch: func(ctx context.Context, client *asc.Client) (int, error) {
+				response, err := findProfileCertificates(ctx, client, "profile-main", "")
+				if err != nil {
+					return 0, err
+				}
+				return len(response.Data), nil
+			},
+			wantSecond: "https://api.appstoreconnect.apple.com/v1/profiles/profile-main/certificates?cursor=page-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			requestURLs := []string{}
+			client := newSigningFetchTestClient(t, func(req *http.Request) *http.Response {
+				calls++
+				requestURLs = append(requestURLs, req.URL.String())
+				if req.URL.Path != tt.path {
+					t.Fatalf("request path = %q, want %q", req.URL.Path, tt.path)
+				}
+				switch calls {
+				case 1:
+					return signingFetchJSONResponse(http.StatusOK, tt.first)
+				case 2:
+					return signingFetchJSONResponse(http.StatusOK, tt.second)
+				default:
+					return signingFetchJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","detail":"unexpected third request"}]}`)
+				}
+			})
+
+			count, err := tt.fetch(context.Background(), client)
+			if err != nil {
+				t.Fatalf("fetch error = %v", err)
+			}
+			if count != 2 {
+				t.Fatalf("result count = %d, want 2", count)
+			}
+			if calls != 2 {
+				t.Fatalf("request count = %d, want 2", calls)
+			}
+			if len(requestURLs) != 2 || requestURLs[1] != tt.wantSecond {
+				t.Fatalf("request URLs = %v, want continuation %q", requestURLs, tt.wantSecond)
+			}
+		})
+	}
+}
+
 func TestResolveSigningAssetsUsesOnlyExistingProfileCertificates(t *testing.T) {
 	profileContent := base64.StdEncoding.EncodeToString([]byte("profile"))
 	profileCertificateContent := base64.StdEncoding.EncodeToString([]byte("profile-certificate"))


### PR DESCRIPTION
## Summary

- detect repeated continuation URLs in certificate and profile discovery loops
- return the shared repeated-pagination sentinel instead of requesting forever
- cover each signing helper with cycle and normal multi-page regressions

## Why

Three signing-fetch helpers paginate with local loops. If App Store Connect repeats a `links.next` URL, those loops would continue issuing the same request indefinitely. They now enforce the same cycle detection contract as the shared paginator.

## Validation

- repeated-cursor and distinct-page tests for all three helpers
- full signing and ASC client suites
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook (`go test -short ./...`)

No live App Store Connect mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paginated certificate and profile retrieval by detecting repeated continuation links.
  * Prevents requests from looping indefinitely when an API returns the same pagination link.
  * Returns a clear error identifying the affected page when repeated pagination is detected.

* **Tests**
  * Added coverage for both repeated-link failures and successful multi-page retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->