### PR TITLE
fix(telemetry): classify snitch descriptions as leaf calls

### DIFF
--- a/cmd/invocation_context.go
+++ b/cmd/invocation_context.go
@@ -91,6 +91,9 @@ func analyzeInvocation(root *ffcli.Command, args []string) invocationAnalysis {
 			}
 		}
 		if len(current.Subcommands) > 0 {
+			if current.Name == "snitch" {
+				return invocationAnalysis{command: current, shape: telemetry.InvocationShapeLeaf}
+			}
 			return invocationAnalysis{
 				command:      current,
 				shape:        telemetry.InvocationShapeUnknownChild,
@@ -115,9 +118,6 @@ func shapeForCommand(command *ffcli.Command, sawFlag bool) telemetry.InvocationS
 
 func shouldRenderConciseUnknownChild(root *ffcli.Command, analysis invocationAnalysis, commandName string) bool {
 	if analysis.shape != telemetry.InvocationShapeUnknownChild || analysis.command == nil {
-		return false
-	}
-	if analysis.command != root && commandName == "asc snitch" {
 		return false
 	}
 	return analysis.command == root || !preservesLegacyChild(analysis, commandName)

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -2101,6 +2101,15 @@ func TestRun_SnitchPreservesPositionalDescription(t *testing.T) {
 	resetReportFlags(t)
 	t.Setenv("GITHUB_TOKEN", "")
 	t.Setenv("GH_TOKEN", "")
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var gotExitCode int
+	var gotContext telemetry.EventContext
+	emitTelemetry = func(_ string, _ string, _ time.Duration, exitCode int, eventContext telemetry.EventContext) {
+		gotExitCode = exitCode
+		gotContext = eventContext
+	}
 
 	_, stderr := captureCommandOutput(t, func() {
 		if code := Run([]string{"snitch", "--dry-run", "status command needs bundle ID support"}, "1.0.0"); code != ExitSuccess {
@@ -2110,6 +2119,9 @@ func TestRun_SnitchPreservesPositionalDescription(t *testing.T) {
 
 	if !strings.Contains(stderr, "status command needs bundle ID support") {
 		t.Fatalf("expected snitch preview to preserve description, got %q", stderr)
+	}
+	if gotExitCode != ExitSuccess || gotContext.InvocationShape != telemetry.InvocationShapeLeaf {
+		t.Fatalf("unexpected telemetry for successful positional snitch: exit=%d context=%+v", gotExitCode, gotContext)
 	}
 }
 


### PR DESCRIPTION
## Problem

`asc snitch` accepts a positional report description and also has a `flush` subcommand. Invocation analysis treated every non-flag token under a command with subcommands as `unknown_child`, even when the positional description ran successfully.

Privacy-safe aggregate telemetry recorded 628 affected `snitch` events in the current seven-day window, including 480 successful calls across hundreds of pseudonymous installations. This materially inflates unknown-child friction and distorts analytics-driven CLI decisions.

## Change

- Classify positional input accepted by `snitch` as a leaf invocation.
- Preserve normal `asc snitch flush` subcommand dispatch.
- Remove the now-obsolete rendering exception that previously prevented valid descriptions from being shown as unknown-command errors.

## Verification

TDD established RED before the implementation: a successful positional dry run emitted `unknown_child`. The regression now asserts exit 0, preserved description output, and `leaf` invocation telemetry.

Passed on the exact head:

- focused root-runner and `snitch` tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- normal commit hooks
- built-binary dry-run validation
- clean synthetic merge with current `main`

No GitHub issue was filed during live verification.

## Compatibility

Telemetry-only correction. Commands, flags, stdout, stderr, exit codes, and `snitch flush` behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unrecognized positional arguments in `snitch` commands.
  - Positional descriptions are now preserved during `snitch --dry-run` executions.
  - Telemetry correctly reports successful dry-run invocations with the expected command structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->