### PR TITLE
test(telemetry): remove Windows timing flake

### DIFF
--- a/internal/telemetry/state_test.go
+++ b/internal/telemetry/state_test.go
@@ -337,9 +337,12 @@ func TestConcurrentStateUpdatesPreserveOptOutAndInstallID(t *testing.T) {
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
+	const concurrentUpdatePairs = 16
 	var wg sync.WaitGroup
-	errs := make(chan error, 100)
-	for i := 0; i < 50; i++ {
+	errs := make(chan error, 2*concurrentUpdatePairs)
+	// Keep enough overlap to exercise the file lock while leaving margin for
+	// Windows hosted runners, where filesystem operations can be descheduled.
+	for i := 0; i < concurrentUpdatePairs; i++ {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()

--- a/internal/telemetry/state_windows_test.go
+++ b/internal/telemetry/state_windows_test.go
@@ -70,7 +70,7 @@ func TestReplaceStateFileWaitsForConcurrentReader(t *testing.T) {
 	}
 }
 
-func TestEnsureInstallIDDoesNotWaitForStateReader(t *testing.T) {
+func TestEnsureInstallIDReportsStateReaderContention(t *testing.T) {
 	setTelemetryTestHome(t)
 
 	if err := SetEnabled(false); err != nil {
@@ -82,12 +82,12 @@ func TestEnsureInstallIDDoesNotWaitForStateReader(t *testing.T) {
 	}
 	reader := openStateFileWithoutDeleteSharing(t, path)
 
-	start := time.Now()
-	if _, err := ensureInstallID(0); err == nil {
+	_, err = ensureInstallID(0)
+	if err == nil {
 		t.Fatal("ensureInstallID(0) succeeded while state reader blocked replacement")
 	}
-	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
-		t.Fatalf("ensureInstallID(0) elapsed = %s, want replacement contention skipped before 500ms", elapsed)
+	if !isRetryableStateReplaceError(err) {
+		t.Fatalf("ensureInstallID(0) error = %v, want retryable replacement error", err)
 	}
 	if err := reader.Close(); err != nil {
 		t.Fatalf("close state reader: %v", err)

--- a/internal/telemetry/state_windows_test.go
+++ b/internal/telemetry/state_windows_test.go
@@ -82,12 +82,26 @@ func TestEnsureInstallIDReportsStateReaderContention(t *testing.T) {
 	}
 	reader := openStateFileWithoutDeleteSharing(t, path)
 
-	_, err = ensureInstallID(0)
-	if err == nil {
+	// Leave enough margin for hosted-runner scheduling variance while keeping
+	// the bound below lockTimeout so an accidental retry is still observable.
+	const promptDeadline = 1500 * time.Millisecond
+	result := make(chan error, 1)
+	go func() {
+		_, err := ensureInstallID(0)
+		result <- err
+	}()
+	var ensureErr error
+	select {
+	case ensureErr = <-result:
+	case <-time.After(promptDeadline):
+		_ = reader.Close()
+		t.Fatalf("ensureInstallID(0) did not return within %s", promptDeadline)
+	}
+	if ensureErr == nil {
 		t.Fatal("ensureInstallID(0) succeeded while state reader blocked replacement")
 	}
-	if !isRetryableStateReplaceError(err) {
-		t.Fatalf("ensureInstallID(0) error = %v, want retryable replacement error", err)
+	if !isRetryableStateReplaceError(ensureErr) {
+		t.Fatalf("ensureInstallID(0) error = %v, want retryable replacement error", ensureErr)
 	}
 	if err := reader.Close(); err != nil {
 		t.Fatalf("close state reader: %v", err)


### PR DESCRIPTION
## Summary

The first attempt of PR #2207 run 33019417515 failed only in the Windows telemetry job: one concurrent state update exhausted the 2-second file-lock budget, and the blocked-reader test failed a 500 ms wall-clock assertion after taking 976 ms. The exact same head passed on the rerun, and current main has passed three successive telemetry-Windows jobs.

This follow-up hardens the tests without changing telemetry behavior:

- Assert the blocked reader returns the expected retryable replacement error instead of measuring scheduler-sensitive elapsed time.
- Keep concurrent state-update coverage while using 16 update pairs, leaving margin for Windows hosted-runner filesystem scheduling.

## Validation

- ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/telemetry -count=1
- ASC_BYPASS_KEYCHAIN=1 go test -short ./internal/telemetry -run TestConcurrentStateUpdatesPreserveOptOutAndInstallID -count=20
- GOOS=windows GOARCH=amd64 go test -c ./internal/telemetry
- make build
- make format
- make check-docs
- make lint
- commit hook short suite across all packages

No production code, CLI contract, API surface, or App Store Connect data was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved concurrency coverage for telemetry state updates, including overlapping operations and platform-specific scheduling behavior.
  * Updated Windows telemetry validation to confirm that state-reader contention returns a retryable error.
  * Added a timeout check to ensure contention handling completes promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->