### PR TITLE
feat(iap): add v2 list query filters

### DIFF
--- a/internal/asc/iap.go
+++ b/internal/asc/iap.go
@@ -127,6 +127,9 @@ type inAppPurchasesQuery struct {
 	listQuery
 	productIDs          []string
 	names               []string
+	states              []string
+	types               []string
+	sort                []string
 	fields              []string
 	include             []string
 	versionFields       []string
@@ -175,6 +178,27 @@ func WithIAPProductIDs(productIDs []string) IAPOption {
 func WithIAPNames(names []string) IAPOption {
 	return func(q *inAppPurchasesQuery) {
 		q.names = normalizeUniqueList(names)
+	}
+}
+
+// WithIAPStates filters in-app purchases by state.
+func WithIAPStates(states []string) IAPOption {
+	return func(q *inAppPurchasesQuery) {
+		q.states = normalizeUniqueList(states)
+	}
+}
+
+// WithIAPTypes filters in-app purchases by type.
+func WithIAPTypes(types []string) IAPOption {
+	return func(q *inAppPurchasesQuery) {
+		q.types = normalizeUniqueList(types)
+	}
+}
+
+// WithIAPSort sets the in-app purchase sort expressions.
+func WithIAPSort(sort []string) IAPOption {
+	return func(q *inAppPurchasesQuery) {
+		q.sort = normalizeUniqueList(sort)
 	}
 }
 
@@ -259,6 +283,9 @@ func buildInAppPurchasesQuery(query *inAppPurchasesQuery) string {
 	addLimit(values, query.limit)
 	addCSV(values, "filter[productId]", query.productIDs)
 	addCSV(values, "filter[name]", query.names)
+	addCSV(values, "filter[state]", query.states)
+	addCSV(values, "filter[inAppPurchaseType]", query.types)
+	addCSV(values, "sort", query.sort)
 	addCSV(values, "fields[inAppPurchases]", query.fields)
 	addCSV(values, "include", query.include)
 	addCSV(values, "fields[inAppPurchaseVersions]", query.versionFields)

--- a/internal/asc/iap_list_query_test.go
+++ b/internal/asc/iap_list_query_test.go
@@ -1,0 +1,40 @@
+package asc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetInAppPurchasesV2_WithStateTypeAndSortFilters(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Pro","productId":"com.example.pro","inAppPurchaseType":"CONSUMABLE","state":"READY_TO_SUBMIT"}}]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", req.Method)
+		}
+		if req.URL.Path != "/v1/apps/123/inAppPurchasesV2" {
+			t.Fatalf("expected path /v1/apps/123/inAppPurchasesV2, got %s", req.URL.Path)
+		}
+		values := req.URL.Query()
+		if values.Get("filter[state]") != "READY_TO_SUBMIT,APPROVED" {
+			t.Fatalf("expected filter[state]=READY_TO_SUBMIT,APPROVED, got %q", values.Get("filter[state]"))
+		}
+		if values.Get("filter[inAppPurchaseType]") != "CONSUMABLE,NON_CONSUMABLE" {
+			t.Fatalf("expected filter[inAppPurchaseType]=CONSUMABLE,NON_CONSUMABLE, got %q", values.Get("filter[inAppPurchaseType]"))
+		}
+		if values.Get("sort") != "name,-inAppPurchaseType" {
+			t.Fatalf("expected sort=name,-inAppPurchaseType, got %q", values.Get("sort"))
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetInAppPurchasesV2(
+		context.Background(),
+		"123",
+		WithIAPStates([]string{"READY_TO_SUBMIT", "APPROVED"}),
+		WithIAPTypes([]string{"CONSUMABLE", "NON_CONSUMABLE"}),
+		WithIAPSort([]string{"name", "-inAppPurchaseType"}),
+	); err != nil {
+		t.Fatalf("GetInAppPurchasesV2() error: %v", err)
+	}
+}

--- a/internal/cli/cmdtest/iap_list_query_surface_test.go
+++ b/internal/cli/cmdtest/iap_list_query_surface_test.go
@@ -204,6 +204,23 @@ func TestIAPListQuerySurfaceRejectsInvalidSelectorsBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestIAPListQuerySurfaceRejectsExplicitlyEmptySelectors(t *testing.T) {
+	for _, name := range []string{"product-id", "name", "state", "type", "sort"} {
+		t.Run(name, func(t *testing.T) {
+			captured := iapListQuerySurfaceStub(t)
+			_, stderr, err := runIAPListQuerySurface(t, "iap", "list", "--app", "app-1", "--"+name, "")
+			if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, err)
+			}
+			want := "--" + name + " must not be empty"
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("expected stderr to contain %q, got %q", want, stderr)
+			}
+			captured.assertNoRequest(t)
+		})
+	}
+}
+
 func TestIAPListQuerySurfaceRejectsNextWithSelectors(t *testing.T) {
 	next := "https://api.appstoreconnect.apple.com/v1/apps/app-1/inAppPurchasesV2?cursor=next"
 	flags := []string{"product-id", "name", "state", "type", "sort"}

--- a/internal/cli/cmdtest/iap_list_query_surface_test.go
+++ b/internal/cli/cmdtest/iap_list_query_surface_test.go
@@ -1,0 +1,220 @@
+package cmdtest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type iapListQuerySurfaceRequest struct {
+	calls int
+	path  string
+	query url.Values
+}
+
+func iapListQuerySurfaceStub(t *testing.T) *iapListQuerySurfaceRequest {
+	t.Helper()
+
+	setupAuth(t)
+	t.Setenv("ASC_APP_ID", "")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+
+	captured := &iapListQuerySurfaceRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		captured.calls++
+		captured.path = req.URL.Path
+		captured.query = req.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"type":"inAppPurchases","id":"iap-1","attributes":{"name":"Pro","productId":"com.example.pro","inAppPurchaseType":"CONSUMABLE","state":"READY_TO_SUBMIT"}}],"links":{"next":""}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Scheme + "://" + req.URL.Host; got != asc.BaseURL {
+			t.Errorf("request origin = %s, want %s", got, asc.BaseURL)
+		}
+		routed := req.Clone(req.Context())
+		routed.URL.Scheme = serverURL.Scheme
+		routed.URL.Host = serverURL.Host
+		routed.Host = serverURL.Host
+		return server.Client().Transport.RoundTrip(routed)
+	})
+	client, err := asc.NewClientWithHTTPClient(
+		"TEST_KEY",
+		"TEST_ISSUER",
+		os.Getenv("ASC_PRIVATE_KEY_PATH"),
+		&http.Client{Transport: transport},
+	)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	t.Cleanup(shared.SetASCClientFactoryForTesting(func() (*asc.Client, error) {
+		return client, nil
+	}))
+
+	return captured
+}
+
+func (r *iapListQuerySurfaceRequest) assertNoRequest(t *testing.T) {
+	t.Helper()
+	if r.calls != 0 {
+		t.Fatalf("expected validation to short-circuit before any request, got %d call(s) to %s?%s", r.calls, r.path, r.query.Encode())
+	}
+}
+
+func runIAPListQuerySurface(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse(args); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	return stdout, stderr, runErr
+}
+
+func TestIAPListQuerySurfaceEmitsDocumentedSelectors(t *testing.T) {
+	captured := iapListQuerySurfaceStub(t)
+
+	stdout, stderr, err := runIAPListQuerySurface(
+		t,
+		"iap", "list",
+		"--app", "app-1",
+		"--product-id", "com.example.pro,com.example.pro2",
+		"--name", "Pro,Pro Plus",
+		"--state", "ready_to_submit,approved",
+		"--type", "consumable,non_consumable",
+		"--sort", "name,-inAppPurchaseType",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("run error: %v (stderr=%q)", err, stderr)
+	}
+
+	if captured.path != "/v1/apps/app-1/inAppPurchasesV2" {
+		t.Fatalf("expected v2 path, got %q", captured.path)
+	}
+	want := url.Values{
+		"filter[productId]":         {"com.example.pro,com.example.pro2"},
+		"filter[name]":              {"Pro,Pro Plus"},
+		"filter[state]":             {"READY_TO_SUBMIT,APPROVED"},
+		"filter[inAppPurchaseType]": {"CONSUMABLE,NON_CONSUMABLE"},
+		"sort":                      {"name,-inAppPurchaseType"},
+	}
+	if got := captured.query; got.Encode() != want.Encode() {
+		t.Fatalf("query = %s, want %s", got.Encode(), want.Encode())
+	}
+	if !strings.Contains(stdout, `"id":"iap-1"`) {
+		t.Fatalf("expected IAP envelope, got %q", stdout)
+	}
+}
+
+func TestIAPListQuerySurfaceRejectsInvalidSelectorsBeforeRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "state",
+			args: []string{"iap", "list", "--app", "app-1", "--state", "NOT_A_STATE"},
+			want: "--state must be one of:",
+		},
+		{
+			name: "type",
+			args: []string{"iap", "list", "--app", "app-1", "--type", "NOT_A_TYPE"},
+			want: "--type must be one of:",
+		},
+		{
+			name: "sort",
+			args: []string{"iap", "list", "--app", "app-1", "--sort", "createdDate"},
+			want: "--sort must be one of:",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			captured := iapListQuerySurfaceStub(t)
+			_, stderr, err := runIAPListQuerySurface(t, test.args...)
+			if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, err)
+			}
+			if !strings.Contains(stderr, test.want) {
+				t.Fatalf("expected stderr to contain %q, got %q", test.want, stderr)
+			}
+			captured.assertNoRequest(t)
+		})
+	}
+}
+
+func TestIAPListQuerySurfaceRejectsNextWithSelectors(t *testing.T) {
+	next := "https://api.appstoreconnect.apple.com/v1/apps/app-1/inAppPurchasesV2?cursor=next"
+	flags := []string{"product-id", "name", "state", "type", "sort"}
+	for _, name := range flags {
+		t.Run(name, func(t *testing.T) {
+			captured := iapListQuerySurfaceStub(t)
+			_, stderr, err := runIAPListQuerySurface(t, "iap", "list", "--next", next, "--"+name, "value")
+			if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, err)
+			}
+			want := "--next cannot be combined with --" + name
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("expected stderr to contain %q, got %q", want, stderr)
+			}
+			captured.assertNoRequest(t)
+		})
+	}
+}
+
+func TestIAPListQuerySurfaceRejectsV2SelectorsOnLegacy(t *testing.T) {
+	flags := []string{"product-id", "name", "state", "type", "sort"}
+	for _, name := range flags {
+		t.Run(name, func(t *testing.T) {
+			captured := iapListQuerySurfaceStub(t)
+			_, stderr, err := runIAPListQuerySurface(t, "iap", "list", "--app", "app-1", "--legacy", "--"+name, "value")
+			if got := rootcmd.ExitCodeFromError(err); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, err)
+			}
+			want := "--" + name + " requires the v2 endpoint"
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("expected stderr to contain %q, got %q", want, stderr)
+			}
+			captured.assertNoRequest(t)
+		})
+	}
+}
+
+func TestIAPListQuerySurfaceKeepsLegacyModeWithoutSelectors(t *testing.T) {
+	captured := iapListQuerySurfaceStub(t)
+
+	_, stderr, err := runIAPListQuerySurface(t, "iap", "list", "--app", "app-1", "--legacy", "--output", "json")
+	if err != nil {
+		t.Fatalf("run error: %v (stderr=%q)", err, stderr)
+	}
+	if captured.path != "/v1/apps/app-1/inAppPurchases" {
+		t.Fatalf("expected legacy path, got %q", captured.path)
+	}
+	if captured.query.Encode() != "" {
+		t.Fatalf("expected no legacy query, got %s", captured.query.Encode())
+	}
+}

--- a/internal/cli/cmdtest/iap_list_query_surface_test.go
+++ b/internal/cli/cmdtest/iap_list_query_surface_test.go
@@ -13,6 +13,7 @@ import (
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	iapcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/iap"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
@@ -126,6 +127,42 @@ func TestIAPListQuerySurfaceEmitsDocumentedSelectors(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"id":"iap-1"`) {
 		t.Fatalf("expected IAP envelope, got %q", stdout)
+	}
+}
+
+func TestIAPListQuerySurfaceDeduplicatesNormalizedEnumValues(t *testing.T) {
+	captured := iapListQuerySurfaceStub(t)
+
+	_, stderr, err := runIAPListQuerySurface(
+		t,
+		"iap", "list",
+		"--app", "app-1",
+		"--state", "ready_to_submit,READY_TO_SUBMIT",
+		"--type", "consumable,CONSUMABLE",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("run error: %v (stderr=%q)", err, stderr)
+	}
+
+	if got := captured.query.Get("filter[state]"); got != "READY_TO_SUBMIT" {
+		t.Fatalf("filter[state] = %q, want READY_TO_SUBMIT", got)
+	}
+	if got := captured.query.Get("filter[inAppPurchaseType]"); got != "CONSUMABLE" {
+		t.Fatalf("filter[inAppPurchaseType] = %q, want CONSUMABLE", got)
+	}
+}
+
+func TestIAPListQueryFlagsAreExperimental(t *testing.T) {
+	command := iapcli.IAPListCommand()
+	for _, name := range []string{"product-id", "name", "state", "type", "sort"} {
+		flagValue := command.FlagSet.Lookup(name)
+		if flagValue == nil {
+			t.Fatalf("--%s is not registered", name)
+		}
+		if !strings.HasPrefix(flagValue.Usage, "[experimental] ") {
+			t.Errorf("--%s usage = %q, want [experimental] prefix", name, flagValue.Usage)
+		}
 	}
 }
 

--- a/internal/cli/iap/helpers_test.go
+++ b/internal/cli/iap/helpers_test.go
@@ -25,3 +25,13 @@ func TestRelationshipResourceIDMissingID(t *testing.T) {
 		t.Fatalf("expected error for missing relationship id")
 	}
 }
+
+func TestNormalizeIAPListEnumDeduplicatesAfterNormalization(t *testing.T) {
+	got, err := normalizeIAPListEnum("ready_to_submit,READY_TO_SUBMIT", "--state", iapListStates)
+	if err != nil {
+		t.Fatalf("unexpected normalization error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "READY_TO_SUBMIT" {
+		t.Fatalf("normalized states = %v, want [READY_TO_SUBMIT]", got)
+	}
+}

--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -146,6 +146,20 @@ Examples:
 					return shared.UsageErrorf("iap list: --%s requires the v2 endpoint", name)
 				}
 			}
+			for _, selector := range []struct {
+				name  string
+				value string
+			}{
+				{"product-id", *productID},
+				{"name", *name},
+				{"state", *state},
+				{"type", *iapType},
+				{"sort", *sort},
+			} {
+				if flagSet(fs, selector.name) && strings.TrimSpace(selector.value) == "" {
+					return shared.UsageErrorf("iap list: --%s must not be empty", selector.name)
+				}
+			}
 
 			productIDValues, err := normalizeIAPListCSV(*productID, "--product-id")
 			if err != nil {

--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -16,6 +16,23 @@ import (
 
 var iapQueryClientFactory = shared.GetASCClient
 
+var iapListStates = []string{
+	"MISSING_METADATA",
+	"WAITING_FOR_UPLOAD",
+	"PROCESSING_CONTENT",
+	"READY_TO_SUBMIT",
+	"WAITING_FOR_REVIEW",
+	"IN_REVIEW",
+	"DEVELOPER_ACTION_NEEDED",
+	"PENDING_BINARY_APPROVAL",
+	"APPROVED",
+	"DEVELOPER_REMOVED_FROM_SALE",
+	"REMOVED_FROM_SALE",
+	"REJECTED",
+}
+
+var iapListSortValues = []string{"name", "-name", "inAppPurchaseType", "-inAppPurchaseType"}
+
 // IAPCommand returns the in-app purchases command group.
 func IAPCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("iap", flag.ExitOnError)
@@ -70,6 +87,11 @@ func IAPListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
+	productID := fs.String("product-id", "", "Filter by product ID(s), comma-separated")
+	name := fs.String("name", "", "Filter by name(s), comma-separated")
+	state := fs.String("state", "", "Filter by state(s), comma-separated: "+strings.Join(iapListStates, ", "))
+	iapType := fs.String("type", "", "Filter by type(s), comma-separated: "+strings.Join(asc.ValidIAPTypes, ", "))
+	sort := fs.String("sort", "", "Sort by (comma-separated): "+strings.Join(iapListSortValues, ", "))
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -88,6 +110,8 @@ func IAPListCommand() *ffcli.Command {
 
 Examples:
   asc iap list --app "APP_ID"
+  asc iap list --app "APP_ID" --product-id "com.example.pro"
+  asc iap list --app "APP_ID" --state READY_TO_SUBMIT --type CONSUMABLE --sort name
   asc iap list --app "APP_ID" --limit 50
   asc iap list --app "APP_ID" --paginate
   asc iap list --app "APP_ID" --include-versions --versions-limit 10
@@ -102,7 +126,7 @@ Examples:
 			if err := shared.ValidateNextURL(*next); err != nil {
 				return fmt.Errorf("iap list: %w", err)
 			}
-			if err := rejectIAPVersionNextFlagConflicts(fs, *next, "iap list", "app", "limit", "include-versions", "versions-limit", "fields", "version-fields"); err != nil {
+			if err := rejectIAPVersionNextFlagConflicts(fs, *next, "iap list", "app", "product-id", "name", "state", "type", "sort", "limit", "include-versions", "versions-limit", "fields", "version-fields"); err != nil {
 				return err
 			}
 			if *limit != 0 && (*limit < 1 || *limit > 200) {
@@ -116,6 +140,32 @@ Examples:
 			}
 			if *legacy && (*includeVersions || *versionsLimit != 0 || strings.TrimSpace(*versionFields) != "") {
 				return shared.UsageError("iap list: --include-versions, --versions-limit, and --version-fields require the v2 endpoint")
+			}
+			for _, name := range []string{"product-id", "name", "state", "type", "sort"} {
+				if *legacy && flagSet(fs, name) {
+					return shared.UsageErrorf("iap list: --%s requires the v2 endpoint", name)
+				}
+			}
+
+			productIDValues, err := normalizeIAPListCSV(*productID, "--product-id")
+			if err != nil {
+				return shared.UsageError("iap list: " + err.Error())
+			}
+			nameValues, err := normalizeIAPListCSV(*name, "--name")
+			if err != nil {
+				return shared.UsageError("iap list: " + err.Error())
+			}
+			stateValues, err := normalizeIAPListEnum(*state, "--state", iapListStates)
+			if err != nil {
+				return shared.UsageError("iap list: " + err.Error())
+			}
+			typeValues, err := normalizeIAPListEnum(*iapType, "--type", asc.ValidIAPTypes)
+			if err != nil {
+				return shared.UsageError("iap list: " + err.Error())
+			}
+			sortValues, err := normalizeIAPListSort(*sort)
+			if err != nil {
+				return shared.UsageError("iap list: " + err.Error())
 			}
 			fieldValues, err := shared.NormalizeSelection(*fields, iapVersionIAPFields, "--fields")
 			if err != nil {
@@ -142,6 +192,11 @@ Examples:
 			opts := []asc.IAPOption{
 				asc.WithIAPLimit(*limit),
 				asc.WithIAPNextURL(*next),
+				asc.WithIAPProductIDs(productIDValues),
+				asc.WithIAPNames(nameValues),
+				asc.WithIAPStates(stateValues),
+				asc.WithIAPTypes(typeValues),
+				asc.WithIAPSort(sortValues),
 				asc.WithIAPFields(fieldValues),
 				asc.WithIAPNestedVersionsLimit(*versionsLimit),
 				asc.WithIAPVersionFields(versionFieldValues),
@@ -606,4 +661,60 @@ func normalizeIAPType(value string) (string, error) {
 		return normalized, nil
 	}
 	return "", fmt.Errorf("--type must be one of: %s", strings.Join(asc.ValidIAPTypes, ", "))
+}
+
+func normalizeIAPListCSV(value, flagName string) ([]string, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("%s must not contain empty values", flagName)
+		}
+		if _, ok := seen[part]; ok {
+			continue
+		}
+		seen[part] = struct{}{}
+		values = append(values, part)
+	}
+	return values, nil
+}
+
+func normalizeIAPListEnum(value, flagName string, allowed []string) ([]string, error) {
+	values, err := normalizeIAPListCSV(value, flagName)
+	if err != nil {
+		return nil, err
+	}
+	for i := range values {
+		values[i] = strings.ToUpper(values[i])
+	}
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		if !slices.Contains(allowed, value) {
+			return nil, fmt.Errorf("%s must be one of: %s", flagName, strings.Join(allowed, ", "))
+		}
+	}
+	return values, nil
+}
+
+func normalizeIAPListSort(value string) ([]string, error) {
+	values, err := normalizeIAPListCSV(value, "--sort")
+	if err != nil {
+		return nil, err
+	}
+	for _, value := range values {
+		if !slices.Contains(iapListSortValues, value) {
+			return nil, fmt.Errorf("--sort must be one of: %s", strings.Join(iapListSortValues, ", "))
+		}
+	}
+	return values, nil
 }

--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -87,11 +87,11 @@ func IAPListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID env)")
-	productID := fs.String("product-id", "", "Filter by product ID(s), comma-separated")
-	name := fs.String("name", "", "Filter by name(s), comma-separated")
-	state := fs.String("state", "", "Filter by state(s), comma-separated: "+strings.Join(iapListStates, ", "))
-	iapType := fs.String("type", "", "Filter by type(s), comma-separated: "+strings.Join(asc.ValidIAPTypes, ", "))
-	sort := fs.String("sort", "", "Sort by (comma-separated): "+strings.Join(iapListSortValues, ", "))
+	productID := fs.String("product-id", "", "[experimental] Filter by product ID(s), comma-separated")
+	name := fs.String("name", "", "[experimental] Filter by name(s), comma-separated")
+	state := fs.String("state", "", "[experimental] Filter by state(s), comma-separated: "+strings.Join(iapListStates, ", "))
+	iapType := fs.String("type", "", "[experimental] Filter by type(s), comma-separated: "+strings.Join(asc.ValidIAPTypes, ", "))
+	sort := fs.String("sort", "", "[experimental] Sort by (comma-separated): "+strings.Join(iapListSortValues, ", "))
 	limit := fs.Int("limit", 0, "Maximum results per page (1-200)")
 	next := fs.String("next", "", "Fetch next page using a links.next URL")
 	paginate := fs.Bool("paginate", false, "Automatically fetch all pages (aggregate results)")
@@ -690,11 +690,10 @@ func normalizeIAPListEnum(value, flagName string, allowed []string) ([]string, e
 	if err != nil {
 		return nil, err
 	}
-	for i := range values {
-		values[i] = strings.ToUpper(values[i])
-	}
 	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
 	for _, value := range values {
+		value = strings.ToUpper(value)
 		if _, ok := seen[value]; ok {
 			continue
 		}
@@ -702,8 +701,9 @@ func normalizeIAPListEnum(value, flagName string, allowed []string) ([]string, e
 		if !slices.Contains(allowed, value) {
 			return nil, fmt.Errorf("%s must be one of: %s", flagName, strings.Join(allowed, ", "))
 		}
+		normalized = append(normalized, value)
 	}
-	return values, nil
+	return normalized, nil
 }
 
 func normalizeIAPListSort(value string) ([]string, error) {


### PR DESCRIPTION
## Summary

- add product ID, name, state, type, and sort controls to `iap list`
- encode the documented v2 filters with local enum validation
- reject query controls with continuation URLs or the legacy endpoint instead of ignoring them

## Why

The v2 in-app purchase list client already modeled product and name filters but the CLI did not expose them, and the documented state, type, and sort controls were missing entirely. This left common catalog audits dependent on broad downloads and local filtering.

## Validation

- exact client query encoding tests
- CLI request, invalid-enum, cursor-conflict, and legacy compatibility regressions
- generated command documentation check
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook (`go test -short ./...`)

No live App Store Connect mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental filters for product ID, name, state, type, and sorting to `iap list`.
  * Added support for comma-separated filter values, normalization, validation, and duplicate removal.
  * Added filtering support for in-app purchase list requests.

* **Bug Fixes**
  * Prevented unsupported filters on legacy endpoints.
  * Added validation for empty or invalid values and incompatible pagination options.

* **Documentation**
  * Added usage examples for the new filtering options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->