### PR TITLE
fix(docs): preserve help output with cold Go cache

### DIFF
--- a/scripts/check-commands-docs.py
+++ b/scripts/check-commands-docs.py
@@ -30,7 +30,9 @@ def run_help_text() -> str:
         capture_output=True,
         text=True,
     )
-    return proc.stderr or proc.stdout
+    # ffcli writes successful help output to stdout. A cold Go module cache can
+    # add download diagnostics to stderr, which must not replace that output.
+    return proc.stdout or proc.stderr
 
 
 def parse_live_commands(help_text: str) -> set[str]:

--- a/scripts/generate-command-docs.py
+++ b/scripts/generate-command-docs.py
@@ -35,7 +35,9 @@ def run_help_text() -> str:
         capture_output=True,
         text=True,
     )
-    return proc.stderr or proc.stdout
+    # ffcli writes successful help output to stdout. A cold Go module cache can
+    # add download diagnostics to stderr, which must not replace that output.
+    return proc.stdout or proc.stderr
 
 
 def parse_help(help_text: str) -> tuple[str, list[tuple[str, str]], list[tuple[str, list[tuple[str, str]]]]]:

--- a/scripts/test_generate_command_docs.py
+++ b/scripts/test_generate_command_docs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib.util
 import unittest
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 
 MODULE_PATH = Path(__file__).with_name("generate-command-docs.py")
@@ -32,6 +33,12 @@ FLAGS
 
 
 class ParseHelpTests(unittest.TestCase):
+    @patch.object(generate_command_docs.subprocess, "run")
+    def test_help_stdout_wins_over_go_download_diagnostics(self, run: Mock) -> None:
+        run.return_value = Mock(stdout=HELP_WITH_SAMPLES, stderr="go: downloading example.com/module\n")
+
+        self.assertEqual(generate_command_docs.run_help_text(), HELP_WITH_SAMPLES)
+
     def test_usage_comes_from_the_usage_section(self) -> None:
         usage, _, _ = generate_command_docs.parse_help(HELP_WITH_SAMPLES)
         self.assertEqual(usage, "asc <subcommand> [flags]")

--- a/scripts/test_generate_command_docs.py
+++ b/scripts/test_generate_command_docs.py
@@ -13,6 +13,12 @@ assert SPEC and SPEC.loader
 generate_command_docs = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(generate_command_docs)
 
+CHECK_MODULE_PATH = Path(__file__).with_name("check-commands-docs.py")
+CHECK_SPEC = importlib.util.spec_from_file_location("check_commands_docs", CHECK_MODULE_PATH)
+assert CHECK_SPEC and CHECK_SPEC.loader
+check_commands_docs = importlib.util.module_from_spec(CHECK_SPEC)
+CHECK_SPEC.loader.exec_module(check_commands_docs)
+
 
 HELP_WITH_SAMPLES = """DESCRIPTION
   asc is a fast, lightweight CLI for App Store Connect from Rork.
@@ -38,6 +44,12 @@ class ParseHelpTests(unittest.TestCase):
         run.return_value = Mock(stdout=HELP_WITH_SAMPLES, stderr="go: downloading example.com/module\n")
 
         self.assertEqual(generate_command_docs.run_help_text(), HELP_WITH_SAMPLES)
+
+    @patch.object(check_commands_docs.subprocess, "run")
+    def test_command_check_stdout_wins_over_go_download_diagnostics(self, run: Mock) -> None:
+        run.return_value = Mock(stdout=HELP_WITH_SAMPLES, stderr="go: downloading example.com/module\n")
+
+        self.assertEqual(check_commands_docs.run_help_text(), HELP_WITH_SAMPLES)
 
     def test_usage_comes_from_the_usage_section(self) -> None:
         usage, _, _ = generate_command_docs.parse_help(HELP_WITH_SAMPLES)


### PR DESCRIPTION
## Summary
- prefer successful `asc --help` stdout over Go download diagnostics on stderr
- preserve stderr as a fallback when stdout is empty
- cover cold-module-cache behavior with a regression test

## Verification
- reproduced the failure with isolated empty `GOMODCACHE` and `GOCACHE` directories
- `python3 scripts/test_generate_command_docs.py`
- cold-cache `python3 scripts/generate-command-docs.py --check`
- `make check-docs`
- pre-commit format, lint, and short test checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command documentation generation by prioritizing valid CLI help output, even when diagnostic messages appear on stderr.
* **Tests**
  * Added coverage to verify help text remains accurate when dependency-download diagnostics are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->