### PR TITLE
apps wall: add TapTape

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1676,6 +1676,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/26/a3/f7/26a3f7f9-3cb6-dc8e-fcbd-0fc93630dd4c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "TapTape",
+    "link": "https://apps.apple.com/us/app/taptape/id6748304805?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/b8/47/72/b8477252-9820-e366-84fc-4736974702a6/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Telescopo: Markdown & Diagrams",
     "link": "https://apps.apple.com/us/app/telescopo-markdown-diagrams/id6747908871?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/eb/ba/d4/ebbad4d9-6a72-5d73-9a18-cf2719e6b8f3/telescopo-icon-0-0-85-220-0-6-0-2x-0-0-0.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `TapTape` to the Wall of Apps

## Entry

- App ID: 6748304805
- App: TapTape
- Link: https://apps.apple.com/us/app/taptape/id6748304805?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TapTape to the applications list, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->