### PR TITLE
fix(json): preserve null sparse resource attributes

### DIFF
--- a/internal/asc/types/resources.go
+++ b/internal/asc/types/resources.go
@@ -234,7 +234,7 @@ func (r *Resource[T]) UnmarshalJSON(data []byte) error {
 		attributesPresent: decoded.Attributes != nil,
 		attributesNull:    bytes.Equal(bytes.TrimSpace(decoded.Attributes), []byte("null")),
 	}
-	if !r.attributesPresent || r.attributesNull {
+	if !r.attributesPresent {
 		return nil
 	}
 	return json.Unmarshal(decoded.Attributes, &r.Attributes)

--- a/internal/asc/types/resources_test.go
+++ b/internal/asc/types/resources_test.go
@@ -118,6 +118,33 @@ func TestResourcePreservesDecodedAttributesPresence(t *testing.T) {
 	}
 }
 
+type nullAwareResourceAttributes struct {
+	sawNull bool
+}
+
+func (a *nullAwareResourceAttributes) UnmarshalJSON(data []byte) error {
+	a.sawNull = string(data) == "null"
+	return nil
+}
+
+func TestResourceDecodesPresentNullAttributesIntoTypedValue(t *testing.T) {
+	var resource Resource[nullAwareResourceAttributes]
+	if err := json.Unmarshal([]byte(`{"type":"apps","id":"app-1","attributes":null}`), &resource); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resource.Attributes.sawNull {
+		t.Fatal("expected the typed attributes decoder to receive null")
+	}
+
+	got, err := json.Marshal(resource)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(got) != `{"type":"apps","id":"app-1","attributes":null}` {
+		t.Fatalf("output = %s", got)
+	}
+}
+
 func TestResourceConstructedByCallerKeepsAttributes(t *testing.T) {
 	resource := Resource[struct{}]{
 		Type:       ResourceTypeApps,


### PR DESCRIPTION
## Summary

- decode an explicitly present `attributes: null` member into the typed resource attributes value
- preserve the generic resource's existing absent/null/output behavior
- cover custom attribute decoders that need to observe a present null value

## Why

The bundle ID query-parity and generic sparse-resource changes exposed an integration bug on current `main`. `Resource[T].UnmarshalJSON` recorded `attributes: null` but returned before invoking a custom `T.UnmarshalJSON`. The bundle ID response marshaller relies on that nested decoder's presence marker, so it omitted the requested null member.

This deterministic failure currently breaks the package test shard for unrelated pull requests that merge against current `main`.

## Validation

- reproduced `TestBundleIDsResponseMarshalPreservesSparseAttributeFields/null` failing on current `main`
- focused generic-resource and bundle-ID regressions
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- commit hook short suite

No live App Store Connect requests or mutations were performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resources with explicitly null attributes.
  * Ensured null attribute values are preserved correctly when data is processed and saved.

* **Tests**
  * Added coverage for decoding and re-encoding resources with null attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->