### PR TITLE
test(metadata): stabilize pagination deadline check

### DIFF
--- a/internal/cli/metadata/localization_fetch_timeout_test.go
+++ b/internal/cli/metadata/localization_fetch_timeout_test.go
@@ -65,7 +65,6 @@ func TestLocalizationFetchesUseFreshDeadlinePerPage(t *testing.T) {
 					if !ok {
 						t.Fatal("expected first-page request deadline")
 					}
-					time.Sleep(60 * time.Millisecond)
 					return metadataFetchJSONResponse(test.firstBody), nil
 				}
 				deadline, ok := req.Context().Deadline()

--- a/internal/cli/metadata/localization_fetch_timeout_test.go
+++ b/internal/cli/metadata/localization_fetch_timeout_test.go
@@ -56,15 +56,24 @@ func TestLocalizationFetchesUseFreshDeadlinePerPage(t *testing.T) {
 			originalTransport := http.DefaultTransport
 			t.Cleanup(func() { http.DefaultTransport = originalTransport })
 			calls := 0
+			var firstDeadline time.Time
 			http.DefaultTransport = metadataFetchRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
 				if calls == 1 {
+					var ok bool
+					firstDeadline, ok = req.Context().Deadline()
+					if !ok {
+						t.Fatal("expected first-page request deadline")
+					}
 					time.Sleep(60 * time.Millisecond)
 					return metadataFetchJSONResponse(test.firstBody), nil
 				}
 				deadline, ok := req.Context().Deadline()
-				if !ok || time.Until(deadline) < 70*time.Millisecond {
-					t.Fatalf("expected fresh second-page deadline, remaining=%s", time.Until(deadline))
+				if !ok {
+					t.Fatal("expected second-page request deadline")
+				}
+				if !deadline.After(firstDeadline) {
+					t.Fatalf("expected second-page deadline after first-page deadline: first=%s second=%s", firstDeadline, deadline)
 				}
 				return metadataFetchJSONResponse(test.lastBody), nil
 			})


### PR DESCRIPTION
## What changed

The metadata pagination deadline test now compares the first- and second-page deadlines directly. It still proves that every page gets a fresh request timeout, without depending on how quickly a loaded CI runner schedules the second request.

## Why

The package shard for #2131 failed even though the implementation was correct: a 100 ms timeout plus a 70 ms remaining-time assertion left only 30 ms for runner scheduling. The second request reached the test after that margin and produced a false failure.

## Validation

- Focused test passed 50 consecutive runs
- Repository commit hooks passed, including command docs, format, lint, and short tests
- No production code changed

Split from the 4.10.0 audit so the CI reliability fix remains independent of the versions feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for localization pagination request timeouts.
  * Validation now confirms that each request receives an appropriate deadline.
  * Added checks to ensure subsequent requests have additional time available, improving confidence in timeout handling across paginated localization fetches.
  * Updated timing verification to reduce reliance on fixed thresholds and make results more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->